### PR TITLE
Improved Iteratee.repeat to stop chewing stack and added Iteratee.collect.

### DIFF
--- a/example/src/main/scala/scalaz/example/ExampleIteratee.scala
+++ b/example/src/main/scala/scalaz/example/ExampleIteratee.scala
@@ -14,12 +14,18 @@ object ExampleIteratee {
     }
   }
 
+  val list = collect[Int, List]
+
+  val repeatHead = repeat[Int, Option[Int], List](head)
+
   def run {
     head(Stream(1, 2, 3)).run assert_=== Some(1)
     length(Stream(10, 20, 30)).run assert_=== 3
     peek(Stream(1, 2, 3)).run assert_=== Some(1)
     head(Stream[Int]()).run assert_=== none[Int]
-    
+    list(Stream(1, 2, 3)).run assert_=== List(1, 2, 3)
+    repeatHead(Stream(1, 2, 3)).run assert_=== List(Some(1), Some(2), Some(3))
+
     // As a monad
     val m1 = head[Int] >>= ((b:Option[Int]) => head[Int] map (b2 => (b <|*|> b2)))
     m1(Stream(1,2,3)).run assert_=== Some(1 -> 2)


### PR DESCRIPTION
Modified Iteratee.repeat to not use bind. The previous approach using bind chewed stack for each continuation.

Added Iteratee.collect in the same style as repeat.
