### PR TITLE
Order for NonEmptyList

### DIFF
--- a/core/src/main/scala/scalaz/NonEmptyList.scala
+++ b/core/src/main/scala/scalaz/NonEmptyList.scala
@@ -104,7 +104,11 @@ object NonEmptyList extends NonEmptyListFunctions with NonEmptyListInstances {
     Some((v.head, v.tail))
 }
 
-trait NonEmptyListInstances {
+trait NonEmptyListInstances0 {
+  implicit def nonEmptyListEqual[A: Equal]: Equal[NonEmptyList[A]] = Equal.equalBy[NonEmptyList[A], List[A]](_.list)(std.list.listEqual[A])
+}
+
+trait NonEmptyListInstances extends NonEmptyListInstances0 {
   implicit val nonEmptyList =
     new Traverse1[NonEmptyList] with Monad[NonEmptyList] with Plus[NonEmptyList] with Comonad[NonEmptyList] with Cobind.FromCojoin[NonEmptyList] with Each[NonEmptyList] with Zip[NonEmptyList] with Unzip[NonEmptyList] with Length[NonEmptyList] {
       def traverse1Impl[G[_] : Apply, A, B](fa: NonEmptyList[A])(f: A => G[B]): G[NonEmptyList[B]] =
@@ -148,7 +152,8 @@ trait NonEmptyListInstances {
     override def show(fa: NonEmptyList[A]) = Show[List[A]].show(fa.list)
   }
 
-  implicit def nonEmptyListEqual[A: Equal]: Equal[NonEmptyList[A]] = Equal.equalBy[NonEmptyList[A], List[A]](_.list)(std.list.listEqual[A])
+  implicit def nonEmptyListOrder[A: Order]: Order[NonEmptyList[A]] =
+    Order.orderBy[NonEmptyList[A], List[A]](_.list)(std.list.listOrder[A])
 }
 
 trait NonEmptyListFunctions {

--- a/tests/src/test/scala/scalaz/NonEmptyListTest.scala
+++ b/tests/src/test/scala/scalaz/NonEmptyListTest.scala
@@ -9,6 +9,7 @@ class NonEmptyListTest extends Spec {
   checkAll("NonEmptyList", plus.laws[NonEmptyList])
   checkAll("NonEmptyList", semigroup.laws[NonEmptyList[Int]])
   checkAll("NonEmptyList", equal.laws[NonEmptyList[Int]])
+  checkAll("NonEmptyList", order.laws[NonEmptyList[Int]])
   checkAll("NonEmptyList", traverse.laws[NonEmptyList])
   checkAll("NonEmptyList", comonad.laws[NonEmptyList])
 


### PR DESCRIPTION
With mild reformatting:

``` scala
scala> :paste
// Entering paste mode (ctrl-D to finish)

import scalaz.{Equal, NonEmptyList, Order}
def pickeo[A, B] = {
  implicit def ea: Equal[A] = null
  implicit def ob: Order[B] = null
  (Equal[NonEmptyList[A]],
   Equal[NonEmptyList[B]],
   Order[NonEmptyList[B]])
}

// Exiting paste mode, now interpreting.

import scalaz.{Equal, NonEmptyList, Order}
pickeo: [A, B]=> (scalaz.Equal[scalaz.NonEmptyList[A]],
                  scalaz.Equal[scalaz.NonEmptyList[B]],
                  scalaz.Order[scalaz.NonEmptyList[B]])

scala> pickeo[Int, String]
res0: (scalaz.Equal[scalaz.NonEmptyList[Int]],
       scalaz.Equal[scalaz.NonEmptyList[String]],
       scalaz.Order[scalaz.NonEmptyList[String]]) =
  (scalaz.Equal$$anon$2@2c0b32bc,
   scalaz.Order$$anon$5@132feb3b,
   scalaz.Order$$anon$5@2efc7854)
```
