### PR TITLE
fix scalaz-seven unidoc Task fail

### DIFF
--- a/core/src/main/scala/scalaz/Show.scala
+++ b/core/src/main/scala/scalaz/Show.scala
@@ -10,7 +10,7 @@ trait Show[F]  { self =>
   def show(f: F): List[Char]
   def shows(f: F): String = show(f).mkString
 
-  def xmlText(f: F): xml.Text = xml.Text(shows(f))
+  def xmlText(f: F): scala.xml.Text = scala.xml.Text(shows(f))
 
   // derived functions
   ////


### PR DESCRIPTION
```
[error] /Users/user/scalaz-scalaz/scalaz-seven/core/src/main/scala/scalaz/Show.scala:13: class Text in package xml cannot be accessed in package scalaz.xml
[error]   def xmlText(f: F): xml.Text = xml.Text(shows(f))
[error]                          ^
[error] /Users/user/scalaz-scalaz/scalaz-seven/core/src/main/scala/scalaz/Show.scala:13: object Text in package xml cannot be accessed in package scalaz.xml
[error]   def xmlText(f: F): xml.Text = xml.Text(shows(f))
[error]                                     ^
[info] No documentation generated with unsucessful compiler run
[error] two errors found
[error] {file:/Users/user/scalaz-scalaz/scalaz-seven/}scalaz/*:unidoc: Scaladoc generation failed
[error] Total time: 223 s, completed Mar 6, 2012 6:51:05 AM
```
