### PR TITLE
plus and empty from Category shouldn't take type parameters.

### DIFF
--- a/core/src/main/scala/scalaz/Category.scala
+++ b/core/src/main/scala/scalaz/Category.scala
@@ -9,7 +9,7 @@ trait Category[=>:[_, _]] extends ArrId[=>:] with Compose[=>:] { self =>
   ////
   // TODO GeneralizedCategory, GeneralizedFunctor, et al, from Scalaz6 ?
 
-  def empty[A]: PlusEmpty[({type λ[α]=(α =>: α)})#λ] = new PlusEmpty[({type λ[α]=(α =>: α)})#λ] with ComposePlus[A] {
+  def empty: PlusEmpty[({type λ[α]=(α =>: α)})#λ] = new PlusEmpty[({type λ[α]=(α =>: α)})#λ] with ComposePlus {
     def empty[A] = id
   }
   def monoid[A]: Monoid[A =>: A] = new Monoid[A =>: A] with ComposeSemigroup[A] {

--- a/core/src/main/scala/scalaz/Compose.scala
+++ b/core/src/main/scala/scalaz/Compose.scala
@@ -9,14 +9,14 @@ trait Compose[=>:[_, _]]  { self =>
   ////
   def compose[A, B, C](f: B =>: C, g: A =>: B): (A =>: C)
 
-  private[scalaz] trait ComposePlus[A] extends Plus[({type λ[α]=(α =>: α)})#λ] {
+  private[scalaz] trait ComposePlus extends Plus[({type λ[α]=(α =>: α)})#λ] {
     def plus[A](f1: (A =>: A), f2: => (A =>: A)) = self.compose(f1, f2)
   }
   private[scalaz] trait ComposeSemigroup[A] extends Semigroup[A =>: A] {
     def append(f1: (A =>: A), f2: => (A =>: A)) = self.compose(f1, f2)
   }
 
-  def plus[A]: Plus[({type λ[α]=(α =>: α)})#λ] = new ComposePlus[A] {}
+  def plus: Plus[({type λ[α]=(α =>: α)})#λ] = new ComposePlus {}
   def semigroup[A]: Semigroup[A =>: A] = new ComposeSemigroup[A] {}
 
   trait ComposeLaw {


### PR DESCRIPTION
``` scala
scala> Category[Function1].empty
res0: scalaz.PlusEmpty[[α]α => α] = scalaz.Category$$anon$2@5a357828

scala> Category[Function1].plus
res1: scalaz.Plus[[α]α => α] = scalaz.Compose$$anon$1@2fd06f5
```
