### PR TITLE
fixes NullPointerException caused by initialization bug in STArray

### DIFF
--- a/effect/src/main/scala/scalaz/effect/ST.scala
+++ b/effect/src/main/scala/scalaz/effect/ST.scala
@@ -64,11 +64,11 @@ trait STRefInstances {
 
 /**Mutable array in state thread S containing values of type A. */
 sealed trait STArray[S, A] {
-  val size: Int
-  val z: A
-  implicit val manifest: Manifest[A]
+  def size: Int
+  def z: A
+  implicit def manifest: Manifest[A]
 
-  private val value: Array[A] = Array.fill(size)(z)
+  private lazy val value: Array[A] = Array.fill(size)(z)
 
   import ST._
 

--- a/tests/src/test/scala/scalaz/effect/STTest.scala
+++ b/tests/src/test/scala/scalaz/effect/STTest.scala
@@ -1,0 +1,31 @@
+package scalaz
+package effect
+
+import std.AllInstances._
+import ST._
+
+class STTest extends Spec {
+  type ForallST[A] = Forall[({type λ[S] = ST[S, A]})#λ]
+
+  "STRef" in {
+    def e1[S] = for {
+      x <- newVar[S](0)
+      r <- x mod {_ + 1}
+    } yield x
+    def e2[S]: ST[S, Int] = for {
+      x <- e1[S]
+      r <- x.read
+    } yield r
+    runST(new ForallST[Int] { def apply[S] = e2[S] }) must be_===(1)
+  }
+
+  "STArray" in {
+    def e1[S] = for {
+      arr <- newArr[S, Boolean](3, true)
+      _ <- arr.write(0, false)
+      r <- arr.freeze
+    } yield r
+    runST(new ForallST[ImmutableArray[Boolean]] { def apply[S] = e1[S] }).toList must be_===(
+      List(false, true, true))
+  }
+}


### PR DESCRIPTION
### steps
1. See the `STTest` that I started:

``` scala
  "STArray" in {
    def e1[S] = for {
      arr <- newArr[S, Boolean](3, true)
      _ <- arr.write(0, false)
      r <- arr.freeze
    } yield r
    runST(new ForallST[ImmutableArray[Boolean]] { def apply[S] = e1[S] }).toList must be_===(
      List(false, true, true))
  }
```
### problem

NullPointerException.

```
[error] ! STArray
[error]   NullPointerException: null (ArrayBuilder.scala:37)
[error] scala.collection.mutable.ArrayBuilder$.make(ArrayBuilder.scala:37)
[error] scala.Array$.newBuilder(Array.scala:52)
[error] scala.Array$.fill(Array.scala:235)
[error] scalaz.effect.STArray$class.$init$(ST.scala:71)
[error] scalaz.effect.STArrayFunctions$$anon$4.<init>(ST.scala:108)
[error] scalaz.effect.STArrayFunctions$class.stArray(ST.scala:108)
[error] scalaz.effect.STArray$.stArray(ST.scala:103)
[error] scalaz.effect.STFunctions$$anonfun$newArr$1.apply(ST.scala:164)
[error] scalaz.effect.STFunctions$$anonfun$newArr$1.apply(ST.scala:164)
[error] scalaz.effect.STFunctions$$anonfun$returnST$1.apply(ST.scala:151)
[error] scalaz.effect.STFunctions$$anonfun$returnST$1.apply(ST.scala:151)
[error] scalaz.effect.STFunctions$$anon$5.apply(ST.scala:142)
[error] scalaz.effect.ST$$anonfun$flatMap$1.apply(ST.scala:125)
[error] scalaz.effect.ST$$anonfun$flatMap$1.apply(ST.scala:125)
[error] scalaz.effect.STFunctions$$anon$5.apply(ST.scala:142)
[error] scalaz.effect.STFunctions$class.runST(ST.scala:155)
[error] scalaz.effect.ST$.runST(ST.scala:135)
[error] scalaz.effect.STTest$$anonfun$3$$anonfun$apply$8.apply(STTest.scala:28)
[error] scalaz.effect.STTest$$anonfun$3$$anonfun$apply$8.apply(STTest.scala:28)
```
### what this changes

To work around the initialization order of STArray trait, I turned `size`, `z`, and `manifest` into defs (these are overridden later as vals), and turned `value` into a lazy val. Now the test passes without NPE.
