### PR TITLE
NonEmptyList.unapplySeq

### DIFF
--- a/core/src/main/scala/scalaz/NonEmptyList.scala
+++ b/core/src/main/scala/scalaz/NonEmptyList.scala
@@ -100,6 +100,9 @@ sealed trait NonEmptyList[+A] {
 object NonEmptyList extends NonEmptyListFunctions with NonEmptyListInstances {
   def apply[A](h: A, t: A*): NonEmptyList[A] =
     nels(h, t: _*)
+
+  def unapplySeq[A](v: NonEmptyList[A]): Option[(A, List[A])] =
+    Some((v.head, v.tail))
 }
 
 trait NonEmptyListInstances {


### PR DESCRIPTION
``` scala
scala> NonEmptyList(1,2,3) match {case NonEmptyList(a,b,c) => (a,b,c)}
res0: (Int, Int, Int) = (1,2,3)

scala> NonEmptyList(1,2,3) match {case NonEmptyList(a,bc@_*) => (a,bc)}
res1: (Int, Seq[Int]) = (1,List(2, 3))

scala> NonEmptyList(1) match {case NonEmptyList(a) => a+42}
res2: Int = 43
```
