### PR TITLE
Fixed Validation's Semigroup instance.

### DIFF
--- a/core/src/main/scala/scalaz/Validation.scala
+++ b/core/src/main/scala/scalaz/Validation.scala
@@ -264,7 +264,7 @@ trait FailProjectionInstances extends FailProjectionInstances0 {
 
   implicit def failProjectionSemigroup[E, A](implicit E0: Semigroup[E]): Semigroup[FailProjection[E, A]] = new IsomorphismSemigroup[FailProjection[E, A], Validation[E, A]] {
     def iso = FailProjectionIso
-    implicit def G: Semigroup[Validation[E, A]] = Validation.validationSemigroup
+    implicit def G: Semigroup[Validation[E, A]] = Validation.validationSemigroupFail
   }
 
   implicit def failProjectionOrder[E: Order, X: Order] = new IsomorphismOrder[FailProjection[E, X], Validation[E, X]] {
@@ -361,8 +361,12 @@ trait ValidationInstances extends ValidationInstances0 {
     def bitraverseImpl[G[_] : Applicative, A, B, C, D](fab: Validation[A, B])(f: (A) => G[C], g: (B) => G[D]) = fab.bitraverse[G, C, D](f, g)
   }
 
-  implicit def validationSemigroup[E, A](implicit E0: Semigroup[E]): Semigroup[Validation[E, A]] = new Semigroup[Validation[E, A]] {
+  def validationSemigroupFail[E, A](implicit E0: Semigroup[E]): Semigroup[Validation[E, A]] = new Semigroup[Validation[E, A]] {
     def append(f1: Validation[E, A], f2: => Validation[E, A]): Validation[E, A] = f1 orElse f2
+  }
+
+  implicit def validationSemigroup[E : Semigroup, A : Semigroup]: Semigroup[Validation[E, A]] = new Semigroup[Validation[E, A]] {
+    def append(f1: Validation [E, A], f2: => Validation[E, A]): Validation[E, A] = f1 append f2
   }
 
   /**

--- a/tests/src/test/scala/scalaz/ValidationTest.scala
+++ b/tests/src/test/scala/scalaz/ValidationTest.scala
@@ -85,7 +85,7 @@ class ValidationTest extends Spec {
     def equal[E: Equal, A: Equal] = Equal[Validation[E, A]]
     def order[E: Order, A: Order] = Order[Validation[E, A]]
     def pointed[E] = Pointed[({type λ[α]=Validation[E, α]})#λ]
-    def semigroup[E: Semigroup, A] = Semigroup[Validation[E, A]]
+    def semigroup[E: Semigroup, A: Semigroup] = Semigroup[Validation[E, A]]
     def applicative[E: Semigroup] = Applicative[({type λ[α]=Validation[E, α]})#λ]
     def traverse[E: Semigroup] = Traverse[({type λ[α]=Validation[E, α]})#λ]
     def plus[E: Semigroup] = Plus[({type λ[α]=Validation[E, α]})#λ]


### PR DESCRIPTION
#103 got polluted with unnecessary commits, so I decided to create a new pull request and close that one. Here's what this is for (from #101):

I've noticed, that `Validation`'s `Semigroup` instance requires that only the left (`Failure`) element is a `Semigroup`. At the same time, `Validation` itself has an `append` method, which requires both elements to be `Semigroups`. I've changed the default instance to use that method. The old definition is still used to generate `FailProjection`'s `Semigroup` instance and is renamed to `validationSemigroupFail`. Here's how this works now:

``` scala
scala> val success1 = 1.success[String]
success1: scalaz.Validation[String,Int] = Success(1)

scala> val success2 = 2.success[String]
success2: scalaz.Validation[String,Int] = Success(2)

scala> val success3 = 1.success[String].fail
success3: scalaz.FailProjection[String,Int] = scalaz.Validation$$anon$18@59bdcda

scala> val success4 = 2.success[String].fail
success4: scalaz.FailProjection[String,Int] = scalaz.Validation$$anon$18@655554a8

scala> success1 |+| success2
res0: scalaz.Validation[String,Int] = Success(3) // was: Success(1)

scala> success3 |+| success4
res1: scalaz.FailProjection[String,Int] = scalaz.Validation$$anon$18@5f6bfe9c

scala> .validation
res2: scalaz.Validation[String,Int] = Success(1)
```

Does this make sense?

**P.S.** [Does not](http://travis-ci.org/#!/folone/scalaz/builds/1998964) break the build.
