### PR TITLE
Trivial: Fixes the scala warning:

### DIFF
--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -395,6 +395,6 @@ trait DisjunctionFunctions {
   def fromTryCatch[T](a: => T): Throwable \/ T = try {
     right(a)
   } catch {
-    case e => left(e)
+    case e: Throwable => left(e)
   }
 }

--- a/core/src/main/scala/scalaz/EitherT.scala
+++ b/core/src/main/scala/scalaz/EitherT.scala
@@ -215,7 +215,7 @@ object EitherT extends EitherTFunctions with EitherTInstances {
   def fromTryCatch[F[+_], A](a: => F[A])(implicit F: Applicative[F]): EitherT[F, Throwable, A] = try {
     right(a)
   } catch {
-    case e => left(F.point(e))
+    case e: Throwable => left(F.point(e))
   }
 }
 

--- a/core/src/main/scala/scalaz/Forall.scala
+++ b/core/src/main/scala/scalaz/Forall.scala
@@ -21,7 +21,6 @@ trait Foralls {
         p((arg: P[A]) => throw new Control(arg))
       } catch {
         case Control(arg) => arg
-        case e => throw e
       }
     }
   }

--- a/core/src/main/scala/scalaz/Validation.scala
+++ b/core/src/main/scala/scalaz/Validation.scala
@@ -466,7 +466,7 @@ trait ValidationFunctions {
   def fromTryCatch[T](a: => T): Validation[Throwable, T] = try {
     success(a)
   } catch {
-    case e => failure(e)
+    case e: Throwable => failure(e)
   }
 
   /** Construct a `Validation` from an `Either`. */

--- a/effect/src/main/scala/scalaz/effect/IO.scala
+++ b/effect/src/main/scala/scalaz/effect/IO.scala
@@ -69,7 +69,7 @@ sealed trait IO[+A] {
 
   /** Executes the handler if an exception is raised. */
   def except[B >: A](handler: Throwable => IO[B]): IO[B] = 
-    io(rw => try { Return(this(rw).run) } catch { case e => handler(e)(rw) })
+    io(rw => try { Return(this(rw).run) } catch { case e: Throwable => handler(e)(rw) })
 
   /**
    * Executes the handler for exceptions that are raised and match the given predicate.


### PR DESCRIPTION
Scala compiler warning: 'This catches all Throwables. If this is really intended, use `case e : Throwable` to clear this warning.'

Fixed by adding 'case e: Throwable' to catch clauses that are meant to catch all Throwables and removing one instance
where the exception is caught and thrown, which is the equivelant to leaving the statement out.
