### PR TITLE
Make glorified Foldable `identity`s into actual `identity`s.

### DIFF
--- a/core/src/main/scala/scalaz/std/IndexedSeq.scala
+++ b/core/src/main/scala/scalaz/std/IndexedSeq.scala
@@ -67,6 +67,8 @@ trait IndexedSeqSubInstances extends IndexedSeqInstances0 with IndexedSeqSub {se
           (bs._1, acc._2 :+ bs._2)
         }))
 
+    override def toIndexedSeq[A](fa: IxSq[A]) = fa
+
     override def foldRight[A, B](fa: IxSq[A], z: => B)(f: (A, => B) => B) = {
       var i = fa.length
       var r = z

--- a/core/src/main/scala/scalaz/std/List.scala
+++ b/core/src/main/scala/scalaz/std/List.scala
@@ -66,6 +66,8 @@ trait ListInstances extends ListInstances0 {
       r
     }
 
+    override def toList[A](fa: List[A]) = fa
+
     def isEmpty[A](fa: List[A]) = fa.isEmpty
 
     def cobind[A, B](fa: List[A])(f: List[A] => B) =

--- a/core/src/main/scala/scalaz/std/Set.scala
+++ b/core/src/main/scala/scalaz/std/Set.scala
@@ -8,6 +8,8 @@ trait SetInstances {
     def plus[A](a: Set[A], b: => Set[A]) = a ++ b
     def isEmpty[A](fa: Set[A]) = fa.isEmpty
 
+    override def toSet[A](fa: Set[A]) = fa
+
     def foldRight[A, B](fa: Set[A], z: => B)(f: (A, => B) => B) = {
       import scala.collection.mutable.ArrayStack
       val s = new ArrayStack[A]

--- a/core/src/main/scala/scalaz/std/Stream.scala
+++ b/core/src/main/scala/scalaz/std/Stream.scala
@@ -35,6 +35,8 @@ trait StreamInstances {
     else
       f(fa.head, foldRight(fa.tail, z)(f))
 
+    override def toStream[A](fa: Stream[A]) = fa
+
     def bind[A, B](fa: Stream[A])(f: A => Stream[B]) = fa flatMap f
     def empty[A]: Stream[A] = scala.Stream.empty
     def plus[A](a: Stream[A], b: => Stream[A]) = a #::: b


### PR DESCRIPTION
``` scala
scala> Foldable[List].toList(List(1,2,3))
res0: List[Int] = List(1, 2, 3)
```

Just a silly optimization.
