### PR TITLE
value class

### DIFF
--- a/core/src/main/scala/scalaz/package.scala
+++ b/core/src/main/scala/scalaz/package.scala
@@ -80,7 +80,7 @@
  *  - [[scalaz.OptionT]] Represents computations of type `F[Option[A]]`
  *  - [[scalaz.EitherT]] Represents computations of type `F[A \/ B]`
  */
-package object scalaz {
+package object scalaz extends TypeAlias {
   import Id._
 
   implicit val idInstance: Traverse1[Id] with Each[Id] with Monad[Id] with Comonad[Id] with Distributive[Id] with Zip[Id] with Unzip[Id] with Cozip[Id] = Id.id

--- a/core/src/main/scala/scalaz/syntax/EitherOps.scala
+++ b/core/src/main/scala/scalaz/syntax/EitherOps.scala
@@ -1,7 +1,7 @@
 package scalaz
 package syntax
 
-trait EitherOps[A] extends Ops[A] {
+final class EitherOps[A](val self: A) extends Super {
   final def left[B]: (A \/ B) =
     \/.left(self)
 
@@ -10,5 +10,5 @@ trait EitherOps[A] extends Ops[A] {
 }
 
 trait ToEitherOps {
-  implicit def ToEitherOps[A](a: A) = new EitherOps[A]{ def self = a }
+  implicit def ToEitherOps[A](a: A) = new EitherOps(a)
 }

--- a/core/src/main/scala/scalaz/syntax/IdOps.scala
+++ b/core/src/main/scala/scalaz/syntax/IdOps.scala
@@ -1,9 +1,9 @@
-package scalaz.syntax
+package scalaz
+package syntax
 
 import annotation.tailrec
-import scalaz.{Applicative, Monoid, NonEmptyList, \/}
 
-trait IdOps[A] extends Ops[A] {
+final class IdOps[A](val self: A) extends Super {
   /**Returns `self` if it is non-null, otherwise returns `d`. */
   final def ??(d: => A)(implicit ev: Null <:< A): A =
     if (self == null) d else self
@@ -76,7 +76,5 @@ trait IdOps[A] extends Ops[A] {
 }
 
 trait ToIdOps {
-  implicit def ToIdOps[A](a: A): IdOps[A] = new IdOps[A] {
-    def self: A = a
-  }
+  implicit def ToIdOps[A](a: A): IdOps[A] = new IdOps(a)
 }

--- a/core/src/main/scala/scalaz/syntax/KleisliOps.scala
+++ b/core/src/main/scala/scalaz/syntax/KleisliOps.scala
@@ -3,7 +3,7 @@ package syntax
 
 import Id._
 
-trait KleisliIdOps[A] extends Ops[A] {
+final class KleisliIdOps[A](val self: A) extends Super {
   /** Lift the value into a Kleisli */
   def liftKleisliId[R]: Kleisli[Id, R, A] = Kleisli[Id, R, A](_ => self)
 
@@ -11,7 +11,7 @@ trait KleisliIdOps[A] extends Ops[A] {
   def liftReader[R]: Reader[R, A] = liftKleisliId
 }
 
-trait KleisliFAOps[F[_], A] extends Ops[F[A]] {
+final class KleisliFAOps[F[_], A](val self: F[A]) extends Super {
   /** Lift the computation into a Kleisli */
   def liftKleisli[R]: Kleisli[F, R, A] = Kleisli[F, R, A](_ => self)
 
@@ -20,11 +20,11 @@ trait KleisliFAOps[F[_], A] extends Ops[F[A]] {
 }
 
 trait ToKleisliOps0 {
-  implicit def ToKleisliOpsUnapply[FA](v: FA)(implicit F0: Unapply[Monad, FA]) =
-    new KleisliFAOps[F0.M, F0.A] { def self = F0(v) }
+  implicit def ToKleisliOpsUnapply[FA](v: FA)(implicit F0: Unapply[Monad, FA]): KleisliFAOps[F0.M, F0.A] =
+    new KleisliFAOps(F0(v))
 }
 
 trait ToKleisliOps extends ToKleisliOps0 {
-  implicit def ToKleisliIdOps[A](a: A) = new KleisliIdOps[A]{ def self = a }
-  implicit def ToKleisliFAOps[F[_], A](fa: F[A]) = new KleisliFAOps[F, A] { def self = fa }
+  implicit def ToKleisliIdOps[A](a: A) = new KleisliIdOps(a)
+  implicit def ToKleisliFAOps[F[_], A](fa: F[A]) = new KleisliFAOps(fa)
 }

--- a/core/src/main/scala/scalaz/syntax/NonEmptyListOps.scala
+++ b/core/src/main/scala/scalaz/syntax/NonEmptyListOps.scala
@@ -1,11 +1,11 @@
 package scalaz
 package syntax
 
-trait NelOps[A] extends Ops[A] {
+final class NelOps[A](val self: A) extends Super {
   final def wrapNel: NonEmptyList[A] =
     NonEmptyList(self)
 }
 
 trait ToNelOps {
-  implicit def ToNelOps[A](a: A) = new NelOps[A]{ def self = a }
+  implicit def ToNelOps[A](a: A) = new NelOps(a)
 }

--- a/core/src/main/scala/scalaz/syntax/ReducerOps.scala
+++ b/core/src/main/scala/scalaz/syntax/ReducerOps.scala
@@ -1,7 +1,7 @@
 package scalaz
 package syntax
 
-trait ReducerOps[A] extends Ops[A] {
+final class ReducerOps[A](val self: A) extends Super {
   /** Convert the value into a monoid */
   def unit[M](implicit r: Reducer[A,M]): M = r.unit(self)
 
@@ -13,5 +13,5 @@ trait ReducerOps[A] extends Ops[A] {
 }
 
 trait ToReducerOps {
-  implicit def ToReducerOps[A](a: A) = new ReducerOps[A]{ def self = a }
+  implicit def ToReducerOps[A](a: A) = new ReducerOps(a)
 }

--- a/core/src/main/scala/scalaz/syntax/StateOps.scala
+++ b/core/src/main/scala/scalaz/syntax/StateOps.scala
@@ -1,11 +1,11 @@
 package scalaz
 package syntax
 
-trait StateOps[A] extends Ops[A] {
+final class StateOps[A](val self: A) extends Super {
   def state[S]: State[S, A] = State.state[S, A](self)
   def stateT[F[_]:Applicative, S]: StateT[F, S, A] = StateT.stateT[F, S, A](self)
 }
 
 trait ToStateOps {
-  implicit def ToStateOps[A](a: A) = new StateOps[A] { def self = a }
+  implicit def ToStateOps[A](a: A) = new StateOps(a)
 }

--- a/core/src/main/scala/scalaz/syntax/TreeOps.scala
+++ b/core/src/main/scala/scalaz/syntax/TreeOps.scala
@@ -1,12 +1,12 @@
 package scalaz
 package syntax
 
-trait TreeOps[A] extends Ops[A] {
+final class TreeOps[A](val self: A) extends Super {
   def node(subForest: Tree[A]*): Tree[A] = Tree.node(self, subForest.toStream)
 
   def leaf: Tree[A] = Tree.leaf(self)
 }
 
 trait ToTreeOps {
-  implicit def ToTreeOps[A](a: A) = new TreeOps[A]{ def self = a }
+  implicit def ToTreeOps[A](a: A) = new TreeOps(a)
 }

--- a/core/src/main/scala/scalaz/syntax/ValidationOps.scala
+++ b/core/src/main/scala/scalaz/syntax/ValidationOps.scala
@@ -1,7 +1,7 @@
 package scalaz
 package syntax
 
-trait ValidationOps[A] extends Ops[A] {
+final class ValidationOps[A](val self: A) extends Super {
   def success[X]: Validation[X, A] = Validation.success[X, A](self)
 
   def successNel[X]: ValidationNel[X, A] = success
@@ -16,5 +16,5 @@ trait ValidationOps[A] extends Ops[A] {
 }
 
 trait ToValidationOps {
-  implicit def ToValidationOps[A](a: A) = new ValidationOps[A]{ def self = a }
+  implicit def ToValidationOps[A](a: A) = new ValidationOps(a)
 }

--- a/core/src/main/scala/scalaz/syntax/WriterOps.scala
+++ b/core/src/main/scala/scalaz/syntax/WriterOps.scala
@@ -1,12 +1,12 @@
 package scalaz
 package syntax
 
-trait WriterOps[A] extends Ops[A] {
+final class WriterOps[A](val self: A) extends Super {
   def set[W](w: W): Writer[W, A] = WriterT.writer(w -> self)
 
   def tell: Writer[A, Unit] = WriterT.tell(self)
 }
 
 trait ToWriterOps {
-  implicit def ToWriterOps[A](a: A) = new WriterOps[A]{ def self = a }
+  implicit def ToWriterOps[A](a: A) = new WriterOps(a)
 }

--- a/core/src/main/scala/scalaz/syntax/std/EitherOps.scala
+++ b/core/src/main/scala/scalaz/syntax/std/EitherOps.scala
@@ -2,14 +2,12 @@ package scalaz
 package syntax
 package std
 
-trait EitherOps[A, B] extends Ops[Either[A, B]] {
+final class EitherOps[A, B](val self: Either[A, B]) extends Super {
 
   final def disjunction: A \/ B = \/ fromEither self
 }
 
 trait ToEitherOps {
-  implicit def ToEitherOpsFromEither[A, B](e: Either[A, B]): EitherOps[A, B] = new EitherOps[A, B] {
-    val self = e
-  }
+  implicit def ToEitherOpsFromEither[A, B](e: Either[A, B]): EitherOps[A, B] = new EitherOps(e)
 }
 

--- a/core/src/main/scala/scalaz/syntax/std/Function1Ops.scala
+++ b/core/src/main/scala/scalaz/syntax/std/Function1Ops.scala
@@ -2,7 +2,7 @@ package scalaz
 package syntax
 package std
 
-trait Function1Ops[T, R] extends Ops[T => R] {
+final class Function1Ops[T, R](val self: T => R) extends Super {
 
   def on[X](f: (R, R) => X, t1: T, t2: T): X = f(self(t1), self(t2))
 
@@ -61,7 +61,5 @@ trait Function1Ops[T, R] extends Ops[T => R] {
 }
 
 trait ToFunction1Ops {
-  implicit def ToFunction1OpsFromBoolean[A, B](f: A => B): Function1Ops[A, B] = new Function1Ops[A, B] {
-    val self = f
-  }
+  implicit def ToFunction1OpsFromBoolean[A, B](f: A => B): Function1Ops[A, B] = new Function1Ops(f)
 }

--- a/core/src/main/scala/scalaz/syntax/std/Function2Ops.scala
+++ b/core/src/main/scala/scalaz/syntax/std/Function2Ops.scala
@@ -2,7 +2,7 @@ package scalaz
 package syntax
 package std
 
-trait Function2Ops[T1, T2, R] extends Ops[(T1, T2) => R] {
+final class Function2Ops[T1, T2, R](val self: (T1, T2) => R) extends Super {
   def flip: (T2, T1) => R = (v2: T2, v1: T1) => self(v1, v2)
 
   def on[X](f: (R, R) => X, t1: (T1, T1), t2: (T2, T2)): X = f(self(t1._1, t2._1), self(t1._2, t2._2))
@@ -15,7 +15,5 @@ trait Function2Ops[T1, T2, R] extends Ops[(T1, T2) => R] {
 }
 
 trait ToFunction2Ops {
-  implicit def ToFunction2Ops[T1, T2, R](f: (T1, T2) => R) = new Function2Ops[T1, T2, R] {
-    val self = f
-  }
+  implicit def ToFunction2Ops[T1, T2, R](f: (T1, T2) => R) = new Function2Ops(f)
 }

--- a/core/src/main/scala/scalaz/syntax/std/IndexedSeqOps.scala
+++ b/core/src/main/scala/scalaz/syntax/std/IndexedSeqOps.scala
@@ -4,9 +4,10 @@ package std
 
 import collection.immutable.IndexedSeq
 
-trait IndexedSeqOps[IS[+_], A] extends Ops[IS[A]] {
+trait IndexedSeqOps0[IS[+_], A] extends Super0 {
+  def self: IS[A]
 
-  protected def v: scalaz.std.IndexedSeqSubFunctions {
+  protected[this] def v: scalaz.std.IndexedSeqSubFunctions {
     type IxSq[+X] = IS[X]
   }
 
@@ -54,9 +55,10 @@ trait IndexedSeqOps[IS[+_], A] extends Ops[IS[A]] {
   final def adjacentPairs: IS[(A, A)] = v.adjacentPairs(self)
 }
 
+final class IndexedSeqOps[A](override val self: IndexedSeq[A]) extends Super with IndexedSeqOps0[IndexedSeq, A] {
+  protected[this] def v = scalaz.std.indexedSeq
+}
+
 trait ToIndexedSeqOps {
-  implicit def ToIndexedSeqOpsFromIndexedSeq[A](a: IndexedSeq[A]): IndexedSeqOps[IndexedSeq, A] = new IndexedSeqOps[IndexedSeq, A] {
-    protected def v = scalaz.std.indexedSeq
-    val self = a
-  }
+  implicit def ToIndexedSeqOpsFromIndexedSeq[A](a: IndexedSeq[A]): IndexedSeqOps[A] = new IndexedSeqOps(a)
 }

--- a/core/src/main/scala/scalaz/syntax/std/ListOps.scala
+++ b/core/src/main/scala/scalaz/syntax/std/ListOps.scala
@@ -5,7 +5,7 @@ package std
 import scalaz.std.{list => l}
 
 
-trait ListOps[A] extends Ops[List[A]] {
+final class ListOps[A](val self: List[A]) extends Super {
   final def intersperse(a: A): List[A] = l.intersperse(self, a)
 
   final def toNel: Option[NonEmptyList[A]] = l.toNel(self)
@@ -54,7 +54,5 @@ trait ListOps[A] extends Ops[List[A]] {
 }
 
 trait ToListOps {
-  implicit def ToListOpsFromList[A](a: List[A]): ListOps[A] = new ListOps[A] {
-    val self = a
-  }
+  implicit def ToListOpsFromList[A](a: List[A]): ListOps[A] = new ListOps[A](a)
 }

--- a/core/src/main/scala/scalaz/syntax/std/MapOps.scala
+++ b/core/src/main/scala/scalaz/syntax/std/MapOps.scala
@@ -4,7 +4,7 @@ package std
 
 import scalaz.std.{ map => dict }
 
-trait MapOps[K, A] extends Ops[Map[K, A]] {
+final class MapOps[K, A](val self: Map[K, A]) extends Super {
   final def alter(k: K)(f: (Option[A] => Option [A])): Map[K, A] = dict.alter(self, k)(f)
   final def intersectWithKey[B, C](m: Map[K, B])(f: (K, A, B) => C): Map[K, C] = dict.intersectWithKey(self, m)(f)
   final def intersectWith[B, C](m: Map[K, B])(f: (A, B) => C): Map[K, C] = dict.intersectWith(self, m)(f)
@@ -15,6 +15,6 @@ trait MapOps[K, A] extends Ops[Map[K, A]] {
 }
 
 trait ToMapOps {
-  implicit def ToMapOpsFromMap[K, V](m: Map[K, V]): MapOps[K, V] = new MapOps[K, V] { val self = m }
+  implicit def ToMapOpsFromMap[K, V](m: Map[K, V]): MapOps[K, V] = new MapOps(m)
 }
 

--- a/core/src/main/scala/scalaz/syntax/std/OptionIdOps.scala
+++ b/core/src/main/scala/scalaz/syntax/std/OptionIdOps.scala
@@ -1,10 +1,11 @@
-package scalaz.syntax
+package scalaz
+package syntax
 package std
 
-trait OptionIdOps[A] extends Ops[A] {
+final class OptionIdOps[A](val self: A) extends Super {
   def some: Option[A] = Some(self)
 }
 
 trait ToOptionIdOps {
-  implicit def ToOptionIdOps[A](a: A) = new OptionIdOps[A] { def self = a }
+  implicit def ToOptionIdOps[A](a: A) = new OptionIdOps(a)
 }

--- a/core/src/main/scala/scalaz/syntax/std/StreamOps.scala
+++ b/core/src/main/scala/scalaz/syntax/std/StreamOps.scala
@@ -2,12 +2,10 @@ package scalaz
 package syntax
 package std
 
-import scalaz.syntax.Ops
-import scalaz.{Monad, Tree, Zipper}
 import scalaz.std.{stream => s}
 
 
-trait StreamOps[A] extends Ops[Stream[A]] {
+final class StreamOps[A](val self: Stream[A]) extends Super {
   final def merge(other: Stream[A]): Stream[A] = s.merge(self, other)
   final def toZipper: Option[Zipper[A]] = s.toZipper(self)
   final def zipperEnd: Option[Zipper[A]] = s.zipperEnd(self)
@@ -20,7 +18,5 @@ trait StreamOps[A] extends Ops[Stream[A]] {
 }
 
 trait ToStreamOps {
-  implicit def ToStreamOpsFromStream[A](a: Stream[A]): StreamOps[A] = new StreamOps[A] {
-    val self = a
-  }
+  implicit def ToStreamOpsFromStream[A](a: Stream[A]): StreamOps[A] = new StreamOps(a)
 }

--- a/core/src/main/scala/scalaz/syntax/std/StringOps.scala
+++ b/core/src/main/scala/scalaz/syntax/std/StringOps.scala
@@ -4,7 +4,7 @@ package std
 
 import scalaz.std.{string => s}
 
-trait StringOps extends Ops[String]{
+final class StringOps(val self: String) extends Super {
   /**
    * Returns the same String value if the given value is 1 otherwise pluralises this String by appending an "s" unless
    * this String ends with "y" and not one of ["ay", "ey", "iy", "oy", "uy"] in which case the 'y' character is chopped and "ies"
@@ -46,7 +46,5 @@ trait StringOps extends Ops[String]{
 }
 
 trait ToStringOps {
-  implicit def ToStringOpsFromString(a:String): StringOps = new StringOps{
-    def self = a
-  }
+  implicit def ToStringOpsFromString(a:String): StringOps = new StringOps(a)
 }

--- a/core/src/main/scala/scalaz/syntax/std/VectorOps.scala
+++ b/core/src/main/scala/scalaz/syntax/std/VectorOps.scala
@@ -2,9 +2,10 @@ package scalaz
 package syntax
 package std
 
+final class VectorOps[A](override val self: Vector[A]) extends Super with IndexedSeqOps0[Vector, A] {
+  protected def v = scalaz.std.vector
+}
+
 trait ToVectorOps {
-  implicit def ToVectorOpsFromVector[A](a: Vector[A]): IndexedSeqOps[Vector, A] = new IndexedSeqOps[Vector, A] {
-    protected def v = scalaz.std.vector
-    val self = a
-  }
+  implicit def ToVectorOpsFromVector[A](a: Vector[A]): VectorOps[A] = new VectorOps(a)
 }

--- a/core/src/main/scala210/scalaz/TypeAlias.scala
+++ b/core/src/main/scala210/scalaz/TypeAlias.scala
@@ -1,0 +1,6 @@
+package scalaz
+
+private[scalaz] trait TypeAlias {
+  final type Super  = AnyVal
+  final type Super0 = Any
+}

--- a/core/src/main/scala29/scalaz/TypeAlias.scala
+++ b/core/src/main/scala29/scalaz/TypeAlias.scala
@@ -1,0 +1,6 @@
+package scalaz
+
+private[scalaz] trait TypeAlias {
+  final type Super  = AnyRef
+  final type Super0 = AnyRef
+}

--- a/effect/src/main/scala/scalaz/syntax/effect/IdOps.scala
+++ b/effect/src/main/scala/scalaz/syntax/effect/IdOps.scala
@@ -4,7 +4,7 @@ package effect
 
 import scalaz.effect.IO
 
-trait IdOps[A] extends Ops[A] {
+final class IdOps[A](val self: A) extends Super {
 
   final def put(implicit S: Show[A]): IO[Unit] =
     IO.put(self)
@@ -19,7 +19,5 @@ trait IdOps[A] extends Ops[A] {
 }
 
 trait ToIdOps {
-  implicit def ToEffectIdOps[A](a: A): IdOps[A] = new IdOps[A] {
-    def self: A = a
-  }
+  implicit def ToEffectIdOps[A](a: A): IdOps[A] = new IdOps(a)
 }


### PR DESCRIPTION
this changes does **not** drop support Scala2.9.

now, we can write each scala version specific code in `src/main/scala210` or `src/main/scala29`.
if scala2.9 the type alias `Super` is `AnyRef`, and then if Scala2.10 the type alias `Super` is `AnyVal`.
