### PR TITLE
ListT#headOption should be OptionT

### DIFF
--- a/core/src/main/scala/scalaz/ListT.scala
+++ b/core/src/main/scala/scalaz/ListT.scala
@@ -20,7 +20,7 @@ sealed case class ListT[M[_], A](underlying: M[List[A]]){
 
   def head(implicit M: Functor[M]) : M[A] = M.map(underlying)(_.head)
 
-  def headOption(implicit M: Functor[M]) : M[Option[A]] = M.map(underlying)(_.headOption)
+  def headOption(implicit M: Functor[M]) : OptionT[M, A] = new OptionT(M.map(underlying)(_.headOption))
   
   def tailM(implicit M: Applicative[M]) : M[ListT[M, A]] = M.map(uncons)(_.get._2)
 


### PR DESCRIPTION
This is a breaking change to the API, but it makes it more consistent with similar methods on other monad transformers, such as EitherT#toOption or OptionT#toLeft.

Also, it will break old code in a very obvious way with a compile error that can be fixed by adding a `.run`.
