### PR TITLE
add alternative implementation of thread pool with fixed number of threads and strategy that optimized for actors

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Actor.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Actor.scala
@@ -1,16 +1,18 @@
-package scalaz
-package concurrent
+package scalaz.concurrent
 
+import scalaz.Contravariant
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
-import annotation.tailrec
 
 /**
  * Processes messages of type `A` sequentially. Messages are submitted to
  * the actor with the method `!`. Processing is typically performed asynchronously,
  * this is controlled by the provided `strategy`.
  *
- * Implementation based on non-intrusive MPSC node-based queue, described by Dmitriy Vyukov:
- * http://www.1024cores.net/home/lock-free-algorithms/queues/non-intrusive-mpsc-node-based-queue
+ * An implementation of message queue based on structure of
+ * <a href="http://www.1024cores.net/home/lock-free-algorithms/queues/non-intrusive-mpsc-node-based-queue">non-intrusive MPSC node-based queue</a>,
+ * described by Dmitriy Vyukov.
+ *
+ * Cooked at kitchen of <a href="https://github.com/plokhotnyuk/actors">actor benchmarks</a>.
  *
  * @see scalaz.concurrent.Promise
  *
@@ -65,7 +67,7 @@ final case class Actor[A](handler: A => Unit, onError: Throwable => Unit = throw
     }
   }
 
-  @tailrec
+  @annotation.tailrec
   private def batchHandle(t: Node[A], i: Int): Node[A] = {
     val n = t.get
     if (n ne null) {

--- a/concurrent/src/main/scala/scalaz/concurrent/FixedThreadPoolExecutor.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/FixedThreadPoolExecutor.scala
@@ -1,0 +1,174 @@
+package scalaz.concurrent
+
+import java.util.concurrent._
+import java.util.concurrent.atomic.{AtomicLong, AtomicBoolean, AtomicReference}
+import java.util.concurrent.locks.AbstractQueuedSynchronizer
+
+/**
+ * A high performance implementation of an `java.util.concurrent.ExecutorService ExecutorService`
+ * with fixed number of pooled threads. It efficiently works with thousands of threads without overuse of CPU
+ * and degradation of latency between submission of task and starting of it execution.
+ *
+ * For applications that require separate or custom pools, a `FixedThreadPoolExecutor`
+ * may be constructed with a given pool size; by default, equal to the number of available processors.
+ *
+ * All threads are created in constructor call using a `java.util.concurrent.ThreadFactory`.
+ * If not otherwise specified, a default thread factory is used, that creates threads with daemon status.
+ *
+ * When running of tasks an uncaught exception can occurs. All unhandled exception are redirected to handler
+ * that if not adjusted, by default, just print stack trace without stopping of execution of worker thread.
+ *
+ * Number of submitted but not yet started tasks is practically unlimited.
+ * `java.util.concurrent.RejectedExecutionException` can occurs only after shutdown
+ * when pool was initialized with default implementation of `onReject: Runnable => Unit`.
+ *
+ * An implementation of task queue based on structure of
+ * <a href="http://www.1024cores.net/home/lock-free-algorithms/queues/non-intrusive-mpsc-node-based-queue">non-intrusive MPSC node-based queue</a>,
+ * described by Dmitriy Vyukov.
+ *
+ * An idea of using of semaphore to control of queue access borrowed from
+ * <a href="https://github.com/laforge49/JActor2/blob/master/jactor-impl/src/main/java/org/agilewiki/jactor/impl/ThreadManagerImpl.java">ThreadManager</a>,
+ * implemented by Bill La Forge.
+ *
+ * Cooked at kitchen of <a href="https://github.com/plokhotnyuk/actors">actor benchmarks</a>.
+ *
+ * @param threadCount   A number of worker threads in pool
+ * @param threadFactory A factory to be used to build worker threads
+ * @param onError       The exception handler for unhandled errors during executing of tasks.
+ * @param onReject      The handler for rejection of task submission after shutdown
+ */
+class FixedThreadPoolExecutor(threadCount: Int = Runtime.getRuntime.availableProcessors(),
+                              threadFactory: ThreadFactory = new ThreadFactory() {
+                                def newThread(worker: Runnable): Thread = new Thread(worker) {
+                                  setDaemon(true)
+                                }
+                              },
+                              onError: Throwable => Unit = _.printStackTrace(),
+                              onReject: Runnable => Unit = {
+                                t => throw new RejectedExecutionException("Task " + t + " rejected.")
+                              }) extends AbstractExecutorService {
+  private val head = new AtomicReference[TaskNode](new TaskNode())
+  private val requests = new CountingSemaphore()
+  private val running = new AtomicBoolean(true)
+  private val tail = new AtomicReference[TaskNode](head.get)
+  private val terminations = new CountDownLatch(threadCount)
+  private val threads = {
+    val tf = threadFactory // to avoid creating of field for the threadFactory constructor param
+    (1 to threadCount).map(_ => tf.newThread(new Runnable() {
+      def run(): Unit = doWork()
+    }))
+  }
+
+  threads.foreach(t => t.getState match {
+    case Thread.State.NEW => t.start()
+    case Thread.State.TERMINATED => throw new IllegalThreadStateException("Thread" + t + " is terminated.")
+    case _ => // to be able to reuse already started threads
+  })
+
+  def shutdown() {
+    checkShutdownAccess()
+    running.lazySet(false)
+  }
+
+  def shutdownNow(): java.util.List[Runnable] = {
+    shutdown()
+    threads.filter(_ ne Thread.currentThread()).foreach(_.interrupt()) // don't interrupt worker thread due call in task
+    drainTo(new java.util.LinkedList[Runnable](), tail.getAndSet(head.get)) // drain up to current head
+  }
+
+  def isShutdown: Boolean = !running.get
+
+  def isTerminated: Boolean = terminations.getCount == 0
+
+  def awaitTermination(timeout: Long, unit: TimeUnit): Boolean = {
+    if (threads.exists(_ eq Thread.currentThread())) terminations.countDown() // don't hang up due call in task
+    terminations.await(timeout, unit)
+  }
+
+  def execute(task: Runnable) {
+    if (running.get) {
+      enqueue(task)
+      requests.releaseShared(1)
+    } else handleReject(task)
+  }
+
+  private def enqueue(task: Runnable) {
+    if (task eq null) throw new NullPointerException
+    val n = new TaskNode(task)
+    head.getAndSet(n).lazySet(n)
+  }
+
+  @annotation.tailrec
+  private def drainTo(ts: java.util.List[Runnable], tn: TaskNode): java.util.List[Runnable] =
+    if (tn eq tail.get) ts
+    else {
+      val n = tn.get
+      ts.add(n.task)
+      drainTo(ts, n)
+    }
+
+  private def doWork() {
+    try {
+      while (running.get) {
+        try {
+          requests.acquireSharedInterruptibly(1)
+          dequeueAndRun()
+        } catch {
+          case ex: Throwable => handleError(ex)
+        }
+      }
+    } finally {
+      terminations.countDown()
+    }
+  }
+
+  @annotation.tailrec
+  private def dequeueAndRun() {
+    val tn = tail.get
+    val n = tn.get
+    if ((n ne null) && tail.compareAndSet(tn, n)) {
+      val t = n.task
+      n.task = null
+      t.run()
+    } else dequeueAndRun()
+  }
+
+  private def handleError(ex: Throwable) {
+    if (running.get || !ex.isInstanceOf[InterruptedException]) onError(ex)
+  }
+
+  private def handleReject(task: Runnable) {
+    onReject(task)
+  }
+
+  private def checkShutdownAccess() {
+    val security = System.getSecurityManager
+    if (security != null) {
+      security.checkPermission(FixedThreadPoolExecutor.shutdownPerm)
+      threads.foreach(security.checkAccess(_))
+    }
+  }
+}
+
+private object FixedThreadPoolExecutor {
+  private val shutdownPerm = new RuntimePermission("modifyThread")
+}
+
+private class CountingSemaphore extends AbstractQueuedSynchronizer() {
+  private val count = new AtomicLong()
+
+  override protected final def tryReleaseShared(releases: Int): Boolean = {
+    count.getAndAdd(releases)
+    true
+  }
+
+  @annotation.tailrec
+  override protected final def tryAcquireShared(acquires: Int): Int = {
+    val current = count.get
+    val next = current - acquires
+    if (next < 0 || count.compareAndSet(current, next)) next.toInt // don't worry, only sign of result value is used
+    else tryAcquireShared(acquires)
+  }
+}
+
+private class TaskNode(var task: Runnable = null) extends AtomicReference[TaskNode]

