### PR TITLE
Alternative implementation of actor code and tests for it

### DIFF
--- a/tests/src/test/scala/scalaz/concurrent/ActorTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/ActorTest.scala
@@ -2,21 +2,83 @@ package scalaz
 package concurrent
 
 import scalaz.Spec
-import std.AllInstances._
+import org.specs2.execute.{Failure, Result, Success}
+import collection.mutable
+import java.util.concurrent._
 
 class ActorTest extends Spec {
-  "code executes async" in {
-    var called = false
-    implicit val strategy = new Strategy {
-      def apply[A](a: => A): () => A = {
-        called = true
-        () => a
-      }
-    }
-    val actor = Actor[Int](a => a)
-    actor ! 0
+  val Timeout = 1000 // in millis
+  val NumOfMessages = 1000
+  val NumOfThreads = 4
+  val NumOfMessagesPerThread = NumOfMessages / NumOfThreads
+  implicit val executor = Executors.newFixedThreadPool(NumOfThreads)
 
-    called must be_===(true)
+  "code executes async" in {
+    val latch = new CountDownLatch(1)
+    val actor = Actor[Int]((i: Int) => latch.countDown())
+    actor ! 1
+    assertCountDown(latch, "Should process a message")
   }
 
+  "code errors are catched and can be handled" in {
+    val latch = new CountDownLatch(1)
+    val actor = Actor[Int]((i: Int) => 100 / i, (ex: Throwable) => latch.countDown())
+    actor ! 0
+    assertCountDown(latch, "Should catch an exception")
+  }
+
+  "actors exchange messages without loss" in {
+    val latch = new CountDownLatch(NumOfMessages)
+    var actor1: Actor[Int] = null
+    val actor2 = Actor[Int]((i: Int) => actor1 ! i - 1)
+    actor1 = Actor[Int] {
+      (i: Int) =>
+        if (i == latch.getCount) {
+          if (i != 0) actor2 ! i - 1
+          latch.countDown()
+          latch.countDown()
+        }
+    }
+    actor1 ! NumOfMessages
+    assertCountDown(latch, "Should exchange " + NumOfMessages + " messages")
+  }
+
+  "actor handles messages in order of sending by each thread" in {
+    val latch = new CountDownLatch(NumOfMessages)
+    val actor = countingDownActor(latch)
+    val phaser = new Phaser(1)
+    for (j <- 1 to NumOfThreads) fork(phaser) {
+      for (i <- 1 to NumOfMessagesPerThread) {
+        actor ! (j, i)
+      }
+    }
+    phaser.arriveAndDeregister() // synchronize start of threads to maximize contention
+    assertCountDown(latch, "Should process " + NumOfMessages + " messages")
+  }
+
+  def countingDownActor(latch: CountDownLatch): Actor[(Int, Int)] = Actor[(Int, Int)] {
+    val ms = mutable.Map[Int, Int]()
+
+    (m: (Int, Int)) =>
+      val (j, i) = m
+      if (ms.getOrElse(j, 0) + 1 == i) {
+        ms.put(j, i)
+        latch.countDown()
+      }
+  }
+
+  def assertCountDown(latch: CountDownLatch, hint: String) : Result = {
+    if (latch.await(Timeout, TimeUnit.MILLISECONDS)) Success()
+    else Failure("Failed to count down within " + Timeout + " millis: " + hint)
+  }
+
+  def fork(phases: Phaser)(f: => Unit) {
+    phases.register()
+    new Thread {
+      override def run() {
+        phases.arriveAndAwaitAdvance()
+        f
+      }
+    }.start()
+  }
 }


### PR DESCRIPTION
An alternative implementation of scalaz.concurrent.Actor to minimize latency and maximizing throughput of message passing.

Pros:
1. Increasing of message sending and handing throughput in ~3 times.
2. Decreasing of message pass latency from 30% (and up to 2 times when actor executed by FJ pool with parallelism = 2).
3. Decreasing number of store fences when handing messages (by using tail.lazySet and minimizing triggering of the suspended flag).    

Cons:
1. Increasing memory footprint per actor in about 16 bytes (or 12 bytes for 32-bit JVM) due using two references for tail and head instead of one reference for mbox.

Other details in topic: https://groups.google.com/forum/#!topic/scalaz/uexBPoQJifU

Dmitriy Vyukov's MPSC node-based queue was used as base: http://www.1024cores.net/home/lock-free-algorithms/queues/non-intrusive-mpsc-node-based-queue

Rest of implementation details were borrowed from Martin's blog & presentations: http://mechanical-sympathy.blogspot.com/

I’d also like to say thank you to all the amazing people helped me by taking the trouble to review code and test on different environments: George Leontiev, Alexey Levan, Yaroslav Klymko, Maxim Fedorov, Alex Siman, Sergiy Onenko, Andrey Borisov.

The biggest thank you is for my wife and children, who had to deal with me hiding in a corner, coding & running benchmarks, when I should have been helping out.
