### PR TITLE
fix NSInfo annotName

### DIFF
--- a/xml/src/main/scala/scalaz/xml/NSInfo.scala
+++ b/xml/src/main/scala/scalaz/xml/NSInfo.scala
@@ -32,7 +32,7 @@ sealed trait NSInfo {
     , uri = n.prefix match {
         case None => uri
         case Some(w) =>
-          prefixes find (_ == w) map (_._2)
+          prefixes.collectFirst{ case (`w`,x) => x }
       }
     , prefix = n.prefix
     )


### PR DESCRIPTION
```
[warn] /Users/kenji/scalaz-scalaz/scalaz-seven/xml/src/main/scala/scalaz/xml/NSInfo.scala:35: comparing values of types (List[Char], List[Char]) and List[Char] using `==' will always yield false
[warn]           prefixes find (_ == w) map (_._2)
```
