### PR TITLE
Add clearing of last processed message from tail node to avoid memory leaks...

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Actor.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Actor.scala
@@ -56,6 +56,7 @@ final case class Actor[A](handler: A => Unit, onError: Throwable => Unit = throw
     val t = tail.get
     val n = batchHandle(t, 1024)
     if (n ne t) {
+      n.a = null.asInstanceOf[A]
       tail.lazySet(n)
       schedule()
     } else {
@@ -78,7 +79,7 @@ final case class Actor[A](handler: A => Unit, onError: Throwable => Unit = throw
   }
 }
 
-private class Node[A](val a: A = null.asInstanceOf[A]) extends AtomicReference[Node[A]]
+private class Node[A](var a: A = null.asInstanceOf[A]) extends AtomicReference[Node[A]]
 
 object Actor extends ActorFunctions with ActorInstances
 


### PR DESCRIPTION
...when queue is empty and no new messages come.

It don't affect throughput and latency noticeably, but adds 'var' definition to sources...

Thank you, @viktorklang ! 
https://github.com/akka/akka/commit/fb2decbcda5dd2b18a2abfbc0425d18e1e780f24#L0R40
