### PR TITLE
Enhanced Tasks and Futures with some more combinator options (gatherUnordered combinator + runFor method on Task)

### DIFF
--- a/tests/src/test/scala/scalaz/concurrent/ConcurrentTaskTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/ConcurrentTaskTest.scala
@@ -6,6 +6,7 @@ import java.util.concurrent.{TimeoutException, ThreadFactory, Executors}
 import scala.collection.immutable.Queue
 import scala.concurrent.SyncVar
 import org.specs2.execute.{Success, Result}
+import org.specs2.matcher.MustMatchers._ 
 
 /**
  *
@@ -73,8 +74,8 @@ object ConcurrentTaskTest extends Spec {
       
       val t =  fork { Thread.sleep(3000); now(1) }(es)
       
-       t.attemptRunFor(100) match {
-         case -\/(ex:TimeoutException)  => //ok
+       t.attemptRunFor(100) must beLike {
+         case -\/(ex:TimeoutException)  => ok
        } 
    
       es.shutdown()
@@ -87,8 +88,8 @@ object ConcurrentTaskTest extends Spec {
       
       val t =  fork { Thread.sleep(1000); now(1) }(es).map(_=> bool = true)
 
-      t.attemptRunFor(100) match {
-        case -\/(ex:TimeoutException)  => //ok
+      t.attemptRunFor(100) must beLike {
+        case -\/(ex:TimeoutException)  => ok
       }
 
       Thread.sleep(1500)

--- a/tests/src/test/scala/scalaz/concurrent/NonDeterminismTaskTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/NonDeterminismTaskTest.scala
@@ -3,6 +3,7 @@ package scalaz.concurrent
 import java.util.concurrent.Executors
 import scalaz.{-\/, Spec}
 import java.util.concurrent.atomic.AtomicInteger
+import org.specs2.matcher.MustMatchers._
 
 /**
  *
@@ -11,7 +12,7 @@ import java.util.concurrent.atomic.AtomicInteger
  * Time: 2:58 PM
  * (c) 2011-2013 Spinoco Czech Republic, a.s.
  */
-object NondeterminismTaskTest extends Spec{
+object NonDeterminismTaskTest extends Spec{
 
   "Future Nondeterminism" should {
     import scalaz.concurrent.Task._
@@ -58,7 +59,7 @@ object NondeterminismTaskTest extends Spec{
 
       val t = fork(Task.gatherUnordered(Seq(t1,t2,t3)))(es3)
       
-      t.attemptRun match {
+      t.attemptRun must beLike {
         case -\/(e) => e must_== ex 
       }
       
@@ -84,7 +85,7 @@ object NondeterminismTaskTest extends Spec{
 
       val t = fork(Task.gatherUnordered(Seq(t1,t2,t3), cancelOnEarlyExit = true))(es3)
 
-      t.attemptRun match {
+      t.attemptRun must beLike {
         case -\/(e) => e must_== ex 
       }
       

--- a/tests/src/test/scala/scalaz/concurrent/NondeterminismFutureTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/NondeterminismFutureTest.scala
@@ -18,13 +18,14 @@ object NondeterminismFutureTest extends Spec {
     import scalaz.concurrent.Future._
     implicit val es = Executors.newFixedThreadPool(1)
     
+    val non = Nondeterminism[Future]
    
     "correctly process gatherUnordered for >1 futures in non-blocking way" in {
       val f1 = fork(now(1))(es)
       val f2 = delay(7).flatMap(_=>fork(now(2))(es))
       val f3 = fork(now(3))(es)
       
-      val f = fork(Future.gatherUnordered(Seq(f1,f2,f3)))(es)
+      val f = fork(non.gatherUnordered(Seq(f1,f2,f3)))(es)
       
       f.run.toSet must_== Set(1,2,3)
     }
@@ -33,13 +34,13 @@ object NondeterminismFutureTest extends Spec {
     "correctly process gatherUnordered for 1 future in non-blocking way" in {
       val f1 = fork(now(1))(es) 
 
-      val f = fork(Future.gatherUnordered(Seq(f1)))(es)
+      val f = fork(non.gatherUnordered(Seq(f1)))(es)
 
       f.run.toSet must_== Set(1)
     }
 
     "correctly process gatherUnordered for empty seq of futures in non-blocking way" in {
-      val f = fork(Future.gatherUnordered(Seq()))(es)
+      val f = fork(non.gatherUnordered(Seq()))(es)
 
       f.run.toSet must_== Set()
     }


### PR DESCRIPTION
I am not completely sure if Nondeterminism[T] should act here as combinator or is just the way to run the tasks. I rather put the combinators on Task/Future object for now. 

If the Nondeterminism is just combinator, then I believe it should be replaced with non blocking code as suggested in this pull request. 

I also added convenience methods for running the Tasks with Timeout. 
