### PR TITLE
adds implicits to Unapply to unpack A into [α]A

### DIFF
--- a/core/src/main/scala/scalaz/Unapply.scala
+++ b/core/src/main/scala/scalaz/Unapply.scala
@@ -62,7 +62,20 @@ trait Unapply[TC[_[_]], MA] {
   def apply(ma: MA): M[A]
 }
 
-trait Unapply_2 {
+trait Unapply_3 {
+  // /** Unpack a value of type `A0` into type `[a]A0`, given a instance of `TC` */
+  implicit def unapplyA[TC[_[_]], A0](implicit TC0: TC[({type λ[α] = A0})#λ]): Unapply[TC, A0] {
+    type M[X] = A0
+    type A = A0
+  } = new Unapply[TC, A0] {
+    type M[X] = A0
+    type A = A0
+    def TC = TC0
+    def apply(ma: M[A0]) = ma
+  }
+}
+
+trait Unapply_2 extends Unapply_3 {
   // Things get tricky with type State[S, A] = StateT[Id, S, A], both unapplyMAB2 and unapplyMFAB2 are applicable
   // Without characterizing this fully, I'm using the standard implicit prioritization to avoid this.
 
@@ -311,7 +324,20 @@ trait UnapplyCo[TC[_[_]], MA] {
   def apply(ma: MA): M[A]
 }
 
-trait UnapplyCo_2 {
+trait UnapplyCo_3 {
+  /** Unpack a value of type `A0` into type `[a]A0`, given a instance of `TC` */
+  implicit def unapplyA[TC[_[_]], A0](implicit TC0: TC[({type λ[α] = A0})#λ]): UnapplyCo[TC, A0] {
+    type M[+X] = A0
+    type A = A0
+  } = new UnapplyCo[TC, A0] {
+    type M[+X] = A0
+    type A = A0
+    def TC = TC0
+    def apply(ma: M[A0]) = ma
+  }
+}
+
+trait UnapplyCo_2 extends UnapplyCo_3 {
   /**Unpack a value of type `M0[F[+_], A0, B0]` into types `[a]M0[F, a, B0]` and `A0`, given an instance of `TC` */
   implicit def unapplyMFAB1[TC[_[_]], F[+_], M0[F[+_], +_, _], A0, B0](implicit TC0: TC[({type λ[α] = M0[F, α, B0]})#λ]): UnapplyCo[TC, M0[F, A0, B0]] {
     type M[+X] = M0[F, X, B0]

--- a/tests/src/test/scala/scalaz/TraverseTest.scala
+++ b/tests/src/test/scala/scalaz/TraverseTest.scala
@@ -26,6 +26,11 @@ class TraverseTest extends Spec {
       s must be_===(none[List[Int]])
     }
 
+    "traverse int function as monoidal applicative" in {
+      val s: Int = List(1, 2, 3) traverseU {_ + 1}
+      s must be_===(9)
+    }
+
     "not blow the stack" in {
       val s: Option[List[Int]] = List.range(0, 32 * 1024).traverseU(x => some(x))
       s.map(_.take(3)) must be_===(some(List(0, 1, 2)))


### PR DESCRIPTION
### steps

currently `Int => Int` cannot be passed into `traverseU`. `Int` is indirectly available as `Applicative` via `Monoid[Int].applicative`, which is `Applicative[[α]Int]`.

``` scala
scala> Applicative[({type λ[α] = Int})#λ]
res0: scalaz.Applicative[[α]Int] = scalaz.Monoid$$anon$1@26b0207f

scala> List(1, 2, 3) traverseU {_ + 1}
<console>:14: error: Unable to unapply type `Int` into a type constructor of kind `M[_]` that is classified by the type class `scalaz.Applicative`
1) Check that the type class is defined by compiling `implicitly[scalaz.Applicative[<type constructor>]]`.
2) Review the implicits in object Unapply, which only cover common type 'shapes'
(implicit not found: scalaz.Unapply[scalaz.Applicative, Int])
              List(1, 2, 3) traverseU {_ + 1}
                            ^
```
### what this changes

I added `unapplyA` as the lowest priority implicit, which unpacks A into [α]A.

``` scala
trait Unapply_3 {
  // /** Unpack a value of type `A0` into type `[a]A0`, given a instance of `TC` */
  implicit def unapplyA[TC[_[_]], A0](implicit TC0: TC[({type λ[α] = A0})#λ]): Unapply[TC, A0] {
    type M[X] = A0
    type A = A0
  } = new Unapply[TC, A0] {
    type M[X] = A0
    type A = A0
    def TC = TC0
    def apply(ma: M[A0]) = ma
  }
}
```

With this, `traverseU` works as follows:

``` scala
scala> List(1, 2, 3) traverseU {_ + 1}
res0: Int = 9
```
