### PR TITLE
Add leibniz to Unapply

### DIFF
--- a/core/src/main/scala/scalaz/Traverse.scala
+++ b/core/src/main/scala/scalaz/Traverse.scala
@@ -47,7 +47,7 @@ trait Traverse[F[_]] extends Functor[F] with Foldable[F] { self =>
 
   /** A version of `traverse` that infers the type constructor `G`. */
   final def traverseU[A,GB](self: F[A])(f: A => GB)(implicit G: Unapply[Applicative, GB]): G.M[F[G.A]] /*G[F[B]]*/ = {
-    G.TC.traverse(self)(a => G(f(a)))(this)
+    G.TC.traverse(self)(G.leibniz.subst[({type λ[α] = A => α})#λ](f))(this)
   }
 
   /** Traverse with `State`. */

--- a/core/src/main/scala/scalaz/Unapply.scala
+++ b/core/src/main/scala/scalaz/Unapply.scala
@@ -23,6 +23,11 @@ import Leibniz.{===, refl}
  *   G.TC.traverse(self)(a => G(f(a)))
  * }
  *
+ * // Deforested version of traverseI
+ * def traverseI2[GB](f: A => GB)(implicit G: Unapply[Applicative, GB]): G.M[F[G.A]] /*G[F[B]*/ = {
+ *   G.TC.traverse(self)(G.leibniz.subst[({type λ[α] = A => α})#λ](f))
+ * }
+ *
  * // Old usage
  * def stateTraverse1 {
  *   import scalaz._, Scalaz._

--- a/core/src/main/scala/scalaz/syntax/TraverseSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/TraverseSyntax.scala
@@ -16,7 +16,7 @@ trait TraverseOps[F[_],A] extends Ops[F[A]] {
 
   /** A version of `traverse` that infers the type constructor `G` */
   final def traverseU[GB](f: A => GB)(implicit G: Unapply[Applicative, GB]): G.M[F[G.A]] /*G[F[B]]*/ = {
-    G.TC.traverse(self)(a => G(f(a)))
+    G.TC.traverse(self)(G.leibniz.subst[({type λ[α] = A => α})#λ](f))
   }
 
   /** Traverse with the identity function */


### PR DESCRIPTION
We can remove some cases where we write `a => U(f(a))`, where `U` is effectively identity, with Leibniz.  This replaces the `apply` methods in various `Unapply*` traits with `leibniz`, and demonstrates this usage in a couple of places.

This is compatible with existing users of `Unapply*` instances, but not definitions of said instances (which are easier to write as a nice side-effect).
