### PR TITLE
Arrow.contravariantInstance; Arrow[A, B] <: Split[A, B] (?)

### DIFF
--- a/core/src/main/scala/scalaz/Arrow.scala
+++ b/core/src/main/scala/scalaz/Arrow.scala
@@ -9,7 +9,7 @@ package scalaz
  * functions.
  */
 ////
-trait Arrow[=>:[_, _]] extends Category[=>:] { self =>
+trait Arrow[=>:[_, _]] extends Category[=>:] with Split[=>:] { self =>
   ////
 
   /** Lift an ordinary function. */
@@ -49,9 +49,13 @@ trait Arrow[=>:[_, _]] extends Category[=>:] { self =>
     >>>(<<<(first[A, B, C](f), swap), swap)
   }
 
-  /** Run `fab` and `fcd` alongside each other.  Sometimes `***`. */
+  /** Alias for `split`. */
   def splitA[A, B, C, D](fab: (A =>: B), fcd: (C =>: D)): ((A, C) =>: (B, D)) =
-      >>>(first[A, B, C](fab), second[C, D, B](fcd))
+    split(fab, fcd)
+
+  /** Run `fab` and `fcd` alongside each other.  Sometimes `***`. */
+  def split[A, B, C, D](f: A =>: B, g: C =>: D): ((A,  C) =>: (B, D)) =
+    >>>(first[A, B, C](f), second[C, D, B](g))
 
   /** Run two `fab`s alongside each other. */
   def product[A, B](fab: (A =>: B)): ((A, A) =>: (B, B)) =

--- a/core/src/main/scala/scalaz/Kleisli.scala
+++ b/core/src/main/scala/scalaz/Kleisli.scala
@@ -235,7 +235,6 @@ private[scalaz] trait KleisliMonadPlus[F[+_], R] extends MonadPlus[({type λ[α]
 
 private[scalaz] trait KleisliArrow[F[+_]]
   extends Arrow[({type λ[α, β] = Kleisli[F, α, β]})#λ]
-  with Split[({type λ[α, β] = Kleisli[F, α, β]})#λ]
   with Choice[({type λ[α, β] = Kleisli[F, α, β]})#λ] {
 
   implicit def F: Monad[F]
@@ -256,7 +255,7 @@ private[scalaz] trait KleisliArrow[F[+_]]
       case \/-(b) => g run b
     }
 
-  def split[A, B, C, D](f: Kleisli[F, A, B], g: Kleisli[F, C, D]): Kleisli[F, (A, C), (B, D)] =
+  override def split[A, B, C, D](f: Kleisli[F, A, B], g: Kleisli[F, C, D]): Kleisli[F, (A, C), (B, D)] =
     Kleisli {
       case (a, c) =>
         F.bind(f run a)(b => F.map(g run c)(d => (b, d)))

--- a/core/src/main/scala/scalaz/std/Function.scala
+++ b/core/src/main/scala/scalaz/std/Function.scala
@@ -46,7 +46,7 @@ trait FunctionInstances extends FunctionInstances0 {
     def equal(a1: () => R, a2: () => R) = Equal[R].equal(a1(), a2())
   }
 
-  implicit def function1Instance = new Arrow[Function1] with Category[Function1] with Choice[Function1] with Split[Function1] {
+  implicit def function1Instance = new Arrow[Function1] with Category[Function1] with Choice[Function1] {
     def arr[A, B](f: A => B) = f
 
     def first[A, B, C](a: A => B) =(ac: (A, C)) => (a(ac._1), ac._2)
@@ -60,7 +60,7 @@ trait FunctionInstances extends FunctionInstances0 {
       case \/-(b) => g(b)
     }
     
-    def split[A, B, C, D](f: A => B, g: C => D): ((A,  C)) => (B, D) = {
+    override def split[A, B, C, D](f: A => B, g: C => D): ((A,  C)) => (B, D) = {
       case (a, c) => (f(a), g(c))
     }
     

--- a/core/src/main/scala/scalaz/std/PartialFunction.scala
+++ b/core/src/main/scala/scalaz/std/PartialFunction.scala
@@ -2,7 +2,7 @@ package scalaz
 package std
 
 trait PartialFunctionInstances {
-  implicit val partialFunctionInstance = new Arrow[PartialFunction] with Category[PartialFunction] with Choice[PartialFunction] with Split[PartialFunction] {
+  implicit val partialFunctionInstance = new Arrow[PartialFunction] with Category[PartialFunction] with Choice[PartialFunction] {
     def arr[A, B](f: (A) => B) = {
       case a => f(a)
     }
@@ -20,7 +20,7 @@ trait PartialFunctionInstances {
       case \/-(b) => g(b)
     }
     
-    def split[A, B, C, D](f: PartialFunction[A, B], g: PartialFunction[C, D]): PartialFunction[(A,  C), (B, D)] = {
+    override def split[A, B, C, D](f: PartialFunction[A, B], g: PartialFunction[C, D]): PartialFunction[(A,  C), (B, D)] = {
       case (a, c) => (f(a), g(c))
     }
                     

--- a/core/src/main/scala/scalaz/syntax/ArrowSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/ArrowSyntax.scala
@@ -35,7 +35,7 @@ trait ToArrowOps0 {
   
 }
 
-trait ToArrowOps extends ToArrowOps0 with ToCategoryOps {
+trait ToArrowOps extends ToArrowOps0 with ToCategoryOps with ToSplitOps {
   
   implicit def ToArrowOps[F[_, _],A, B](v: F[A, B])(implicit F0: Arrow[F]) =
       new ArrowOps[F,A, B] { def self = v; implicit def F: Arrow[F] = F0 }
@@ -46,7 +46,7 @@ trait ToArrowOps extends ToArrowOps0 with ToCategoryOps {
   ////
 }
 
-trait ArrowSyntax[F[_, _]] extends CategorySyntax[F] {
+trait ArrowSyntax[F[_, _]] extends CategorySyntax[F] with SplitSyntax[F] {
   implicit def ToArrowOps[A, B](v: F[A, B]): ArrowOps[F, A, B] = new ArrowOps[F, A, B] { def self = v; implicit def F: Arrow[F] = ArrowSyntax.this.F }
 
   def F: Arrow[F]

--- a/project/GenTypeClass.scala
+++ b/project/GenTypeClass.scala
@@ -62,7 +62,7 @@ object TypeClass {
   lazy val choice = TypeClass("Choice", *^*->*, extendsList = Seq(category))
   lazy val split = TypeClass("Split", *^*->*, extendsList = Seq(category))
   lazy val first = TypeClass("First", *^*->*)
-  lazy val arrow = TypeClass("Arrow", *^*->*, extendsList = Seq(category))
+  lazy val arrow = TypeClass("Arrow", *^*->*, extendsList = Seq(category, split))
 
   lazy val liftIO = TypeClass("LiftIO", *->*, pack = Seq("scalaz", "effect"))
   lazy val monadIO = TypeClass("MonadIO", *->*, extendsList = Seq(liftIO, monad), pack = Seq("scalaz", "effect"))


### PR DESCRIPTION
We had `Arrow.covariantInstance`, and I said in #249 that arrow had a contravariant instance too, so here it is.

Also I put `Split` above `Arrow` in the hierarchy.  That seems to have been the intended meaning of 7326546f355beb313dbdfaf11e7018511b88bbe8; if not, let me know.
