### PR TITLE
Added missing 'get' for MonadState instances.

### DIFF
--- a/core/src/main/scala/scalaz/MonadState.scala
+++ b/core/src/main/scala/scalaz/MonadState.scala
@@ -5,6 +5,7 @@ package scalaz
   */
 trait MonadState[F[_,_],S] extends Monad[({type f[x]=F[S,x]})#f] {
   def init: F[S,S]
+  def get: F[S, S]
   def put(s: S): F[S,Unit]
   def modify(f: S => S): F[S, Unit] = bind(init)(s => put(f(s)))
   def gets[A](f: S => A): F[S, A] = bind(init)(s => point(f(s)))

--- a/core/src/main/scala/scalaz/ReaderWriterStateT.scala
+++ b/core/src/main/scala/scalaz/ReaderWriterStateT.scala
@@ -89,6 +89,7 @@ private[scalaz] trait ReaderWriterStateTMonad[F[+_], R, W, S]
     ReaderWriterStateT((r, s) => F.point((W.zero, f(r), s)))
   def init: ReaderWriterStateT[F, R, W, S, S] =
     ReaderWriterStateT((_, s) => F.point((W.zero, s, s)))
+  def get = init
   def put(s: S): ReaderWriterStateT[F, R, W, S, Unit] =
     ReaderWriterStateT((r, _) => F.point((W.zero, (), s)))
   override def modify(f: S => S): ReaderWriterStateT[F, R, W, S, Unit] =

--- a/core/src/main/scala/scalaz/StateT.scala
+++ b/core/src/main/scala/scalaz/StateT.scala
@@ -188,6 +188,8 @@ private[scalaz] trait StateTMonadState[S, F[+_]] extends MonadState[({type f[s, 
 
   def init: StateT[F, S, S] = StateT(s => F.point((s, s)))
 
+  def get = init
+
   def put(s: S): StateT[F, S, Unit] = StateT(_ => F.point((s, ())))
 
   override def modify(f: S => S): StateT[F, S, Unit] = StateT(s => F.point((f(s), ())))


### PR DESCRIPTION
Adding a `get` function to the `MonadState` typeclass. `get` is available on `State` but not when using `StateT`.

I'm not sure how handy this function would be as an addition, but I see that it is on the haskell `MonadState` type class. This does also make the intention a little clearer during usage, as calling `init` might seem a little strange if the state already exists.

Signed-off-by: Gary Pamparà gpampara@gmail.com
