### PR TITLE
Switch 'default' scala version to 2.10.0.

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -42,7 +42,7 @@ object build extends Build {
   lazy val standardSettings: Seq[Sett] = Defaults.defaultSettings ++ sbtrelease.ReleasePlugin.releaseSettings ++ Seq[Sett](
     organization := "org.scalaz",
 
-    scalaVersion := "2.9.2",
+    scalaVersion := "2.10.0",
     crossScalaVersions := Seq("2.9.2", "2.9.3", "2.10.0"),
     resolvers += Resolver.sonatypeRepo("releases"),
 


### PR DESCRIPTION
Reasoning:
- Compiler fails a _tiny_ bit less frequently, making it easier to debug and experiment.
- Will force the issue on the 2.10 warnings.

This is more of a question, because I find myself constantly doing `++2.10.0` anyway.  Thoughts?
