### PR TITLE
fix nonEmptyList instance type

### DIFF
--- a/core/src/main/scala/scalaz/NonEmptyList.scala
+++ b/core/src/main/scala/scalaz/NonEmptyList.scala
@@ -103,7 +103,7 @@ object NonEmptyList extends NonEmptyListFunctions with NonEmptyListInstances {
 }
 
 trait NonEmptyListInstances {
-  implicit val nonEmptyList: Traverse[NonEmptyList] with Monad[NonEmptyList] with Plus[NonEmptyList] with Comonad[NonEmptyList] with Each[NonEmptyList] =
+  implicit val nonEmptyList =
     new Traverse[NonEmptyList] with Monad[NonEmptyList] with Plus[NonEmptyList] with Comonad[NonEmptyList] with Cobind.FromCojoin[NonEmptyList] with Each[NonEmptyList] with Zip[NonEmptyList] with Unzip[NonEmptyList] {
       def traverseImpl[G[_] : Applicative, A, B](fa: NonEmptyList[A])(f: A => G[B]): G[NonEmptyList[B]] =
         fa traverse f


### PR DESCRIPTION
d034a78794462b433961005be8e9ccfab96a89b5

`Zip[NonEmptyList]` and `Unzip[NonEmptyList]` has been implemented.
but `implicit val nonEmptyList` type is wrong
