### PR TITLE
Adding 'update', 'start', and 'end' to Zipper

### DIFF
--- a/core/src/main/scala/scalaz/Zipper.scala
+++ b/core/src/main/scala/scalaz/Zipper.scala
@@ -33,6 +33,11 @@ sealed trait Zipper[+A] {
   }
 
   /**
+   * Apply f to the focus and update with the result.
+   */
+  def modify[AA >: A](f: A => AA) = this.update(f(this.focus))
+
+  /**
    * Possibly moves to next element to the right of focus.
    */
   def next: Option[Zipper[A]] = rights match {


### PR DESCRIPTION
Hi, I recently asked on the scalaz mailing list whether there was a method of updating the focus that I didn't notice.  Shortly thereafter, retronym added a copy method.  However, it's rather cumbersome to user a copy method to edit the focus, so this pull request contains an 'update' method which takes a new focus.  Runar thought 'update' is a necessary addition.

I also added a method 'start' which goes to the first element in the Zipper.  Since a Zipper must be non-empty, this will always succeed so a return value doesn't need to be an Option.  This is much more convenient than 'move(0).get'.

'end' is a harder sell since scalaz Zippers are backed by Streams.  However, since 'findPrevious' is defined, I think it makes sense to have 'end'.  This provides an easy way to find the last match of a predicate.
