### PR TITLE
MonadWriter typeclass (Previously #94)

### DIFF
--- a/core/src/main/scala/scalaz/ListenableMonadWriter.scala
+++ b/core/src/main/scala/scalaz/ListenableMonadWriter.scala
@@ -1,0 +1,14 @@
+package scalaz
+
+trait ListenableMonadWriter[F[_, _], W] extends MonadWriter[F, W] {
+  def listen[A](ma: F[W, A]): F[W, (A, W)]
+
+  def pass[A](ma: F[W, (A, W => W)]): F[W, A] =
+    bind(listen(ma)){ case ((a, f), w) => writer(f(w), a) }
+
+  val listenableMonadWriterSyntax = new scalaz.syntax.ListenableMonadWriterSyntax[F, W]{}
+}
+
+object ListenableMonadWriter {
+  def apply[F[_, _], W](implicit LMW: ListenableMonadWriter[F, W]) = LMW
+}

--- a/core/src/main/scala/scalaz/MonadWriter.scala
+++ b/core/src/main/scala/scalaz/MonadWriter.scala
@@ -1,0 +1,14 @@
+package scalaz
+
+trait MonadWriter[F[_, _], W] extends Monad[({type f[+x] = F[W, x]})#f] {
+  implicit def W: Monoid[W]
+  
+  def writer[A](v: (W, A)): F[W, A]
+  def tell(w: W): F[W, Unit] = writer((w, ()))
+
+  val monadWriterSyntax = new scalaz.syntax.MonadWriterSyntax[F, W]{}
+}
+
+object MonadWriter {
+  def apply[F[+_, +_], W](implicit F: MonadWriter[F, W]) = F
+}

--- a/core/src/main/scala/scalaz/Unapply.scala
+++ b/core/src/main/scala/scalaz/Unapply.scala
@@ -233,6 +233,30 @@ object Unapply2 extends Unapply2_0 {
   }
 }
 
