### PR TITLE
Provide instances/functions for immutable.IndexedSeq, not the mutable/im...

### DIFF
--- a/core/src/main/scala/scalaz/Cord.scala
+++ b/core/src/main/scala/scalaz/Cord.scala
@@ -1,5 +1,7 @@
 package scalaz
 
+import collection.immutable.IndexedSeq
+
 import std.anyVal._
 import std.string._
 import std.indexedSeq.indexedSeqMonoid
@@ -109,7 +111,7 @@ sealed trait Cord extends syntax.Ops[FingerTree[Int, String]] {
 
   def toList: List[Char] = toIndexedSeq.toList
   def toStream: Stream[Char] = toIndexedSeq.toStream
-  def toIndexedSeq: IndexedSeq[Char] = self.foldMap(_.toIndexedSeq : IndexedSeq[Char])
+  def toIndexedSeq: IndexedSeq[Char] = self.foldMap(_.toIndexedSeq)
   override def toString: String = {
     val sb = new StringBuilder(self.measure)
     self foreach (sb ++= _)

--- a/core/src/main/scala/scalaz/std/IndexedSeq.scala
+++ b/core/src/main/scala/scalaz/std/IndexedSeq.scala
@@ -2,6 +2,7 @@ package scalaz
 package std
 
 import annotation.tailrec
+import collection.immutable.IndexedSeq
 import collection.IndexedSeqLike
 import collection.generic.{CanBuildFrom, GenericTraversableTemplate}
 

--- a/core/src/main/scala/scalaz/syntax/std/IndexedSeqOps.scala
+++ b/core/src/main/scala/scalaz/syntax/std/IndexedSeqOps.scala
@@ -2,6 +2,7 @@ package scalaz
 package syntax
 package std
 
+import collection.immutable.IndexedSeq
 import scalaz.std.{indexedSeq => v}
 
 trait IndexedSeqOps[A] extends Ops[IndexedSeq[A]] {


### PR DESCRIPTION
...mutable shared trait.

Because `scala.IndexedSeq` is `scala.collection.IndexedSeq`, whose covariant functor is just for pretend.  With this change:

``` scala
scala> Monad[IndexedSeq]
<console>:12: error: could not find implicit value for parameter F: scalaz.Monad[IndexedSeq]
              Monad[IndexedSeq]
                   ^

scala> Monad[collection.immutable.IndexedSeq]
res1: scalaz.Monad[scala.collection.immutable.IndexedSeq] = scalaz.std.IndexedSeqSubInstances$$anon$1@36916057

scala> List(1,2,3).toIndexedSeq |+| List(4,5,6).toIndexedSeq
res2: scala.collection.immutable.IndexedSeq[Int] = Vector(1, 2, 3, 4, 5, 6)
```
