### PR TITLE
Minor syntax tidy-up

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Actor.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Actor.scala
@@ -23,7 +23,7 @@ final case class Actor[A](handler: A => Unit, onError: Throwable => Unit = throw
   private val suspended = new AtomicBoolean(true)
   private val mbox = new ConcurrentLinkedQueue[A]
 
-  val toEffect: Run[A] = Run[A]((a) => this ! a)
+  val toEffect: Run[A] = Run[A](a => this ! a)
 
   /** Alias for `apply` */
   def !(a: A) {
@@ -66,7 +66,7 @@ object Actor extends ActorFunctions with ActorInstances
 
 trait ActorInstances {
   implicit def actorContravariant: Contravariant[Actor] = new Contravariant[Actor] {
-    def contramap[A, B](r: Actor[A])(f: (B) => A): Actor[B] = r contramap f
+    def contramap[A, B](r: Actor[A])(f: B => A): Actor[B] = r contramap f
   }
 }
 

--- a/concurrent/src/main/scala/scalaz/concurrent/Promise.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Promise.scala
@@ -172,10 +172,10 @@ trait PromiseInstances {
     def cobind[A, B](fa: Promise[A])(f: (Promise[A]) => B): Promise[B] = promise(f(fa))
     def point[A](a: => A): Promise[A] = promise(a)
     def copoint[A](p: Promise[A]): A = p.get
-    def traverseImpl[G[_] : Applicative, A, B](fa: Promise[A])(f: (A) => G[B]): G[Promise[B]] =
+    def traverseImpl[G[_] : Applicative, A, B](fa: Promise[A])(f: A => G[B]): G[Promise[B]] =
       Applicative[G].map(f(fa.get))(promise(_: B)(fa.strategy))
     override def foldRight[A, B](fa: Promise[A], z: => B)(f: (A, => B) => B): B = f(fa.get, z)
-    def bind[A, B](fa: Promise[A])(f: (A) => Promise[B]): Promise[B] = fa flatMap f
+    def bind[A, B](fa: Promise[A])(f: A => Promise[B]): Promise[B] = fa flatMap f
   }
 }
 

--- a/concurrent/src/main/scala/scalaz/concurrent/Run.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Run.scala
@@ -26,7 +26,7 @@ object Run {
   implicit def RunFrom[A](e: Run[A]): A => Unit = e.run _
 
   implicit val runContravariant = new Contravariant[Run] {
-    def contramap[A, B](r: Run[A])(f: (B) => A): Run[B] = new Run[B] {
+    def contramap[A, B](r: Run[A])(f: B => A): Run[B] = new Run[B] {
 
       def strategy: Strategy = r.strategy
 

--- a/core/src/main/scala/scalaz/Arrow.scala
+++ b/core/src/main/scala/scalaz/Arrow.scala
@@ -22,7 +22,7 @@ trait Arrow[=>:[_, _]] extends Category[=>:] with Split[=>:] { self =>
     new Applicative[({type λ[α] = (C =>: α)})#λ] {
       def point[A](a: => A): C =>: A = arr(_ => a)
       def ap[A, B](fa: => (C =>: A))(f: => (C =>: (A => B))): (C =>: B) = <<<(arr((y: (A => B, A)) => y._1(y._2)), combine(f, fa))
-      override def map[A, B](fa: (C =>: A))(f: (A) => B): (C =>: B) =
+      override def map[A, B](fa: (C =>: A))(f: A => B): (C =>: B) =
 	<<<(arr(f), fa)
     }
 

--- a/core/src/main/scala/scalaz/BKTree.scala
+++ b/core/src/main/scala/scalaz/BKTree.scala
@@ -187,7 +187,7 @@ trait BKTreeFunctions {
 
 trait BKTreeInstances {
   implicit def bKTreeInstance: Functor[BKTree] with Length[BKTree] = new Functor[BKTree] with Length[BKTree] {
-    def map[A, B](fa: BKTree[A])(f: (A) => B): BKTree[B] = fa map f
+    def map[A, B](fa: BKTree[A])(f: A => B): BKTree[B] = fa map f
     def length[A](fa: BKTree[A]): Int = fa.size
   }
   implicit def bKTreeMonoid[A: MetricSpace]: Monoid[BKTree[A]] = new Monoid[BKTree[A]] {

--- a/core/src/main/scala/scalaz/Bitraverse.scala
+++ b/core/src/main/scala/scalaz/Bitraverse.scala
@@ -33,7 +33,7 @@ trait Bitraverse[F[_, _]] extends Bifunctor[F] with Bifoldable[F] { self =>
   def bitraverseF[G[_] : Applicative, A, B, C, D](f: A => G[C], g: B => G[D]): F[A, B] => G[F[C, D]] =
     bitraverseImpl(_)(f, g)
 
-  def bimap[A, B, C, D](fab: F[A, B])(f: (A) => C, g: (B) => D): F[C, D] = {
+  def bimap[A, B, C, D](fab: F[A, B])(f: A => C, g: B => D): F[C, D] = {
     bitraverseImpl[Id, A, B, C, D](fab)(f, g)
   }
 

--- a/core/src/main/scala/scalaz/Cofree.scala
+++ b/core/src/main/scala/scalaz/Cofree.scala
@@ -88,7 +88,7 @@ private[scalaz] trait CofreeComonad[S[+_]] extends Comonad[({type f[x] = Cofree[
 
   def cojoin[A](a: Cofree[S, A]) = a.duplicate
 
-  def map[A, B](fa: Cofree[S, A])(f: (A) => B) = fa map f
+  def map[A, B](fa: Cofree[S, A])(f: A => B) = fa map f
 
   def cobind[A, B](fa: Cofree[S, A])(f: (Cofree[S, A]) => B) = fa extend f
 }

--- a/core/src/main/scala/scalaz/Cokleisli.scala
+++ b/core/src/main/scala/scalaz/Cokleisli.scala
@@ -61,9 +61,9 @@ trait CokleisliFunctions {
 }
 
 private[scalaz] trait CokleisliMonad[F[_], R] extends Monad[({type λ[α] = Cokleisli[F, R, α]})#λ] {
-  override def ap[A, B](fa: => Cokleisli[F, R, A])(f: => Cokleisli[F, R, (A) => B]) = f flatMap (fa map _)
+  override def ap[A, B](fa: => Cokleisli[F, R, A])(f: => Cokleisli[F, R, A => B]) = f flatMap (fa map _)
   def point[A](a: => A) = Cokleisli(_ => a)
-  def bind[A, B](fa: Cokleisli[F, R, A])(f: (A) => Cokleisli[F, R, B]) = fa flatMap f
+  def bind[A, B](fa: Cokleisli[F, R, A])(f: A => Cokleisli[F, R, B]) = fa flatMap f
 }
 
 private[scalaz] trait CokleisliCompose[F[_]] extends Compose[({type λ[α, β] = Cokleisli[F, α, β]})#λ] {
@@ -79,7 +79,7 @@ private[scalaz] trait CokleisliArrow[F[_]]
 
   implicit def F: Comonad[F]
 
-  def arr[A, B](f: (A) => B) = Cokleisli(a => f(F.copoint(a)))
+  def arr[A, B](f: A => B) = Cokleisli(a => f(F.copoint(a)))
   def id[A] = Cokleisli(F.copoint)
 
   def first[A, B, C](f: Cokleisli[F, A, B]) =

--- a/core/src/main/scala/scalaz/Composition.scala
+++ b/core/src/main/scala/scalaz/Composition.scala
@@ -5,7 +5,7 @@ private[scalaz] trait CompositionFunctor[F[_], G[_]] extends Functor[({type λ[�
 
   implicit def G: Functor[G]
 
-  override def map[A, B](fga: F[G[A]])(f: (A) => B): F[G[B]] = F(fga)(ga => G(ga)(f))
+  override def map[A, B](fga: F[G[A]])(f: A => B): F[G[B]] = F(fga)(ga => G(ga)(f))
 }
 
 private[scalaz] trait CompositionApply[F[_], G[_]] extends Apply[({type λ[α] = F[G[α]]})#λ] with CompositionFunctor[F, G] {

--- a/core/src/main/scala/scalaz/Endo.scala
+++ b/core/src/main/scala/scalaz/Endo.scala
@@ -60,12 +60,12 @@ trait EndoFunctions {
   import Isomorphism.{IsoSet, IsoFunctorTemplate}
 
   implicit def IsoEndo[A] = new IsoSet[Endo[A], A => A] {
-    def to: (Endo[A]) => (A) => A = _.run
-    def from: ((A) => A) => Endo[A] = endo
+    def to: (Endo[A]) => A => A = _.run
+    def from: (A => A) => Endo[A] = endo
   }
 
   implicit def IsoFunctorEndo = new IsoFunctorTemplate[Endo, ({type λ[α]=(α => α)})#λ] {
-    def to[A](fa: Endo[A]): (A) => A = fa.run
-    def from[A](ga: (A) => A): Endo[A] = endo(ga)
+    def to[A](fa: Endo[A]): A => A = fa.run
+    def from[A](ga: A => A): Endo[A] = endo(ga)
   }
 }

--- a/core/src/main/scala/scalaz/EphemeralStream.scala
+++ b/core/src/main/scala/scalaz/EphemeralStream.scala
@@ -98,7 +98,7 @@ trait EphemeralStreamInstances {
   // TODO more instances
   implicit val ephemeralStreamInstance = new MonadPlus[EphemeralStream] with Zip[EphemeralStream] with Unzip[EphemeralStream] {
     def plus[A](a: EphemeralStream[A], b: => EphemeralStream[A]) = a ++ b
-    def bind[A, B](fa: EphemeralStream[A])(f: (A) => EphemeralStream[B]) = fa flatMap f
+    def bind[A, B](fa: EphemeralStream[A])(f: A => EphemeralStream[B]) = fa flatMap f
     def point[A](a: => A) = EphemeralStream(a)
     def empty[A] = EphemeralStream()
     def zip[A, B](a: => EphemeralStream[A], b: => EphemeralStream[B]) = a zip b

--- a/core/src/main/scala/scalaz/Equal.scala
+++ b/core/src/main/scala/scalaz/Equal.scala
@@ -54,7 +54,7 @@ object Equal {
   def equalBy[A, B: Equal](f: A => B): Equal[A] = Equal[B] contramap f
 
   def equalContravariant: Contravariant[Equal] = new Contravariant[Equal] {
-    def contramap[A, B](r: Equal[A])(f: (B) => A) = r.contramap(f)
+    def contramap[A, B](r: Equal[A])(f: B => A) = r.contramap(f)
   }
 
   def equal[A](f: (A, A) => Boolean): Equal[A] = new Equal[A] {

--- a/core/src/main/scala/scalaz/Foldable.scala
+++ b/core/src/main/scala/scalaz/Foldable.scala
@@ -224,7 +224,7 @@ object Foldable {
    * Example:
    * {{{
    * new Foldable[Option] with Foldable.FromFoldMap[Option] {
-   *   def foldMap[A, B](fa: Option[A])(f: (A) => B)(implicit F: Monoid[B]) = fa match {
+   *   def foldMap[A, B](fa: Option[A])(f: A => B)(implicit F: Monoid[B]) = fa match {
    *     case Some(a) => f(a)
    *     case None    => F.zero
    *   }
@@ -250,7 +250,7 @@ object Foldable {
    * }}}
    */
   trait FromFoldr[F[_]] extends Foldable[F] {
-    override def foldMap[A, B](fa: F[A])(f: (A) => B)(implicit F: Monoid[B]) =
+    override def foldMap[A, B](fa: F[A])(f: A => B)(implicit F: Monoid[B]) =
         foldr[A, B](fa, F.zero)( x => y => F.append(f(x),  y))
   }
 

--- a/core/src/main/scala/scalaz/Id.scala
+++ b/core/src/main/scala/scalaz/Id.scala
@@ -29,9 +29,9 @@ trait IdInstances {
 
       def cozip[A, B](a: Id[A \/ B]): (A \/ B) = a
 
-      def traverse1Impl[G[_] : Apply, A, B](fa: Id[A])(f: (A) => G[B]): G[Id[B]] = f(fa)
+      def traverse1Impl[G[_] : Apply, A, B](fa: Id[A])(f: A => G[B]): G[Id[B]] = f(fa)
 
-      def distributeImpl[G[_] : Functor, A, B](fa: G[A])(f: (A) => Id[B]): Id[G[B]] = Functor[G].map(fa)(f)
+      def distributeImpl[G[_] : Functor, A, B](fa: G[A])(f: A => Id[B]): Id[G[B]] = Functor[G].map(fa)(f)
 
       override def foldRight[A, B](fa: Id[A], z: => B)(f: (A, => B) => B): B = f(fa, z)
 
@@ -39,7 +39,7 @@ trait IdInstances {
 
       // Overrides for efficiency.
 
-      override def lift[A, B](f: (A) => B): Id[A] => Id[B] = f
+      override def lift[A, B](f: A => B): Id[A] => Id[B] = f
 
       // `ffa: Id[Id[A]]`, gives, "cyclic aliasing or subtyping involving type Id", but `ffa: A` is identical.
       override def join[A](ffa: A) = ffa
@@ -50,7 +50,7 @@ trait IdInstances {
 
       override def ap[A, B](fa: => Id[A])(f: => Id[A => B]): Id[B] = f(fa)
 
-      def each[A](fa: Id[A])(f: (A) => Unit) {
+      def each[A](fa: Id[A])(f: A => Unit) {
         f(fa)
       }
 

--- a/core/src/main/scala/scalaz/IdT.scala
+++ b/core/src/main/scala/scalaz/IdT.scala
@@ -17,7 +17,7 @@ final case class IdT[F[_], A](run: F[A]) {
     F.foldRight[A, Z](run, z)(f)
   }
 
-  def traverse[G[_], B](f: (A) => G[B])(implicit F: Traverse[F], G: Applicative[G]): G[IdT[F, B]] = {
+  def traverse[G[_], B](f: A => G[B])(implicit F: Traverse[F], G: Applicative[G]): G[IdT[F, B]] = {
     import std.option._
     G.map(F.traverse(run)(f))(IdT(_))
   }
@@ -103,7 +103,7 @@ private[scalaz] trait IdTFoldable[F[_]] extends Foldable.FromFoldr[({type λ[α]
 private[scalaz] trait IdTTraverse[F[_]] extends Traverse[({type λ[α] = IdT[F, α]})#λ] with IdTFoldable[F] with IdTFunctor[F]{
   implicit def F: Traverse[F]
 
-  def traverseImpl[G[_] : Applicative, A, B](fa: IdT[F, A])(f: (A) => G[B]): G[IdT[F, B]] = fa traverse f
+  def traverseImpl[G[_] : Applicative, A, B](fa: IdT[F, A])(f: A => G[B]): G[IdT[F, B]] = fa traverse f
 }
 
 private[scalaz] object IdTHoist extends Hoist[IdT] {

--- a/core/src/main/scala/scalaz/Isomorphism.scala
+++ b/core/src/main/scala/scalaz/Isomorphism.scala
@@ -167,7 +167,7 @@ trait IsomorphismEach[F[_], G[_]] extends Each[F] {
 
   def iso: F <~> G
 
-  def each[A](fa: F[A])(f: (A) => Unit) = G.each(iso.to(fa))(f)
+  def each[A](fa: F[A])(f: A => Unit) = G.each(iso.to(fa))(f)
 }
 
 trait IsomorphismIndex[F[_], G[_]] extends Index[F] {
@@ -197,7 +197,7 @@ trait IsomorphismContravariant[F[_], G[_]] extends Contravariant[F] {
 trait IsomorphismApply[F[_], G[_]] extends Apply[F] with IsomorphismFunctor[F, G] {
   implicit def G: Apply[G]
 
-  override def ap[A, B](fa: => F[A])(f: => F[(A) => B]): F[B] = iso.from(G.ap(iso.to(fa))(iso.to(f)))
+  override def ap[A, B](fa: => F[A])(f: => F[A => B]): F[B] = iso.from(G.ap(iso.to(fa))(iso.to(f)))
 }
 
 trait IsomorphismApplicative[F[_], G[_]] extends Applicative[F] with IsomorphismApply[F, G] {
@@ -205,7 +205,7 @@ trait IsomorphismApplicative[F[_], G[_]] extends Applicative[F] with Isomorphism
 
   def point[A](a: => A): F[A] = iso.from(G.point(a))
 
-  override def ap[A, B](fa: => F[A])(f: => F[(A) => B]): F[B] = iso.from(G.ap(iso.to(fa))(iso.to(f)))
+  override def ap[A, B](fa: => F[A])(f: => F[A => B]): F[B] = iso.from(G.ap(iso.to(fa))(iso.to(f)))
 }
 
 trait IsomorphismBind[F[_], G[_]] extends Bind[F] with IsomorphismApply[F, G] {
@@ -259,7 +259,7 @@ trait IsomorphismFoldable[F[_], G[_]] extends Foldable[F] {
 
   def iso: F <~> G
 
-  override def foldMap[A, B](fa: F[A])(f: (A) => B)(implicit F: Monoid[B]) = G.foldMap(iso.to(fa))(f)
+  override def foldMap[A, B](fa: F[A])(f: A => B)(implicit F: Monoid[B]) = G.foldMap(iso.to(fa))(f)
 
   override def foldLeft[A, B](fa: F[A], z: B)(f: (B, A) => B) = G.foldLeft(iso.to(fa), z)(f)
 
@@ -269,7 +269,7 @@ trait IsomorphismFoldable[F[_], G[_]] extends Foldable[F] {
 trait IsomorphismTraverse[F[_], G[_]] extends Traverse[F] with IsomorphismFoldable[F, G] with IsomorphismFunctor[F, G] {
   implicit def G: Traverse[G]
 
-  def traverseImpl[H[_] : Applicative, A, B](fa: F[A])(f: (A) => H[B]): H[F[B]] =
+  def traverseImpl[H[_] : Applicative, A, B](fa: F[A])(f: A => H[B]): H[F[B]] =
     Applicative[H].map(G.traverseImpl(iso.to(fa))(f))(iso.from.apply)
 }
 
@@ -278,13 +278,13 @@ trait IsomorphismBifunctor[F[_, _], G[_, _]] extends Bifunctor[F] {
 
   implicit def G: Bifunctor[G]
 
-  override def bimap[A, B, C, D](fab: F[A, B])(f: (A) => C, g: (B) => D): F[C, D] =
+  override def bimap[A, B, C, D](fab: F[A, B])(f: A => C, g: B => D): F[C, D] =
     iso.from(G.bimap(iso.to(fab))(f, g))
 }
 
 trait IsomorphismBitraverse[F[_, _], G[_, _]] extends Bitraverse[F] with IsomorphismBifunctor[F, G] {
   implicit def G: Bitraverse[G]
 
-  def bitraverseImpl[H[_]: Applicative, A, B, C, D](fab: F[A, B])(f: (A) => H[C], g: (B) => H[D]): H[F[C, D]] =
+  def bitraverseImpl[H[_]: Applicative, A, B, C, D](fab: F[A, B])(f: A => H[C], g: B => H[D]): H[F[C, D]] =
     Applicative[H].map(G.bitraverseImpl(iso.to(fab))(f, g))(iso.from.apply)
 }

--- a/core/src/main/scala/scalaz/Kleisli.scala
+++ b/core/src/main/scala/scalaz/Kleisli.scala
@@ -162,7 +162,7 @@ trait KleisliFunctions {
   /**Pure Kleisli arrow */
   def ask[M[+_] : Monad, A]: Kleisli[M, A, A] = kleisli(a => Monad[M].point(a))
 
-  def local[M[+_] : Monad, A, R](f: (R) => R)(fa: Kleisli[M, R, A]): Kleisli[M, R, A] = kleisli[M, R, A](r => fa.run(f(r)))
+  def local[M[+_] : Monad, A, R](f: R => R)(fa: Kleisli[M, R, A]): Kleisli[M, R, A] = kleisli[M, R, A](r => fa.run(f(r)))
 }
 
 object Kleisli extends KleisliFunctions with KleisliInstances {
@@ -187,7 +187,7 @@ private[scalaz] trait KleisliFunctor[F[+_], R] extends Functor[({type λ[α] = K
 
 private[scalaz] trait KleisliApply[F[+_], R] extends Apply[({type λ[α] = Kleisli[F, R, α]})#λ] with KleisliFunctor[F, R] {
   implicit def F: Apply[F]
-  override def ap[A, B](fa: => Kleisli[F, R, A])(f: => Kleisli[F, R, (A) => B]): Kleisli[F, R, B] = Kleisli[F, R, B](r => F.ap(fa(r))(f(r)))
+  override def ap[A, B](fa: => Kleisli[F, R, A])(f: => Kleisli[F, R, A => B]): Kleisli[F, R, B] = Kleisli[F, R, B](r => F.ap(fa(r))(f(r)))
 }
 
 private[scalaz] trait KleisliDistributive[F[+_], R] extends Distributive[({type λ[α] = Kleisli[F, R, α]})#λ] with KleisliFunctor[F, R] {
@@ -211,7 +211,7 @@ private[scalaz] trait KleisliMonadReader[F[+_], R] extends MonadReader[({type f[
   implicit def F: Monad[F]
 
   def ask: Kleisli[F, R, R] = Kleisli[F, R, R](r => F.point(r))
-  def local[A](f: (R) => R)(fa: Kleisli[F, R, A]): Kleisli[F, R, A] = Kleisli[F, R, A](r => fa.run(f(r)))
+  def local[A](f: R => R)(fa: Kleisli[F, R, A]): Kleisli[F, R, A] = Kleisli[F, R, A](r => fa.run(f(r)))
 }
 
 private[scalaz] trait KleisliHoist[R] extends Hoist[({type λ[α[+_], β] = Kleisli[α, R, β]})#λ] {
@@ -243,7 +243,7 @@ private[scalaz] trait KleisliArrow[F[+_]]
 
   def id[A]: Kleisli[F, A, A] = kleisli(a => F.point(a))
 
-  def arr[A, B](f: (A) => B): Kleisli[F, A, B] = kleisli(a => F.point(f(a)))
+  def arr[A, B](f: A => B): Kleisli[F, A, B] = kleisli(a => F.point(f(a)))
 
   def first[A, B, C](f: Kleisli[F, A, B]): Kleisli[F, (A, C), (B, C)] = kleisli[F, (A, C), (B, C)] {
     case (a, c) => F.map(f.run(a))((b: B) => (b, c))

--- a/core/src/main/scala/scalaz/LazyOption.scala
+++ b/core/src/main/scala/scalaz/LazyOption.scala
@@ -108,11 +108,11 @@ trait LazyOptionInstances {
   import LazyOption._
 
   implicit val lazyOptionInstance: Traverse[LazyOption] with MonadPlus[LazyOption] with Cozip[LazyOption] with Zip[LazyOption] with Unzip[LazyOption] = new Traverse[LazyOption] with MonadPlus[LazyOption] with Cozip[LazyOption] with Zip[LazyOption] with Unzip[LazyOption] {
-    def traverseImpl[G[_]: Applicative, A, B](fa: LazyOption[A])(f: (A) => G[B]): G[LazyOption[B]] =  fa traverse (a => f(a))
+    def traverseImpl[G[_]: Applicative, A, B](fa: LazyOption[A])(f: A => G[B]): G[LazyOption[B]] =  fa traverse (a => f(a))
     override def foldRight[A, B](fa: LazyOption[A], z: => B)(f: (A, => B) => B): B = fa.foldRight(z)(f)
     override def ap[A, B](fa: => LazyOption[A])(f: => LazyOption[A => B]): LazyOption[B] = fa ap f
     def plus[A](a: LazyOption[A], b: => LazyOption[A]): LazyOption[A] = a orElse b
-    def bind[A, B](fa: LazyOption[A])(f: (A) => LazyOption[B]): LazyOption[B] = fa flatMap (a => f(a))
+    def bind[A, B](fa: LazyOption[A])(f: A => LazyOption[B]): LazyOption[B] = fa flatMap (a => f(a))
     def point[A](a: => A): LazyOption[A] = lazySome(a)
     def empty[A]: LazyOption[A] = lazyNone
     def cozip[A, B](a: LazyOption[A \/ B]) =

--- a/core/src/main/scala/scalaz/LazyTuple.scala
+++ b/core/src/main/scala/scalaz/LazyTuple.scala
@@ -83,8 +83,8 @@ trait LazyTupleFunctions {
 
 trait LazyTuple2Instances1 {
   implicit def lazyTuple2Instance[A1, A2] = new Bitraverse[LazyTuple2] {
-    override def bimap[A, B, C, D](fab: LazyTuple2[A, B])(f: (A) => C, g: (B) => D): LazyTuple2[C, D] = LazyTuple.lazyTuple2(f(fab._1), g(fab._2))
-    def bitraverseImpl[G[_]: Applicative, A, B, C, D](fab: LazyTuple2[A, B])(f: (A) => G[C], g: (B) => G[D]): G[LazyTuple2[C, D]] = {
+    override def bimap[A, B, C, D](fab: LazyTuple2[A, B])(f: A => C, g: B => D): LazyTuple2[C, D] = LazyTuple.lazyTuple2(f(fab._1), g(fab._2))
+    def bitraverseImpl[G[_]: Applicative, A, B, C, D](fab: LazyTuple2[A, B])(f: A => G[C], g: B => G[D]): G[LazyTuple2[C, D]] = {
       Applicative[G].apply2(f(fab._1), g(fab._2))(LazyTuple.lazyTuple2(_, _))
     }
   }

--- a/core/src/main/scala/scalaz/MetricSpace.scala
+++ b/core/src/main/scala/scalaz/MetricSpace.scala
@@ -45,7 +45,7 @@ object MetricSpace {
 
   ////
   val metricSpaceInstance = new Contravariant[MetricSpace] {
-    def contramap[A, B](r: MetricSpace[A])(f: (B) => A): MetricSpace[B] = r contramap f
+    def contramap[A, B](r: MetricSpace[A])(f: B => A): MetricSpace[B] = r contramap f
   }
 
   def metricSpace[A](f: (A, A) => Int): MetricSpace[A] = new MetricSpace[A] {

--- a/core/src/main/scala/scalaz/Name.scala
+++ b/core/src/main/scala/scalaz/Name.scala
@@ -20,7 +20,7 @@ object Name {
   implicit val name = new Monad[Name] with Comonad[Name] with Cobind.FromCojoin[Name] with Distributive[Name] {
     def point[A](a: => A) = Name(a)
 
-    override def map[A, B](fa: Name[A])(f: (A) => B) = Name(f(fa.value))
+    override def map[A, B](fa: Name[A])(f: A => B) = Name(f(fa.value))
     override def ap[A, B](fa: => Name[A])(f: => Name[A => B]) =
       Name(f.value apply fa.value)
     def bind[A,B](v: Name[A])(f: A => Name[B]): Name[B] = Name(f(v.value).value)

--- a/core/src/main/scala/scalaz/NonEmptyList.scala
+++ b/core/src/main/scala/scalaz/NonEmptyList.scala
@@ -128,7 +128,7 @@ trait NonEmptyListInstances extends NonEmptyListInstances0 {
       override def foldLeft[A, B](fa: NonEmptyList[A], z: B)(f: (B, A) => B): B =
         fa.tail.foldLeft(f(z, fa.head))(f)
 
-      def bind[A, B](fa: NonEmptyList[A])(f: (A) => NonEmptyList[B]): NonEmptyList[B] = fa flatMap f
+      def bind[A, B](fa: NonEmptyList[A])(f: A => NonEmptyList[B]): NonEmptyList[B] = fa flatMap f
 
       def point[A](a: => A): NonEmptyList[A] = NonEmptyList(a)
 

--- a/core/src/main/scala/scalaz/OptionT.scala
+++ b/core/src/main/scala/scalaz/OptionT.scala
@@ -31,7 +31,7 @@ final case class OptionT[F[+_], +A](run: F[Option[A]]) {
     F.foldRight[Option[A], Z](run, z)((a, b) => Foldable[Option].foldRight[A, Z](a, b)(f))
   }
 
-  def traverse[G[_], B](f: (A) => G[B])(implicit F: Traverse[F], G: Applicative[G]): G[OptionT[F, B]] = {
+  def traverse[G[_], B](f: A => G[B])(implicit F: Traverse[F], G: Applicative[G]): G[OptionT[F, B]] = {
     import std.option._
     G.map(F.traverse(run)(o => Traverse[Option].traverse(o)(f)))(OptionT(_))
   }
@@ -151,7 +151,7 @@ private[scalaz] trait OptionTFoldable[F[+_]] extends Foldable.FromFoldr[({type �
 private[scalaz] trait OptionTTraverse[F[+_]] extends Traverse[({type λ[α] = OptionT[F, α]})#λ] with OptionTFoldable[F] with OptionTFunctor[F]{
   implicit def F: Traverse[F]
 
-  def traverseImpl[G[_] : Applicative, A, B](fa: OptionT[F, A])(f: (A) => G[B]): G[OptionT[F, B]] = fa traverse f
+  def traverseImpl[G[_] : Applicative, A, B](fa: OptionT[F, A])(f: A => G[B]): G[OptionT[F, B]] = fa traverse f
 }
 
 private[scalaz] trait OptionTHoist extends Hoist[OptionT] {

--- a/core/src/main/scala/scalaz/Order.scala
+++ b/core/src/main/scala/scalaz/Order.scala
@@ -65,7 +65,7 @@ object Order {
   ////
 
   implicit val orderInstance: Contravariant[Order] = new Contravariant[Order] {
-    def contramap[A, B](r: Order[A])(f: (B) => A): Order[B] = r.contramap(f)
+    def contramap[A, B](r: Order[A])(f: B => A): Order[B] = r.contramap(f)
   }
 
   implicit def fromScalaOrdering[A](implicit O: SOrdering[A]): Order[A] = new Order[A] {

--- a/core/src/main/scala/scalaz/Product.scala
+++ b/core/src/main/scala/scalaz/Product.scala
@@ -6,7 +6,7 @@ private[scalaz] trait ProductFunctor[F[_], G[_]] extends Functor[({type λ[α] =
 
   implicit def G: Functor[G]
 
-  override def map[A, B](fa: (F[A], G[A]))(f: (A) => B): (F[B], G[B]) = (F.map(fa._1)(f), G.map(fa._2)(f))
+  override def map[A, B](fa: (F[A], G[A]))(f: A => B): (F[B], G[B]) = (F.map(fa._1)(f), G.map(fa._2)(f))
 }
 
 private[scalaz] trait ProductApply[F[_], G[_]] extends Apply[({type λ[α] = (F[α], G[α])})#λ] with ProductFunctor[F, G] {

--- a/core/src/main/scala/scalaz/ReaderWriterStateT.scala
+++ b/core/src/main/scala/scalaz/ReaderWriterStateT.scala
@@ -78,7 +78,7 @@ private[scalaz] trait ReaderWriterStateTMonadReader[F[+_], R, W, S]
     ReaderWriterStateT((r, s) => F.point((W.zero, a, s)))
   def ask: ReaderWriterStateT[F, R, W, S, R] =
     ReaderWriterStateT((r, s) => F.point((W.zero, r, s)))
-  def local[A](f: (R) => R)(fa: ReaderWriterStateT[F, R, W, S, A]): ReaderWriterStateT[F, R, W, S, A] =
+  def local[A](f: R => R)(fa: ReaderWriterStateT[F, R, W, S, A]): ReaderWriterStateT[F, R, W, S, A] =
     ReaderWriterStateT((r, s) => fa.run(f(r), s))
   def init: ReaderWriterStateT[F, R, W, S, S] =
     ReaderWriterStateT((r, s) => F.point((W.zero, s, s)))

--- a/core/src/main/scala/scalaz/Semigroup.scala
+++ b/core/src/main/scala/scalaz/Semigroup.scala
@@ -34,7 +34,7 @@ trait Semigroup[F]  { self =>
   final def compose: Compose[({type λ[α, β]=F})#λ] = new SemigroupCompose {}
 
   private[scalaz] trait SemigroupApply extends Apply[({type λ[α]=F})#λ] {
-    override def map[A, B](fa: F)(f: (A) => B) = fa
+    override def map[A, B](fa: F)(f: A => B) = fa
     def ap[A, B](fa: => F)(f: => F) = append(f, fa)
   }
 

--- a/core/src/main/scala/scalaz/Show.scala
+++ b/core/src/main/scala/scalaz/Show.scala
@@ -39,7 +39,7 @@ object Show {
   }
 
   implicit def showContravariant: Contravariant[Show] = new Contravariant[Show] {
-    def contramap[A, B](r: Show[A])(f: (B) => A): Show[B] = new Show[B] {
+    def contramap[A, B](r: Show[A])(f: B => A): Show[B] = new Show[B] {
       override def show(b: B): Cord = r.show(f(b))
     }
   }

--- a/core/src/main/scala/scalaz/StoreT.scala
+++ b/core/src/main/scala/scalaz/StoreT.scala
@@ -137,12 +137,12 @@ trait StoreTInstances extends StoreTInstances0 {
 }
 
 private[scalaz] trait IndexedStoreTFunctorLeft[F[+_], A0, B0] extends Functor[({type λ[+α]=IndexedStoreT[F, α, A0, B0]})#λ]{
-  override def map[A, B](fa: IndexedStoreT[F, A, A0, B0])(f: (A) => B): IndexedStoreT[F, B, A0, B0] = fa imap f
+  override def map[A, B](fa: IndexedStoreT[F, A, A0, B0])(f: A => B): IndexedStoreT[F, B, A0, B0] = fa imap f
 }
 
 private[scalaz] trait IndexedStoreTFunctorRight[F[+_], I0, A0] extends Functor[({type λ[+α]=IndexedStoreT[F, I0, A0, α]})#λ]{
   implicit def F: Functor[F]
-  override def map[A, B](fa: IndexedStoreT[F, I0, A0, A])(f: (A) => B): IndexedStoreT[F, I0, A0, B] = fa map f
+  override def map[A, B](fa: IndexedStoreT[F, I0, A0, A])(f: A => B): IndexedStoreT[F, I0, A0, B] = fa map f
 }
 
 private[scalaz] trait IndexedStoreTContravariant[F[+_], I0, B0] extends Contravariant[({type λ[-α]=IndexedStoreT[F, I0, α, B0]})#λ] {

--- a/core/src/main/scala/scalaz/Tree.scala
+++ b/core/src/main/scala/scalaz/Tree.scala
@@ -120,9 +120,9 @@ trait TreeInstances {
     def point[A](a: => A): Tree[A] = Tree.leaf(a)
     def cojoin[A](a: Tree[A]): Tree[Tree[A]] = a.cobind(identity(_))
     def copoint[A](p: Tree[A]): A = p.rootLabel
-    override def map[A, B](fa: Tree[A])(f: (A) => B) = fa map f
-    def bind[A, B](fa: Tree[A])(f: (A) => Tree[B]): Tree[B] = fa flatMap f
-    def traverse1Impl[G[_]: Apply, A, B](fa: Tree[A])(f: (A) => G[B]): G[Tree[B]] = fa traverse1 f
+    override def map[A, B](fa: Tree[A])(f: A => B) = fa map f
+    def bind[A, B](fa: Tree[A])(f: A => Tree[B]): Tree[B] = fa flatMap f
+    def traverse1Impl[G[_]: Apply, A, B](fa: Tree[A])(f: A => G[B]): G[Tree[B]] = fa traverse1 f
     override def foldRight[A, B](fa: Tree[A], z: => B)(f: (A, => B) => B): B = fa.foldRight(z)(f)
     override def foldRight1[A](fa: Tree[A])(f: (A, => A) => A): A = fa.subForest.foldRight(fa.rootLabel)((t, a) => treeInstance.foldRight(t, a)(f))
     override def foldLeft[A, B](fa: Tree[A], z: B)(f: (B, A) => B): B =
@@ -130,7 +130,7 @@ trait TreeInstances {
     override def foldLeft1[A](fa: Tree[A])(f: (A, A) => A): A = fa.flatten match {
       case h #:: t => t.foldLeft(h)(f)
     }
-    override def foldMap[A, B](fa: Tree[A])(f: (A) => B)(implicit F: Monoid[B]): B = fa foldMap f
+    override def foldMap[A, B](fa: Tree[A])(f: A => B)(implicit F: Monoid[B]): B = fa foldMap f
   }
 
   implicit def treeEqual[A](implicit A: Equal[A]): Equal[Tree[A]] = new Equal[Tree[A]] {

--- a/core/src/main/scala/scalaz/Zipper.scala
+++ b/core/src/main/scala/scalaz/Zipper.scala
@@ -332,7 +332,7 @@ sealed trait Zipper[+A] {
   def deleteRightCOr[AA >: A](z: => Zipper[AA]): Zipper[AA] =
     deleteRightC getOrElse z
 
-  def traverse[G[_] : Applicative, B](f: (A) => G[B]): G[Zipper[B]] = {
+  def traverse[G[_] : Applicative, B](f: A => G[B]): G[Zipper[B]] = {
     val z = (Zipper.zipper(_: Stream[B], _: B, _: Stream[B])).curried
     val G = Applicative[G]
     import std.stream.streamInstance
@@ -367,7 +367,7 @@ trait ZipperInstances {
       a.positions
     def copoint[A](p: Zipper[A]): A =
       p.focus
-    def traverseImpl[G[_] : Applicative, A, B](za: Zipper[A])(f: (A) => G[B]): G[Zipper[B]] =
+    def traverseImpl[G[_] : Applicative, A, B](za: Zipper[A])(f: A => G[B]): G[Zipper[B]] =
       za traverse f
     override def foldRight[A, B](fa: Zipper[A], z: => B)(f: (A, => B) => B): B =
       fa.foldRight(z)(f)
@@ -377,7 +377,7 @@ trait ZipperInstances {
       zipper(Stream.continually(a), a, Stream.continually(a))
     def ap[A, B](fa: => Zipper[A])(f: => Zipper[A => B]): Zipper[B] =
       fa ap f
-    override def map[A, B](fa: Zipper[A])(f: (A) => B): Zipper[B] =
+    override def map[A, B](fa: Zipper[A])(f: A => B): Zipper[B] =
       fa map f
   }
 

--- a/core/src/main/scala/scalaz/std/Either.scala
+++ b/core/src/main/scala/scalaz/std/Either.scala
@@ -58,13 +58,13 @@ trait EitherInstances0 {
 trait EitherInstances extends EitherInstances0 {
   implicit def eitherInstance = new Bitraverse[Either] {
     override def bimap[A, B, C, D](fab: Either[A, B])
-                                  (f: (A) => C, g: (B) => D) = fab match {
+                                  (f: A => C, g: B => D) = fab match {
       case Left(a)  => Left(f(a))
       case Right(b) => Right(g(b))
     }
 
     def bitraverseImpl[G[_] : Applicative, A, B, C, D](fab: Either[A, B])
-                                                  (f: (A) => G[C], g: (B) => G[D]) = fab match {
+                                                  (f: A => G[C], g: B => G[D]) = fab match {
       case Left(a)  => Applicative[G].map(f(a))(b => Left(b))
       case Right(b) => Applicative[G].map(g(b))(d => Right(d))
     }
@@ -72,14 +72,14 @@ trait EitherInstances extends EitherInstances0 {
 
   /** Right biased monad */
   implicit def eitherMonad[L] = new Traverse[({type l[a] = Either[L, a]})#l] with Monad[({type l[a] = Either[L, a]})#l] with Cozip[({type l[a] = Either[L, a]})#l] {
-    def bind[A, B](fa: Either[L, A])(f: (A) => Either[L, B]) = fa match {
+    def bind[A, B](fa: Either[L, A])(f: A => Either[L, B]) = fa match {
       case Left(a)  => Left(a)
       case Right(b) => f(b)
     }
 
     def point[A](a: => A) = Right(a)
 
-    def traverseImpl[G[_] : Applicative, A, B](fa: Either[L, A])(f: (A) => G[B]) = fa match {
+    def traverseImpl[G[_] : Applicative, A, B](fa: Either[L, A])(f: A => G[B]) = fa match {
       case Left(x)  => Applicative[G].point(Left(x))
       case Right(x) => Applicative[G].map(f(x))(Right(_))
     }
@@ -188,7 +188,7 @@ trait EitherInstances extends EitherInstances0 {
 
   implicit def eitherRightLInstance[L] = new Monad[({type λ[α] = RightProjection[L, α]})#λ] {
     def point[A](a: => A) = Right(a).right
-    def bind[A, B](fa: RightProjection[L, A])(f: (A) => RightProjection[L, B]) = fa.e match {
+    def bind[A, B](fa: RightProjection[L, A])(f: A => RightProjection[L, B]) = fa.e match {
       case Left(a)  => Left(a).right
       case Right(b) => f(b)
     }
@@ -196,7 +196,7 @@ trait EitherInstances extends EitherInstances0 {
 
   implicit def eitherFirstRightLInstance[L] = new Monad[({type λ[α] = RightProjection[L, α] @@ First})#λ] {
     def point[A](a: => A) = First(Right(a).right)
-    def bind[A, B](fa: RightProjection[L, A] @@ First)(f: (A) => RightProjection[L, B] @@ First) = First(
+    def bind[A, B](fa: RightProjection[L, A] @@ First)(f: A => RightProjection[L, B] @@ First) = First(
       fa.e match {
         case Left(a)  => Left(a).right
         case Right(b) => f(b)
@@ -206,7 +206,7 @@ trait EitherInstances extends EitherInstances0 {
 
   implicit def eitherLastRightLInstance[L] = new Monad[({type λ[α] = RightProjection[L, α] @@ Last})#λ] {
     def point[A](a: => A) = Last(Right(a).right)
-    def bind[A, B](fa: RightProjection[L, A] @@ Last)(f: (A) => RightProjection[L, B] @@ Last) =
+    def bind[A, B](fa: RightProjection[L, A] @@ Last)(f: A => RightProjection[L, B] @@ Last) =
       fa.e match {
         case Left(a)  => Last(Left(a).right)
         case Right(b) => f(b)
@@ -215,7 +215,7 @@ trait EitherInstances extends EitherInstances0 {
 
   implicit def eitherLeftRInstance[R] = new Monad[({type λ[α] = LeftProjection[α, R]})#λ] {
     def point[A](a: => A) = Left(a).left
-    def bind[A, B](fa: LeftProjection[A, R])(f: (A) => LeftProjection[B, R]) = fa.e match {
+    def bind[A, B](fa: LeftProjection[A, R])(f: A => LeftProjection[B, R]) = fa.e match {
       case Left(a)  => f(a)
       case Right(b) => Right(b).left
     }
@@ -223,7 +223,7 @@ trait EitherInstances extends EitherInstances0 {
 
   implicit def eitherFirstLeftRInstance[R] = new Monad[({type λ[α] = LeftProjection[α, R] @@ First})#λ] {
     def point[A](a: => A) = First(Left(a).left)
-    def bind[A, B](fa: LeftProjection[A, R] @@ First)(f: (A) => LeftProjection[B, R] @@ First) = First(
+    def bind[A, B](fa: LeftProjection[A, R] @@ First)(f: A => LeftProjection[B, R] @@ First) = First(
       fa.e match {
         case Left(a)  => f(a)
         case Right(b) => Right(b).left
@@ -233,7 +233,7 @@ trait EitherInstances extends EitherInstances0 {
 
   implicit def eitherLastLeftRInstance[R] = new Monad[({type λ[α] = LeftProjection[α, R] @@ Last})#λ] {
     def point[A](a: => A) = Last(Left(a).left)
-    def bind[A, B](fa: LeftProjection[A, R] @@ Last)(f: (A) => LeftProjection[B, R] @@ Last) = Last(
+    def bind[A, B](fa: LeftProjection[A, R] @@ Last)(f: A => LeftProjection[B, R] @@ Last) = Last(
       fa.e match {
         case Left(a)  => f(a)
         case Right(b) => Right(b).left

--- a/core/src/main/scala/scalaz/std/Function.scala
+++ b/core/src/main/scala/scalaz/std/Function.scala
@@ -32,7 +32,7 @@ trait FunctionInstances extends FunctionInstances0 {
 
     override def map[A,B](fa: () => A)(f: A => B) = () => f(fa())
 
-    def traverseImpl[G[_]: Applicative, A, B](fa: () => A)(f: (A) => G[B]) =
+    def traverseImpl[G[_]: Applicative, A, B](fa: () => A)(f: A => G[B]) =
       Applicative[G].map(f(fa()))((b: B) => () => b)
 
     override def foldRight[A, B](fa: () => A, z: => B)(f: (A, => B) => B) = f(fa(), z)
@@ -51,9 +51,9 @@ trait FunctionInstances extends FunctionInstances0 {
 
     def first[A, B, C](a: A => B) =(ac: (A, C)) => (a(ac._1), ac._2)
     
-    def compose[A, B, C](f: (B) => C, g: (A) => B) = f compose g
+    def compose[A, B, C](f: B => C, g: A => B) = f compose g
 
-    def id[A]: (A) => A = a => a
+    def id[A]: A => A = a => a
 
     def choice[A, B, C](f: => A => C, g: => B => C): (A \/ B) => C = {
       case -\/(a) => f(a)
@@ -83,7 +83,7 @@ trait FunctionInstances extends FunctionInstances0 {
   }
 
   implicit def function1Contravariant[R] = new Contravariant[({type l[a] = (a => R)})#l] {
-    def contramap[A, B](r: (A) => R)(f: (B) => A) = r compose f
+    def contramap[A, B](r: A => R)(f: B => A) = r compose f
   }
 
   implicit def function1Group[A, R](implicit R0: Group[R]) = new Function1Group[A, R] {
@@ -152,10 +152,10 @@ trait Function1Monoid[A, R] extends Monoid[A => R] with Function1Semigroup[A, R]
 
 trait Function1Comonad[M, R] extends Comonad[({type λ[α]=(M => α)})#λ] {
   implicit def M: Monoid[M]
-  def cojoin[A](a: (M) => A) = (m1: M) => (m2: M) => a(M.append(m1, m1))
-  def copoint[A](p: (M) => A) = p(M.zero)
-  def cobind[A, B](fa: (M) => A)(f: ((M) => A) => B) = (m1: M) => f((m2: M) => fa(M.append(m1, m2)))
-  def map[A, B](fa: (M) => A)(f: (A) => B) = fa andThen f
+  def cojoin[A](a: M => A) = (m1: M) => (m2: M) => a(M.append(m1, m1))
+  def copoint[A](p: M => A) = p(M.zero)
+  def cobind[A, B](fa: M => A)(f: (M => A) => B) = (m1: M) => f((m2: M) => fa(M.append(m1, m2)))
+  def map[A, B](fa: M => A)(f: A => B) = fa andThen f
 }
 
 trait Function1Group[A, R] extends Group[A => R] with Function1Monoid[A, R] {

--- a/core/src/main/scala/scalaz/std/IndexedSeq.scala
+++ b/core/src/main/scala/scalaz/std/IndexedSeq.scala
@@ -41,7 +41,7 @@ trait IndexedSeqInstances extends IndexedSeqInstances0 {
 
 trait IndexedSeqSubInstances extends IndexedSeqInstances0 with IndexedSeqSub {self =>
   val ixSqInstance = new Traverse[IxSq] with MonadPlus[IxSq] with Each[IxSq] with Index[IxSq] with Length[IxSq] with Zip[IxSq] with Unzip[IxSq] with IsEmpty[IxSq] {
-    def each[A](fa: IxSq[A])(f: (A) => Unit) = fa foreach f
+    def each[A](fa: IxSq[A])(f: A => Unit) = fa foreach f
     def index[A](fa: IxSq[A], i: Int) = if (fa.size > i) Some(fa(i)) else None
     def length[A](fa: IxSq[A]) = fa.length
     def point[A](a: => A) = empty :+ a

--- a/core/src/main/scala/scalaz/std/List.scala
+++ b/core/src/main/scala/scalaz/std/List.scala
@@ -12,7 +12,7 @@ trait ListInstances0 {
 
 trait ListInstances extends ListInstances0 {
   implicit val listInstance = new Traverse[List] with MonadPlus[List] with Each[List] with Index[List] with Length[List] with Zip[List] with Unzip[List] with IsEmpty[List] {
-    def each[A](fa: List[A])(f: (A) => Unit) = fa foreach f
+    def each[A](fa: List[A])(f: A => Unit) = fa foreach f
     def index[A](fa: List[A], i: Int) = {
       var n = 0
       var k: Option[A] = None

--- a/core/src/main/scala/scalaz/std/Option.scala
+++ b/core/src/main/scala/scalaz/std/Option.scala
@@ -10,10 +10,10 @@ trait OptionInstances0 {
 trait OptionInstances extends OptionInstances0 {
   implicit val optionInstance = new Traverse[Option] with MonadPlus[Option] with Each[Option] with Index[Option] with Length[Option] with Cozip[Option] with Zip[Option] with Unzip[Option] with IsEmpty[Option] {
     def point[A](a: => A) = Some(a)
-    def each[A](fa: Option[A])(f: (A) => Unit) = fa foreach f
+    def each[A](fa: Option[A])(f: A => Unit) = fa foreach f
     def index[A](fa: Option[A], n: Int) = if (n == 0) fa else None
     def length[A](fa: Option[A]) = if (fa.isEmpty) 0 else 1
-    override def ap[A, B](fa: => Option[A])(f: => Option[(A) => B]) = f match {
+    override def ap[A, B](fa: => Option[A])(f: => Option[A => B]) = f match {
       case Some(f) => fa match {
         case Some(x) => Some(f(x))
         case None    => None

--- a/core/src/main/scala/scalaz/std/PartialFunction.scala
+++ b/core/src/main/scala/scalaz/std/PartialFunction.scala
@@ -3,7 +3,7 @@ package std
 
 trait PartialFunctionInstances {
   implicit val partialFunctionInstance = new Arrow[PartialFunction] with Category[PartialFunction] with Choice[PartialFunction] {
-    def arr[A, B](f: (A) => B) = {
+    def arr[A, B](f: A => B) = {
       case a => f(a)
     }
     def compose[A, B, C](f: PartialFunction[B, C], g: PartialFunction[A, B]) = new PartialFunction[A, C] {

--- a/core/src/main/scala/scalaz/std/Set.scala
+++ b/core/src/main/scala/scalaz/std/Set.scala
@@ -3,7 +3,7 @@ package std
 
 trait SetInstances {
   implicit val setInstance = new Traverse[Set] with MonadPlus[Set] with Each[Set] with Length[Set] with IsEmpty[Set] {
-    def each[A](fa: Set[A])(f: (A) => Unit) = fa foreach f
+    def each[A](fa: Set[A])(f: A => Unit) = fa foreach f
     def length[A](fa: Set[A]) = fa.size
     def point[A](a: => A) = Set(a)
     def bind[A, B](fa: Set[A])(f: A => Set[B]) = fa flatMap f

--- a/core/src/main/scala/scalaz/std/Stream.scala
+++ b/core/src/main/scala/scalaz/std/Stream.scala
@@ -5,7 +5,7 @@ import annotation.tailrec
 
 trait StreamInstances {
   implicit val streamInstance: Traverse[Stream] with MonadPlus[Stream] with Each[Stream] with Index[Stream] with Length[Stream] with Zip[Stream] with Unzip[Stream] with IsEmpty[Stream] = new Traverse[Stream] with MonadPlus[Stream] with Each[Stream] with Index[Stream] with Length[Stream] with Zip[Stream] with Unzip[Stream] with IsEmpty[Stream] {
-    def traverseImpl[G[_], A, B](fa: Stream[A])(f: (A) => G[B])(implicit G: Applicative[G]): G[Stream[B]] = {
+    def traverseImpl[G[_], A, B](fa: Stream[A])(f: A => G[B])(implicit G: Applicative[G]): G[Stream[B]] = {
       val seed: G[Stream[B]] = G.point(Stream[B]())
 
       foldRight(fa, seed) {
@@ -13,7 +13,7 @@ trait StreamInstances {
       }
     }
 
-    def each[A](fa: Stream[A])(f: (A) => Unit) = fa foreach f
+    def each[A](fa: Stream[A])(f: A => Unit) = fa foreach f
     def length[A](fa: Stream[A]) = fa.length
     def index[A](fa: Stream[A], i: Int) = {
       var n = 0
@@ -33,7 +33,7 @@ trait StreamInstances {
     else
       f(fa.head, foldRight(fa.tail, z)(f))
 
-    def bind[A, B](fa: Stream[A])(f: (A) => Stream[B]) = fa flatMap f
+    def bind[A, B](fa: Stream[A])(f: A => Stream[B]) = fa flatMap f
     def empty[A]: Stream[A] = scala.Stream.empty
     def plus[A](a: Stream[A], b: => Stream[A]) = a #::: b
     def isEmpty[A](s: Stream[A]) = s.isEmpty

--- a/core/src/main/scala/scalaz/std/Tuple.scala
+++ b/core/src/main/scala/scalaz/std/Tuple.scala
@@ -3,9 +3,9 @@ package std
 
 trait TupleInstances0 {
   implicit def tuple2Bitraverse[A1, A2] = new Bitraverse[Tuple2] {
-    override def bimap[A, B, C, D](fab: (A, B))(f: (A) => C, g: (B) => D) =
+    override def bimap[A, B, C, D](fab: (A, B))(f: A => C, g: B => D) =
       (f(fab._1), g(fab._2))
-    def bitraverseImpl[G[_]: Applicative, A, B, C, D](fab: (A, B))(f: (A) => G[C], g: (B) => G[D]) =
+    def bitraverseImpl[G[_]: Applicative, A, B, C, D](fab: (A, B))(f: A => G[C], g: B => G[D]) =
       Applicative[G].apply2(f(fab._1), g(fab._2))((_, _))
   }
 
@@ -518,7 +518,7 @@ private[scalaz] trait Tuple8Semigroup[A1, A2, A3, A4, A5, A6, A7, A8] extends Se
     )
 }
 private[scalaz] trait Tuple1Functor extends Traverse[Tuple1] {
-  override def map[A, B](fa: Tuple1[A])(f: (A) => B) =
+  override def map[A, B](fa: Tuple1[A])(f: A => B) =
     Tuple1(f(fa._1))
   def traverseImpl[G[_], A, B](fa: Tuple1[A])(f: A => G[B])(implicit G: Applicative[G]) =
     G.map(f(fa._1))(Tuple1.apply)

--- a/core/src/main/scala/scalaz/std/java/util/concurrent/Callable.scala
+++ b/core/src/main/scala/scalaz/std/java/util/concurrent/Callable.scala
@@ -10,10 +10,10 @@ trait CallableInstances {
   }
 
   implicit def callableMonad: Monad[Callable] = new Monad[Callable] {
-    override def map[A, B](fa: Callable[A])(f: (A) => B) = new Callable[B] {
+    override def map[A, B](fa: Callable[A])(f: A => B) = new Callable[B] {
       def call() = f(fa.call)
     }
-    def bind[A, B](fa: Callable[A])(f: (A) => Callable[B]) = new Callable[B] {
+    def bind[A, B](fa: Callable[A])(f: A => Callable[B]) = new Callable[B] {
       def call() = f(fa.call).call
     }
     def point[A](a: => A) = new Callable[A] {

--- a/core/src/main/scala/scalaz/std/java/util/map.scala
+++ b/core/src/main/scala/scalaz/std/java/util/map.scala
@@ -11,7 +11,7 @@ trait MapInstances {
       new SimpleImmutableEntry(f(fab.getKey), g(fab.getValue))
 
     def bitraverseImpl[G[_]: Applicative, A, B, C, D](fab: Entry[A, B])
-                                                 (f: (A) => G[C], g: (B) => G[D]) =
+                                                 (f: A => G[C], g: B => G[D]) =
       Applicative[G].apply2(f(fab.getKey), g(fab.getValue))(new SimpleImmutableEntry(_, _))
 
   }

--- a/core/src/main/scala/scalaz/std/util/parsing/combinator/Parser.scala
+++ b/core/src/main/scala/scalaz/std/util/parsing/combinator/Parser.scala
@@ -11,7 +11,7 @@ trait Parsers {
     type Parser[A] = parser.Parser[A]
     def instance: Monad[Parser] = new Monad[Parser] {
       def point[A](a: => A): Parser[A] = parser.success(a)
-      def bind[A, B](fa: Parser[A])(f: (A) => Parser[B]): Parser[B] = fa flatMap f
+      def bind[A, B](fa: Parser[A])(f: A => Parser[B]): Parser[B] = fa flatMap f
     }
   }
 
@@ -29,7 +29,7 @@ trait Parsers {
       object dummyParser extends combinator.Parsers
       def instance: Monad[Parser] = new Monad[Parser] {
         def pure[A](a: => A): Parser[A] = dummyParser.success(a).asInstanceOf[Parser[A]] // please look the other way!
-        def bind[A, B](fa: Parser[A])(f: (A) => Parser[B]): Parser[B] = fa flatMap f
+        def bind[A, B](fa: Parser[A])(f: A => Parser[B]): Parser[B] = fa flatMap f
       }
     }
 

--- a/core/src/main/scala/scalaz/syntax/std/Function1Ops.scala
+++ b/core/src/main/scala/scalaz/syntax/std/Function1Ops.scala
@@ -14,7 +14,7 @@ trait Function1Ops[T, R] extends Ops[T => R] {
   def kleisli[Z[+_]](implicit z: Applicative[Z]): Kleisli[Z, T, R] =
     Kleisli.kleisli((t: T) => z.point(self(t)))
 
-  def unary_!(implicit m: Memo[T, R]): (T) => R = m(self)
+  def unary_!(implicit m: Memo[T, R]): T => R = m(self)
 
   def toValidation[E](e: => E)(implicit ev: R =:= Boolean): T => Validation[NonEmptyList[E], T] =
     (t: T) => (if (self(t): Boolean) success(t) else failure(nel(e, Nil)))

--- a/core/src/main/scala/scalaz/syntax/std/StreamOps.scala
+++ b/core/src/main/scala/scalaz/syntax/std/StreamOps.scala
@@ -13,7 +13,7 @@ trait StreamOps[A] extends Ops[Stream[A]] {
   final def zipperEnd: Option[Zipper[A]] = s.zipperEnd(self)
   final def heads: Stream[Stream[A]] = s.heads(self)
   final def tails: Stream[Stream[A]] = s.tails(self)
-  final def zapp[B, C](f: Stream[A => B => C]): Stream[(B) => C] = s.zapp(self)(f)
+  final def zapp[B, C](f: Stream[A => B => C]): Stream[B => C] = s.zapp(self)(f)
   final def unfoldForest[B](f: A => (B, () => Stream[A])): Stream[Tree[B]] = s.unfoldForest(self)(f)
   final def unfoldForestM[B, M[_] : Monad](f: A => M[(B, Stream[A])]): M[Stream[Tree[B]]] = s.unfoldForestM(self)(f)
   final def intersperse(a: A): Stream[A] = s.intersperse(self, a)

--- a/effect/src/main/scala/scalaz/effect/IO.scala
+++ b/effect/src/main/scala/scalaz/effect/IO.scala
@@ -155,8 +155,8 @@ trait IOInstances extends IOInstances0 {
 
 private trait IOMonad extends Monad[IO] {
   def point[A](a: => A): IO[A] = IO(a)
-  override def map[A, B](fa: IO[A])(f: (A) => B) = fa map f
-  def bind[A, B](fa: IO[A])(f: (A) => IO[B]): IO[B] = fa flatMap f
+  override def map[A, B](fa: IO[A])(f: A => B) = fa map f
+  def bind[A, B](fa: IO[A])(f: A => IO[B]): IO[B] = fa flatMap f
 }
 
 private trait IOLiftIO extends LiftIO[IO] {

--- a/effect/src/main/scala/scalaz/effect/RegionT.scala
+++ b/effect/src/main/scala/scalaz/effect/RegionT.scala
@@ -47,7 +47,7 @@ trait RegionTMonad[S, M[+_]] extends Monad[({type λ[α] = RegionT[S, M, α]})#�
   implicit def M: Monad[M]
 
   def point[A](a: => A): RegionT[S, M, A] = RegionT(kleisli(s => M.point(a)))
-  def bind[A, B](fa: RegionT[S, M, A])(f: (A) => RegionT[S, M, B]): RegionT[S, M, B] =
+  def bind[A, B](fa: RegionT[S, M, A])(f: A => RegionT[S, M, B]): RegionT[S, M, B] =
     RegionT(kleisli(s => M.bind(fa.value.run(s))((a: A) => f(a).value.run(s))))
 }
 

--- a/effect/src/main/scala/scalaz/effect/ST.scala
+++ b/effect/src/main/scala/scalaz/effect/ST.scala
@@ -197,6 +197,6 @@ trait STInstances extends STInstance0 {
 
   implicit def stMonad[S]: Monad[({type λ[α] = ST[S, α]})#λ] = new Monad[({type λ[α] = ST[S, α]})#λ] {
     def point[A](a: => A): ST[S, A] = returnST(a)
-    def bind[A, B](fa: ST[S, A])(f: (A) => ST[S, B]): ST[S, B] = fa flatMap f
+    def bind[A, B](fa: ST[S, A])(f: A => ST[S, B]): ST[S, B] = fa flatMap f
   }
 }

--- a/iteratee/src/main/scala/scalaz/iteratee/Input.scala
+++ b/iteratee/src/main/scala/scalaz/iteratee/Input.scala
@@ -89,7 +89,7 @@ trait InputInstances {
        , eof = 0
      )
      def point[A](a: => A): Input[A] = elInput(a)
-     def traverseImpl[G[_]: Applicative, A, B](fa: Input[A])(f: (A) => G[B]): G[Input[B]] = fa.fold(
+     def traverseImpl[G[_]: Applicative, A, B](fa: Input[A])(f: A => G[B]): G[Input[B]] = fa.fold(
        empty = Applicative[G].point(emptyInput[B])
        , el = x => Applicative[G].map(f(x))(b => elInput(b))
        , eof = Applicative[G].point(eofInput[B])
@@ -99,13 +99,13 @@ trait InputInstances {
        , el = a => f(a, z)
        , eof = z
      )
-     def each[A](fa: Input[A])(f: (A) => Unit) = fa foreach (a => f(a))
+     def each[A](fa: Input[A])(f: A => Unit) = fa foreach (a => f(a))
      def plus[A](a: Input[A], b: => Input[A]): Input[A] = a.fold(
        empty = b
        , el = _ => a
        , eof = b
      )
-     def bind[A, B](fa: Input[A])(f: (A) => Input[B]): Input[B] = fa flatMap (a => f(a))
+     def bind[A, B](fa: Input[A])(f: A => Input[B]): Input[B] = fa flatMap (a => f(a))
      def empty[A]: Input[A] = emptyInput
    }
 

--- a/iteratee/src/main/scala/scalaz/iteratee/IterateeT.scala
+++ b/iteratee/src/main/scala/scalaz/iteratee/IterateeT.scala
@@ -351,7 +351,7 @@ private[scalaz] trait IterateeTMonad[E, F[_]] extends Monad[({type λ[α] = Iter
   implicit def F: Monad[F]
 
   def point[A](a: => A) = StepT.sdone(a, emptyInput).pointI
-  override def map[A, B](fa: IterateeT[E, F, A])(f: (A) => B): IterateeT[E, F, B] = fa map f
+  override def map[A, B](fa: IterateeT[E, F, A])(f: A => B): IterateeT[E, F, B] = fa map f
   def bind[A, B](fa: IterateeT[E, F, A])(f: A => IterateeT[E, F, B]): IterateeT[E, F, B] = fa flatMap f
 }
 

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalaCheckBinding.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalaCheckBinding.scala
@@ -10,17 +10,17 @@ object ScalaCheckBinding {
   import typelevel._
 
   implicit val ArbitraryMonad: Monad[Arbitrary] = new Monad[Arbitrary] {
-    def bind[A, B](fa: Arbitrary[A])(f: (A) => Arbitrary[B]) = Arbitrary(fa.arbitrary.flatMap(f(_).arbitrary))
+    def bind[A, B](fa: Arbitrary[A])(f: A => Arbitrary[B]) = Arbitrary(fa.arbitrary.flatMap(f(_).arbitrary))
     def point[A](a: => A) = Arbitrary(sized(_ => value(a)))
-    override def map[A, B](fa: Arbitrary[A])(f: (A) => B) = Arbitrary(fa.arbitrary.map(f))
-    override def ap[A, B](fa: => Arbitrary[A])(f: => Arbitrary[(A) => B]) = Arbitrary(fa.arbitrary.ap(f.arbitrary))
+    override def map[A, B](fa: Arbitrary[A])(f: A => B) = Arbitrary(fa.arbitrary.map(f))
+    override def ap[A, B](fa: => Arbitrary[A])(f: => Arbitrary[A => B]) = Arbitrary(fa.arbitrary.ap(f.arbitrary))
   }
 
   implicit val GenMonad: Monad[Gen] = new Monad[Gen] {
     def point[A](a: => A) = sized(_ => value(a))
-    override def ap[A, B](fa: => Gen[A])(f: => Gen[(A) => B]) = fa ap f
-    def bind[A, B](fa: Gen[A])(f: (A) => Gen[B]) = fa flatMap f
-    override def map[A, B](fa: Gen[A])(f: (A) => B) = fa map f
+    override def ap[A, B](fa: => Gen[A])(f: => Gen[A => B]) = fa ap f
+    def bind[A, B](fa: Gen[A])(f: A => Gen[B]) = fa flatMap f
+    override def map[A, B](fa: Gen[A])(f: A => B) = fa map f
     override def apply2[A, B, C](fa: => Gen[A], fb: => Gen[B])(f: (A, B) => C) = fa.map2(fb)(f)
     override def apply3[A, B, C, D](fa: => Gen[A], fb: => Gen[B], fc: => Gen[C])(f: (A, B, C) => D) = fa.map3(fb, fc)(f)
     override def apply4[A, B, C, D, E](fa: => Gen[A], fb: => Gen[B], fc: => Gen[C], fd: => Gen[D])(f: (A, B, C, D) => E) = fa.map4(fb, fc, fd)(f)

--- a/typelevel/src/main/scala/scalaz/typelevel/Func.scala
+++ b/typelevel/src/main/scala/scalaz/typelevel/Func.scala
@@ -189,7 +189,7 @@ private[scalaz] trait FuncFunctor[F[_], TC[F[_]] <: Functor[F], R] extends Funct
 private[scalaz] trait FuncApply[F[_], TC[F[_]] <: Apply[F], R] extends Apply[({type λ[α] = Func[F, TC, R, α]})#λ] with FuncFunctor[F, TC, R] {
   implicit def TC: KTypeClass[TC]
   implicit def F: TC[F]
-  def ap[A, B](fa: => Func[F, TC, R, A])(f: => Func[F, TC, R, (A) => B]): Func[F, TC, R, B] = func(r => F.ap(fa.runA(r))(f.runA(r)))
+  def ap[A, B](fa: => Func[F, TC, R, A])(f: => Func[F, TC, R, A => B]): Func[F, TC, R, B] = func(r => F.ap(fa.runA(r))(f.runA(r)))
 }
 
 private[scalaz] trait FuncApplicative[F[_], TC[F[_]] <: Applicative[F], R] extends Applicative[({type λ[α] = Func[F, TC, R, α]})#λ] with FuncApply[F, TC, R] {


### PR DESCRIPTION
This patch makes the syntax used for unary functions consistent by removing redundant parentheses from `Function1` types (and a couple of literals). So, `(A) => B` becomes `A => B`.
