### PR TITLE
New TraversableTraverse implementation to avoid stack overflow

### DIFF
--- a/core/src/main/scala/scalaz/Traverse.scala
+++ b/core/src/main/scala/scalaz/Traverse.scala
@@ -20,14 +20,8 @@ object Traverse {
   }
 
   implicit def TraversableTraverse[CC[X] <: collection.SeqLike[X, CC[X]] : CanBuildAnySelf]: Traverse[CC] = new Traverse[CC] {
-    def traverse[F[_] : Applicative, A, B](f: A => F[B], as: CC[A]): F[CC[B]] = {
-      implicit val cbf = implicitly[CanBuildAnySelf[CC]].builder[B, B]
-      val ap: Apply[F] = implicitly[Apply[F]]
-
-      // Build up the result using streams to avoid potentially expensive prepend operation on other collections.
-      val flistbs: F[Stream[B]] = as.toStream.foldr(Stream.empty[B].η[F])((x, ys) => ap(f(x) ∘ ((a: B) => (b: Stream[B]) => a #:: b), ys))
-      flistbs ∘ (_.toList.map(identity)(collection.breakOut))
-    }
+    def traverse[F[_] : Applicative, A, B](f: A => F[B], as: CC[A]): F[CC[B]] =
+      as.foldLeft(implicitly[CanBuildAnySelf[CC]].builder[B, B]().η[F])((b, a) => (b <**> f(a))(_ += _)) ∘ (_.result)
   }
 
   implicit def Tuple1Traverse: Traverse[Tuple1] = new Traverse[Tuple1] {


### PR DESCRIPTION
This uses the builder directly without converting to a stream or list. I'm just a little uncomfortable with passing around the mutable builder, although I'm pretty sure there shouldn't be any concurrent access since a fold is usually (always?) done sequentially. I'm also using Applicative instead of Apply to build the new collection (any performance reason not to?).

It passes scalaz tests and my own tests that involve Akka (so I am doing concurrent operations where possible), as well as some other simple tests in the console using Promise.
