### PR TITLE
Make Function0 map/bind lazy in their implementation.

### DIFF
--- a/core/src/main/scala/scalaz/std/Function.scala
+++ b/core/src/main/scala/scalaz/std/Function.scala
@@ -22,7 +22,9 @@ trait FunctionInstances extends FunctionInstances0 {
 
     def copoint[A](p: () => A) = p()
 
-    def bind[A, B](fa: () => A)(f: (A) => () => B) = f(fa())
+    def bind[A, B](fa: () => A)(f: (A) => () => B) = () => f(fa())()
+
+    override def map[A,B](fa: () => A)(f: A => B) = () => f(fa())
 
     def traverseImpl[G[_]: Applicative, A, B](fa: () => A)(f: (A) => G[B]) =
       Applicative[G].map(f(fa()))((b: B) => () => b)

--- a/tests/src/test/scala/scalaz/std/FunctionTest.scala
+++ b/tests/src/test/scala/scalaz/std/FunctionTest.scala
@@ -42,6 +42,25 @@ class FunctionTest extends Spec {
 
   checkAll("Function1", comonad.laws[({type λ[α]=(Int => α)})#λ])
 
+  // Likely could be made to cover all the FunctionN types.
+  "Function0 map eagerness" ! prop{(number: Int) =>
+    var modifiableNumber: Int = number
+    val methodCall: () => Int = () => modifiableNumber
+    val mappedCall: () => Int = Monad[Function0].map(methodCall)(_ + 3)
+    modifiableNumber += 1
+    mappedCall() must be_===(number + 4)
+  }
+
+  // Likely could be made to cover all the FunctionN types.
+  "Function0 bind eagerness" ! prop{(number: Int) =>
+    var modifiableNumber: Int = number
+    val methodCall: () => Int = () => modifiableNumber
+    val mappedCall = Monad[Function0].bind(methodCall)((value: Int) => () => value + 3)
+    modifiableNumber += 1
+    mappedCall() must be_===(number + 4)
+  }
+
+
   object instances {
     def equal[A, R: Equal] = Equal[() => R]
     def semigroup[A, R: Semigroup] = Semigroup[A => R]


### PR DESCRIPTION
Previously if you (flat)mapped a Function0 it would execute it at the point of mapping and create the new Function0 with that value. This brings it in line with the other FunctionN variations by mapping at call time.

I'm somewhat of two minds about this change as it does make sense to do the existing behaviour if the Function0 can be guaranteed to be pure however.
