### PR TITLE
Monoid, Show and Equal instance for scala.xml.NodeSeq.

### DIFF
--- a/core/src/main/scala/scalaz/std/AllInstances.scala
+++ b/core/src/main/scala/scalaz/std/AllInstances.scala
@@ -10,6 +10,7 @@ trait AllInstances
   with scalaz.std.java.util.MapInstances
   with scalaz.std.java.math.BigIntegerInstances
   with scalaz.std.java.util.concurrent.CallableInstances
+  with NodeSeqInstances
   // Intentionally omitted: IterableInstances
 
 object AllInstances extends AllInstances

--- a/core/src/main/scala/scalaz/std/NodeSeq.scala
+++ b/core/src/main/scala/scalaz/std/NodeSeq.scala
@@ -1,0 +1,15 @@
+package scalaz
+package std
+
+import scala.xml.{ Node, NodeSeq, PrettyPrinter }
+
+trait NodeSeqInstances {
+  implicit val nodeSeqInstance: Monoid[NodeSeq] with Show[NodeSeq] with Equal[NodeSeq] = new Monoid[NodeSeq] with Show[NodeSeq] with Equal[NodeSeq] {
+    def zero = NodeSeq.Empty
+    def append(f1: NodeSeq, f2: ⇒ NodeSeq) = f1 ++ f2
+    def show(as: NodeSeq) = new PrettyPrinter(80, 2) formatNodes as toList
+    def equal(a1: NodeSeq, a2: NodeSeq): Boolean = a1 == a2
+  }
+}
+
+object nodeseq extends NodeSeqInstances

--- a/tests/src/test/scala/scalaz/std/NodeSeqTest.scala
+++ b/tests/src/test/scala/scalaz/std/NodeSeqTest.scala
@@ -1,0 +1,26 @@
+package scalaz
+package std
+
+import std.nodeseq._
+import syntax.apply._
+import scalaz.scalacheck.ScalazProperties._
+import scalaz.scalacheck.ScalaCheckBinding._
+import org.scalacheck.{ Gen, Arbitrary }
+import Id._
+
+import scala.xml.{ Node, NodeSeq, XML }
+
+class NodeSeqTest extends Spec {
+  {
+    val validStr = """[a-zA-Z]+""".r
+    val strFilter = (s: String) ⇒ validStr.pattern.matcher(s).matches
+    val genNode = (Gen.alphaStr.filter(strFilter) |@| Gen.alphaStr.filter(strFilter)) { (s1, s2) ⇒
+      XML.loadString("<" + s1 + ">" + s2 + "</" + s1 + ">")
+    }
+    val genNodeSeq = Gen.containerOf[Array, Node](genNode)
+    implicit val NodeSeqArb = Arbitrary[NodeSeq](genNodeSeq map (_ toSeq))
+
+    checkAll(monoid.laws[NodeSeq])
+    checkAll(equal.laws[NodeSeq])
+  }
+}


### PR DESCRIPTION
Haven't found `Monoid` instance for `NodeSeq`, so I've added it.
**P.S.** It [does not](http://travis-ci.org/#!/folone/scalaz/jobs/1984821) break the build.
