### PR TITLE
Scalaz7 - takeWhile, joinI, and fixed iteratee examples

### DIFF
--- a/core/src/main/scala/scalaz/iteratee/IterateeT.scala
+++ b/core/src/main/scala/scalaz/iteratee/IterateeT.scala
@@ -4,6 +4,7 @@ package iteratee
 import Input._
 import Identity._
 import StepT._
+import effect._
 
 sealed trait IterateeT[X, E, F[_], A] {
   val value: F[StepT[X, E, F, A]]
@@ -79,6 +80,40 @@ sealed trait IterateeT[X, E, F[_], A] {
   def >>==[B, C](f: StepT[X, E, F, A] => IterateeT[X, B, F, C])(implicit m: Bind[F]): IterateeT[X, B, F, C] =
     iterateeT(m.bind((s: StepT[X, E, F, A]) => f(s).value)(value))
 
+  def mapI[G[_]](f: F ~> G)(implicit ftr: Functor[F]): IterateeT[X, E, G, A] = {
+    def step: StepT[X, E, F, A] => StepT[X, E, G, A] =
+      _.fold(
+        cont = k => scont[X, E, G, A](k andThen loop)
+      , done = (a, i) => sdone[X, E, G, A](a, i)
+      , err = e => serr[X, E, G, A](e)
+      )
+    def loop: IterateeT[X, E, F, A] => IterateeT[X, E, G, A] = i => iterateeT(f(ftr.fmap(step)(i.value)))
+    loop(this)
+  }
+  
+  def up[G[_]](implicit pt: Pointed[G], ftr: Functor[F], cpt: CoPointed[F]): IterateeT[X, E, G, A] = {
+    mapI(new (F ~> G) {
+      def apply[A](a: F[A]) = pt.point(cpt.coPoint(a))
+    })
+  }
+  
+  def joinI[I, B](implicit outer: IterateeT[X, E, F, A] =:= IterateeT[X, E, F, StepT[X, I, F, B]], m: Monad[F]): IterateeT[X, E, F, B] = {
+    implicit val b = m.bind
+    implicit val p = m.pointed
+    implicit val ip = IterateeTPointed[X, E, F]
+    def check: StepT[X, I, F, B] => IterateeT[X, E, F, B] = _.fold(
+      cont = k => k(eofInput) >>== { s => s.mapContOr(_ => sys.error("diverging iteratee"), check(s)) }
+    , done = (a, _) => ip.point(a)
+    , err = e => err(e)
+    )
+
+    outer(this) flatMap check
+  }
+  
+  def <~[O](e: EnumerateeT[X, O, E, F, A])(implicit m: Monad[F]): IterateeT[X, O, F, A] = {
+    implicit val b = m.bind
+    (this >>== e).joinI[E, A]
+  }
 }
 
 object IterateeT extends IterateeTs {
@@ -301,6 +336,43 @@ trait IterateeTs {
       )
     }
 
+  implicit def enumStream[X, E, F[_]: Pointed : Bind, A](xs: Stream[E]): EnumeratorT[X, E, F, A] = { s =>
+    xs match {
+      case h #:: t => s.mapContOr(_(elInput(h)) >>== enumStream(t), s.pointI)
+      case _ => s.pointI
+    }
+  }
+  
+  implicit def enumIterator[X, E, A](x: Iterator[E]): EnumeratorT[X, E, IO, A] = {
+    def loop: EnumeratorT[X, E, IO, A] = { s =>
+      s.mapContOr(
+        k =>
+          if (x.hasNext) {
+            val n = x.next
+            k(elInput(n)) >>== loop
+          } else s.pointI
+      , s.pointI
+      )
+    }
+    loop
+  }
+
+  import java.io._
+  implicit def enumReader[X, A](r: Reader): EnumeratorT[X, IoExceptionOr[Char], IO, A] = {
+    def loop: EnumeratorT[X, IoExceptionOr[Char], IO, A] = { s =>
+      s.mapContOr(
+        k => {
+          val i = r.read
+          val c = IoExceptionOr(i.toChar)
+          if (i != -1) k(elInput(c)) >>== loop
+          else s.pointI
+        }
+      , s.pointI
+      )
+    }
+    loop
+  }
+
   def checkCont0[X, E, F[_], A](z: EnumeratorT[X, E, F, A] => (Input[E] => IterateeT[X, E, F, A]) => IterateeT[X, E, F, A])(implicit p: Pointed[F]): EnumeratorT[X, E, F, A] = {
     def step: EnumeratorT[X, E, F, A] = {
       s =>
@@ -335,4 +407,28 @@ trait IterateeTs {
     checkCont0[X, E, F, A](s => k => k(elInput(e)) >>== s)
   }
 
+  def doneOr[X, O, I, F[_]: Pointed, A](f: (Input[I] => IterateeT[X, I, F, A]) => IterateeT[X, O, F, StepT[X, I, F, A]]): EnumerateeT[X, O, I, F, A] = { s =>
+    def d: IterateeT[X, O, F, StepT[X, I, F, A]] = done(s, emptyInput)
+    s.fold(
+      cont = k => f(k)
+    , done = (_, _) => d
+    , err = _ => d
+    )
+  }
+  
+  def takeWhile[X, E, F[_], A](p: E => Boolean)(implicit m: Monad[F]): EnumerateeT[X, E, E, F, A] = {
+    implicit val pt = m.pointed
+    implicit val b = m.bind
+    def loop = step andThen cont[X, E, F, StepT[X, E, F, A]]
+    def step: (Input[E] => IterateeT[X, E, F, A]) => (Input[E] => IterateeT[X, E, F, StepT[X, E, F, A]]) = { k => in =>
+      in.fold(
+        el = el =>
+          if (p(el)) k(in) >>== doneOr(loop) 
+          else k(eofInput).map(sdone[X, E, F, A](_, in))
+      , empty = cont(step(k))
+      , eof = k(in).map(sdone[X, E, F, A](_, in))
+      )
+    }
+    doneOr(loop)
+  }
 }

--- a/example/src/main/scala/scalaz/example/Example.scala
+++ b/example/src/main/scala/scalaz/example/Example.scala
@@ -20,6 +20,7 @@ object Example {
     geo.ExampleVincenty.run
     concurrent.ExampleActor.run
     concurrent.HammerTime.run
+    iteratee.ExampleIteratee.run
     WordCount.wordCount
   }
 

--- a/example/src/main/scala/scalaz/example/iteratee/ExampleIteratee.scala
+++ b/example/src/main/scala/scalaz/example/iteratee/ExampleIteratee.scala
@@ -9,37 +9,33 @@ object ExampleIteratee {
 
 
   def run {
-    /*
-    (head[Int] enumerate Stream(1, 2, 3) run) assert_=== Some(1)
-    (length[Int] enumerate Stream(10, 20, 30) run) assert_=== 3
-    (peek[Int] enumerate Stream(1, 2, 3) run) assert_=== Some(1)
-    (head[Int] enumerate Stream() run) assert_=== None
+    ((head[Int, Identity] >>== Stream(1, 2, 3)) run(_ => none)) assert_=== Some(1)
+    ((length[Int, Identity] >>== Stream(10, 20, 30)) run(_ => -1)) assert_=== 3
+    ((peek[Int, Identity] >>== Stream(1, 2, 3)) run(_ => none)) assert_=== Some(1)
+    ((head[Int, Identity] >>== Stream()) run(_ => some(0))) assert_=== None
 
-    (head[Int] enumerateUp Iterator(1, 2, 3) flatMap (_.runT) unsafePerformIO) assert_=== Some(1)
-    (length[Int] enumerateUp Iterator(10, 20, 30) flatMap (_.runT) unsafePerformIO) assert_=== 3
-    (peek[Int] enumerateUp Iterator(1, 2, 3) flatMap (_.runT) unsafePerformIO) assert_=== Some(1)
-    (head[Int] enumerateUp Iterator() flatMap (_.runT) unsafePerformIO) assert_=== None
+    ((head[Int, IO] >>== Iterator(1, 2, 3)) runT(_ => IO(none)) unsafePerformIO) assert_=== Some(1)
+    ((length[Int, IO] >>== Iterator(10, 20, 30)) runT(_ => IO(-1)) unsafePerformIO) assert_=== 3
+    ((peek[Int, IO] >>== Iterator(1, 2, 3)) runT(_ => IO(none)) unsafePerformIO) assert_=== Some(1)
+    ((head[Int, IO] >>== Iterator()) runT(_ => IO(Some(-1))) unsafePerformIO) assert_=== None
 
     import java.io._
 
     def r = new StringReader("file contents")
 
-
-    (head[IoExceptionOr[Char]] enumerateUp r map (_ map (_ flatMap (_.toOption))) flatMap (_.runT) unsafePerformIO) assert_=== Some('f')
-    (length[IoExceptionOr[Char]] enumerateUp r flatMap (_.runT) unsafePerformIO) assert_=== 13
-    (peek[IoExceptionOr[Char]] enumerateUp r map (_ map (_ flatMap (_.toOption))) flatMap (_.runT) unsafePerformIO) assert_=== Some('f')
-    (head[IoExceptionOr[Char]] enumerateUp (new StringReader("")) map (_ map (_ flatMap (_.toOption))) flatMap (_.runT) unsafePerformIO) assert_=== None
+    ((head[IoExceptionOr[Char], IO] >>== r) map (_ flatMap (_.toOption)) runT(_ => IO(none)) unsafePerformIO) assert_=== Some('f')
+    ((length[IoExceptionOr[Char], IO] >>== r) runT(_ => IO(-1)) unsafePerformIO) assert_=== 13
+    ((peek[IoExceptionOr[Char], IO] >>== r) map (_ flatMap (_.toOption)) runT(_ => IO(none)) unsafePerformIO) assert_=== Some('f')
+    ((head[IoExceptionOr[Char], IO] >>== new StringReader("")) map (_ flatMap (_.toOption)) runT(_ => IO(Some('z'))) unsafePerformIO) assert_=== None
 
     // As a monad
-    val m1 = head[Int] >>= ((b:Option[Int]) => head[Int] map (b2 => (b <|*|> b2)))
-    (m1 enumerate Stream(1,2,3) run) assert_=== Some(1 -> 2)
+    val m1 = head[Int, Identity] flatMap ((b:Option[Int]) => head[Int, Identity] map (b2 => (b <|*|> b2)))
+    ((m1 >>== Stream(1,2,3)) run(_ => none)) assert_=== Some(1 -> 2)
 
-    val coli = takeWhile[Int, Identity, List[Int]](_ <= 5) apply collect[Int, List]
-    ((coli enumerate (1 to 10).toStream run) run) assert_=== (1 to 5).toList
-    (coli flatMap { i: Iteratee[Int, List[Int]] => length[Int] map (l => i.run :+ l) } enumerate (1 to 17).toStream run) assert_=== (1 to 5).toList :+ 12
+    val coli = collect[Int, List] <~ takeWhile(_ <= 5) 
+    ((coli >>== (1 to 10).toStream) run(_ => List())) assert_=== (1 to 5).toList
 
-    val colc = takeWhile[IoExceptionOr[Char], IO, List[IoExceptionOr[Char]]](_.fold(_ => false, _ != ' ')) apply collect[IoExceptionOr[Char], List].up[IO]
-    (colc enumerateT r map { _ map { _ map { _.map(_.toOption).sequence } } } flatMap { _.runT } flatMap { _.runT } unsafePerformIO) assert_=== Some(List('f', 'i', 'l', 'e'))
-    */
+    val colc = collect[IoExceptionOr[Char], List].up[IO] <~ takeWhile(_.fold(_ => false, _ != ' '))
+    ((colc >>== r) map(_ flatMap (_.toOption)) runT(_ => IO(List())) unsafePerformIO) assert_=== List('f', 'i', 'l', 'e')
   }
 }


### PR DESCRIPTION
I'm not crazy about the name of this function

```
<~ : IterateeT[X, I, F, A] => EnumerateeT[X, O, I, F, A] => IterateeT[X, O, F, A]
```

but it is a really useful function.

I'd also like to be able to take it the other way and do 

```
~> : EnumerateeT[X, O, I, F, A] => IterateeT[X, I, F, A] => IterateeT[X, O, F, A]
```

In this way I would hope we could make things read in a left to right manner such as

```
(1 to 5).toStream >>== (takeWhile(_ <= 5) ~> collect[Int, List])
```

but I fear the type inferencer will fall over on something like that. :(
