### PR TITLE
Use sbt-extras directly from Travis CI default environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: scala
 scala:
+  - 2.10.0
   - 2.9.2
+  - 2.9.1
+  - 2.8.1
 jdk:
   - oraclejdk7
 
-install: /bin/true
-script: ./sbt -J-Xss1M -J-Xms512M -J-Xmx1000M -J-XX:MaxPermSize=128M ++$TRAVIS_SCALA_VERSION ";clean;compile;test"


### PR DESCRIPTION
Travis CI recently adopted sbt-extras, as default `sbt` command. You can thus speed up a little the scalaz build and get rid of own sbt-extras setup. Travis team will do his best to keep its default sbt/scala tools up to date...

BTW, I propose you to build against the whole Scala matrix supported by Scalaz (second commit).
