### PR TITLE
Fix typo in OSGi exports of effect jar

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -132,7 +132,7 @@ object build extends Build {
     settings = standardSettings ++ Seq[Sett](
       name := "scalaz-effect",
       typeClasses := TypeClass.effect,
-      osgiExport("scalaz.effect", "scalaz.std.sffect", "scalaz.syntax.effect")
+      osgiExport("scalaz.effect", "scalaz.std.effect", "scalaz.syntax.effect")
     ),
     dependencies = Seq(core)
   )


### PR DESCRIPTION
The scalaz-effect JAR has a typo in its package export list, exporting scalaz.std.sffect instead of scalaz.std.effect.  

I've tested the other JARs in Apache Karaf using the following commands:

```
bundle:install mvn:org.scala-ide/scala-library/2.9.2.v20120330-163119-949a4804e4-vfinal
bundle:install mvn:org.scalaz/scalaz-core_2.9.2/7.0.0-M3
bundle:install mvn:org.scalaz/scalaz-effect_2.9.2/7.0.0-M3
bundle:install mvn:org.scalaz/scalaz-iteratee_2.9.2/7.0.0-M3
bundle:install mvn:org.scalaz/scalaz-concurrent_2.9.2/7.0.0-M3
bundle:install mvn:org.scalaz/scalaz-typelevel_2.9.2/7.0.0-M3
bundle:install mvn:org.scalaz/scalaz-xml_2.9.2/7.0.0-M3
```

After fixing the typo in the effect manifest, everything in this list can be resolved successfully.
