### PR TITLE
Fix issue where f2 would be evaluated twice in some cases

### DIFF
--- a/core/src/main/scala/scalaz/std/Option.scala
+++ b/core/src/main/scala/scalaz/std/Option.scala
@@ -56,7 +56,7 @@ trait OptionInstances extends OptionInstances0 {
     def append(f1: Option[A], f2: => Option[A]) = (f1, f2) match {
       case (Some(a1), Some(a2)) => Some(Semigroup[A].append(a1, a2))
       case (Some(a1), None)     => f1
-      case (None, Some(a2))     => Some(a2)
+      case (None, sa2 @ Some(a2)) => sa2
       case (None, None)         => None
     }
 


### PR DESCRIPTION
The pass by name function f2 was being evaluated twice in the option monoid in one case, which could be a very expensive operation.
