### PR TITLE
Eliminated race and subsequent pattern error from Future#chooseAny.

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Future.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Future.scala
@@ -196,10 +196,10 @@ object Future {
           }
         fs2.zipWithIndex.foreach { case ((f,flatch,ref), ind) => f.runAsync { a =>
           ref.set(a)
-          flatch.countDown 
-          latch.countDown
           // actually ok if two threads clobber each other here
           if (!result.isDefined) result = Some((a, ind))
+          flatch.countDown 
+          latch.countDown
         }}
         latch.await // wait for any one of the threads to finish
         val Some((a, ind)) = result // extract the winner


### PR DESCRIPTION
There was a race condition where the latches were released
before the result was set. This meant that the pattern on
line 285 fails. The failed pattern match resulted in an
exception and an eventual deadlock.

Fixes #308.

@pchiusano for review.

A wider question for this is how can / are tests going to be formulated around scalaz-concurrent? There needs to be a significant investment in testing this sort of code, but I am not really sure of a good place to start. 
