### PR TITLE
Added Equal instance for any subclass of java.lang.Enum plus Test

### DIFF
--- a/core/src/main/scala/scalaz/std/AllInstances.scala
+++ b/core/src/main/scala/scalaz/std/AllInstances.scala
@@ -10,6 +10,7 @@ trait AllInstances
   with scalaz.std.util.parsing.combinator.Parsers
   with scalaz.std.java.util.MapInstances
   with scalaz.std.java.math.BigIntegerInstances
+  with scalaz.std.java.EnumInstances
   with scalaz.std.java.util.concurrent.CallableInstances
   with NodeSeqInstances
   // Intentionally omitted: IterableInstances

--- a/core/src/main/scala/scalaz/std/java/Enum.scala
+++ b/core/src/main/scala/scalaz/std/java/Enum.scala
@@ -1,0 +1,10 @@
+package scalaz
+package std.java
+
+trait EnumInstances {
+    
+   implicit def EnumEqual[E <: java.lang.Enum[E]](implicit ev: E <:< java.lang.Enum[E]) = Equal.equal[E]( _ eq _ )
+   
+}
+
+object enum extends EnumInstances

--- a/tests/src/test/scala/scalaz/std/java/EnumTest.scala
+++ b/tests/src/test/scala/scalaz/std/java/EnumTest.scala
@@ -1,0 +1,30 @@
+package scalaz
+package std
+package java
+
+import scalaz.scalacheck.ScalazProperties._
+import scalaz.scalacheck.ScalazArbitrary._
+
+class EnumTest extends Spec {
+   
+    "equal" in {
+        import _root_.java.util.concurrent.TimeUnit
+        import syntax.equal._
+        import enum._
+        TimeUnit.values forall ( tu => tu === tu )
+    }
+    
+    "not-equal" in {
+        import _root_.java.util.concurrent.TimeUnit
+        import syntax.equal._
+        import enum._
+        //get all 2-element subsets of TimeUnit
+        @annotation.tailrec def pairs[A](l: List[A], acc: List[(A, A)] = Nil): List[(A, A)] = l match {
+          case Nil | (_ :: Nil)      => acc
+          case x :: (xxs @ (_ :: _)) => pairs(xxs, (xxs map (x -> _)) ::: acc)
+        }
+        pairs(TimeUnit.values.toList) forall { case (tu1, tu2) => tu1 =/= tu2 } 
+        
+    }
+
+}


### PR DESCRIPTION
Any sublass of `java.lang.Enum` now has an `Equal` instance:

``` scala
import scalaz.syntax.equal._
import scalaz.std.java.enum._

import java.util.concurrent.TimeUnit._
SECONDS === SECONDS //true
MINUTES =/= SECONDS //true
```
