### PR TITLE
Generalized enumArray to enumIndexedSeq.

### DIFF
--- a/iteratee/src/main/scala/scalaz/iteratee/EnumeratorT.scala
+++ b/iteratee/src/main/scala/scalaz/iteratee/EnumeratorT.scala
@@ -166,10 +166,7 @@ trait EnumeratorTFunctions {
         )
     }
 
-  /**
-   * An enumerator that yields the elements of the specified array from index min (inclusive) to max (exclusive)
-   */
-  def enumArray[E, F[_]: Monad](a : Array[E], min: Int = 0, max: Option[Int] = None) : EnumeratorT[E, F] =
+  def enumIndexedSeq[E, F[_]: Monad](a : IndexedSeq[E], min: Int = 0, max: Option[Int] = None) : EnumeratorT[E, F] =
     new EnumeratorT[E, F] {
       private val limit = max.map(_ min (a.length)).getOrElse(a.length)
       def apply[A] = {
@@ -180,10 +177,15 @@ trait EnumeratorTFunctions {
                    else             s.pointI
             )   
         }
-
         loop(min)
       }
     }
+
+  /**
+   * An enumerator that yields the elements of the specified array from index min (inclusive) to max (exclusive)
+   */
+  def enumArray[E, F[_]: Monad](a : Array[E], min: Int = 0, max: Option[Int] = None) : EnumeratorT[E, F] =
+    enumIndexedSeq(a, min, max)
 
   def repeat[E, F[_] : Monad](e: E): EnumeratorT[E, F] =
     new EnumeratorT[E, F] {


### PR DESCRIPTION
This retains the enumArray function for backwards compatibility,
but it now just delegates to enumIndexedSeq. In theory, there's
nothing functionally that prevents this from being generalized
further to take a Seq instead, except that the implementation
would prefer to have a performant apply(). Since you'd likely
only want to feed this an indexed sequence, preferring a
different enumeration for a non-indexed one, it seems safer to
only generalize it this far.
