### PR TITLE
examples don't compile because of broken imports in ExampleApplication.scala

### DIFF
--- a/example/src/main/scala/scalaz/example/http/ExampleApplication.scala
+++ b/example/src/main/scala/scalaz/example/http/ExampleApplication.scala
@@ -1,7 +1,7 @@
 package scalaz.example
 package http
 
-import scalaz.{Request => _, _}
+import scalaz._
 import Scalaz._
 import scalaz.http._
 import response._


### PR DESCRIPTION
The only thing that bothers me is if it was indeed an attempt to hide Request i.e {Request => _} as indicated by Jason's commit message "Avoid ambigious reference to Request." 

But which ambiguous reference? Did intellij mess-up the imports? or was there a refactoring that moved Request or removed the other "Request"?

This aside how can I go about running that example? 
