### PR TITLE
Derived left/right biases for Bifoldable and Bitraverse.

### DIFF
--- a/core/src/main/scala/scalaz/Bifoldable.scala
+++ b/core/src/main/scala/scalaz/Bifoldable.scala
@@ -47,6 +47,22 @@ trait Bifoldable[F[_, _]]  { self =>
   final def bifoldL[A, B, C](fa: F[A, B], z: C)(f: C => A => C)(g: C => B => C): C =
     bifoldLeft(fa, z)(Function.uncurried(f))(Function.uncurried(g))
 
+  def leftFoldable[X]: Foldable[({type λ[α] = F[α, X]})#λ] = new Foldable[({type λ[α] = F[α, X]})#λ] {
+    def foldMap[A,B](fa: F[A, X])(f: A => B)(implicit F: Monoid[B]): B =
+      bifoldMap(fa)(f)(Function const F.zero)
+
+    def foldRight[A, B](fa: F[A, X], z: => B)(f: (A, => B) => B): B =
+      bifoldRight(fa, z)(f)((_, b) => b)
+  }
+
+  def rightFoldable[X]: Foldable[({type λ[α] = F[X, α]})#λ] = new Foldable[({type λ[α] = F[X, α]})#λ] {
+    def foldMap[A,B](fa: F[X, A])(f: A => B)(implicit F: Monoid[B]): B =
+      bifoldMap(fa)(Function const F.zero)(f)
+
+    def foldRight[A, B](fa: F[X, A], z: => B)(f: (A, => B) => B): B =
+      bifoldRight(fa, z)((_, b) => b)(f)
+  }
+
   ////
   val bifoldableSyntax = new scalaz.syntax.BifoldableSyntax[F] { def F = Bifoldable.this }
 }

--- a/core/src/main/scala/scalaz/Bitraverse.scala
+++ b/core/src/main/scala/scalaz/Bitraverse.scala
@@ -34,6 +34,16 @@ trait Bitraverse[F[_, _]] extends Bifunctor[F] with Bifoldable[F] { self =>
     bitraverseImpl[Id, A, B, C, D](fab)(f, g)
   }
 
+  def leftTraverse[X]: Traverse[({type λ[α] = F[α, X]})#λ] = new Traverse[({type λ[α] = F[α, X]})#λ] {
+    def traverseImpl[G[_]:Applicative,A,B](fa: F[A, X])(f: A => G[B]): G[F[B, X]] =
+      bitraverseImpl(fa)(f, x => Pointed[G] point x)
+  }
+
+  def rightTraverse[X]: Traverse[({type λ[α] = F[X, α]})#λ] = new Traverse[({type λ[α] = F[X, α]})#λ] {
+    def traverseImpl[G[_]:Applicative,A,B](fa: F[X, A])(f: A => G[B]): G[F[X, B]] =
+      bitraverseImpl(fa)(x => Pointed[G] point x, f)
+  }
+
   class Bitraversal[G[_]](implicit G: Applicative[G]) {
     def run[A,B,C,D](fa: F[A,B])(f: A => G[C])(g: B => G[D]): G[F[C, D]] = bitraverseImpl[G,A,B,C,D](fa)(f, g)
   }


### PR DESCRIPTION
``` scala
scala> Bitraverse[\/].rightTraverse.traverse(42.left[Int])(x => Vector(x + 3))
res11: scala.collection.immutable.Vector[scalaz.\/[Int,Int]] = Vector(-\/(42))

scala> Bitraverse[\/].leftTraverse.traverse(42.left[Int])(x => Vector(x + 3))
res12: scala.collection.immutable.Vector[scalaz.\/[Int,Int]] = Vector(-\/(45))

scala> Bifoldable[\/].leftFoldable.foldMap(42.left[Int])(identity)
res14: Int = 42

scala> Bifoldable[\/].rightFoldable.foldMap(42.left[Int])(identity)
res15: Int = 0
```
