### PR TITLE
scalaJSONObjectPLens and scalaJSONArrayPLens is deprecated

### DIFF
--- a/core/src/main/scala/scalaz/PLens.scala
+++ b/core/src/main/scala/scalaz/PLens.scala
@@ -549,12 +549,14 @@ trait PLensFunctions extends PLensInstances with PLensFamilyFunctions {
 
   import util.parsing.json._
 
+  @deprecated("scalaJSONObjectPLens will be removed", "7.1.0")
   def scalaJSONObjectPLens: JSONType @?> Map[String, Any] =
     plens {
       case JSONObject(m) => Some(Store(JSONObject(_), m))
       case _             => None
     }
 
+  @deprecated("scalaJSONArrayPLens will be removed", "7.1.0")
   def scalaJSONArrayPLens: JSONType @?> List[Any] =
     plens {
       case JSONArray(a) => Some(Store(JSONArray(_), a))


### PR DESCRIPTION
because `scala.util.parsing.json` is deprecated from Scala2.11
https://github.com/scala/scala/commit/3e1a075a7e8b9178
