### PR TITLE
Specialize foldLeft for NonEmptyList; foldLeft/foldLeft1 for Tree.

### DIFF
--- a/core/src/main/scala/scalaz/NonEmptyList.scala
+++ b/core/src/main/scala/scalaz/NonEmptyList.scala
@@ -124,6 +124,10 @@ trait NonEmptyListInstances extends NonEmptyListInstances0 {
         case h :: t => foldLeft1(NonEmptyList.nel(f(fa.head, h), t))(f)
       }
 
+      // would otherwise use traverse1Impl
+      override def foldLeft[A, B](fa: NonEmptyList[A], z: B)(f: (B, A) => B): B =
+        fa.tail.foldLeft(f(z, fa.head))(f)
+
       def bind[A, B](fa: NonEmptyList[A])(f: (A) => NonEmptyList[B]): NonEmptyList[B] = fa flatMap f
 
       def point[A](a: => A): NonEmptyList[A] = NonEmptyList(a)

--- a/core/src/main/scala/scalaz/Tree.scala
+++ b/core/src/main/scala/scalaz/Tree.scala
@@ -125,6 +125,11 @@ trait TreeInstances {
     def traverse1Impl[G[_]: Apply, A, B](fa: Tree[A])(f: (A) => G[B]): G[Tree[B]] = fa traverse1 f
     override def foldRight[A, B](fa: Tree[A], z: => B)(f: (A, => B) => B): B = fa.foldRight(z)(f)
     override def foldRight1[A](fa: Tree[A])(f: (A, => A) => A): A = fa.subForest.foldRight(fa.rootLabel)((t, a) => treeInstance.foldRight(t, a)(f))
+    override def foldLeft[A, B](fa: Tree[A], z: B)(f: (B, A) => B): B =
+      fa.flatten.foldLeft(z)(f)
+    override def foldLeft1[A](fa: Tree[A])(f: (A, A) => A): A = fa.flatten match {
+      case h #:: t => t.foldLeft(h)(f)
+    }
     override def foldMap[A, B](fa: Tree[A])(f: (A) => B)(implicit F: Monoid[B]): B = fa foldMap f
   }
 


### PR DESCRIPTION
While NEL provides a specialized `foldLeft1`, the derived `foldLeft` doesn't use this.  Here we specialize the `foldLeft`/`foldLeft1` for both `Traverse1` instances.
