### PR TITLE
Implement Foldable[Stream]#foldLeft in terms of Stream#foldLeft

### DIFF
--- a/core/src/main/scala/scalaz/std/Stream.scala
+++ b/core/src/main/scala/scalaz/std/Stream.scala
@@ -28,6 +28,8 @@ trait StreamInstances {
       k
     }
 
+    override def foldLeft[A, B](fa: Stream[A], z: B)(f: (B, A) => B): B = fa.foldLeft(z)(f)
+
     override def foldRight[A, B](fa: Stream[A], z: => B)(f: (A, => B) => B): B = if (fa.isEmpty)
       z
     else


### PR DESCRIPTION
This avoids SOE on Foldable[Stream].foldLeft on large streams.

As requested by @larsrh, I [posted on the mailing list](https://groups.google.com/forum/?fromgroups=#!topic/scalaz/6H34GUL6eSA) about this a couple of days ago, but there have been no responses yet.
