### PR TITLE
Arrow is also Pointed in the covariant parameter.

### DIFF
--- a/core/src/main/scala/scalaz/Arrow.scala
+++ b/core/src/main/scala/scalaz/Arrow.scala
@@ -13,10 +13,12 @@ trait Arrow[=>:[_, _]] extends Category[=>:] { self =>
 
   def first[A, B, C](f: (A =>: B)): ((A, C) =>: (B, C))
 
-  def applyInstance[C]: Apply[({type λ[α] = (C =>: α)})#λ] =
-    new Apply[({type λ[α] = (C =>: α)})#λ] {
+  def covariantInstance[C]: Applicative[({type λ[α] = (C =>: α)})#λ] =
+    new Applicative[({type λ[α] = (C =>: α)})#λ] {
+      def point[A](a: => A): C =>: A = arr(_ => a)
       def ap[A, B](fa: => (C =>: A))(f: => (C =>: (A => B))): (C =>: B) = <<<(arr((y: (A => B, A)) => y._1(y._2)), combine(f, fa))
-      def map[A, B](fa: (C =>: A))(f: (A) => B): (C =>: B) = <<<(arr(f), fa)
+      override def map[A, B](fa: (C =>: A))(f: (A) => B): (C =>: B) =
+	<<<(arr(f), fa)
     }
 
   def <<<[A, B, C](fbc: (B =>: C), fab: (A =>: B)): =>:[A, C] =


### PR DESCRIPTION
``` scala
scala> Arrow[Function1].covariantInstance[Int].point("hi")
res3: Int => java.lang.String = <function1>

scala> res3(3)
res5: java.lang.String = hi
```
