### PR TITLE
put `\/`/`NonEmptyList` specific syntax into own syntax traits

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Timer.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Timer.scala
@@ -1,11 +1,12 @@
 package scalaz
 package concurrent
 
-import scalaz._
-import Scalaz._
 import scala.annotation.tailrec
-import java.util.concurrent.locks.ReentrantReadWriteLock
 import scala.collection.immutable.SortedMap
+
+import java.util.concurrent.locks.ReentrantReadWriteLock
+
+import scalaz.syntax.either._
 
 trait Timeout
 object Timeout extends Timeout

--- a/core/src/main/scala/scalaz/syntax/EitherOps.scala
+++ b/core/src/main/scala/scalaz/syntax/EitherOps.scala
@@ -1,0 +1,14 @@
+package scalaz
+package syntax
+
+trait EitherOps[A] extends Ops[A] {
+  final def left[B]: (A \/ B) =
+    \/.left(self)
+
+  final def right[B]: (B \/ A) =
+    \/.right(self)
+}
+
+trait ToEitherOps {
+  implicit def ToEitherOps[A](a: A) = new EitherOps[A]{ def self = a }
+}

--- a/core/src/main/scala/scalaz/syntax/IdOps.scala
+++ b/core/src/main/scala/scalaz/syntax/IdOps.scala
@@ -1,9 +1,7 @@
 package scalaz.syntax
 
 import annotation.tailrec
