### PR TITLE
Add InvariantFunctor (from Scalaz 6)

### DIFF
--- a/core/src/main/scala/scalaz/InvariantFunctor.scala
+++ b/core/src/main/scala/scalaz/InvariantFunctor.scala
@@ -1,0 +1,66 @@
+package scalaz
+
+import BijectionT.Bijection
+import Isomorphism.<=>
+
+/**
+ * Unary type constructor that supports an `xmap` operation that converts an `F[A]` to an `F[B]` given
+ * two functions, `A => B` and `B => A`.
+ *
+ * An invariant functor must satisfy two laws:
+ *  - identity - xmap(ma)(identity, identity) == ma
+ *  - composite - xmap(xmap(ma, f1, g1), f2, g2) == xmap(ma, f2 compose f1, g1, compose g2)
+ *
+ * Also known as an exponential functor.
+ *
+ * @see http://hackage.haskell.org/packages/archive/invariant/latest/doc/html/Data-Functor-Invariant.html
+ * @see http://comonad.com/reader/2008/rotten-bananas/
+ */
+trait InvariantFunctor[F[_]] {
+
+  /** Converts `ma` to a value of type `F[B]` using the provided functions `f` and `g`. */
+  def xmap[A, B](ma: F[A], f: A => B, g: B => A): F[B]
+
+  /** Converts `ma` to a value of type `F[B]` using the provided bijection. */
+  def xmapb[A, B](ma: F[A])(b: Bijection[A, B]): F[B] = xmap(ma, b.to, b.from)
+
+  /** Converts `ma` to a value of type `F[B]` using the provided isomorphism. */
+  def xmapi[A, B](ma: F[A])(iso: A <=> B): F[B] = xmap(ma, iso.to, iso.from)
+
+  trait InvariantFunctorLaw {
+
+    def identity[A](fa: F[A])(implicit FA: Equal[F[A]]): Boolean =
+      FA.equal(xmap[A, A](fa, x => x, x => x), fa)
+
+    def composite[A, B, C](fa: F[A], f1: A => B, g1: B => A, f2: B => C, g2: C => B)(implicit FC: Equal[F[C]]): Boolean =
+      FC.equal(xmap(xmap(fa, f1, g1), f2, g2), xmap(fa, f2 compose f1, g1 compose g2))
+  }
+
+  def invariantFunctorLaw = new InvariantFunctorLaw {}
+
+  val invariantFunctorSyntax = new scalaz.syntax.InvariantFunctorSyntax[F] { def F = InvariantFunctor.this }
+}
+
+object InvariantFunctor {
+  @inline def apply[F[_]](implicit F: InvariantFunctor[F]): InvariantFunctor[F] = F
+
+  /** Every functor is an invariant functor, where `B => A` is ignored. */
+  implicit def liftFunctorToInvariantFunctor[F[_]](implicit F: Functor[F]): InvariantFunctor[F] = new InvariantFunctor[F] {
+    def xmap[A, B](ma: F[A], f: A => B, g: B => A): F[B] = F.map(ma)(f)
+  }
+
+  /** Semigroup is an invariant functor. */
+  implicit val semigroupInvariantFunctor: InvariantFunctor[Semigroup] = new InvariantFunctor[Semigroup] {
+    def xmap[A, B](ma: Semigroup[A], f: A => B, g: B => A): Semigroup[B] = new Semigroup[B] {
+      def append(x: B, y: => B): B = f(ma.append(g(x), g(y)))
+    }
+  }
+
+  /** Monoid is an invariant functor. */
+  implicit val monoidInvariantFunctor: InvariantFunctor[Monoid] = new InvariantFunctor[Monoid] {
+    def xmap[A, B](ma: Monoid[A], f: A => B, g: B => A): Monoid[B] = new Monoid[B] {
+      def zero: B = f(ma.zero)
+      def append(x: B, y: => B): B = f(ma.append(g(x), g(y)))
+    }
+  }
+}

