### PR TITLE
Lens -> State integration returning the old value

### DIFF
--- a/core/src/main/scala/scalaz/Lens.scala
+++ b/core/src/main/scala/scalaz/Lens.scala
@@ -86,7 +86,7 @@ sealed trait LensFamily[-A1, +A2, +B1, -B2] {
     mods[B](f)
 
   /** Modify the portion of the state viewed through the lens and return its old value. */
-  def modo[B <: B2](f: B1 => B): IndexedState[A1, A2, B1] =
+  def modo(f: B1 => B2): IndexedState[A1, A2, B1] =
     IndexedState(a => {
       val c = run(a)
       val o = c.pos
@@ -94,8 +94,8 @@ sealed trait LensFamily[-A1, +A2, +B1, -B2] {
     })
 
   /** Modify the portion of the state viewed through the lens and return its old value. */
-  def <%=[B <: B2](f: B1 => B): IndexedState[A1, A2, B1] =
-    modo[B](f)
+  def <%=(f: B1 => B2): IndexedState[A1, A2, B1] =
+    modo(f)
 
   /** Set the portion of the state viewed through the lens and return its new value. */
   def assign[B <: B2](b: => B): IndexedState[A1, A2, B] =


### PR DESCRIPTION
- provides `LensFamily.modo` which returns the old value (as an alternative to `LensFamily.mods` which returns the new value)
- provides `LensFamily.assigno` which returns the old value (as an alternative to `LensFamily.assign` which returns the new value)
- both `modo` and `assigno` are provisional names
- both `modo` and `assigno` do not have a symbolic alias yet

I'd welcome suggestions for the final names of these new variants as well as suggestions for the symbolic aliases.
