### PR TITLE
Fix parseBoolean for Scala 2.10

### DIFF
--- a/core/src/main/scala/scalaz/std/String.scala
+++ b/core/src/main/scala/scalaz/std/String.scala
@@ -41,10 +41,10 @@ trait StringFunctions {
   // Parsing functions.
   import Validation.{success, failure}
 
-  def parseBoolean(s:String): Validation[NumberFormatException, Boolean] = try {
+  def parseBoolean(s:String): Validation[IllegalArgumentException, Boolean] = try {
     success(s.toBoolean)
   } catch {
-    case e: NumberFormatException => failure(e)
+    case e: IllegalArgumentException => failure(e)
   }
 
   def parseByte(s:String): Validation[NumberFormatException, Byte] = try {

--- a/core/src/main/scala/scalaz/syntax/std/StringOps.scala
+++ b/core/src/main/scala/scalaz/syntax/std/StringOps.scala
@@ -30,7 +30,7 @@ trait StringOps extends Ops[String]{
 
   // Parsing functions.
 
-  def parseBoolean: Validation[NumberFormatException, Boolean] = s.parseBoolean(self)
+  def parseBoolean: Validation[IllegalArgumentException, Boolean] = s.parseBoolean(self)
 
   def parseByte: Validation[NumberFormatException, Byte] = s.parseByte(self)
 

--- a/tests/src/test/scala/scalaz/std/StringTest.scala
+++ b/tests/src/test/scala/scalaz/std/StringTest.scala
@@ -8,4 +8,13 @@ class StringTest extends Spec {
   checkAll(monoid.laws[String])
 
   checkAll(order.laws[String].withProp("benchmark", order.scalaOrdering[String]))
+
+  "parseBoolean" in {
+    import string.parseBoolean
+    implicit val s = Show.showFromToString[IllegalArgumentException]
+    implicit val e = Equal.equalA[IllegalArgumentException]
+    parseBoolean("true") must be_===(Validation.success(true))
+    parseBoolean("false") must be_===(Validation.success(false))
+    parseBoolean("1").isSuccess must be_===(false)
+  }
 }


### PR DESCRIPTION
StringFunctions.parseBoolean fails on Scala 2.10 because the standard library now throws IllegalArgumentException instead of NumberFormatException from String.toBoolean.  This adds a test case and fixes for both Scala 2.9 and 2.10.
