### PR TITLE
include VectorInstances and ToVectorOps to import Scalaz._

### DIFF
--- a/core/src/main/scala/scalaz/std/AllInstances.scala
+++ b/core/src/main/scala/scalaz/std/AllInstances.scala
@@ -2,7 +2,8 @@ package scalaz.std
 
 trait AllInstances
   extends AnyValInstances with FunctionInstances with ListInstances with MapInstances
-  with OptionInstances with SetInstances with StringInstances with StreamInstances with TupleInstances
+  with OptionInstances with SetInstances with StringInstances with StreamInstances
+  with TupleInstances with VectorInstances
   with EitherInstances with PartialFunctionInstances with TypeConstraintInstances
   with scalaz.std.math.BigDecimalInstances with scalaz.std.math.BigInts
   with scalaz.std.math.OrderingInstances

--- a/core/src/main/scala/scalaz/syntax/std/ToAllStdOps.scala
+++ b/core/src/main/scala/scalaz/syntax/std/ToAllStdOps.scala
@@ -3,5 +3,5 @@ package syntax
 package std
 
 trait ToAllStdOps
-  extends ToBooleanOps with ToOptionOps with ToOptionIdOps with ToListOps with ToStreamOps
+  extends ToBooleanOps with ToOptionOps with ToOptionIdOps with ToListOps with ToStreamOps with ToVectorOps
   with ToFunction2Ops with ToFunction1Ops with ToStringOps with ToTupleOps with ToMapOps with ToEitherOps


### PR DESCRIPTION
### steps

Currently `Vector` instances and functions are not brought in with `import Scalaz._`.

``` scala
scala> import scalaz._
import scalaz._

scala> import Scalaz._
import Scalaz._

scala> Vector(1, 2) >>= { x => Vector(x + 1)}
<console>:14: error: could not find implicit value for parameter F0: scalaz.Bind[scala.collection.immutable.Vector]
              Vector(1, 2) >>= { x => Vector(x + 1)}
                    ^

scala> Vector(1, 2) filterM { x => Vector(true, false) }
<console>:14: error: value filterM is not a member of scala.collection.immutable.Vector[Int]
              Vector(1, 2) filterM { x => Vector(true, false) }
                           ^
```
### what this implements

Why not bring them in?

``` scala
scala> import scalaz._
import scalaz._

scala> import Scalaz._
import Scalaz._

scala> Vector(1, 2) >>= { x => Vector(x + 1)}
res0: scala.collection.immutable.Vector[Int] = Vector(2, 3)

scala> Vector(1, 2) filterM { x => Vector(true, false) }
res1: scala.collection.immutable.Vector[Vector[Int]] = Vector(Vector(1, 2), Vector(1), Vector(2), Vector())
```
