### PR TITLE
Generalised endomorphic arrows

### DIFF
--- a/core/src/main/scala/scalaz/Endomorphic.scala
+++ b/core/src/main/scala/scalaz/Endomorphic.scala
@@ -1,0 +1,57 @@
+package scalaz
+
+/** Endomorphisms have special properties among arrows, so are captured in this newtype.
+  *
+  * Endomorphic[Function1, A] is equivalent to Endo[A]
+  */
+sealed trait Endomorphic[=>:[_, _], A] {
+
+  def run: A =>: A
+
+  final def compose(that: Endomorphic[=>:, A])(implicit F: Compose[=>:]): Endomorphic[=>:, A] =
+    Endomorphic[=>:, A](F.compose(run, that.run))
+
+  final def andThen(that: Endomorphic[=>:, A])(implicit F: Compose[=>:]): Endomorphic[=>:, A] =
+    that.compose(this)
+
+}
+
+object Endomorphic extends EndomorphicFunctions with EndomorphicInstances {
+
+  def apply[=>:[_, _], A](ga: A =>: A) = new Endomorphic[=>:, A] {
+    val run = ga
+  }
+}
+
+trait EndomorphicFunctions {
+
+  /** Endomorphic Kleisli arrow */
+  final def endoKleisli[F[_]: Monad, A](f: A => F[A]): Endomorphic[({type λ[α, β] = Kleisli[F, α, β]})#λ, A] =
+    Endomorphic[({type λ[α, β] = Kleisli[F, α, β]})#λ, A](Kleisli(f))
+}
+
+trait EndomorphicInstances extends EndomorphicInstances0 {
+
+  implicit def endomorphicMonoid[=>:[_, _], A](implicit G: Category[=>:]): Monoid[Endomorphic[=>:, A]] =
+    new Monoid[Endomorphic[=>:, A]] with EndomorphicSemigroup[=>:, A] {
+      val F = G
+      def zero: Endomorphic[=>:, A] = Endomorphic(G.id)
+    }
+
+  implicit def kleisliEndoInstance[F[_]: Monad, A]: Monoid[Endomorphic[({type λ[α, β] = Kleisli[F, α, β]})#λ, A]] =
+    endomorphicMonoid[({type λ[α, β] = Kleisli[F, α, β]})#λ, A]
+}
+
+trait EndomorphicInstances0 {
+
+  implicit def endomorphicSemigroup[=>:[_, _], A](implicit G: Compose[=>:]): Semigroup[Endomorphic[=>:, A]] =
+    new EndomorphicSemigroup[=>:, A] {
+      val F = G
+    }
+
+}
+
+private[scalaz] trait EndomorphicSemigroup[=>:[_, _], A] extends Semigroup[Endomorphic[=>:, A]] {
+  implicit def F: Compose[=>:]
+  def append(f1: Endomorphic[=>:, A], f2: => Endomorphic[=>:, A]) = Endomorphic(F.compose(f1.run, f2.run))
+}

--- a/core/src/main/scala/scalaz/Kleisli.scala
+++ b/core/src/main/scala/scalaz/Kleisli.scala
@@ -70,6 +70,9 @@ sealed trait Kleisli[M[_], A, B] { self =>
     mapK[({type l[a] = T[M, a]})#l, B](ma => T.liftM(ma))
 
   def local[AA](f: AA => A): Kleisli[M, AA, B] = kleisli(f andThen run)
+
+  def endo(implicit M: Functor[M], ev: A >~> B): Endomorphic[({type λ[α, β] = Kleisli[M, α, β]})#λ, A] =
+    Endomorphic[({type λ[α, β] = Kleisli[M, α, β]})#λ, A](map(ev.apply))
 }
 
 //

--- a/tests/src/test/scala/scalaz/MonoidTest.scala
+++ b/tests/src/test/scala/scalaz/MonoidTest.scala
@@ -12,6 +12,15 @@ class MonoidTest extends Spec {
     incTimesThree(0) must be_===(3)
   }
 
+  "endo kleisli multiply" in {
+    import syntax.monoid._
+
+    val k = Kleisli { i: Int => if (i % 2 == 0) Some(i * 2) else None }
+
+    val kTimes3 = k.endo.multiply(3)
+    kTimes3.run(2) must be_=== (Some(16))
+  }
+
   "unfold" in {
     val ss = std.stream.unfold(1) {
       case x if x < 10 => Some((x.toString, x * 2))


### PR DESCRIPTION
This patch introduces a type `Endomorphic[A]` to wrap a value of `A =>: A`, with an associated monoid instance when `=>:` is a Category: mappend is `<<<`, and mzero is `id`.

(This is the same monoid as can be derived from the non-implicit `def monoid[A]: Monoid[A =>: A]` on `Category`; `Endomorphic` is essentially a newtype to aid in correctly choosing this monoid implicitly.)

A useful case is when `=>:` is `Kleisli[F, _, _]` (pseudo-syntax) for some monad `F`.

A bit of history: Myself and @S11001001 originally did this work on [another branch](https://github.com/bmjames/scalaz/commits/endomorphisms), and redefined the existing `Endo` to be an alias `Endo[A] = Endomorphic[Function1, A]`. However, this broke some existing code using `Endo`, and introduced the requirement to import the Arrow instance for `Function1` any time `Endo` was used. I was unsuccessful in finding an elegant way to avoid the breakage, so I have reworked `Endomorphic` as a distinct type, and left `Endo` as it was.
