### PR TITLE
Set is not a Functor

### DIFF
--- a/core/src/main/scala/scalaz/Foldable.scala
+++ b/core/src/main/scala/scalaz/Foldable.scala
@@ -28,10 +28,6 @@ trait Foldable[F[_]]  { self =>
     implicit def G = G0
   }
 
-  //  /**Right-associative fold of a structure. */
-//  def foldRight[A, B](fa: F[A], z: => B)(f: (A, => B) => B): B =
-//    foldMap(fa)((a: A) => (Endo.endo(f.curried(a)(_: B)))) apply z
-
   /**Left-associative fold of a structure. */
   def foldLeft[A, B](fa: F[A], z: B)(f: (B, A) => B): B = {
     import Dual._, Endo._, syntax.std.all._

--- a/core/src/main/scala/scalaz/std/Set.scala
+++ b/core/src/main/scala/scalaz/std/Set.scala
@@ -2,24 +2,14 @@ package scalaz
 package std
 
 trait SetInstances {
-  implicit val setInstance = new Traverse[Set] with MonadPlus[Set] with Each[Set] with Length[Set] with IsEmpty[Set] {
+  implicit val setInstance: Foldable[Set] with IsEmpty[Set] with Length[Set] = new Foldable[Set] with IsEmpty[Set] with Length[Set] with Foldable.FromFoldr[Set] {
     def each[A](fa: Set[A])(f: A => Unit) = fa foreach f
     def length[A](fa: Set[A]) = fa.size
-    def point[A](a: => A) = Set(a)
-    def bind[A, B](fa: Set[A])(f: A => Set[B]) = fa flatMap f
     def empty[A] = Set()
     def plus[A](a: Set[A], b: => Set[A]) = a ++ b
     def isEmpty[A](fa: Set[A]) = fa.isEmpty
-    override def map[A, B](l: Set[A])(f: A => B) = l map f
 
-    // TODO duplication with ListInstances
-    def traverseImpl[F[_], A, B](l: Set[A])(f: A => F[B])(implicit F: Applicative[F]) = {
-      DList.fromList(l.toList).foldr(F.point(Set[B]())) {
-        (a, fbs) => F.apply2(f(a), fbs)((a, b) => b + a)
-      }
-    }
-
-    override def foldRight[A, B](fa: Set[A], z: => B)(f: (A, => B) => B) = {
+    def foldRight[A, B](fa: Set[A], z: => B)(f: (A, => B) => B) = {
       import scala.collection.mutable.ArrayStack
       val s = new ArrayStack[A]
       fa.foreach(a => s += a)

--- a/tests/src/test/scala/scalaz/std/SetTest.scala
+++ b/tests/src/test/scala/scalaz/std/SetTest.scala
@@ -8,7 +8,5 @@ import org.scalacheck.Prop.forAll
 class SetTest extends Spec {
   checkAll(order.laws[Set[Int]])
   checkAll(monoid.laws[Set[Int]])
-  checkAll(monadPlus.strongLaws[Set])
-  checkAll(traverse.laws[Set])
   checkAll(isEmpty.laws[Set])
 }


### PR DESCRIPTION
This commit removes the `Functor` instance for `Set` (which implies removal of `MonadPlus`, `Traversable`, ... instances).

I am not actually sure whether `Set` is also a reasonable `Foldable`, since it doesn't even have a sensible order. In Haskell, only `Data.Set.Set` (corresponds to `immutable.TreeSet`) is a `Foldable`. Maybe we should do the same thing.
