### PR TITLE
remove unnecessary type parameter foldMapIdentity

### DIFF
--- a/core/src/main/scala/scalaz/Foldable.scala
+++ b/core/src/main/scala/scalaz/Foldable.scala
@@ -85,7 +85,7 @@ trait Foldable[F[_]]  { self =>
     foldLeftM(fa, z)((b, a) => f(b)(a))
 
   /** Unbiased sum of monoidal values. */
-  def foldMapIdentity[A,B](fa: F[A])(implicit F: Monoid[A]): A = foldMap(fa)(a => a)
+  def foldMapIdentity[A](fa: F[A])(implicit F: Monoid[A]): A = foldMap(fa)(a => a)
   def toList[A](fa: F[A]): List[A] = foldLeft(fa, scala.List[A]())((t, h) => h :: t).reverse
   def toIndexedSeq[A](fa: F[A]): IndexedSeq[A] = foldLeft(fa, IndexedSeq[A]())(_ :+ _)
   def toSet[A](fa: F[A]): Set[A] = foldLeft(fa, Set[A]())(_ + _)


### PR DESCRIPTION
BTW, what's the reason there are [foldMapIdentity](https://github.com/scalaz/scalaz/blob/v7.0.0/core/src/main/scala/scalaz/Foldable.scala#L79) and [fold](https://github.com/scalaz/scalaz/blob/v7.0.0/core/src/main/scala/scalaz/Foldable.scala#L46)?
they have same signatures.
