### PR TITLE
Adds traverseM to traverseOps

### DIFF
--- a/core/src/main/scala/scalaz/syntax/TraverseSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/TraverseSyntax.scala
@@ -19,6 +19,10 @@ trait TraverseOps[F[_],A] extends Ops[F[A]] {
     G.TC.traverse(self)(G.leibniz.subst[({type λ[α] = A => α})#λ](f))
   }
 
+  /** A version of `traverse` where a subsequent monadic join is applied to the inner result. */
+  final def traverseM[G[_], B](f: A => G[F[B]])(implicit G: Applicative[G], FM: Monad[F]): G[F[B]] =
+    G.map(G.traverse(self)(f))(FM.join)
+
   /** Traverse with the identity function */
   final def sequence[G[_], B](implicit ev: A === G[B], G: Applicative[G]): G[F[B]] = {
     val fgb: F[G[B]] = ev.subst[F](self)

--- a/tests/src/test/scala/scalaz/TraverseTest.scala
+++ b/tests/src/test/scala/scalaz/TraverseTest.scala
@@ -77,6 +77,11 @@ class TraverseTest extends Spec {
       } yield IO(a - s))
       state.eval(0).unsafePerformIO().take(3) must be_===(Stream(0, 1, 1))
     }
+
+    "traverse with monadic join" in {
+      val s: Writer[String, List[Int]] = List(1, 2, 3).traverseM[({ type λ[α] = Writer[String, α] })#λ, Int](x => Writer(x.toString, List(x, x * 2)))
+      s.run must be_===(("123", List(1, 2, 2, 4, 3, 6)))
+    }
   }
 
   "derived functions" should {


### PR DESCRIPTION
A utility method for the very common F[A].traverse(f: A => G[F[B]]).map(Monad[F].join) : G[F[B]] pattern.
