### PR TITLE
Bind for Name and Need too strict; also Distributive.

### DIFF
--- a/core/src/main/scala/scalaz/Name.scala
+++ b/core/src/main/scala/scalaz/Name.scala
@@ -17,7 +17,7 @@ object Name {
   }
   def unapply[A](v: Name[A]): Option[A] = Some(v.value)
 
-  implicit val name = new Monad[Name] with Comonad[Name] with Cobind.FromCojoin[Name] {
+  implicit val name = new Monad[Name] with Comonad[Name] with Cobind.FromCojoin[Name] with Distributive[Name] {
     def point[A](a: => A) = Name(a)
 
     override def map[A, B](fa: Name[A])(f: (A) => B) = Name(f(fa.value))
@@ -26,6 +26,8 @@ object Name {
     def bind[A,B](v: Name[A])(f: A => Name[B]): Name[B] = Name(f(v.value).value)
     def cojoin[A](a: Name[A]): Name[Name[A]] = Name(a)
     def copoint[A](p: Name[A]): A = p.value
+    def distributeImpl[G[_], A, B](fa: G[A])(f: A => Name[B])(implicit G: Functor[G]) =
+      Name(G.map(fa)(a => f(a).value))
   }
   implicit def nameEqual[A: Equal]: Equal[Name[A]] = new Equal[Name[A]] {
     def equal(a1: Name[A], a2: Name[A]): Boolean = Equal[A].equal(a1.value, a2.value)
@@ -41,7 +43,7 @@ object Need {
   }
   def unapply[A](x: Need[A]): Option[A] = Some(x.value)
 
-  implicit val need = new Monad[Need] with Comonad[Need] with Cobind.FromCojoin[Need] {
+  implicit val need = new Monad[Need] with Comonad[Need] with Cobind.FromCojoin[Need] with Distributive[Need] {
     def point[A](a: => A) = Need(a)
     override def map[A, B](fa: Need[A])(f: A => B) = Need(f(fa.value))
     override def ap[A, B](fa: => Need[A])(f: => Need[A => B]) =
@@ -49,6 +51,8 @@ object Need {
     def bind[A, B](v: Need[A])(f: A => Need[B]): Need[B] = Need(f(v.value).value)
     def cojoin[A](a: Need[A]): Need[Need[A]] = Need(a)
     def copoint[A](p: Need[A]): A = p.value
+    def distributeImpl[G[_], A, B](fa: G[A])(f: A => Need[B])(implicit G: Functor[G]) =
+      Need(G.map(fa)(a => f(a).value))
   }
   implicit def needEqual[A: Equal]: Equal[Need[A]] = new Equal[Need[A]] {
     def equal(a1: Need[A], a2: Need[A]): Boolean = Equal[A].equal(a1.value, a2.value)
@@ -56,11 +60,13 @@ object Need {
 }
 
 object Value {
-  implicit val value = new Monad[Value] with Comonad[Value] with Cobind.FromCojoin[Value] {
+  implicit val value = new Monad[Value] with Comonad[Value] with Cobind.FromCojoin[Value] with Distributive[Value] {
     def point[A](a: => A) = Value(a)
     def bind[A, B](v: Value[A])(f: A => Value[B]): Value[B] = f(v.value)
     def cojoin[A](a: Value[A]): Value[Value[A]] = Value(a)
     def copoint[A](p: Value[A]): A = p.value
+    def distributeImpl[G[_], A, B](fa: G[A])(f: A => Value[B])(implicit G: Functor[G]) =
+      Value(G.map(fa)(a => f(a).value))
   }
   implicit def valueEqual[A: Equal]: Equal[Value[A]] = new Equal[Value[A]] {
     def equal(a1: Value[A], a2: Value[A]): Boolean = Equal[A].equal(a1.value, a2.value)


### PR DESCRIPTION
I also included ap for both to reduce delay tree sizes.

``` scala
// Entering paste mode (ctrl-D to finish)

val x = Need{println("hi"); 42}
val xx = x flatMap (a => Need{println("hi again"); a + 3})
^D
// Exiting paste mode, now interpreting.

// "hi" prints here without this change
x: scalaz.Need[Int] = scalaz.Need$$anon$4@42f52f61
xx: scalaz.Need[Int] = scalaz.Need$$anon$4@6ef9ab9e

scala> xx.value
hi
hi again
res1: Int = 45
```

Distributive for Name, Need, and Value are also included.
