### PR TITLE
Added equals and hashCode to NonEmptyList

### DIFF
--- a/core/src/main/scala/scalaz/NonEmptyList.scala
+++ b/core/src/main/scala/scalaz/NonEmptyList.scala
@@ -61,6 +61,15 @@ sealed trait NonEmptyList[+A] {
   }
 
   override def toString: String = "NonEmpty" + (head :: tail)
+  
+  override def equals(any: Any): Boolean =
+    any match {
+      case that: NonEmptyList[_] => this.list == that.list
+      case _ => false
+    }
+
+  override def hashCode: Int =
+    list.hashCode
 }
 
 trait NonEmptyLists {


### PR DESCRIPTION
E.g. necessary to use _Validation[NonEmptyList[String], A]_ properly.