--- a/concurrent/src/main/scala/scalaz/concurrent/Strategy.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Strategy.scala
@@ -1,7 +1,7 @@
 package scalaz
 package concurrent
 
-import java.util.concurrent.{ExecutorService, ThreadFactory, Executors}
+import java.util.concurrent.{Executor, ExecutorService}
 
 /**
  * Evaluate an expression in some specific manner. A typical strategy will schedule asynchronous
@@ -22,16 +22,7 @@ trait Strategys extends StrategysLow {
    * The default executor service is a fixed thread pool with N daemon threads,
    * where N is equal to the number of available processors.
    */
-  val DefaultExecutorService: ExecutorService = {
-    import Executors._
-    newFixedThreadPool(Runtime.getRuntime.availableProcessors, new ThreadFactory {
-      def newThread(r: Runnable) = {
-        val t = defaultThreadFactory.newThread(r)
-        t.setDaemon(true)
-        t
-      }
-    })
-  }
+  val DefaultExecutorService: ExecutorService = new FixedThreadPoolExecutor()
 
   /**
    * A strategy that executes its arguments on `DefaultExecutorService`
@@ -51,8 +42,6 @@ trait StrategysLow {
     }
   }
 
-  import java.util.concurrent.ExecutorService
-
   /**
    * A strategy that evaluates its arguments using an implicit ExecutorService.
    */