-import scalaz.{Applicative, Monoid, NonEmptyList, Kleisli, Reader, \/}
-
-import scalaz.Id._
+import scalaz.{Applicative, Monoid, NonEmptyList, \/}
 
 trait IdOps[A] extends Ops[A] {
   /**Returns `self` if it is non-null, otherwise returns `d`. */
@@ -28,12 +26,15 @@ trait IdOps[A] extends Ops[A] {
   final def squared: (A, A) =
     (self, self)
 
+  @deprecated("use scalaz.syntax.either._", "7.1")
   def left[B]: (A \/ B) =
     \/.left(self)
 
+  @deprecated("use scalaz.syntax.either._", "7.1")
   def right[B]: (B \/ A) =
     \/.right(self)
 
+  @deprecated("use scalaz.syntax.nel._", "7.1")
   final def wrapNel: NonEmptyList[A] =
     NonEmptyList(self)
 

--- a/core/src/main/scala/scalaz/syntax/NonEmptyListOps.scala
+++ b/core/src/main/scala/scalaz/syntax/NonEmptyListOps.scala
@@ -1,0 +1,11 @@
+package scalaz
+package syntax
+
+trait NelOps[A] extends Ops[A] {
+  final def wrapNel: NonEmptyList[A] =
+    NonEmptyList(self)
+}
+
+trait ToNelOps {
+  implicit def ToNelOps[A](a: A) = new NelOps[A]{ def self = a }
+}

--- a/core/src/main/scala/scalaz/syntax/Syntax.scala
+++ b/core/src/main/scala/scalaz/syntax/Syntax.scala
@@ -2,10 +2,10 @@ package scalaz
 package syntax
 
 trait Syntaxes {
+
   //
   // Type classes over * -> *
   //
-
 
   object semigroup extends ToSemigroupOps
 
@@ -56,6 +56,10 @@ trait Syntaxes {
 
   object monadPlus extends ToMonadPlusOps
 
+  object foldable extends ToFoldableOps
+
+  object foldable1 extends ToFoldable1Ops
+
   object traverse extends ToTraverseOps
 
   object traverse1 extends ToTraverse1Ops
@@ -87,6 +91,7 @@ trait Syntaxes {
   object monadTell extends ToMonadTellOps
 
   object monadListen extends ToMonadListenOps
+
   //
   // Data
   //
@@ -101,13 +106,13 @@ trait Syntaxes {
 
   object state extends ToStateOps
 
-  object foldable extends ToFoldableOps
-
-  object foldable1 extends ToFoldable1Ops
-
   object validation extends ToValidationOps
 
   object kleisli extends ToKleisliOps
+
+  object either extends ToEitherOps
+
+  object nel extends ToNelOps
 
   //
   // Mixed
@@ -117,7 +122,18 @@ trait Syntaxes {
 
 }
 
-trait ToDataOps extends ToIdOps with ToTreeOps with ToWriterOps with ToValidationOps with ToReducerOps with ToKleisliOps
+trait ToDataOps
+  extends ToIdOps
+  with ToTreeOps
+  with ToReducerOps
+  with ToWriterOps
+  with ToStateOps
+  with ToValidationOps
+  with ToKleisliOps
+  // TODO those are not yet included because of ambiguities when importing all syntax
+  // can be included again when the @deprecated methods are being removed
+  // with ToEitherOps
+  // with ToNelOps
 
 trait ToTypeClassOps
   extends ToSemigroupOps with ToMonoidOps with ToEqualOps with ToLengthOps with ToShowOps

--- a/core/src/main/scala/scalaz/syntax/ValidationOps.scala
+++ b/core/src/main/scala/scalaz/syntax/ValidationOps.scala
@@ -1,7 +1,7 @@
 package scalaz
 package syntax
 
-trait ValidationV[A] extends Ops[A] {
+trait ValidationOps[A] extends Ops[A] {
   def success[X]: Validation[X, A] = Validation.success[X, A](self)
 
   def successNel[X]: ValidationNel[X, A] = success
@@ -16,5 +16,5 @@ trait ValidationV[A] extends Ops[A] {
 }
 
 trait ToValidationOps {
-  implicit def ToValidationV[A](a: A) = new ValidationV[A]{ def self = a }
+  implicit def ToValidationOps[A](a: A) = new ValidationOps[A]{ def self = a }
 }

--- a/core/src/main/scala/scalaz/syntax/std/Function1Ops.scala
+++ b/core/src/main/scala/scalaz/syntax/std/Function1Ops.scala
@@ -3,8 +3,6 @@ package syntax
 package std
 
 trait Function1Ops[T, R] extends Ops[T => R] {
-  import NonEmptyList._
-  import Validation._
 
   def on[X](f: (R, R) => X, t1: T, t2: T): X = f(self(t1), self(t2))
 
@@ -17,7 +15,7 @@ trait Function1Ops[T, R] extends Ops[T => R] {
   def unary_!(implicit m: Memo[T, R]): T => R = m(self)
 
   def toValidation[E](e: => E)(implicit ev: R =:= Boolean): T => Validation[NonEmptyList[E], T] =
-    (t: T) => (if (self(t): Boolean) success(t) else failure(nel(e, Nil)))
+    (t: T) => (if (self(t): Boolean) Success(t) else Failure(NonEmptyList(e)))
 
   def byName: (=> T) => R = t => self(t)
 

--- a/tests/src/test/scala/scalaz/BitraverseTest.scala
+++ b/tests/src/test/scala/scalaz/BitraverseTest.scala
@@ -22,7 +22,7 @@ class BitraverseTest extends Spec {
 
 
   "left/right bias" in {
-    import scalaz.syntax.id._
+    import scalaz.syntax.either._
 
     Bitraverse[\/].rightTraverse.traverse(42.left[Int])(x => Vector(x + 3)) must be_===(Vector(-\/(42)))
     Bitraverse[\/].leftTraverse.traverse(42.left[Int])(x => Vector(x + 3))  must be_===(Vector(-\/(45)))

--- a/tests/src/test/scala/scalaz/EitherTTest.scala
+++ b/tests/src/test/scala/scalaz/EitherTTest.scala
@@ -30,7 +30,7 @@ class EitherTTest extends Spec {
   // compilation test
   // https://gist.github.com/vmarquez/5106252/
   {
-    import scalaz.syntax.id._
+    import scalaz.syntax.either._
 
     case class ABC(s:String)
 

--- a/tests/src/test/scala/scalaz/concurrent/TimerTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/TimerTest.scala
@@ -6,7 +6,7 @@ import scalaz.scalacheck.ScalazArbitrary._
 import std.AllInstances._
 import org.specs2.execute.{Failure, Result}
 import ConcurrentTest._
-import scalaz._,Scalaz._
+import scalaz.syntax.either._
 
 class TimerTest extends Spec {
   def withTimer[T](expression: Timer => T): T = {


### PR DESCRIPTION
As pointed out in IRC, there was an inconsistency:

> Why is it that in order to get .fail and .success I need to import syntax.validation._, but to get .left and .right I need to import syntax.id._ as opposed to syntax.disjuction._ or something?

Hence, deprecate `left`, `right` and `wrapNel` in `IdOps`, and put them into their own syntax traits.

Speaking of which, I think we should finally deprecate `object Scalaz`.
