### PR TITLE
Attempt at fixing hang in promise.

### DIFF
--- a/tests/src/test/scala/scalaz/concurrent/PromiseTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/PromiseTest.scala
@@ -5,6 +5,7 @@ import scalaz.scalacheck.ScalazProperties._
 import scalaz.scalacheck.ScalazArbitrary._
 import std.AllInstances._
 import org.scalacheck.Prop._
+import ConcurrentTest._
 
 class PromiseTest extends Spec {
   implicit def promiseEqual[A: Equal] = Equal[A].contramap((_: Promise[A]).get)
@@ -16,5 +17,21 @@ class PromiseTest extends Spec {
   check(throws(Promise({throw new Error("x"); 1}).flatMap(_ => Promise(2)).get, classOf[Error]))
   check(throws(Promise(0).filter(_ != 0).get, classOf[Promise.BrokenException]))
   check(forAll((x: Int) => Promise(x).filter(_ => true).get === x))
+
+  class OhNo extends RuntimeException("OhNo!")
+
+  "Promise" should {
+    import Scalaz._
+    "not hang when an error occurs in sequence" in {
+      withTimeout(2000) {
+        throws(List(Promise({ throw new OhNo(); 1 })).sequence.get, classOf[OhNo])
+      }
+    }
+    "not hang when an error occurs on filter" in {
+      withTimeout(2000) {
+        throws(Promise({ throw new OhNo(); 2 }).filter(_ > 2).get, classOf[OhNo])
+      }
+    }
+  }
 
 }


### PR DESCRIPTION
The specific case that causes an issue is Cont#eval,
that results in Unfulfilled and then later errors out.
This meant the error handling chain was broken,
and Promises waiting on a result would never be
completed (or broken).

Fixes #267.

@runarorama If you had time, could you have a look at this for me. I think what I am doing is somewhat of a kludge, but I have not yet been able to come up with a better formulation for the error handling to ensure it always propagates.
