### PR TITLE
Unnecessary parameter

### DIFF
--- a/iteratee/src/main/scala/scalaz/iteratee/EnumerateeT.scala
+++ b/iteratee/src/main/scala/scalaz/iteratee/EnumerateeT.scala
@@ -132,12 +132,12 @@ trait EnumerateeTFunctions {
       }
     }
 
-  def group[E, F[_], G[_]](n: Int)(implicit F: Pointed[F], FE: Monoid[F[E]], G: Monad[G], G1: Copointed[G]): EnumerateeT[E, F[E], G] =
+  def group[E, F[_], G[_]](n: Int)(implicit F: Pointed[F], FE: Monoid[F[E]], G: Monad[G]): EnumerateeT[E, F[E], G] =
     new EnumerateeT[E, F[E], G] {
       def apply[A] = take[E, F](n).up[G].sequenceI.apply[A]
     }
 
-  def splitOn[E, F[_], G[_]](p: E => Boolean)(implicit F: Pointed[F], FE: Monoid[F[E]], G: Monad[G], G1: Copointed[G]): EnumerateeT[E, F[E], G] =
+  def splitOn[E, F[_], G[_]](p: E => Boolean)(implicit F: Pointed[F], FE: Monoid[F[E]], G: Monad[G]): EnumerateeT[E, F[E], G] =
     new EnumerateeT[E, F[E], G] {
       def apply[A] = {
         (takeWhile[E, F](p).up[G] flatMap (xs => drop[E, G](1).map(_ => xs))).sequenceI.apply[A]


### PR DESCRIPTION
When I use splitOn, I cann't compile source code.

Because its parameter is contained Copointed.

But Copointed is not used.
