### PR TITLE
Minor Readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ Scalaz has been been modularised.
   type class with an instance of a more specific type class:
 
 ```scala
-def bar[M: Functor] = ()
+def bar[M[_]: Functor] = ()
 
-def foo[M: Monad] = bar // Monad[M] is a subtype of Functor[M]
+def foo[M[_]: Monad] = bar[M] // Monad[M] is a subtype of Functor[M]
 ```
 
 * The hierarchy itself is largely the same as in Scalaz 6. However, there have been a few


### PR DESCRIPTION
The short code example under the heading _Type Class Hierarchy_ doesn't appear to be valid Scala, so I changed it to something that compiles.

I also noticed that all the code blocks except one specified Scala syntax, so I changed that too.
