### PR TITLE
Removes the ambiguity-inducing ^ method from FunctorOps and FunctorSyntax

### DIFF
--- a/core/src/main/scala/scalaz/syntax/FunctorSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/FunctorSyntax.scala
@@ -42,8 +42,6 @@ trait ToFunctorOps extends ToFunctorOps0 {
     def lift(implicit F: Functor[F]) = F.lift(self)
   }
 
-  def ^[F[_],A,B](fa: F[A])(f: A => B)(implicit F: Functor[F]) = F(fa)(f)
-
   implicit def ToFunctorIdV[A](v: A) = new FunctorIdV[A] { def self = v }
 
   trait FunctorIdV[A] extends Ops[A] {
@@ -61,7 +59,6 @@ trait FunctorSyntax[F[_]]  {
   implicit def ToLiftV[A, B](v: A => B): LiftV[A, B] = new LiftV[A, B] {
     def self = v
   }
-  def ^[A, B](fa: F[A])(f: A => B) = F(fa)(f)
 
   trait LiftV[A,B] extends Ops[A => B] {
     def lift = F.lift(self)


### PR DESCRIPTION
This symbolic name for the map function is superfluous, and previously caused
ambiguity problems when functor syntax was imported from multiple locations, such as:

scala> import scalaz.syntax.traverse._
import scalaz.syntax.traverse._

scala> import scalaz.std.option._
import scalaz.std.option._

scala> ^(Option(1), Option(2)) { _ + _ }

which previously was a compilation error due to ambiguity, but which is now fine.
