### PR TITLE
Travis CI: Extend the build matrix for Scalaz Seven branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: scala
 scala:
+  - 2.10.0
   - 2.9.2
 jdk:
   - oraclejdk7
-
-install: /bin/true
-script: ./sbt -J-Xss1M -J-Xms512M -J-Xmx1000M -J-XX:MaxPermSize=128M ++$TRAVIS_SCALA_VERSION ";clean;compile;test"
+  - openjdk7


### PR DESCRIPTION
Travis CI has introduced new 64-bit infrastructure for JVM builds:

I got following results:
- 2.10.0 fails (with both JDK7) when `;compile;test` targets are coupled: https://travis-ci.org/gildegoma/scalaz/builds/4095250
- the whole build matrix passes when I split `compile` and `test` in two processes: https://travis-ci.org/gildegoma/scalaz/builds/4101184

Is the second way to build a correct practice, or should we tune JVM args, to get the default build style to pass as well ?
