### PR TITLE
Added Semigroup[A @@ minVal] and Semigroup[A @@ MaxVal] for A: Order

### DIFF
--- a/core/src/main/scala/scalaz/Order.scala
+++ b/core/src/main/scala/scalaz/Order.scala
@@ -95,5 +95,10 @@ object Order {
     }
   }
 
+  import Tags._  
+  implicit def orderMaxValSemigroup[A: Order]: Semigroup[A @@ MaxVal] = Semigroup.instance((a1, a2) => MaxVal(Order[A].max(a1, a2)))
+  implicit def orderMinValSemigroup[A: Order]: Semigroup[A @@ MinVal] = Semigroup.instance((a1, a2) => MinVal(Order[A].min(a1, a2)))
+
+
   ////
 }

--- a/tests/src/test/scala/scalaz/OrderTest.scala
+++ b/tests/src/test/scala/scalaz/OrderTest.scala
@@ -13,4 +13,19 @@ class OrderTest extends Spec {
       (F maximum xs: Option[Int]) must be_===(F minimum xsdual: Option[Int])
       (F minimum xs: Option[Int]) must be_===(F maximum xsdual: Option[Int])
   }
+  
+  "semigroups min" ! prop {
+    (xs: NonEmptyList[Int]) =>
+	  val F = Foldable1[NonEmptyList]
+	  import Tags._
+	  import syntax.foldable1._
+	  (xs map MinVal).suml1 must be_===(F minimum1 xs)
+  }
+  "semigroups max" ! prop {
+    (xs: NonEmptyList[Int]) =>
+	  val F = Foldable1[NonEmptyList]
+	  import Tags._
+	  import syntax.foldable1._
+	  (xs map MaxVal).suml1 must be_===(F maximum1 xs)
+  }
 }


### PR DESCRIPTION
Any Ordered type `A` gives rise to two `Semigroups` (implicitly available from the `Order` module):

``` scala
Semigroup[A @@ MinVal]
Semigroup[A @@ MaxVal]
```

Examples:

``` scala
forall[A : Order] (nel: NonEmptyList[A]) => (nel map MinVal).suml1 === nel.minimum1
forall[A : Order] (nel: NonEmptyList[A]) => (nel map MaxVal).suml1 === nel.maximum1
```
