### PR TITLE
Fix #266 and a similar problem in partitionM

### DIFF
--- a/core/src/main/scala/scalaz/std/IndexedSeq.scala
+++ b/core/src/main/scala/scalaz/std/IndexedSeq.scala
@@ -161,7 +161,7 @@ trait IndexedSeqSubFunctions extends IndexedSeqSub {
   /** A pair of passing and failing values of `as` against `p`. */
   final def partitionM[A, M[_] : Monad](as: IxSq[A])(p: A => M[Boolean]): M[(IxSq[A], IxSq[A])] =
     lazyFoldRight(as, Monad[M].point(empty[A], empty[A]))((a, g) =>
-      Monad[M].bind(p(as.head))(b =>
+      Monad[M].bind(p(a))(b =>
         Monad[M].map(g) {
           case (x, y) => if (b) (a +: x, y) else (x, a +: y)
         }

--- a/tests/src/test/scala/scalaz/std/IndexedSeqTest.scala
+++ b/tests/src/test/scala/scalaz/std/IndexedSeqTest.scala
@@ -57,6 +57,14 @@ class IndexedSeqTest extends Spec {
                    .map(_.toIndexedSeq).toIndexedSeq))
   }
 
+  "partitionM" ! prop {
+    (xs: IndexedSeq[Int]) =>
+      val (evens, odds) = xs.partitionM[Id](evenp)
+      (evens.toSet & odds.toSet) must be_===(Set[Int]())
+      (evens.filter(evenp) ++
+       odds.filter(i => !evenp(i))).toSet must be_===(xs.toSet)
+  }
+
   "findM" ! prop {
     (xs: IndexedSeq[Int]) =>
       val i = xs indexWhere evenp


### PR DESCRIPTION
This restores the `lazyFoldRight` version of `spanM` (after a fashion), fixes the problem #266 with it, fixes a similar problem with `partitionM`, and tests the lot.

The issue was the `as` reference, which used to mean the current tail, but meant the whole seq after `lazyFoldRight` was added.  `partitionM` had its own offending `as` reference.
