### PR TITLE
Make the \/ constructors public constructors so that -\/ and \/- can be ...

### DIFF
--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -266,8 +266,8 @@ sealed trait \/[+A, +B] {
 
 
 }
-private case class -\/[+A](a: A) extends (A \/ Nothing)
-private case class \/-[+B](b: B) extends (Nothing \/ B)
+case class -\/[+A](a: A) extends (A \/ Nothing)
+case class \/-[+B](b: B) extends (Nothing \/ B)
 
 object \/ extends DisjunctionInstances with DisjunctionFunctions {
 


### PR DESCRIPTION
...used in pattern matching.

I understand that you should always be able to get by with fold instead of using pattern matching, but I have several places where I'm already pattern matching on something containing the disjunction, and being able to use -\/ or \/- in the pattern leads to more readable code.

I think that it is ironic that internally we are pattern matching on these all over Either.scala instead of using fold.
