### PR TITLE
Fixed Validation's Monoid instance.

### DIFF
--- a/core/src/main/scala/scalaz/Validation.scala
+++ b/core/src/main/scala/scalaz/Validation.scala
@@ -346,12 +346,12 @@ trait ValidationInstances0 extends ValidationInstances1 {
       f1 compare f2
   }
 
-  implicit def ValidationMonoid[E: Monoid, A: Semigroup]: Monoid[Validation[E, A]] =
+  implicit def ValidationMonoid[E: Semigroup, A: Monoid]: Monoid[Validation[E, A]] =
     new Monoid[Validation[E, A]] {
       def append(a1: Validation[E, A], a2: => Validation[E, A]) =
         a1 +++ a2
       def zero =
-        Failure(Monoid[E].zero)
+        Success(Monoid[A].zero)
     }
 }
 

--- a/tests/src/test/scala/scalaz/ValidationTest.scala
+++ b/tests/src/test/scala/scalaz/ValidationTest.scala
@@ -11,6 +11,7 @@ class ValidationTest extends Spec {
   type ValidationInt[A] = Validation[Int, A]
 
   checkAll("Validation", semigroup.laws[ValidationInt[Int]])
+  checkAll("Validation", monoid.laws[ValidationInt[Int]])
   checkAll("Validation", plus.laws[ValidationInt])
   checkAll("Validation", applicative.laws[ValidationInt])
   checkAll("Validation", traverse.laws[ValidationInt])


### PR DESCRIPTION
Followup to #129.
I've added a check for monoid laws to `Validation`'s tests, and found out, the identity element is wrong. Which resulted in things like:

``` scala
scala> List(1.success[String], 2.success[String]).suml
res12: scalaz.Validation[String,Int] = Failure()

scala> List(1.success[String], 2.success[String]).concatenate
res13: scalaz.Validation[String,Int] = Failure()
```

So, I've fixed it. This is how it is now:

``` scala
scala> List(1.success[String], 2.success[String]).suml
res0: scalaz.Validation[String,Int] = Success(3)

scala> List(1.success[String], 2.success[String]).concatenate
res1: scalaz.Validation[String,Int] = Success(3)
```
