### PR TITLE
Changed Validation's Semigroup instance. Again.

### DIFF
--- a/tests/src/test/scala/scalaz/ValidationTest.scala
+++ b/tests/src/test/scala/scalaz/ValidationTest.scala
@@ -69,7 +69,7 @@ class ValidationTest extends Spec {
     def equal[E: Equal, A: Equal] = Equal[Validation[E, A]]
     def order[E: Order, A: Order] = Order[Validation[E, A]]
     def pointed[E] = Pointed[({type λ[α]=Validation[E, α]})#λ]
-    def semigroup[E, A: Semigroup] = Semigroup[Validation[E, A]]
+    def semigroup[E: Semigroup, A: Semigroup] = Semigroup[Validation[E, A]]
     def applicative[E: Semigroup] = Applicative[({type λ[α]=Validation[E, α]})#λ]
     def traverse[E: Semigroup] = Traverse[({type λ[α]=Validation[E, α]})#λ]
     def plus[E: Semigroup] = Plus[({type λ[α]=Validation[E, α]})#λ]


### PR DESCRIPTION
Hello.
I was [shown](http://stackoverflow.com/questions/11903968/does-scalaz-have-something-to-accumulate-in-both-error-and-success#comment15849937_11905824), that after merge, `Validation`'s `Semigroup` instance went back to the old state, before #114. Is this an intended change, or just a copy of the old branch state?
This pull request returns the instance back, to the state, described in #114.
