### PR TITLE
remove instances for Nothing

### DIFF
--- a/core/src/main/scala/scalaz/std/AnyVal.scala
+++ b/core/src/main/scala/scalaz/std/AnyVal.scala
@@ -32,25 +32,6 @@ trait AnyValInstances {
     override def equalIsNatural: Boolean = true
   }
 
-  implicit val nothingInstance: Semigroup[Nothing] with Show[Nothing] with Enum[Nothing] =
-    new Semigroup[Nothing] with Show[Nothing] with Enum[Nothing] {
-      override def shows(f: Nothing) = f.toString
-      def append(f1: Nothing, f2: => Nothing) = f1
-      def order(x: Nothing, y: Nothing) = Ordering.EQ
-      def succ(n: Nothing) = n
-      def pred(n: Nothing) = n
-
-      override def succn(a: Int, b: Nothing) = b
-
-      override def predn(a: Int, b: Nothing) = b
-
-      override def min = None
-
-      override def max = None
-
-      override def equalIsNatural: Boolean = true
-    }
-
   implicit object booleanInstance extends Enum[Boolean] with Show[Boolean] {
     override def shows(f: Boolean) = f.toString
 


### PR DESCRIPTION
This commit removes all instances for `Nothing`. In my opinion, they are not very useful, since the coding style for projects using scalaz usually eschews `Nothing` anyway.