@@ -65,6 +54,19 @@ trait StrategysLow {
         def call = a
       })
       () => fut.get
+    }
+  }
+
+  /**
+   * A strategy that optimized for actors and evaluates its arguments using an implicit Executor
+   * without returning of results.
+   */
+  def actorExecutor(implicit e: Executor) = new Strategy {
+    def apply[A](a: => A) = {
+      e.execute(new Runnable() {
+        def run(): Unit = a
+      })
+      () => null.asInstanceOf[A]
     }
   }
 

--- a/tests/src/test/scala/scalaz/concurrent/ActorTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/ActorTest.scala
@@ -19,7 +19,7 @@ class ActorTest extends Spec {
     assertCountDown(latch, "Should process a message")
   }
 
-  "code errors are catched and can be handled" in {
+  "code errors are caught and can be handled" in {
     val latch = new CountDownLatch(1)
     val actor = Actor[Int]((i: Int) => 100 / i, (ex: Throwable) => latch.countDown())
     actor ! 0

--- a/tests/src/test/scala/scalaz/concurrent/FixedThreadPoolExecutorTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/FixedThreadPoolExecutorTest.scala
@@ -1,0 +1,168 @@
+package scalaz.concurrent
+
+import scalaz.Spec
+import org.specs2.matcher.MustThrownMatchers._
+import org.specs2.execute.{Failure, Success, Result}
+import collection.JavaConversions._
+import java.util.concurrent._
+import java.util.concurrent.atomic.AtomicBoolean
+
+class FixedThreadPoolExecutorTest extends Spec {
+  val NumOfTasks = 1000
+  val Timeout = 1000 // in millis
+
+  "tasks executes async" in {
+    testWith(new FixedThreadPoolExecutor) {
+      e =>
+        val latch = new CountDownLatch(NumOfTasks)
+        for (i <- 1 to NumOfTasks) {
+          e.execute(new Runnable() {
+            def run() {
+              latch.countDown()
+            }
+          })
+        }
+        assertCountDown(latch, "Should execute a command")
+    }
+  }
+
+  "errors of tasks are caught and can be handled without interruption of worker threads" in {
+    val latch = new CountDownLatch(NumOfTasks)
+    testWith(new FixedThreadPoolExecutor(threadCount = 1, // single thread to check if it wasn't terminated later
+      onError = _ => latch.countDown())) {
+      e =>
+        for (i <- 1 to NumOfTasks) {
+          e.execute(new Runnable() {
+            def run() {
+              throw new RuntimeException()
+            }
+          })
+        }
+        e.isTerminated must_== false
+        assertCountDown(latch, "Should propagate an exception")
+    }
+  }
+
+  "shutdownNow interrupts threads and returns non-completed tasks in order of submitting" in {
+    testWith(new FixedThreadPoolExecutor(1)) {
+      e =>
+        val task1 = new Runnable() {
+          def run() {
+            // do nothing
+          }
+        }
+        val latch = new CountDownLatch(1)
+        val task2 = new Runnable() {
+          def run() {
+            e.execute(task1)
+            e.execute(this)
+            latch.countDown()
+            Thread.sleep(Timeout) // should be interrupted
+          }
+        }
+        e.execute(task2)
+        assertCountDown(latch, "Two new tasks should be submitted during completing a task")
+        e.shutdownNow() must_== new java.util.LinkedList(Seq(task1, task2))
+        e.isShutdown must_== true
+    }
+  }
+
+  "awaitTermination blocks until all tasks terminates after a shutdown request" in {
+    testWith(new FixedThreadPoolExecutor) {
+      e =>
+        val running = new AtomicBoolean(true)
+        val semaphore = new Semaphore(0)
+        e.execute(new Runnable() {
+          final def run() {
+            semaphore.release()
+            while (running.get) {
+              // hard to interrupt loop
+            }
+          }
+        })
+        semaphore.acquire()
+        e.shutdownNow() must beEmpty
+        e.awaitTermination(1, TimeUnit.MILLISECONDS) must_== false
+        running.lazySet(false)
+        e.awaitTermination(Timeout, TimeUnit.MILLISECONDS) must_== true
+    }
+  }
+
+  "null tasks are not accepted" in {
+    testWith(new FixedThreadPoolExecutor) {
+      e =>
+        e.execute(null) must throwA[NullPointerException]
+    }
+  }
+
+  "terminates safely when shutdownNow called during task execution" in {
+    testWith(new FixedThreadPoolExecutor) {
+      e =>
+        val latch = new CountDownLatch(1)
+        e.execute(new Runnable() {
+          def run() {
+            e.shutdownNow()
+            latch.countDown()
+          }
+        })
+        assertCountDown(latch, "Shutdown should be called")
+        e.awaitTermination(Timeout, TimeUnit.MILLISECONDS) must_== true
+        e.isTerminated must_== true
+    }
+  }
+
+  "duplicated shutdownNow/shutdown is allowed" in {
+    testWith(new FixedThreadPoolExecutor) {
+      e =>
+        e.shutdownNow()
+        e.shutdown()
+        e.shutdownNow() must not(throwA[Throwable])
+        e.shutdown() must not(throwA[Throwable])
+    }
+  }
+
+  "all tasks which are submitted after shutdown are rejected by default" in {
+    testWith(new FixedThreadPoolExecutor) {
+      e =>
+        e.shutdown()
+        val executed = new AtomicBoolean(false)
+        e.execute(new Runnable() {
+          def run() {
+            executed.set(true) // should not be executed
+          }
+        }) must throwA[RejectedExecutionException]
+        executed.get must_== false
+    }
+  }
+
+  "all tasks which are submitted after shutdown can be handled by onReject" in {
+    val latch = new CountDownLatch(1)
+    testWith(new FixedThreadPoolExecutor(onReject = _ => latch.countDown())) {
+      e =>
+        e.shutdown()
+        val executed = new AtomicBoolean(false)
+        e.execute(new Runnable() {
+          def run() {
+            executed.set(true) // Should not be executed
+          }
+        })
+        e.shutdownNow() must beEmpty
+        executed.get must_== false
+        assertCountDown(latch, "OnReject should be called")
+    }
+  }
+
+  def testWith(executor: ExecutorService)(testCode: ExecutorService => Result): Result = {
+    try {
+      testCode(executor)
+    } finally {
+      executor.shutdownNow()
+      executor.awaitTermination(Timeout, TimeUnit.MILLISECONDS)
+    }
+  }
+
+  def assertCountDown(latch: CountDownLatch, hint: String): Result = {
+    if (latch.await(Timeout, TimeUnit.MILLISECONDS)) Success()
+    else Failure("Failed to count down within " + Timeout + " millis: " + hint)
+  }
+}


### PR DESCRIPTION
...and with minor improvements of imports, docs & test title.

Inspired by 'Mechanical Sympathy' posts of Martin Thompson, MPSC node bases queue described by Dmitry Vyukov and using of a semaphore to control access to shared queue implemented by Bill La Forge in `ThreadManagerImpl` from his JActor2 project, in `FixedThreadPoolExecutor` I minimized usage of CPU time and latency between submission of task and starting of it execution, compared with well known `ThreadPoolExecutor` and `ForkJoinPool` from `java.util.concurrent`.

Please see results of actor benchmarks for different actor libraries that uses different implementation of `ExecutionService` interface:
https://github.com/plokhotnyuk/actors/blob/81a3308d6f39b3a6429c4933b2156d5ac0c0a1f4/out0_poolSize1.txt
https://github.com/plokhotnyuk/actors/blob/81a3308d6f39b3a6429c4933b2156d5ac0c0a1f4/out0_poolSize10.txt
https://github.com/plokhotnyuk/actors/blob/81a3308d6f39b3a6429c4933b2156d5ac0c0a1f4/out0_poolSize100.txt
https://github.com/plokhotnyuk/actors/blob/81a3308d6f39b3a6429c4933b2156d5ac0c0a1f4/out0_poolSize1000.txt
https://github.com/plokhotnyuk/actors/blob/81a3308d6f39b3a6429c4933b2156d5ac0c0a1f4/out1_poolSize1.txt
https://github.com/plokhotnyuk/actors/blob/81a3308d6f39b3a6429c4933b2156d5ac0c0a1f4/out1_poolSize10.txt
https://github.com/plokhotnyuk/actors/blob/81a3308d6f39b3a6429c4933b2156d5ac0c0a1f4/out1_poolSize100.txt
https://github.com/plokhotnyuk/actors/blob/81a3308d6f39b3a6429c4933b2156d5ac0c0a1f4/out1_poolSize1000.txt

I would like to thanks all of you, who try and use it.

It is was cooked at kitchen of actor benchmarks: https://github.com/plokhotnyuk/actors and if it doesn't contradict with Scalaz conventions, I would like to preserve link to it in docs to simplify of picking it up by you to improve/maintain `Actor`, `FixedThreadPoolExecutor` and `Strategy` from `scalaz.concurrent` in future. 

Special thanks to amazing people inspired me and helped me with testing, reviewing and bug fixing of this code: Alex Levan, Bill La Forge, Dmitry Vyukov, George Leontiev, Martin Thompson, Sergiy Onenko, Viktor Klang, Yaroslav Klymko.

Some ideas like using of MPSC node based queue for message queue for actors encouraged @viktorklang to implement `SingleConsumerOnlyUnboundedMailbox` in Akka 2.2, than his implementation encouraged me to port a fix of potentially memory leak that was resolved in his code: https://github.com/scalaz/scalaz/pull/396 

Also very special thanks to my wife, Elena, who’s been the main source of inspiration to me all this time.
