### PR TITLE
Export scalaz-style instance property checking

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -114,7 +114,7 @@ object build extends Build {
     id = "scalaz",
     base = file("."),
     settings = standardSettings ++ Unidoc.settings,
-    aggregate = Seq(core, concurrent, effect, example, iterv, iteratee, scalacheckBinding, tests, typelevel, xml)
+    aggregate = Seq(core, concurrent, effect, example, iterv, iteratee, testlib, typelevel, xml, tests)
   )
 
   lazy val core = Project(
@@ -205,23 +205,27 @@ object build extends Build {
     )
   )
 
-  lazy val scalacheckBinding = Project(
-    id           = "scalacheck-binding",
-    base         = file("scalacheck-binding"),
+  lazy val testlib = Project(
+    id           = "testlib",
+    base         = file("testlib"),
     dependencies = Seq(core, concurrent, typelevel),
     settings     = standardSettings ++ Seq[Sett](
-      name := "scalaz-scalacheck-binding",
-      libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.10.0" cross CrossVersion.full,
-      osgiExport("scalaz.scalacheck")
+      name := "scalaz-testlib",
+      libraryDependencies ++= Seq(
+        "org.specs2" %% "specs2" % "1.12.3" cross CrossVersion.full,
+        "org.scalacheck" %% "scalacheck" % "1.10.0" cross CrossVersion.full
+      ),
+      osgiExport("scalaz.testlib")
     )
   )
 
   lazy val tests = Project(
     id = "tests",
     base = file("tests"),
-    dependencies = Seq(core, iteratee, concurrent, effect, typelevel, scalacheckBinding % "test"),
-    settings = standardSettings ++Seq[Sett](
+    dependencies = Seq(core, iteratee, concurrent, effect, typelevel, testlib % "test"),
+    settings = standardSettings ++ Seq[Sett](
       name := "scalaz-tests",
+      publishTo := None,
       libraryDependencies ++= Seq(
         "org.specs2" %% "specs2" % "1.12.3" % "test" cross CrossVersion.full,
         "org.scalacheck" %% "scalacheck" % "1.10.0" % "test" cross CrossVersion.full

--- a/testlib/src/main/scala/scalaz/testlib/ScalaCheckBinding.scala
+++ b/testlib/src/main/scala/scalaz/testlib/ScalaCheckBinding.scala
@@ -1,5 +1,5 @@
 package scalaz
-package scalacheck
+package testlib
 
 /**
  * Type class instances for types from <a href="https://github.com/rickynils/scalacheck">Scalacheck</a>

--- a/testlib/src/main/scala/scalaz/testlib/ScalazArbitrary.scala
+++ b/testlib/src/main/scala/scalaz/testlib/ScalazArbitrary.scala
@@ -1,5 +1,5 @@
 package scalaz
-package scalacheck
+package testlib
 
 import java.math.BigInteger
 import org.scalacheck.{Pretty, Gen, Arbitrary}

--- a/testlib/src/main/scala/scalaz/testlib/ScalazProperties.scala
+++ b/testlib/src/main/scala/scalaz/testlib/ScalazProperties.scala
@@ -1,5 +1,5 @@
 package scalaz
-package scalacheck
+package testlib
 
 import org.scalacheck.{Arbitrary, Prop, Properties}
 import Prop.forAll

--- a/testlib/src/main/scala/scalaz/testlib/Spec.scala
+++ b/testlib/src/main/scala/scalaz/testlib/Spec.scala
@@ -1,4 +1,5 @@
 package scalaz
+package testlib
 
 import org.specs2.matcher._
 import org.specs2.mutable.FragmentsBuilder

--- a/tests/src/test/scala/scalaz/ApplyTest.scala
+++ b/tests/src/test/scala/scalaz/ApplyTest.scala
@@ -5,7 +5,7 @@ import syntax.apply._
 import std.option.some
 import syntax.traverse._
 
-class ApplyTest extends Spec {
+class ApplyTest extends testlib.Spec {
   "mapN" in {
     Apply[Option].apply2(some("1"), some("2"))(_ + _) must be_===(some("12"))
     Apply[Option].apply3(some("1"), some("2"), some("3"))(_ + _ + _) must be_===(some("123"))

--- a/tests/src/test/scala/scalaz/BKTreeTest.scala
+++ b/tests/src/test/scala/scalaz/BKTreeTest.scala
@@ -1,14 +1,14 @@
 package scalaz
 
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 import std.AllInstances._
-import scalaz.scalacheck.ScalazArbitrary._
-import scalaz.scalacheck.ScalaCheckBinding._
+import scalaz.testlib.ScalazArbitrary._
+import scalaz.testlib.ScalaCheckBinding._
 import org.scalacheck.{Arbitrary, Gen}
 
 
-class BKTreeTest extends Spec {
+class BKTreeTest extends testlib.Spec {
   implicit val IntArb = Arbitrary[Int](Gen.choose(Int.MinValue / 4, Int.MaxValue / 4))
 
   "string distance" in {

--- a/tests/src/test/scala/scalaz/BindTest.scala
+++ b/tests/src/test/scala/scalaz/BindTest.scala
@@ -3,7 +3,7 @@ package scalaz
 import std.AllInstances._
 import syntax.bind._
 
-class BindTest extends Spec {
+class BindTest extends testlib.Spec {
 
   ">>=" in {
     (List(1, 2, 3) >>= (x => List(x, x))) must be_===(List(1, 1, 2, 2, 3, 3))

--- a/tests/src/test/scala/scalaz/BitraverseTest.scala
+++ b/tests/src/test/scala/scalaz/BitraverseTest.scala
@@ -1,11 +1,11 @@
 package scalaz
 
 import scalaz.std.AllInstances.{tuple2Instance => _, _}
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalaCheckBinding._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalaCheckBinding._
+import scalaz.testlib.ScalazArbitrary._
 
-class BitraverseTest extends Spec {
+class BitraverseTest extends testlib.Spec {
 
   implicit val LE = Bitraverse[\/].leftTraverse[Int]
   implicit val RE = Bitraverse[\/].rightTraverse[Int]

--- a/tests/src/test/scala/scalaz/BooleanSyntaxTest.scala
+++ b/tests/src/test/scala/scalaz/BooleanSyntaxTest.scala
@@ -2,7 +2,7 @@ package scalaz
 
 import std.AllInstances._
 
-class BooleanSyntaxTest extends Spec {
+class BooleanSyntaxTest extends testlib.Spec {
   "boolean syntax" in {
     import syntax.id._
     import syntax.std.boolean._

--- a/tests/src/test/scala/scalaz/CaseInsensitiveTest.scala
+++ b/tests/src/test/scala/scalaz/CaseInsensitiveTest.scala
@@ -1,10 +1,10 @@
 package scalaz
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 
-class CaseInsensitiveTest extends Spec {
+class CaseInsensitiveTest extends testlib.Spec {
 
   "map identity" ! prop {
     (a: CaseInsensitive[String]) =>

--- a/tests/src/test/scala/scalaz/CoKleisliTest.scala
+++ b/tests/src/test/scala/scalaz/CoKleisliTest.scala
@@ -1,6 +1,6 @@
 package scalaz
 
-class CokleisliTest extends Spec {
+class CokleisliTest extends testlib.Spec {
 
   // TODO enforce laws.
 

--- a/tests/src/test/scala/scalaz/DListTest.scala
+++ b/tests/src/test/scala/scalaz/DListTest.scala
@@ -1,10 +1,10 @@
 package scalaz
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 
-class DListTest extends Spec {
+class DListTest extends testlib.Spec {
   checkAll(equal.laws[DList[Int]])
   checkAll(monoid.laws[DList[Int]])
   checkAll(monadPlus.laws[DList])

--- a/tests/src/test/scala/scalaz/DigitTest.scala
+++ b/tests/src/test/scala/scalaz/DigitTest.scala
@@ -1,11 +1,11 @@
 package scalaz
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
-import scalaz.scalacheck.ScalaCheckBinding._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
+import scalaz.testlib.ScalaCheckBinding._
 import org.scalacheck.{Gen, Arbitrary}
 
-class DigitTest extends Spec {
+class DigitTest extends testlib.Spec {
   checkAll(order.laws[Digit])
 }

--- a/tests/src/test/scala/scalaz/EitherTTest.scala
+++ b/tests/src/test/scala/scalaz/EitherTTest.scala
@@ -1,10 +1,10 @@
 package scalaz
 
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 import std.AllInstances._
 
-class EitherTTest extends Spec {
+class EitherTTest extends testlib.Spec {
 
   type EitherTListInt[A] = EitherT[List, Int, A]
   type EitherTOptionInt[A] = EitherT[Option, Int, A]

--- a/tests/src/test/scala/scalaz/FingerTreeTest.scala
+++ b/tests/src/test/scala/scalaz/FingerTreeTest.scala
@@ -4,7 +4,7 @@ import org.specs2.mutable.Specification
 import org.specs2.ScalaCheck
 import org.scalacheck.Prop._
 import FingerTree._
-import scalacheck.ScalazArbitrary._
+import testlib.ScalazArbitrary._
 import std.anyVal._
 import syntax.equal._
 import std.stream._

--- a/tests/src/test/scala/scalaz/FunctorTest.scala
+++ b/tests/src/test/scala/scalaz/FunctorTest.scala
@@ -4,7 +4,7 @@ import std.AllInstances._
 import std.option.some
 import syntax.functor._
 
-class FunctorTest extends Spec {
+class FunctorTest extends testlib.Spec {
 
   "mapply" in {
     1.mapply(some((a: Int) => a)) must be_===(some(1))

--- a/tests/src/test/scala/scalaz/HeapTest.scala
+++ b/tests/src/test/scala/scalaz/HeapTest.scala
@@ -1,10 +1,10 @@
 package scalaz
 
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 import scalaz.std.AllInstances._
 
-class HeapTest extends Spec {
+class HeapTest extends testlib.Spec {
   checkAll(equal.laws[Heap[Int]])
   checkAll(monoid.laws[Heap[Int]])
 

--- a/tests/src/test/scala/scalaz/IdSyntaxTest.scala
+++ b/tests/src/test/scala/scalaz/IdSyntaxTest.scala
@@ -2,7 +2,7 @@ package scalaz
 
 import std.AllInstances._
 
-class IdSyntaxTest extends Spec {
+class IdSyntaxTest extends testlib.Spec {
   "smorgasbord" in {
     import syntax.id._
     2 |> (_ * 3) must be_===(6)

--- a/tests/src/test/scala/scalaz/IdTest.scala
+++ b/tests/src/test/scala/scalaz/IdTest.scala
@@ -1,11 +1,11 @@
 package scalaz
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 import Id._
 
-class IdTest extends Spec {
+class IdTest extends testlib.Spec {
   checkAll(monad.laws[Id])
   checkAll(traverse.laws[Id])
 }

--- a/tests/src/test/scala/scalaz/InsertionMapTest.scala
+++ b/tests/src/test/scala/scalaz/InsertionMapTest.scala
@@ -1,10 +1,10 @@
 package scalaz
 
-import scalacheck.ScalazArbitrary._
-import scalacheck.ScalazProperties._
+import testlib.ScalazArbitrary._
+import testlib.ScalazProperties._
 import std.AllInstances._
 
-class InsertionMapTest extends Spec {
+class InsertionMapTest extends testlib.Spec {
   checkAll(equal.laws[InsertionMap[Int, String]])
 
   "isEmpty == keys.isEmpty" ! prop {

--- a/tests/src/test/scala/scalaz/KleisliTest.scala
+++ b/tests/src/test/scala/scalaz/KleisliTest.scala
@@ -1,12 +1,12 @@
 package scalaz
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 import org.scalacheck.{Gen, Arbitrary}
 import Id._
 
-class KleisliTest extends Spec {
+class KleisliTest extends testlib.Spec {
 
   type KleisliOpt[A, B] = Kleisli[Option, A, B]
   type KleisliOptInt[B] = KleisliOpt[Int, B]

--- a/tests/src/test/scala/scalaz/LazyOptionTTest.scala
+++ b/tests/src/test/scala/scalaz/LazyOptionTTest.scala
@@ -1,10 +1,10 @@
 package scalaz
 
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 import std.AllInstances._
 
-class LazyOptionTTest extends Spec {
+class LazyOptionTTest extends testlib.Spec {
 
   type LazyOptionTList[A] = LazyOptionT[List, A]
 

--- a/tests/src/test/scala/scalaz/LazyTupleTest.scala
+++ b/tests/src/test/scala/scalaz/LazyTupleTest.scala
@@ -1,10 +1,10 @@
 package scalaz
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 
-class LazyTupleTest extends Spec {
+class LazyTupleTest extends testlib.Spec {
 
   type A = Int
   type B = Int

--- a/tests/src/test/scala/scalaz/LevenshteinTest.scala
+++ b/tests/src/test/scala/scalaz/LevenshteinTest.scala
@@ -1,11 +1,11 @@
 package scalaz
 
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary
-import scalaz.scalacheck.ScalazArbitrary.{stateTArb => _, _}
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary
+import scalaz.testlib.ScalazArbitrary.{stateTArb => _, _}
 import std.AllInstances._
 
-class LevenshteinTest extends Spec {
+class LevenshteinTest extends testlib.Spec {
   "string distance" in {
     MetricSpace[String].distance("kitten", "sitting") must be_===(3)
   }

--- a/tests/src/test/scala/scalaz/LiskovTest.scala
+++ b/tests/src/test/scala/scalaz/LiskovTest.scala
@@ -1,6 +1,6 @@
 package scalaz
 
-class LiskovTest extends Spec {
+class LiskovTest extends testlib.Spec {
 
   trait Co1[+ _]
 

--- a/tests/src/test/scala/scalaz/ListTTest.scala
+++ b/tests/src/test/scala/scalaz/ListTTest.scala
@@ -1,10 +1,10 @@
 package scalaz
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 
-class ListTTest extends Spec {
+class ListTTest extends testlib.Spec {
   type ListTOpt[A] = ListT[Option, A]
 
   "fromList / toList" ! prop {

--- a/tests/src/test/scala/scalaz/MonadPlusTest.scala
+++ b/tests/src/test/scala/scalaz/MonadPlusTest.scala
@@ -4,7 +4,7 @@ import std.AllInstances._
 import std.option.{some, none}
 import syntax.functor._
 
-class MonadPlusTest extends Spec {
+class MonadPlusTest extends testlib.Spec {
 
   "unite" in {
     MonadPlus[List].unite(List(some(1), none[Int], some(2))) must be_===(List(1, 2))

--- a/tests/src/test/scala/scalaz/MonoidTest.scala
+++ b/tests/src/test/scala/scalaz/MonoidTest.scala
@@ -2,7 +2,7 @@ package scalaz
 
 import std.AllInstances._
 
-class MonoidTest extends Spec {
+class MonoidTest extends testlib.Spec {
   "endo multiply" in {
     import syntax.monoid._
 

--- a/tests/src/test/scala/scalaz/NeedTest.scala
+++ b/tests/src/test/scala/scalaz/NeedTest.scala
@@ -1,10 +1,10 @@
 package scalaz
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 
-class NeedTest extends Spec {
+class NeedTest extends testlib.Spec {
   // TODO check distributive laws
 
   checkAll("Value", monad.laws[Value])

--- a/tests/src/test/scala/scalaz/NonEmptyListTest.scala
+++ b/tests/src/test/scala/scalaz/NonEmptyListTest.scala
@@ -1,10 +1,10 @@
 package scalaz
 
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 import std.AllInstances._
 
-class NonEmptyListTest extends Spec {
+class NonEmptyListTest extends testlib.Spec {
   checkAll("NonEmptyList", monad.laws[NonEmptyList])
   checkAll("NonEmptyList", plus.laws[NonEmptyList])
   checkAll("NonEmptyList", semigroup.laws[NonEmptyList[Int]])

--- a/tests/src/test/scala/scalaz/OptionTTest.scala
+++ b/tests/src/test/scala/scalaz/OptionTTest.scala
@@ -1,10 +1,10 @@
 package scalaz
 
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 import std.AllInstances._
 
-class OptionTTest extends Spec {
+class OptionTTest extends testlib.Spec {
 
   type OptionTList[A] = OptionT[List, A]
   type OptionTOption[A] = OptionT[Option, A]

--- a/tests/src/test/scala/scalaz/OrderingTest.scala
+++ b/tests/src/test/scala/scalaz/OrderingTest.scala
@@ -1,8 +1,8 @@
 package scalaz
 
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 
-class OrderingTest extends Spec {
+class OrderingTest extends testlib.Spec {
   checkAll("Ordering", enum.laws[Ordering])
 }

--- a/tests/src/test/scala/scalaz/PLensTTest.scala
+++ b/tests/src/test/scala/scalaz/PLensTTest.scala
@@ -1,11 +1,11 @@
 package scalaz
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 import org.scalacheck.{Gen, Arbitrary}
 
-class PLensTTest extends Spec {
+class PLensTTest extends testlib.Spec {
   import PLensT._
 
   "list head" in {

--- a/tests/src/test/scala/scalaz/ReaderWriterStateTTest.scala
+++ b/tests/src/test/scala/scalaz/ReaderWriterStateTTest.scala
@@ -1,12 +1,12 @@
 package scalaz
 
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary
-import scalaz.scalacheck.ScalazArbitrary.{stateTArb => _, _}
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary
+import scalaz.testlib.ScalazArbitrary.{stateTArb => _, _}
 import std.AllInstances._
 import org.scalacheck.{Gen, Arbitrary}
 
-class ReaderWriterStateTTest extends Spec {
+class ReaderWriterStateTTest extends testlib.Spec {
   type RWSOptInt[A] = RWST[Option, Int, Int, Int, A]
   implicit val RWSOptIntArb = Arbitrary(Gen.oneOf[RWSOptInt[Int]](
     Gen.value(RWST[Option, Int, Int, Int, Int]((r: Int, s: Int) => None)),

--- a/tests/src/test/scala/scalaz/RopeTest.scala
+++ b/tests/src/test/scala/scalaz/RopeTest.scala
@@ -1,6 +1,6 @@
 package scalaz
 
-import scalacheck.ScalazArbitrary._
+import testlib.ScalazArbitrary._
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 import reflect.ClassManifest

--- a/tests/src/test/scala/scalaz/StateTTest.scala
+++ b/tests/src/test/scala/scalaz/StateTTest.scala
@@ -1,12 +1,12 @@
 package scalaz
 
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary
-import scalaz.scalacheck.ScalazArbitrary.{stateTArb => _, _}
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary
+import scalaz.testlib.ScalazArbitrary.{stateTArb => _, _}
 import std.AllInstances._
 import Id._
 
-class StateTTest extends Spec {
+class StateTTest extends testlib.Spec {
 
   type StateTList[S, A] = StateT[List, S, A]
   type StateTListInt[A] = StateTList[Int, A]

--- a/tests/src/test/scala/scalaz/StoreTTest.scala
+++ b/tests/src/test/scala/scalaz/StoreTTest.scala
@@ -1,10 +1,10 @@
 package scalaz
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 
-class StoreTTest extends Spec {
+class StoreTTest extends testlib.Spec {
 
   implicit def storeTuple1IntEqual = new Equal[StoreT[Tuple1, Int, Int]] {
     def equal(a1: StoreT[Tuple1, Int, Int], a2: StoreT[Tuple1, Int, Int]) = (a1.run, a2.run) match {

--- a/tests/src/test/scala/scalaz/StreamTTest.scala
+++ b/tests/src/test/scala/scalaz/StreamTTest.scala
@@ -1,10 +1,10 @@
 package scalaz
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 
-class StreamTTest extends Spec {
+class StreamTTest extends testlib.Spec {
   type StreamTOpt[A] = StreamT[Option, A]
 
   "fromStream / toStream" ! prop {

--- a/tests/src/test/scala/scalaz/SyntaxTest.scala
+++ b/tests/src/test/scala/scalaz/SyntaxTest.scala
@@ -1,6 +1,6 @@
 package scalaz
 
-class SyntaxTest extends Spec {
+class SyntaxTest extends testlib.Spec {
   val resultToProp = () // shodow pesky Specs implicit view
 
   "functor syntax" in {

--- a/tests/src/test/scala/scalaz/TraverseTest.scala
+++ b/tests/src/test/scala/scalaz/TraverseTest.scala
@@ -1,8 +1,8 @@
 package scalaz
 
-import scalacheck.ScalazProperties
+import testlib.ScalazProperties
 
-class TraverseTest extends Spec {
+class TraverseTest extends testlib.Spec {
 
   import scalaz._
   import scalaz.State._

--- a/tests/src/test/scala/scalaz/TreeLocTest.scala
+++ b/tests/src/test/scala/scalaz/TreeLocTest.scala
@@ -1,10 +1,10 @@
 package scalaz
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 
-class TreeLocTest extends Spec {
+class TreeLocTest extends testlib.Spec {
 
   checkAll("TreeLoc", equal.laws[Tree[Int]])
 

--- a/tests/src/test/scala/scalaz/TreeTest.scala
+++ b/tests/src/test/scala/scalaz/TreeTest.scala
@@ -1,11 +1,11 @@
 package scalaz
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 import Tree._
 
-class TreeTest extends Spec {
+class TreeTest extends testlib.Spec {
 
   checkAll("Tree", equal.laws[Tree[Int]])
 

--- a/tests/src/test/scala/scalaz/ValidationTest.scala
+++ b/tests/src/test/scala/scalaz/ValidationTest.scala
@@ -1,9 +1,9 @@
 package scalaz
 
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 
-class ValidationTest extends Spec {
+class ValidationTest extends testlib.Spec {
   import std.AllInstances._
 
   checkAll("Validation", order.laws[Validation[Int, Int]])

--- a/tests/src/test/scala/scalaz/WriterTTest.scala
+++ b/tests/src/test/scala/scalaz/WriterTTest.scala
@@ -1,14 +1,14 @@
 package scalaz
 
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
-import scalaz.scalacheck.ScalaCheckBinding._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
+import scalaz.testlib.ScalaCheckBinding._
 import std.AllInstances._
 import org.scalacheck.Arbitrary
 import scalaz._
 import Id._
 
-class WriterTTest extends Spec {
+class WriterTTest extends testlib.Spec {
 
   type WriterTOpt[W, A] = WriterT[Option, W, A]
   type WriterTOptInt[A] = WriterTOpt[Int, A]

--- a/tests/src/test/scala/scalaz/ZipperTest.scala
+++ b/tests/src/test/scala/scalaz/ZipperTest.scala
@@ -6,10 +6,10 @@ import Zipper._
 import syntax.equal._
 import org.scalacheck._
 import org.scalacheck.Prop._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 
-class ZipperTest extends Spec {
+class ZipperTest extends testlib.Spec {
   // TODO retronym Get this working again under Scala 2.10.0-M6+
   // val props = new Properties("Zipper") {
   //   property("Zipper From Stream") = forAll((xs: Stream[Int]) =>

--- a/tests/src/test/scala/scalaz/concurrent/ActorTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/ActorTest.scala
@@ -1,10 +1,9 @@
 package scalaz
 package concurrent
 
-import scalaz.Spec
 import std.AllInstances._
 
-class ActorTest extends Spec {
+class ActorTest extends testlib.Spec {
   "code executes async" in {
     var called = false
     implicit val strategy = new Strategy {

--- a/tests/src/test/scala/scalaz/concurrent/PromiseTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/PromiseTest.scala
@@ -1,11 +1,11 @@
 package scalaz
 package concurrent
 
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 import std.AllInstances._
 
-class PromiseTest extends Spec {
+class PromiseTest extends testlib.Spec {
   implicit def promiseEqual[A: Equal] = Equal[A].contramap((_: Promise[A]).get)
 
   checkAll(monad.laws[Promise])

--- a/tests/src/test/scala/scalaz/effect/STTest.scala
+++ b/tests/src/test/scala/scalaz/effect/STTest.scala
@@ -4,7 +4,7 @@ package effect
 import std.AllInstances._
 import ST._
 
-class STTest extends Spec {
+class STTest extends testlib.Spec {
   type ForallST[A] = Forall[({type λ[S] = ST[S, A]})#λ]
 
   "STRef" in {

--- a/tests/src/test/scala/scalaz/iteratee/Enumeratee2TTest.scala
+++ b/tests/src/test/scala/scalaz/iteratee/Enumeratee2TTest.scala
@@ -9,7 +9,7 @@ import Either3._
 import MonadPartialOrder._
 import Id._
 
-class Enumeratee2TTest extends Spec {
+class Enumeratee2TTest extends testlib.Spec {
   implicit val ls = listShow[Either3[Int, (Int, Int), Int]]
   implicit val v = IterateeT.IterateeTMonad[Int, Id]
   implicit val vt = IterateeT.IterateeTMonadTrans[Int]

--- a/tests/src/test/scala/scalaz/iteratee/EnumeratorPTest.scala
+++ b/tests/src/test/scala/scalaz/iteratee/EnumeratorPTest.scala
@@ -10,12 +10,12 @@ import org.scalacheck.{Pretty, Gen, Arbitrary}
 import Arbitrary._
 import Gen._
 import syntax.functor._
-import scalaz.scalacheck.ScalaCheckBinding._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalaCheckBinding._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 import Id._
 
-class EnumeratorPTest extends Spec {
+class EnumeratorPTest extends testlib.Spec {
   implicit val intO = Order[Int].order _
   "cogroupE" should {
     "work the same as directly using the nested iteratee " in {

--- a/tests/src/test/scala/scalaz/iteratee/EnumeratorTTest.scala
+++ b/tests/src/test/scala/scalaz/iteratee/EnumeratorTTest.scala
@@ -9,12 +9,12 @@ import org.scalacheck.{Pretty, Gen, Arbitrary}
 import Arbitrary._
 import Gen._
 import syntax.functor._
-import scalaz.scalacheck.ScalaCheckBinding._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalaCheckBinding._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 import Id._
 
-class EnumeratorTTest extends Spec {
+class EnumeratorTTest extends testlib.Spec {
   implicit def enumeratorTArb[F[_], A](implicit FA: Arbitrary[List[A]], F: Monad[F]): Arbitrary[EnumeratorT[A, F]] = Functor[Arbitrary].map(FA)(l => EnumeratorT.enumStream[A, F](l.toStream))
 
   implicit def enumeratorEqual[A](implicit EQ: Equal[A]): Equal[Enumerator[A]] = new Equal[Enumerator[A]] {

--- a/tests/src/test/scala/scalaz/iteratee/IterateeTTest.scala
+++ b/tests/src/test/scala/scalaz/iteratee/IterateeTTest.scala
@@ -6,7 +6,7 @@ import Iteratee._
 import effect._
 import Id._
 
-class IterateeTTest extends Spec {
+class IterateeTTest extends testlib.Spec {
   "head" in {
     (head[Int, Id] &= enumStream(Stream(1, 2, 3))).run must be_===(Some(1))
   }

--- a/tests/src/test/scala/scalaz/std/AnyValTest.scala
+++ b/tests/src/test/scala/scalaz/std/AnyValTest.scala
@@ -2,13 +2,13 @@ package scalaz
 package std
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
-import scalaz.scalacheck.ScalaCheckBinding._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
+import scalaz.testlib.ScalaCheckBinding._
 import Tags._
 import org.scalacheck.{Gen, Arbitrary}
 
-class AnyValTest extends Spec {
+class AnyValTest extends testlib.Spec {
 
   checkAll("Unit", order.laws[Unit])
   checkAll("Boolean", order.laws[Boolean].withProp("benchmark", order.scalaOrdering[Boolean]))

--- a/tests/src/test/scala/scalaz/std/EitherTest.scala
+++ b/tests/src/test/scala/scalaz/std/EitherTest.scala
@@ -2,11 +2,11 @@ package scalaz
 package std
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 import Tags._
 
-class EitherTest extends Spec {
+class EitherTest extends testlib.Spec {
   checkAll("Either", order.laws[Either[Int, Int]])
   checkAll("Either.LeftProjection", order.laws[Either.LeftProjection[Int, Int]])
   checkAll("Either.LeftProjection @@ First", order.laws[Either.LeftProjection[Int, Int] @@ First])

--- a/tests/src/test/scala/scalaz/std/FunctionTest.scala
+++ b/tests/src/test/scala/scalaz/std/FunctionTest.scala
@@ -2,10 +2,10 @@ package scalaz
 package std
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 
-class FunctionTest extends Spec {
+class FunctionTest extends testlib.Spec {
   type A = Int
   type B = Int
   type C = Int

--- a/tests/src/test/scala/scalaz/std/IterableTest.scala
+++ b/tests/src/test/scala/scalaz/std/IterableTest.scala
@@ -1,11 +1,11 @@
 package scalaz
 package std
 
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 import std.AllInstances._
 
-class IterableTest extends Spec {
+class IterableTest extends testlib.Spec {
 
   import std.iterable._
 

--- a/tests/src/test/scala/scalaz/std/LensTest.scala
+++ b/tests/src/test/scala/scalaz/std/LensTest.scala
@@ -2,13 +2,13 @@ package scalaz
 package std
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 import org.scalacheck.{Gen, Arbitrary}
 import Lens.{lens => _, _}
 import Id._
 
-class LensTest extends Spec {
+class LensTest extends testlib.Spec {
 
   {
     implicit def lensArb = Arbitrary(Gen.value(Lens.lensId[Id, Int]))

--- a/tests/src/test/scala/scalaz/std/ListTest.scala
+++ b/tests/src/test/scala/scalaz/std/ListTest.scala
@@ -2,12 +2,12 @@ package scalaz
 package std
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary.NonEmptyListArbitrary
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary.NonEmptyListArbitrary
 import Id._
 import syntax.std._
 
-class ListTest extends Spec {
+class ListTest extends testlib.Spec {
   checkAll(equal.laws[List[Int]])
   checkAll(monoid.laws[List[Int]])
   checkAll(monadPlus.strongLaws[List])

--- a/tests/src/test/scala/scalaz/std/MapTest.scala
+++ b/tests/src/test/scala/scalaz/std/MapTest.scala
@@ -2,10 +2,10 @@ package scalaz
 package std
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
+import scalaz.testlib.ScalazProperties._
 import scala.math.{Ordering => SOrdering}
 
-class MapTest extends Spec {
+class MapTest extends testlib.Spec {
   "map ordering" ! prop {
     val O = implicitly[Order[Map[String,Int]]]
     val O2 = SOrdering.Iterable(implicitly[SOrdering[(String,Int)]])

--- a/tests/src/test/scala/scalaz/std/NodeSeqTest.scala
+++ b/tests/src/test/scala/scalaz/std/NodeSeqTest.scala
@@ -3,14 +3,14 @@ package std
 
 import std.nodeseq._
 import syntax.apply._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalaCheckBinding._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalaCheckBinding._
 import org.scalacheck.{ Gen, Arbitrary }
 import Id._
 
 import scala.xml.{ Node, NodeSeq, XML }
 
-class NodeSeqTest extends Spec {
+class NodeSeqTest extends testlib.Spec {
   {
     val validStr = """[a-zA-Z]+""".r
     val strFilter = (s: String) ⇒ validStr.pattern.matcher(s).matches

--- a/tests/src/test/scala/scalaz/std/OptionTest.scala
+++ b/tests/src/test/scala/scalaz/std/OptionTest.scala
@@ -2,12 +2,12 @@ package scalaz
 package std
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 import Tags._
 import org.scalacheck.Prop._
 
-class OptionTest extends Spec {
+class OptionTest extends testlib.Spec {
 
   checkAll("Option", order.laws[Option[Int]])
   checkAll("Option @@ First", order.laws[Option[Int] @@ First])

--- a/tests/src/test/scala/scalaz/std/SetTest.scala
+++ b/tests/src/test/scala/scalaz/std/SetTest.scala
@@ -2,10 +2,10 @@ package scalaz
 package std
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
+import scalaz.testlib.ScalazProperties._
 import org.scalacheck.Prop.forAll
 
-class SetTest extends Spec {
+class SetTest extends testlib.Spec {
   checkAll(equal.laws[Set[Int]])
   checkAll(monadPlus.strongLaws[Option])
   checkAll(traverse.laws[Option])

--- a/tests/src/test/scala/scalaz/std/StreamTest.scala
+++ b/tests/src/test/scala/scalaz/std/StreamTest.scala
@@ -2,9 +2,9 @@ package scalaz
 package std
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
+import scalaz.testlib.ScalazProperties._
 
-class StreamTest extends Spec {
+class StreamTest extends testlib.Spec {
   checkAll(equal.laws[Stream[Int]])
   checkAll(monoid.laws[Stream[Int]])
   checkAll(monadPlus.strongLaws[Stream])

--- a/tests/src/test/scala/scalaz/std/StringTest.scala
+++ b/tests/src/test/scala/scalaz/std/StringTest.scala
@@ -2,9 +2,9 @@ package scalaz
 package std
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
+import scalaz.testlib.ScalazProperties._
 
-class StringTest extends Spec {
+class StringTest extends testlib.Spec {
   checkAll(monoid.laws[String])
 
   checkAll(order.laws[String].withProp("benchmark", order.scalaOrdering[String]))

--- a/tests/src/test/scala/scalaz/std/TupleTest.scala
+++ b/tests/src/test/scala/scalaz/std/TupleTest.scala
@@ -2,10 +2,10 @@ package scalaz
 package std
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 
-class TupleTest extends Spec {
+class TupleTest extends testlib.Spec {
 
   type A = Int
   type B = Int

--- a/tests/src/test/scala/scalaz/std/java/math/BigIntegerTest.scala
+++ b/tests/src/test/scala/scalaz/std/java/math/BigIntegerTest.scala
@@ -5,11 +5,11 @@ package math
 
 import _root_.java.math.BigInteger
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 import Tags._
 
-class BigIntegerTest extends Spec {
+class BigIntegerTest extends testlib.Spec {
   checkAll("BigInteger", order.laws[BigInteger])
   checkAll("BigInteger @@ Multiplication", order.laws[BigInteger @@ Multiplication])
   checkAll("BigInteger", group.laws[BigInteger])

--- a/tests/src/test/scala/scalaz/std/java/util/concurrent/CallableTest.scala
+++ b/tests/src/test/scala/scalaz/std/java/util/concurrent/CallableTest.scala
@@ -6,9 +6,9 @@ package concurrent
 
 import _root_.java.util.concurrent.Callable
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 
-class CallableTest extends Spec {
+class CallableTest extends testlib.Spec {
   checkAll("Callable", equal.laws[Callable[Int]])
 }

--- a/tests/src/test/scala/scalaz/std/math/BigIntTest.scala
+++ b/tests/src/test/scala/scalaz/std/math/BigIntTest.scala
@@ -3,11 +3,11 @@ package std
 package math
 
 import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalazArbitrary._
 import Tags._
 
-class BigIntTest extends Spec {
+class BigIntTest extends testlib.Spec {
   checkAll("BigInt", order.laws[BigInt])
   checkAll("BigInt @@ Multiplication", order.laws[BigInt @@ Multiplication])
 

--- a/tests/src/test/scala/scalaz/typelevel/CompositionTest.scala
+++ b/tests/src/test/scala/scalaz/typelevel/CompositionTest.scala
@@ -2,11 +2,11 @@ package scalaz
 package typelevel
 
 import scalaz.std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalaCheckBinding._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalaCheckBinding._
 import org.scalacheck.Arbitrary
 
-class CompositionTest extends Spec {
+class CompositionTest extends testlib.Spec {
 
   import syntax.typelevel.all._
 

--- a/tests/src/test/scala/scalaz/typelevel/ProductTest.scala
+++ b/tests/src/test/scala/scalaz/typelevel/ProductTest.scala
@@ -2,11 +2,11 @@ package scalaz
 package typelevel
 
 import scalaz.std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalaCheckBinding._
+import scalaz.testlib.ScalazProperties._
+import scalaz.testlib.ScalaCheckBinding._
 import org.scalacheck.Arbitrary
 
-class ProductTest extends Spec {
+class ProductTest extends testlib.Spec {
 
   import syntax.typelevel.all._
 


### PR DESCRIPTION
- rename `scalacheck-binding` to `testlib`
- move our usual `Spec` to the new `testlib`

This way, other projects can depend on "org.scalaz" % "scalaz-testlib" and
test their own instances the same way it is done in scalaz:

``` scala
object TryTest extends Spec {

  // check properties of your own instances
  checkAll(monad.laws[scala.util.Try])

}
```

As a side note, I also disabled publishing for `scalaz-tests`, since it doesn't contain any source files at all.
