### PR TITLE
Travis CI: Add OpenJDK 7 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ scala:
   - 2.8.1
 jdk:
   - oraclejdk7
-
+  - openjdk7


### PR DESCRIPTION
Note: There seem to give problems with OpenJDK6. Are you still interested in JDK6 support, even after OracleJDK6 EOL in late 2012?
