### PR TITLE
Add _.succ syntax for Nats

### DIFF
--- a/typelevel/src/main/scala/scalaz/typelevel/Syntax.scala
+++ b/typelevel/src/main/scala/scalaz/typelevel/Syntax.scala
@@ -6,6 +6,7 @@ package typelevel
 
 trait Syntax
   extends syntax.HLists
+  with syntax.Nats
   with syntax.TypeClasses
 
 object Syntax extends Syntax

--- a/typelevel/src/main/scala/scalaz/typelevel/syntax/Nat.scala
+++ b/typelevel/src/main/scala/scalaz/typelevel/syntax/Nat.scala
@@ -1,0 +1,14 @@
+package scalaz.typelevel.syntax
+
+import scalaz.typelevel.{Succ, Nat}
+
+final class NatOps[N <: Nat](nat: N) {
+  def succ: Succ[N] = Succ(nat)
+}
+
+trait Nats {
+  implicit def ToNatOps[N <: Nat](nat: N): NatOps[N] =
+    new NatOps(nat)
+}
+
+object Nats extends Nats


### PR DESCRIPTION
This adds a `succ` method to instances of `Nat`, with the most specific possible return type. The motivation for this is to make the API a little more symmetrical after the addition of the `pred` method.
