### PR TITLE
Update deprecation message for <|*|> on ApplyOps

### DIFF
--- a/core/src/main/scala/scalaz/syntax/ApplySyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/ApplySyntax.scala
@@ -19,7 +19,7 @@ trait ApplyOps[F[_],A] extends Ops[F[A]] {
   final def <*[B](fb: F[B]): F[A] = F.apply2(self,fb)((a,_) => a)
 
   /** Combine `self` and `fb` according to `Apply[F]` with a function that constructs a `Tuple2[A, B]` */
-  @deprecated("Use `a <*> b` instead", "7")
+  @deprecated("Use `a tuple b` instead", "7")
   final def <|*|>[B](fb: F[B]): F[(A, B)] = F.tuple2(self,fb)
 
   @deprecated("Use `^(f1,f2..fN)((a,b,c) => ..)` instead", "7")


### PR DESCRIPTION
In 941225833, @pchiusano changed the meaning of the `<*>` operator to be the same as `<|*|>`, deprecating `<|*|>` in the process.

In 4e61f458, @eed3si9n reverted the change to `<*>`, but the deprecation message on `<|*|>` was not changed, so I believe it is now incorrect.