+trait Unapply21[TC[_[_, _], _], MAB]{
+  type M[_, _]
+  type A
+  type B
+  def TC: TC[M, A]
+
+  def apply(mabc: MAB): M[A, B]
+}
+
+object Unapply21 {
+  implicit def unapply210MFABC[TC[_[_, _], _], F[+_,+_], M0[_[+_], _, _], A0, B0, C](implicit TC0: TC[({type f[a, b] = M0[({type m[+x] = F[a, x]})#m, C, b]})#f, A0]): Unapply21[TC, M0[({type f[+x] = F[A0, x]})#f, C, B0]]{
+    type M[X, Y] = M0[({type f[+a] = F[X, a]})#f, C, Y]
+    type A = A0
+    type B = B0
+  } = new Unapply21[TC, M0[({type f[+x] = F[A0, x]})#f, C, B0]]{
+    type M[X, Y] = M0[({type f[+a] = F[X, a]})#f, C, Y]
+    type A = A0
+    type B = B0
+
+    def TC = TC0
+    def apply(ma: M0[({type f[+a] = F[A0, a]})#f, C, B0]) = ma
+  }
+}
+
 trait UnapplyProduct[TC[_[_]], MA, MB] {
   type M[X]
   type A

--- a/core/src/main/scala/scalaz/WriterT.scala
+++ b/core/src/main/scala/scalaz/WriterT.scala
@@ -100,73 +100,73 @@ object WriterT extends WriterTFunctions with WriterTInstances {
     writerT(v)
 }
 
-trait WriterTInstances13 {
+trait WriterTInstances14 {
   implicit def writerFunctor[W]: WriterTFunctor[Id, W] = new WriterTFunctor[Id, W] {
     implicit def F = idInstance
   }
 }
-trait WriterTInstances12 extends WriterTInstances13 {
+trait WriterTInstances13 extends WriterTInstances14 {
   implicit def writerTFunctor[F[+_], W](implicit F0: Functor[F]) = new WriterTFunctor[F, W] {
     implicit def F = F0
   }
 }
 
-trait WriterTInstances11 extends WriterTInstances12 {
+trait WriterTInstances12 extends WriterTInstances13 {
   implicit def writerPointed[W](implicit W0: Monoid[W]): Pointed[({type λ[+α]=Writer[W, α]})#λ] = new WriterTPointed[Id, W] {
     implicit def F = idInstance
     implicit def W = W0
   }
 }
-trait WriterTInstances10 extends WriterTInstances11 {
+trait WriterTInstances11 extends WriterTInstances12 {
   implicit def writerTPointed[F[+_], W](implicit W0: Monoid[W], F0: Pointed[F]): Pointed[({type λ[+α]=WriterT[F, W, α]})#λ] = new WriterTPointed[F, W] {
     implicit def F = F0
     implicit def W = W0
   }
 }
 
-trait WriterTInstances9 extends WriterTInstances10 {
+trait WriterTInstances10 extends WriterTInstances11 {
   implicit def writerApply[W](implicit W0: Semigroup[W]) = new WriterTApply[Id, W] {
     implicit def F = idInstance
     implicit def W = W0
   }
 }
 
-trait WriterTInstances8 extends WriterTInstances9 {
+trait WriterTInstances9 extends WriterTInstances10 {
   implicit def writerTApply[F[+_], W](implicit W0: Semigroup[W], F0: Apply[F]) = new WriterTApply[F, W] {
     implicit def F = F0
     implicit def W = W0
   }
 }
 
-trait WriterTInstances7 extends WriterTInstances8 {
+trait WriterTInstances8 extends WriterTInstances9 {
   implicit def writerApplicative[W](implicit W0: Monoid[W]) = new WriterTApplicative[Id, W] {
     implicit def F = idInstance
     implicit def W = W0
   }
 }
 
-trait WriterTInstances6 extends WriterTInstances7 {
+trait WriterTInstances7 extends WriterTInstances8 {
   implicit def writerTApplicative[F[+_], W](implicit W0: Monoid[W], F0: Applicative[F]) = new WriterTApplicative[F, W] {
     implicit def F = F0
     implicit def W = W0
   }
 }
 
-trait WriterTInstances5 extends WriterTInstances6 {
+trait WriterTInstances6 extends WriterTInstances7 {
   implicit def writerMonad[W](implicit W0: Monoid[W]) = new WriterTMonad[Id, W] {
     implicit def F = idInstance
     implicit def W = W0
   }
 }
 
-trait WriterTInstance4 extends WriterTInstances5 {
+trait WriterTInstance5 extends WriterTInstances6 {
   implicit def writerTMonad[F[+_], W](implicit W0: Monoid[W], F0: Monad[F]) = new WriterTMonad[F, W] {
     implicit def F = F0
     implicit def W = W0
   }
 }
 
-trait WriterTInstances3 extends WriterTInstance4 {
+trait WriterTInstances4 extends WriterTInstance5 {
   implicit def writerBifunctor = new WriterTBifunctor[Id] {
     implicit def F = idInstance
   }
@@ -179,7 +179,7 @@ trait WriterTInstances3 extends WriterTInstance4 {
   implicit def writerEqual[W, A](implicit E: Equal[(W, A)]) = E.contramap((_: Writer[W, A]).run)
 }
 
-trait WriterTInstances2 extends WriterTInstances3 {
+trait WriterTInstances3 extends WriterTInstances4 {
   implicit def writerTBifunctor[F[+_]](implicit F0: Functor[F]) = new WriterTBifunctor[F] {
     implicit def F = F0
   }
@@ -192,13 +192,13 @@ trait WriterTInstances2 extends WriterTInstances3 {
   implicit def writerTEqual[F[+_], W, A](implicit E: Equal[F[(W, A)]]) = E.contramap((_: WriterT[F, W, A]).run)
 }
 
-trait WriterTInstances1 extends WriterTInstances2 {
+trait WriterTInstances2 extends WriterTInstances3 {
   implicit def writerComonad[W] = new WriterComonad[W] {
     implicit def F = implicitly
   }
 }
 
-trait WriterTInstances0 extends WriterTInstances1 {
+trait WriterTInstances1 extends WriterTInstances2 {
   implicit def writerBitraverse: WriterTBitraverse[Id] = new WriterTBitraverse[Id] {
     implicit def F = idInstance
   }
@@ -210,7 +210,7 @@ trait WriterTInstances0 extends WriterTInstances1 {
   }
 }
 
-trait WriterTInstances extends WriterTInstances0 {
+trait WriterTInstances0 extends WriterTInstances1 {
   implicit def writerTBitraverse[F[+_]](implicit F0: Traverse[F]) = new WriterTBitraverse[F] {
     implicit def F = F0
   }
@@ -222,6 +222,13 @@ trait WriterTInstances extends WriterTInstances0 {
   implicit def writerEach[F[+_], W](implicit F0: Each[F]) = new WriterTEach[F, W] {
     implicit def F = F0
   }
+}
+
+trait WriterTInstances extends WriterTInstances0 {  
+  implicit def writerTListenableMonadWriter[F[+_], W](implicit F0: Monad[F], W0: Monoid[W]) = new WriterMonadWriter[F, W] {  
+    implicit def F = F0  
+    implicit def W = W0  
+  }  
 }
 
 trait WriterTFunctions {
@@ -341,4 +348,14 @@ trait WriterComonad[W] extends Comonad[({type λ[+α] = Writer[W, α]})#λ] with
 
   override def cobind[A, B](fa: Writer[W, A])(f: (Writer[W, A]) => B): Writer[W, B] =
     Writer(fa.written, f(fa))
+}
+
+private[scalaz] trait WriterMonadWriter[F[+_], W] extends ListenableMonadWriter[({type f[+w, +a] = WriterT[F, w, a]})#f, W] with WriterTMonad[F, W] {
+  implicit def F: Monad[F]
+  implicit def W: Monoid[W]
+
+  def writer[A](v: (W, A)): WriterT[F, W, A] = WriterT.writerT(F.point(v))
+
+  def listen[A](fa: WriterT[F, W, A]): WriterT[F, W, (A, W)] =
+    WriterT(F.bind(fa.run){ case (w, a) => F.point((w, (a, w))) })
 }

--- a/core/src/main/scala/scalaz/package.scala
+++ b/core/src/main/scala/scalaz/package.scala
@@ -103,7 +103,7 @@ package object scalaz {
   type =?>[E, A] = Kleisli[Option, E, A]
   type Reader[E, A] = ReaderT[Id, E, A]
 
-  type Writer[W, A] = WriterT[Id, W, A]
+  type Writer[+W, +A] = WriterT[Id, W, A]
   type Unwriter[W, A] = UnwriterT[Id, W, A]
 
   object Reader {

--- a/core/src/main/scala/scalaz/syntax/ListenableMonadWriterSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/ListenableMonadWriterSyntax.scala
@@ -1,0 +1,25 @@
+package scalaz
+package syntax
+
+trait ListenableMonadWriterOps[F[_, _], W, A] extends Ops[F[W, A]] {
+  implicit def LMW: ListenableMonadWriter[F, W]
+
+  final def written: F[W, W] = LMW.map(LMW.listen(self)){ case (_, w) => w }
+
+  final def listen: F[W, (A, W)] = LMW.listen[A](self)
+}
+
+trait ToListenableMonadWriterOps0 {
+  implicit def ToListenableMonadWriterOpsUnapply[FA](v: FA)(implicit F0: Unapply21[ListenableMonadWriter, FA]) =
+    new ListenableMonadWriterOps[F0.M, F0.A, F0.B]{ def self = F0(v); implicit def LMW = F0.TC }
+}
+
+trait ToListenableMonadWriterOps extends ToListenableMonadWriterOps0 with ToMonadWriterOps {
+  implicit def ToListenableMonadWriterOps[F[_, _], A, W](v: F[W, A])(implicit F0: ListenableMonadWriter[F, W]) = 
+    new ListenableMonadWriterOps[F, W, A]{ def self = v; implicit def LMW = F0 }
+}
+
+trait ListenableMonadWriterSyntax[F[_, _], W] extends MonadWriterSyntax[F, W] {
+  implicit def ToListenableMonadWriterOps[A](v: F[W, A])(implicit F0: ListenableMonadWriter[F, W]) =
+    new ListenableMonadWriterOps[F, W, A]{ def self = v; implicit def LMW = F0 }
+}

--- a/core/src/main/scala/scalaz/syntax/MonadWriterSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadWriterSyntax.scala
@@ -1,0 +1,26 @@
+package scalaz
+package syntax
+
+trait MonadWriterOps[F[_, _], W, A] extends Ops[F[W, A]] {
+  implicit def MW: MonadWriter[F, W]
+
+  final def :++>(w: => W): F[W, A] = MW.bind(self)(a => MW.map(MW.tell(w))(_ => a))
+
+  final def :++>>(f: A => W): F[W, A] =
+     MW.bind(self)(a => MW.map(MW.tell(f(a)))(_ => a))
+}
+
+trait ToMonadWriterOps0 {
+  implicit def ToMonadWriterOpsUnapply[FA](v: FA)(implicit F0: Unapply21[MonadWriter, FA]) = 
+    new MonadWriterOps[F0.M, F0.A, F0.B]{ def self = F0(v); implicit def MW = F0.TC }
+}
+
+trait ToMonadWriterOps extends ToMonadWriterOps0 {
+  implicit def ToMonadWriterOps[F[_, _], A, W](v: F[W, A])(implicit F0: MonadWriter[F, W]) = 
+    new MonadWriterOps[F, W, A]{ def self = v; implicit def MW = F0 }
+}
+
+trait MonadWriterSyntax[F[_, _], W] {
+  implicit def ToMonadWriterOps[A](v: F[W, A])(implicit F0: MonadWriter[F, W]) =
+    new MonadWriterOps[F, W, A]{ def self = v; implicit def MW = F0 }
+}

--- a/core/src/main/scala/scalaz/syntax/Syntax.scala
+++ b/core/src/main/scala/scalaz/syntax/Syntax.scala
@@ -87,6 +87,9 @@ trait Syntaxes {
 
   object split extends ToSplitOps
 
+  object monadWriter extends ToMonadWriterOps
+
+  object listenableMonadWriter extends ToListenableMonadWriterOps
   //
   // Data
   //
@@ -125,4 +128,4 @@ trait ToTypeClassOps
   with ToBifoldableOps with ToCozipOps
   with ToPlusOps with ToApplicativePlusOps with ToMonadPlusOps with ToTraverseOps with ToBifunctorOps
   with ToBitraverseOps with ToArrIdOps with ToComposeOps with ToCategoryOps
-  with ToArrowOps with ToFoldableOps with ToChoiceOps with ToSplitOps with ToZipOps with ToUnzipOps
+  with ToArrowOps with ToFoldableOps with ToChoiceOps with ToSplitOps with ToZipOps with ToUnzipOps with ToMonadWriterOps with ToListenableMonadWriterOps


### PR DESCRIPTION
Previous discussion: https://github.com/scalaz/scalaz/pull/94

Partially a port from Haskell MonadWriter.

It pemits to use Writer Monad Transformer computation without type annotations nightmare

This comes with two implementations: WriterT and EitherT

There is also a special syntax which currently includes:

:++> like WriterT
:++>> like WriterT
written like WriterT
listen : (MonadWriter F, Monoid W) => F[W, (A, W)]

Here is an (updated) example

``` scala
package scalaz

import scalaz.std.string._
import scalaz.syntax.listenableMonadWriter._

object MonadWriterExample extends App {
  implicit val monadWriter = EitherT.listenableMonadWriter[Writer, String, String]

  case class Person(firstName: String, age: Int)

  def notEmpty(s: String) = Option(s).filter(x => !x.isEmpty && !x.forall(_.isWhitespace)) match {
    case Some(r) => monadWriter.right[String](r)
    case None => monadWriter.left[String]("Empty String")
  }

  def majority(age: Int) =
    if(age >= 18) monadWriter.right[Int](age)
    else monadWriter.left[Int]("This person is not an adult")

  def validateData(firstName: String, age: Int) = for {
    n <- notEmpty(firstName) :++>> (x => "The first name is => " + x + "\n")
    a <- majority(age)       :++>> (x => "She is an adult => " + x + "\n") 
  } yield Person(n, a)

  def showMe(v: (Person, String)) {
    println("Log produced during computation -------")
    println(v._2)
    println("Computation result --------------------")
    println(v._1)
  }

  println(validateData("", 17).listen.map(showMe).run.run) // showMe will not be called, no log accumulated
  println()
  println()
  println(validateData("Nath", 5).listen.map(showMe).run.run) // showMe will not be called: log value is "Firstname name is => Nath"
  println()
  println()
  validateData("Mimie", 20).listen.map(showMe)
}
```
