### PR TITLE
Curry xmaps in core, for better inference.

### DIFF
--- a/core/src/main/scala/scalaz/Lens.scala
+++ b/core/src/main/scala/scalaz/Lens.scala
@@ -26,17 +26,17 @@ sealed trait LensT[F[+_], A, B] {
   import BijectionT._
   import WriterT._
 
-  def xmapA[X](f: A => X, g: X => A)(implicit F: Functor[F]): LensT[F, X, B] =
+  def xmapA[X](f: A => X)(g: X => A)(implicit F: Functor[F]): LensT[F, X, B] =
     lensT(x => F.map(run(g(x)))(_ map (f)))
 
   def xmapbA[X](b: Bijection[A, X])(implicit F: Functor[F]): LensT[F, X, B] =
-    xmapA(b to _, b from _)
+    xmapA(b to _)(b from _)
 
-  def xmapB[X](f: B => X, g: X => B)(implicit F: Functor[F]): LensT[F, A, X] =
-    lensT(a => F.map(run(a))(_ xmap (f, g)))
+  def xmapB[X](f: B => X)(g: X => B)(implicit F: Functor[F]): LensT[F, A, X] =
+    lensT(a => F.map(run(a))(_.xmap(f)(g)))
 
   def xmapbB[X](b: Bijection[B, X])(implicit F: Functor[F]): LensT[F, A, X] =
-    xmapB(b to _, b from _)
+    xmapB(b to _)(b from _)
 
   def get(a: A)(implicit F: Functor[F]): F[B] =
     F.map(run(a))(_.pos)

--- a/core/src/main/scala/scalaz/PLens.scala
+++ b/core/src/main/scala/scalaz/PLens.scala
@@ -41,17 +41,17 @@ sealed trait PLensT[F[+_], A, B] {
   def mapC[C](f: Store[B, A] => Store[C, A])(implicit F: Functor[F]): PLensT[F, A, C] =
     plensT(a => F.map(run(a))(_ map f))
 
-  def xmapA[X](f: A => X, g: X => A)(implicit F: Functor[F]): PLensT[F, X, B] =
+  def xmapA[X](f: A => X)(g: X => A)(implicit F: Functor[F]): PLensT[F, X, B] =
     plensO(x => runO(g(x)) map (_ map (f)))
 
   def xmapbA[X](b: Bijection[A, X])(implicit F: Functor[F]): PLensT[F, X, B] =
-    xmapA(b to _, b from _)
+    xmapA(b to _)(b from _)
 
-  def xmapB[X](f: B => X, g: X => B)(implicit F: Functor[F]): PLensT[F, A, X] =
-    plensO(a => runO(a) map (_ xmap (f, g)))
+  def xmapB[X](f: B => X)(g: X => B)(implicit F: Functor[F]): PLensT[F, A, X] =
+    plensO(a => runO(a) map (_.xmap(f)(g)))
 
   def xmapbB[X](b: Bijection[B, X])(implicit F: Functor[F]): PLensT[F, A, X] =
-    xmapB(b to _, b from _)
+    xmapB(b to _)(b from _)
 
   def get(a: A)(implicit F: Functor[F]): F[Option[B]] =
     F.map(run(a))(_ map (_.pos))

--- a/core/src/main/scala/scalaz/StoreT.scala
+++ b/core/src/main/scala/scalaz/StoreT.scala
@@ -11,11 +11,11 @@ sealed trait StoreT[F[+_], A, +B] {
   import StoreT._
   import BijectionT._
 
-  def xmap[X](f: A => X, g: X => A)(implicit F: Functor[F]): StoreT[F, X, B] =
+  def xmap[X](f: A => X)(g: X => A)(implicit F: Functor[F]): StoreT[F, X, B] =
     storeT(F.map(set)(_ compose g), f(pos))
 
   def bmap[X](b: Bijection[A, X])(implicit F: Functor[F]): StoreT[F, X, B] =
-    xmap(b to _, b from _)
+    xmap(b to _)(b from _)
 
   def put(a: A)(implicit F: Functor[F]): F[B] =
     F.map(run._1)(_(a))


### PR DESCRIPTION
Left iterv alone, as it's for compatibility.

``` scala
scala> val greet = mapVLens[String, Int]("greetings")
greet: scalaz.package.@>[Map[String,Int],Option[Int]] = scalaz.LensTFunctions$$anon$5@1a7bfda8

scala> greet.xmapB(_ map (_ toString))(_ map (Integer parseInt))
res5: scalaz.LensT[scalaz.Id.Id,Map[String,Int],Option[java.lang.String]] = scalaz.LensTFunctions$$anon$5@4fb4399c
```
