### PR TITLE
Replace Endo#fix with a utility function

### DIFF
--- a/core/src/main/scala/scalaz/Endo.scala
+++ b/core/src/main/scala/scalaz/Endo.scala
@@ -8,9 +8,6 @@ sealed trait Endo[A] {
 
   final def apply(a: A): A = run(a)
 
-  /** `run(run(run(...` */
-  final def fix: A = apply(fix)
-
   /** Do `other`, than call myself with its result. */
   final def compose(other: Endo[A]): Endo[A] = Endo.endo(run compose other.run)
 

--- a/core/src/main/scala/scalaz/std/AllFunctions.scala
+++ b/core/src/main/scala/scalaz/std/AllFunctions.scala
@@ -7,5 +7,6 @@ trait AllFunctions
   with StreamFunctions
   with math.OrderingFunctions
   with StringFunctions
+  with FunctionFunctions
 
 object AllFunctions extends AllFunctions

--- a/core/src/main/scala/scalaz/std/Function.scala
+++ b/core/src/main/scala/scalaz/std/Function.scala
@@ -132,7 +132,15 @@ trait FunctionInstances extends FunctionInstances0 {
   }
 }
 
-object function extends FunctionInstances
+trait FunctionFunctions {
+  /** `f(f(f(...` for referentially transparent `f`. */
+  final def fix[A](f: (=> A) => A): A = {
+    lazy val a: A = f(a)
+    a
+  }
+}
+
+object function extends FunctionFunctions with FunctionInstances
 
 //
 // Type class implementation traits

--- a/tests/src/test/scala/scalaz/std/FunctionTest.scala
+++ b/tests/src/test/scala/scalaz/std/FunctionTest.scala
@@ -2,6 +2,7 @@ package scalaz
 package std
 
 import std.AllInstances._
+import std.AllFunctions.fix
 import scalaz.scalacheck.ScalazProperties._
 import scalaz.scalacheck.ScalazArbitrary._
 
@@ -62,6 +63,11 @@ class FunctionTest extends Spec {
     mappedCall() must be_===(number + 4)
   }
 
+  "fix" ! prop{(n: Int) =>
+    fix[Int](_ => n) must be_===(n)
+    (fix[Stream[Int]](ns => n #:: (2*n) #:: ns).take(4).toList
+      must be_===(List(n, 2*n, n, 2*n)))
+  }
 
   object instances {
     def equal[A, R: Equal] = Equal[() => R]


### PR DESCRIPTION
I believe it was @bmjames who observed that `Endo#fix` was not actually useful for anything but producing bottoms.  This removes it in favor of a function on functions that can actually be used.
