### PR TITLE
HListFunc (Composition of functor functions)

### DIFF
--- a/example/src/main/scala/scalaz/example/WordCount.scala
+++ b/example/src/main/scala/scalaz/example/WordCount.scala
@@ -11,7 +11,8 @@ object WordCount {
   }
 
   def wordCount {
-    import scalaz.typelevel.{AppFuncU, HList, HNil}, scalaz.typelevel.syntax.hlist._,
+    import scalaz.typelevel.{AppFunc, AppFuncU, HList, HNil},
+      scalaz.typelevel.syntax.hlist._,
       scalaz.State._, scalaz.std.anyVal._, scalaz.std.list._,
       scalaz.std.boolean.test, scalaz.syntax.equal._
 
@@ -33,10 +34,10 @@ object WordCount {
     } @>>> AppFuncU { (x: Int) => x }
 
     // Compose applicative functions in parallel
-    val countAll = countWord @&&& countLine @&&& countChar
-
-    // ... and execute them in a single traversal
-    val (wordCountState :: lineCount :: HNil) :: charCount :: HNil = countAll traverse text
+    val countAll = countChar :: countLine :: (countWord consA AppFunc.HNil)
+    
+    // ... and execute them in a single traversal 
+    val charCount :: lineCount ::  wordCountState :: HNil = countAll traverse text
     val wordCount = wordCountState.eval(false)
 
     println("%d\t%d\t%d\t".format(lineCount, wordCount, charCount)) // 2	9	35


### PR DESCRIPTION
This is an improvement to #161, which implemented `Func`.

`AppFunc` data type implemented `@&&&` method to composite two applicative functions producing another function that returns `Tuple2[F, G]`. @larsrh suggested I use `typelevel` package, and thus `Func` was created to handle several typeclasses generically. `@&&&` was refactored to use `HList`, but it remained to handle only two items at a time.
## What this changes

As per @larsrh's suggestion, this provides composition that produces a function that returns n-item `HList`.

``` scala
scala> import scalaz._, scalaz.std.AllInstances._, typelevel._, Func._
import scalaz._
import scalaz.std.AllInstances._
import typelevel._
import Func._

scala> AppFuncU { (x: Int) => x + 1 } :: AppFuncU { (x: Int) => List(x, 5) } :: AppFunc.HNil
res0: scalaz.typelevel.HListFunc[scalaz.typelevel.TCCons[scalaz.Unapply[scalaz.Applicative,Int]{type M[X] = Int; type A = Int}#M,scalaz.typelevel.TCCons[scalaz.Unapply[scalaz.Applicative,List[Int]]{type M[X] = List[X]; type A = Int}#M,scalaz.typelevel.TCNil]],scalaz.Applicative,Int,Int] = scalaz.typelevel.Func$$anon$4@538f7b25

scala> res0.runA(10)
res1: scalaz.typelevel.TCCons[scalaz.Unapply[scalaz.Applicative,Int]{type M[X] = Int; type A = Int}#M,scalaz.typelevel.TCCons[scalaz.Unapply[scalaz.Applicative,List[Int]]{type M[X] = List[X]; type A = Int}#M,scalaz.typelevel.TCNil]]#Product[Int] = GenericCons(11,GenericCons(List(10, 5),GenericNil()))

scala> res0 traverse List(1, 2, 3)
res2: scalaz.typelevel.TCCons[scalaz.Unapply[scalaz.Applicative,Int]{type M[X] = Int; type A = Int}#M,scalaz.typelevel.TCCons[scalaz.Unapply[scalaz.Applicative,List[Int]]{type M[X] = List[X]; type A = Int}#M,scalaz.typelevel.TCNil]]#Product[List[Int]] = GenericCons(9,GenericCons(List(List(1, 2, 3), List(1, 2, 5), List(1, 5, 3), List(1, 5, 5), List(5, 2, 3), List(5, 2, 5), List(5, 5, 3), List(5, 5, 5)),GenericNil()))
```
