### PR TITLE
Tiny optimisation to the Semigroup for Map.

### DIFF
--- a/core/src/main/scala/scalaz/std/Map.scala
+++ b/core/src/main/scala/scalaz/std/Map.scala
@@ -14,10 +14,12 @@ trait MapInstances {
   implicit def mapMonoid[K, V: Semigroup]: Monoid[Map[K, V]] = new Monoid[Map[K, V]] {
     def zero = Map[K, V]()
     def append(m1: Map[K, V], m2: => Map[K, V]) = {
+      // Eagerly consume m2 as the value is used more than once.
+      val m2Instance: Map[K, V] = m2
       // semigroups are not commutative, so order may matter. 
       val (from, to, semigroup) = {
-        if (m1.size > m2.size) (m2, m1, Semigroup[V].append(_: V, _: V))
-        else (m1, m2, (Semigroup[V].append(_: V, _: V)).flip)
+        if (m1.size > m2Instance.size) (m2Instance, m1, Semigroup[V].append(_: V, _: V))
+        else (m1, m2Instance, (Semigroup[V].append(_: V, _: V)).flip)
       }
 
       from.foldLeft(to) {


### PR DESCRIPTION
Inside the append method the second parameter (which is call by name) is actually used twice, once to check the size and the second time to assign it to either from or to. I just added in a val that eagerly consumes the call by name parameter and used that instead.
