### PR TITLE
IoExceptionOr extractor

### DIFF
--- a/effect/src/main/scala/scalaz/effect/IoExceptionOr.scala
+++ b/effect/src/main/scala/scalaz/effect/IoExceptionOr.scala
@@ -33,6 +33,7 @@ object IoExceptionOr extends IoExceptionOrFunctions {
     } catch {
       case e: java.io.IOException => ioException(e)
     }
+  def unapply[A](ioExceptionOr: IoExceptionOr[A]) = ioExceptionOr.toOption
 }
 
 trait IoExceptionOrFunctions {


### PR DESCRIPTION
I want to use extractor.

scalaz.iteratee.EnumeratorT.enumReader can be tractable.

An emxample.

``` scala
object Test extends SafeApp {

  object Extractor {
    def unapply[A](c: IoExceptionOr[A]) = c.toOption
  }

  override def runc =
    putStrTo[Char](System.out) %=
    collect[IoExceptionOr[Char], Char, IO] {
      case Extractor(c) => c
    } &=
    enumReader[IO](new FileReader("test")) run

}
```
