### PR TITLE
fix Function1Comonad#cojoin

### DIFF
--- a/core/src/main/scala/scalaz/std/Function.scala
+++ b/core/src/main/scala/scalaz/std/Function.scala
@@ -148,7 +148,7 @@ trait Function1Monoid[A, R] extends Monoid[A => R] with Function1Semigroup[A, R]
 
 trait Function1Comonad[M, R] extends Comonad[({type λ[α]=(M => α)})#λ] {
   implicit def M: Monoid[M]
-  def cojoin[A](a: M => A) = (m1: M) => (m2: M) => a(M.append(m1, m1))
+  def cojoin[A](a: M => A) = (m1: M) => (m2: M) => a(M.append(m1, m2))
   def copoint[A](p: M => A) = p(M.zero)
   def cobind[A, B](fa: M => A)(f: (M => A) => B) = (m1: M) => f((m2: M) => fa(M.append(m1, m2)))
   def map[A, B](fa: M => A)(f: A => B) = fa andThen f


### PR DESCRIPTION
old implementation does not satisfy `cobind(identity) === cojoin`

``` scala
scala> import scalaz._,Scalaz._
import scalaz._
import Scalaz._

scala> val f = {x: Int => x + 1}
f: Int => Int = <function1>

scala> val f1 = f.cojoin
f1: Int => (Int => Int) = <function1>

scala> val f2 = f.cobind(identity)
f2: Int => (Int => Int) = <function1>

scala> f1(2)(3)
res0: Int = 5

scala> f2(2)(3)
res1: Int = 6
```
