### PR TITLE
fix Heap#toUnsortedList.

### DIFF
--- a/core/src/main/scala/scalaz/Heap.scala
+++ b/core/src/main/scala/scalaz/Heap.scala
@@ -70,7 +70,7 @@ sealed trait Heap[A] {
 
   def toUnsortedStream: Stream[A] = fold(Stream(), (_, _, t) => t.flatten.map(_.value))
 
-  def toUnsortedList: List[A] = toStream.toList
+  def toUnsortedList: List[A] = toUnsortedStream.toList
 
   def toStream: Stream[A] =
     std.stream.unfold(this)(_.uncons)


### PR DESCRIPTION
Previous implementation is so slow. Because it returns **sorted** List in spite of `toUnsortedList`.