--- a/core/src/main/scala/scalaz/syntax/InvariantFunctorSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/InvariantFunctorSyntax.scala
@@ -1,0 +1,40 @@
+package scalaz
+package syntax
+
+import BijectionT.Bijection
+import Isomorphism.<=>
+
+/** Wraps a value `self` and provides methods related to `InvariantFunctor`. */
+trait InvariantFunctorOps[F[_], A] extends Ops[F[A]] {
+  implicit def F: InvariantFunctor[F]
+
+  final def xmap[B](f: A => B, g: B => A): F[B] = F.xmap(self, f, g)
+  final def xmapb[B](b: Bijection[A, B]): F[B] = F.xmapb(self)(b)
+  final def xmapi[B](iso: A <=> B): F[B] = F.xmapi(self)(iso)
+}
+
+trait ToInvariantFunctorOps0 {
+  implicit def ToInvariantFunctorOpsUnapply[FA](v: FA)(implicit F0: Unapply[InvariantFunctor, FA]) =
+    new InvariantFunctorOps[F0.M, F0.A] {
+      def self = F0(v)
+      implicit def F: InvariantFunctor[F0.M] = F0.TC
+    }
+}
+
+trait ToInvariantFunctorOps extends ToInvariantFunctorOps0 {
+  implicit def ToInvariantFunctorOps[F[_], A](v: F[A])(implicit F0: InvariantFunctor[F]) =
+    new InvariantFunctorOps[F, A] {
+      def self = v
+      implicit def F: InvariantFunctor[F] = F0
+    }
+}
+
+trait InvariantFunctorSyntax[F[_]]  {
+  implicit def ToInvariantFunctorOps[A](v: F[A]): InvariantFunctorOps[F, A] =
+    new InvariantFunctorOps[F,A] {
+      def self = v
+      implicit def F: InvariantFunctor[F] = InvariantFunctorSyntax.this.F
+    }
+
+  def F: InvariantFunctor[F]
+}

--- a/core/src/main/scala/scalaz/syntax/Syntax.scala
+++ b/core/src/main/scala/scalaz/syntax/Syntax.scala
@@ -31,6 +31,8 @@ trait Syntaxes {
 
   object functor extends ToFunctorOps
 
+  object invariantFunctor extends ToInvariantFunctorOps
+
   object contravariant extends ToContravariantOps
 
   object apply extends ToApplyOps

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazProperties.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazProperties.scala
@@ -349,4 +349,18 @@ object ScalazProperties {
     }
   }
 
+  object invariantFunctor {
+    def identity[F[_], X](implicit F: InvariantFunctor[F], afx: Arbitrary[F[X]], ef: Equal[F[X]]) =
+      forAll(F.invariantFunctorLaw.identity[X] _)
+
+    def composite[F[_], X, Y, Z](implicit F: InvariantFunctor[F], af: Arbitrary[F[X]], axy: Arbitrary[(X => Y)],
+                                   ayz: Arbitrary[(Y => Z)], ayx: Arbitrary[(Y => X)], azy: Arbitrary[(Z => Y)], ef: Equal[F[Z]]) =
+      forAll(F.invariantFunctorLaw.composite[X, Y, Z] _)
+
+    def laws[F[_]](implicit F: InvariantFunctor[F], af: Arbitrary[F[Int]], axy: Arbitrary[(Int => Int)],
+                   ef: Equal[F[Int]]) = new Properties("invariantFunctor") {
+      property("identity") = identity[F, Int]
+      property("composite") = composite[F, Int, Int, Int]
+    }
+  }
 }

--- a/tests/src/test/scala/scalaz/InvariantFunctorTest.scala
+++ b/tests/src/test/scala/scalaz/InvariantFunctorTest.scala
@@ -1,0 +1,47 @@
+package scalaz
+
+import BijectionT.{Bijection, liftBijection}
+import Id.Id
+import Isomorphism.{<=>, IsoSet}
+import std.AllInstances._
+import std.option.some
+import syntax.invariantFunctor._
+import scalaz.scalacheck.ScalazProperties._
+
+class InvariantFunctorTest extends Spec {
+
+  checkAll(invariantFunctor.laws[Id])
+  checkAll(invariantFunctor.laws[Option])
+
+  "xmap" in {
+    some(1).xmap[Int](_ + 1, _ - 1) must be_===(some(2))
+  }
+
+  "xmap iso" in {
+    val succI: Int <=> Int = new IsoSet[Int, Int] {
+      def to = (_: Int) + 1
+      def from = (_: Int) - 1
+    }
+    some(1) xmapi succI must be_===(some(2))
+  }
+
+  "xmap bijection" in {
+    val succB: Bijection[Int, Int] = liftBijection[Id, Id, Int, Int](_ + 1, _ - 1)
+    some(1) xmapb succB must be_===(some(2))
+  }
+
+  case class Num(x: Int)
+  implicit val showNum = Show.showA[Num]
+  implicit val eqNum = Equal.equalA[Num]
+
+  "semigroup" in {
+    val sg: Semigroup[Num] = Semigroup[Int].xmap[Num](Num.apply _, _.x)
+    sg.append(Num(1), Num(2)) must be_===(Num(3))
+  }
+
+  "monoid" in {
+    val sg: Monoid[Num] = Monoid[Int].xmap[Num](Num.apply _, _.x)
+    sg.append(Num(1), Num(2)) must be_===(Num(3))
+    sg.zero must be_===(Num(0))
+  }
+}


### PR DESCRIPTION
This PR adds a Scalaz 7 version of InvariantFunctor from Scalaz 6.

Lens, PLens, StoreT, StateT do not have InvariantFunctor instances, although in general they could.

Also, note that Bijection[A, B] is redundant with IsoSet[A, B].
