### PR TITLE
Produce immutable.IndexedSeq, not collection.IndexedSeq, in functions

### DIFF
--- a/core/src/main/scala/scalaz/Foldable.scala
+++ b/core/src/main/scala/scalaz/Foldable.scala
@@ -9,6 +9,7 @@ package scalaz
 trait Foldable[F[_]]  { self =>
   ////
   import collection.generic.CanBuildFrom
+  import collection.immutable.IndexedSeq
 
   /** Map each element of the structure to a [[scalaz.Monoid]], and combine the results. */
   def foldMap[A,B](fa: F[A])(f: A => B)(implicit F: Monoid[B]): B

--- a/core/src/main/scala/scalaz/ImmutableArray.scala
+++ b/core/src/main/scala/scalaz/ImmutableArray.scala
@@ -1,6 +1,7 @@
 package scalaz
 
 import reflect.ClassManifest
+import collection.immutable.IndexedSeq
 import collection.mutable.{ArrayBuilder, Builder}
 import collection.generic.CanBuildFrom
 import collection.IndexedSeqOptimized

--- a/core/src/main/scala/scalaz/Injective.scala
+++ b/core/src/main/scala/scalaz/Injective.scala
@@ -1,5 +1,7 @@
 package scalaz
 
+import collection.immutable.IndexedSeq
+
 /** Given Injective[Foo]: If type Foo[A] = Foo[B] then A ~ B
   *
   * This represents an assertion that is used by other code that requires this condition.

--- a/core/src/main/scala/scalaz/syntax/FoldableSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/FoldableSyntax.scala
@@ -6,6 +6,7 @@ sealed abstract class FoldableOps[F[_],A] extends Ops[F[A]] {
   implicit def F: Foldable[F]
   ////
   import collection.generic.CanBuildFrom
+  import collection.immutable.IndexedSeq
 
   final def foldMap[B: Monoid](f: A => B = (a: A) => a): B = F.foldMap(self)(f)
   final def foldMap1Opt[B: Semigroup](f: A => B = (a: A) => a): Option[B] = F.foldMap1Opt(self)(f)

--- a/project/build.scala
+++ b/project/build.scala
@@ -372,7 +372,7 @@ object build extends Build {
       (pimp, conv)
     }
 
-    val source = "package scalaz\npackage syntax\npackage std\n\n" +
+    val source = "package scalaz\npackage syntax\npackage std\n\nimport collection.immutable.IndexedSeq\n\n" +
       tuples.map(_._1).mkString("\n") +
       "\n\ntrait ToTupleOps {\n" +
          tuples.map("  " + _._2).mkString("\n") +

--- a/tests/src/test/scala/scalaz/std/TupleTest.scala
+++ b/tests/src/test/scala/scalaz/std/TupleTest.scala
@@ -1,6 +1,8 @@
 package scalaz
 package std
 
+import collection.immutable.IndexedSeq
+
 import std.AllInstances._
 import scalaz.scalacheck.ScalazProperties._
 import scalaz.scalacheck.ScalazArbitrary._


### PR DESCRIPTION
Where the latter was produced before, e.g. Foldable#toIndexedSeq.  This is more consistent with `IndexedSeq` instances, and even `toIndexedSeq` in Scala collections means the immutable version.

Sequel to #177.
