### PR TITLE
roll back <*> as infix of ap

### DIFF
--- a/core/src/main/scala/scalaz/syntax/ApplySyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/ApplySyntax.scala
@@ -6,7 +6,7 @@ trait ApplyOps[F[_],A] extends Ops[F[A]] {
   implicit def F: Apply[F]
   ////
 
-  final def <*>[B](f: F[B]): F[(A,B)] = F.tuple(self,f)
+  final def <*>[B](f: F[A => B]): F[B] = F.ap(self)(f)
   final def tuple[B](f: F[B]): F[(A,B)] = F.tuple(self,f)
 
   @deprecated("Use `a tuple b` instead", "7")

--- a/tests/src/test/scala/scalaz/ApplyTest.scala
+++ b/tests/src/test/scala/scalaz/ApplyTest.scala
@@ -33,4 +33,8 @@ class ApplyTest extends Spec {
     Apply[Option].ap(some("1"), some("2"), some("3"), some("4"))(some((_: String) + (_: String) + (_: String) + (_: String))) must be_===(some("1234"))
     Apply[Option].ap(some("1"), some("2"), some("3"), some("4"), some("5"))(some((_: String) + (_: String) + (_: String) + (_: String) + (_: String))) must be_===(some("12345"))
   }
+
+  "<*>" in {
+    some(9) <*> some({(_: Int) + 3}) must be_===(some(12))
+  }
 }


### PR DESCRIPTION
see https://groups.google.com/forum/#!topic/scalaz/g0YPdgBeEAw
### steps

``` scala
scala> 9.some <*> {(_: Int) + 3}.some
res20: Option[(Int, Int => Int)] = Some((9,<function1>))
```
### what this changes

I am rolling <*> back as infix `ap`.

``` scala
scala> 9.some <*> {(_: Int) + 3}.some
res0: Option[Int] = Some(12)
```
