### PR TITLE
add more explicit return type. s/private[scalaz] trait/private trait/

### DIFF
--- a/core/src/main/scala/scalaz/BijectionT.scala
+++ b/core/src/main/scala/scalaz/BijectionT.scala
@@ -133,7 +133,7 @@ sealed abstract class BijectionTInstances extends BijectionTInstances0 {
     }
 }
 
-private[scalaz] trait BijectionTSplit[F[_], G[_]] extends Split[({type λ[α, β] = BijectionT[F, G, α, β]})#λ] {
+private trait BijectionTSplit[F[_], G[_]] extends Split[({type λ[α, β] = BijectionT[F, G, α, β]})#λ] {
   implicit def F: Bind[F]
   implicit def G: Bind[G]
 
@@ -146,7 +146,7 @@ private[scalaz] trait BijectionTSplit[F[_], G[_]] extends Split[({type λ[α, β
     )
 }
 
-private[scalaz] trait BijectionTCategory[F[_], G[_]] extends Category[({type λ[α, β] = BijectionT[F, G, α, β]})#λ] with BijectionTSplit[F, G] {
+private trait BijectionTCategory[F[_], G[_]] extends Category[({type λ[α, β] = BijectionT[F, G, α, β]})#λ] with BijectionTSplit[F, G] {
   implicit def F: Monad[F]
   implicit def G: Monad[G]
 

--- a/core/src/main/scala/scalaz/Cofree.scala
+++ b/core/src/main/scala/scalaz/Cofree.scala
@@ -79,7 +79,7 @@ sealed abstract class CofreeInstances {
   implicit def cofreeComonad[S[_]]: Comonad[({type f[x] = Cofree[S, x]})#f] = new CofreeComonad[S] {}
 }
 
-private[scalaz] trait CofreeComonad[S[_]] extends Comonad[({type f[x] = Cofree[S, x]})#f] {
+private trait CofreeComonad[S[_]] extends Comonad[({type f[x] = Cofree[S, x]})#f] {
   def copoint[A](p: Cofree[S, A]) = p.head
 
   override def cojoin[A](a: Cofree[S, A]) = a.duplicate

--- a/core/src/main/scala/scalaz/Cokleisli.scala
+++ b/core/src/main/scala/scalaz/Cokleisli.scala
@@ -42,20 +42,20 @@ sealed abstract class CokleisliInstances extends CokleisliInstances0 {
 
 trait CokleisliFunctions
 
-private[scalaz] trait CokleisliMonad[F[_], R] extends Monad[({type λ[α] = Cokleisli[F, R, α]})#λ] {
+private trait CokleisliMonad[F[_], R] extends Monad[({type λ[α] = Cokleisli[F, R, α]})#λ] {
   override def ap[A, B](fa: => Cokleisli[F, R, A])(f: => Cokleisli[F, R, A => B]) = f flatMap (fa map _)
   def point[A](a: => A) = Cokleisli(_ => a)
   def bind[A, B](fa: Cokleisli[F, R, A])(f: A => Cokleisli[F, R, B]) = fa flatMap f
 }
 
-private[scalaz] trait CokleisliCompose[F[_]] extends Compose[({type λ[α, β] = Cokleisli[F, α, β]})#λ] {
+private trait CokleisliCompose[F[_]] extends Compose[({type λ[α, β] = Cokleisli[F, α, β]})#λ] {
   implicit def F: Cobind[F]
 
   override def compose[A, B, C](f: Cokleisli[F, B, C], g: Cokleisli[F, A, B]) = f compose g
 }
 
 
-private[scalaz] trait CokleisliArrow[F[_]]
+private trait CokleisliArrow[F[_]]
   extends Arrow[({type λ[α, β] = Cokleisli[F, α, β]})#λ]
   with CokleisliCompose[F] {
 

--- a/core/src/main/scala/scalaz/Compose.scala
+++ b/core/src/main/scala/scalaz/Compose.scala
@@ -11,10 +11,10 @@ trait Compose[=>:[_, _]]  { self =>
   /** Associative `=>:` binary operator. */
   def compose[A, B, C](f: B =>: C, g: A =>: B): (A =>: C)
 
-  private[scalaz] trait ComposePlus extends Plus[({type λ[α]=(α =>: α)})#λ] {
+  protected[this] trait ComposePlus extends Plus[({type λ[α]=(α =>: α)})#λ] {
     def plus[A](f1: (A =>: A), f2: => (A =>: A)) = self.compose(f1, f2)
   }
-  private[scalaz] trait ComposeSemigroup[A] extends Semigroup[A =>: A] {
+  protected[this] trait ComposeSemigroup[A] extends Semigroup[A =>: A] {
     def append(f1: (A =>: A), f2: => (A =>: A)) = self.compose(f1, f2)
   }
 

--- a/core/src/main/scala/scalaz/Composition.scala
+++ b/core/src/main/scala/scalaz/Composition.scala
@@ -1,6 +1,6 @@
 package scalaz
 
-private[scalaz] trait CompositionFunctor[F[_], G[_]] extends Functor[({type λ[α] = F[G[α]]})#λ] {
+private trait CompositionFunctor[F[_], G[_]] extends Functor[({type λ[α] = F[G[α]]})#λ] {
   implicit def F: Functor[F]
 
   implicit def G: Functor[G]
@@ -8,7 +8,7 @@ private[scalaz] trait CompositionFunctor[F[_], G[_]] extends Functor[({type λ[�
   override def map[A, B](fga: F[G[A]])(f: A => B): F[G[B]] = F(fga)(ga => G(ga)(f))
 }
 
-private[scalaz] trait CompositionApply[F[_], G[_]] extends Apply[({type λ[α] = F[G[α]]})#λ] with CompositionFunctor[F, G] {
+private trait CompositionApply[F[_], G[_]] extends Apply[({type λ[α] = F[G[α]]})#λ] with CompositionFunctor[F, G] {
   implicit def F: Apply[F]
 
   implicit def G: Apply[G]
@@ -17,7 +17,7 @@ private[scalaz] trait CompositionApply[F[_], G[_]] extends Apply[({type λ[α] =
     F.apply2(f, fa)((ff, ga) => G.ap(ga)(ff))
 }
 
-private[scalaz] trait CompositionApplicative[F[_], G[_]] extends Applicative[({type λ[α] = F[G[α]]})#λ] with CompositionApply[F, G] {
+private trait CompositionApplicative[F[_], G[_]] extends Applicative[({type λ[α] = F[G[α]]})#λ] with CompositionApply[F, G] {
   implicit def F: Applicative[F]
 
   implicit def G: Applicative[G]
@@ -25,7 +25,7 @@ private[scalaz] trait CompositionApplicative[F[_], G[_]] extends Applicative[({t
   def point[A](a: => A): F[G[A]] = F.point(G.point(a))
 }
 
-private[scalaz] trait CompositionPlus[F[_], G[_]] extends Plus[({type λ[α] = F[G[α]]})#λ] {
+private trait CompositionPlus[F[_], G[_]] extends Plus[({type λ[α] = F[G[α]]})#λ] {
   implicit def F: Plus[F]
 
   implicit def G: Plus[G]
@@ -34,7 +34,7 @@ private[scalaz] trait CompositionPlus[F[_], G[_]] extends Plus[({type λ[α] = F
     F.plus(a, b)
 }
 
-private[scalaz] trait CompositionPlusEmpty[F[_], G[_]] extends PlusEmpty[({type λ[α] = F[G[α]]})#λ] with CompositionPlus[F, G] {
+private trait CompositionPlusEmpty[F[_], G[_]] extends PlusEmpty[({type λ[α] = F[G[α]]})#λ] with CompositionPlus[F, G] {
   implicit def F: PlusEmpty[F]
 
   implicit def G: PlusEmpty[G]
@@ -42,13 +42,13 @@ private[scalaz] trait CompositionPlusEmpty[F[_], G[_]] extends PlusEmpty[({type 
   def empty[A]: F[G[A]] = F.empty[G[A]]
 }
 
-private[scalaz] trait CompositionApplicativePlus[F[_], G[_]] extends ApplicativePlus[({type λ[α] = F[G[α]]})#λ] with CompositionApplicative[F, G] with CompositionPlusEmpty[F, G] {
+private trait CompositionApplicativePlus[F[_], G[_]] extends ApplicativePlus[({type λ[α] = F[G[α]]})#λ] with CompositionApplicative[F, G] with CompositionPlusEmpty[F, G] {
   implicit def F: ApplicativePlus[F]
 
   implicit def G: ApplicativePlus[G]
 }
 
-private[scalaz] trait CompositionFoldable[F[_], G[_]] extends Foldable[({type λ[α] = F[G[α]]})#λ]  {
+private trait CompositionFoldable[F[_], G[_]] extends Foldable[({type λ[α] = F[G[α]]})#λ]  {
   implicit def F: Foldable[F]
 
   implicit def G: Foldable[G]
@@ -63,7 +63,7 @@ private[scalaz] trait CompositionFoldable[F[_], G[_]] extends Foldable[({type λ
     F.foldLeft(fa, z)((b, a) => G.foldLeft(a, b)(f))
 }
 
-private[scalaz] trait CompositionTraverse[F[_], G[_]] extends Traverse[({type λ[α] = F[G[α]]})#λ] with CompositionFunctor[F, G] with CompositionFoldable[F, G] {
+private trait CompositionTraverse[F[_], G[_]] extends Traverse[({type λ[α] = F[G[α]]})#λ] with CompositionFunctor[F, G] with CompositionFoldable[F, G] {
   implicit def F: Traverse[F]
 
   implicit def G: Traverse[G]
@@ -73,7 +73,7 @@ private[scalaz] trait CompositionTraverse[F[_], G[_]] extends Traverse[({type λ
 
 }
 
-private[scalaz] trait CompositionDistributive[F[_], G[_]] extends Distributive[({type λ[α] = F[G[α]]})#λ] with CompositionFunctor[F, G] {
+private trait CompositionDistributive[F[_], G[_]] extends Distributive[({type λ[α] = F[G[α]]})#λ] with CompositionFunctor[F, G] {
   implicit def F: Distributive[F]
 
   implicit def G: Distributive[G]
@@ -82,7 +82,7 @@ private[scalaz] trait CompositionDistributive[F[_], G[_]] extends Distributive[(
     F(F.distribute(a)(f))(G.cosequence(_))
 }
 
-private[scalaz] trait CompositionZip[F[_], G[_]] extends Zip[({type λ[α] = F[G[α]]})#λ] {
+private trait CompositionZip[F[_], G[_]] extends Zip[({type λ[α] = F[G[α]]})#λ] {
   implicit def T: Functor[F]
 
   implicit def F: Zip[F]
@@ -93,7 +93,7 @@ private[scalaz] trait CompositionZip[F[_], G[_]] extends Zip[({type λ[α] = F[G
     F.zipWith(a, b)(G.zip(_, _))
 }
 
-private[scalaz] trait CompositionUnzip[F[_], G[_]] extends Unzip[({type λ[α] = F[G[α]]})#λ] {
+private trait CompositionUnzip[F[_], G[_]] extends Unzip[({type λ[α] = F[G[α]]})#λ] {
   implicit def T: Functor[F]
 
   implicit def F: Unzip[F]
@@ -107,7 +107,7 @@ private[scalaz] trait CompositionUnzip[F[_], G[_]] extends Unzip[({type λ[α] =
   }
 }
 
-private[scalaz] trait CompositionBifunctor[F[_, _], G[_, _]] extends Bifunctor[({type λ[α, β]=F[G[α, β], G[α, β]]})#λ] {
+private trait CompositionBifunctor[F[_, _], G[_, _]] extends Bifunctor[({type λ[α, β]=F[G[α, β], G[α, β]]})#λ] {
   implicit def F: Bifunctor[F]
 
   implicit def G: Bifunctor[G]
@@ -116,7 +116,7 @@ private[scalaz] trait CompositionBifunctor[F[_, _], G[_, _]] extends Bifunctor[(
     F.bimap(fab)(G.bimap(_)(f, g), G.bimap(_)(f, g))
 }
 
-private[scalaz] trait CompositionBifoldable[F[_, _], G[_, _]] extends Bifoldable[({type λ[α, β]=F[G[α, β], G[α, β]]})#λ] {
+private trait CompositionBifoldable[F[_, _], G[_, _]] extends Bifoldable[({type λ[α, β]=F[G[α, β], G[α, β]]})#λ] {
   implicit def F: Bifoldable[F]
 
   implicit def G: Bifoldable[G]
@@ -129,7 +129,7 @@ private[scalaz] trait CompositionBifoldable[F[_, _], G[_, _]] extends Bifoldable
     F.bifoldLeft(fa, z)((b, a) => G.bifoldLeft(a, b)(f)(g))((b, a) => G.bifoldLeft(a, b)(f)(g))
 }
 
-private[scalaz] trait CompositionBitraverse[F[_, _], G[_, _]]
+private trait CompositionBitraverse[F[_, _], G[_, _]]
   extends Bitraverse[({type λ[α, β]=F[G[α, β], G[α, β]]})#λ]
   with CompositionBifunctor[F, G] with CompositionBifoldable[F, G]{
 

--- a/core/src/main/scala/scalaz/Coproduct.scala
+++ b/core/src/main/scala/scalaz/Coproduct.scala
@@ -105,7 +105,7 @@ sealed abstract class CoproductInstances1 extends CoproductInstances0 {
   }
 }
 
-private[scalaz] trait CoproductFunctor[F[_], G[_]] extends Functor[({type λ[α]=Coproduct[F, G, α]})#λ] {
+private trait CoproductFunctor[F[_], G[_]] extends Functor[({type λ[α]=Coproduct[F, G, α]})#λ] {
   implicit def F: Functor[F]
   implicit def G: Functor[G]
 
@@ -113,7 +113,7 @@ private[scalaz] trait CoproductFunctor[F[_], G[_]] extends Functor[({type λ[α]
     a map f
 }
 
-private[scalaz] trait CoproductContravariant[F[_], G[_]] extends Contravariant[({type λ[α]=Coproduct[F, G, α]})#λ] {
+private trait CoproductContravariant[F[_], G[_]] extends Contravariant[({type λ[α]=Coproduct[F, G, α]})#λ] {
   implicit def F: Contravariant[F]
   implicit def G: Contravariant[G]
 
@@ -121,7 +121,7 @@ private[scalaz] trait CoproductContravariant[F[_], G[_]] extends Contravariant[(
     a contramap f
 }
 
-private[scalaz] trait CoproductFoldable[F[_], G[_]] extends Foldable[({type λ[α]=Coproduct[F, G, α]})#λ] {
+private trait CoproductFoldable[F[_], G[_]] extends Foldable[({type λ[α]=Coproduct[F, G, α]})#λ] {
   implicit def F: Foldable[F]
   implicit def G: Foldable[G]
 
@@ -132,7 +132,7 @@ private[scalaz] trait CoproductFoldable[F[_], G[_]] extends Foldable[({type λ[�
     fa foldMap f
 }
 
-private[scalaz] trait CoproductTraverse[F[_], G[_]] extends Traverse[({type λ[α]=Coproduct[F, G, α]})#λ] {
+private trait CoproductTraverse[F[_], G[_]] extends Traverse[({type λ[α]=Coproduct[F, G, α]})#λ] {
   implicit def F: Traverse[F]
   implicit def G: Traverse[G]
 
@@ -143,7 +143,7 @@ private[scalaz] trait CoproductTraverse[F[_], G[_]] extends Traverse[({type λ[�
     )
 }
 
-private[scalaz] trait CoproductCobind[F[_], G[_]] extends Cobind[({type λ[α]=Coproduct[F, G, α]})#λ] {
+private trait CoproductCobind[F[_], G[_]] extends Cobind[({type λ[α]=Coproduct[F, G, α]})#λ] {
   implicit def F: Cobind[F]
   implicit def G: Cobind[G]
 
@@ -155,7 +155,7 @@ private[scalaz] trait CoproductCobind[F[_], G[_]] extends Cobind[({type λ[α]=C
 
 }
 
-private[scalaz] trait CoproductComonad[F[_], G[_]] extends Comonad[({type λ[α]=Coproduct[F, G, α]})#λ] {
+private trait CoproductComonad[F[_], G[_]] extends Comonad[({type λ[α]=Coproduct[F, G, α]})#λ] {
   implicit def F: Comonad[F]
   implicit def G: Comonad[G]
 

--- a/core/src/main/scala/scalaz/Dual.scala
+++ b/core/src/main/scala/scalaz/Dual.scala
@@ -19,12 +19,12 @@ sealed abstract class DualInstances extends DualInstances0 {
     Tag subst F0.reverseOrder
 }
 
-private[scalaz] trait DualSemigroup[F] extends Semigroup[F @@ Tags.Dual] {
+private trait DualSemigroup[F] extends Semigroup[F @@ Tags.Dual] {
   implicit def F: Semigroup[F]
   def append(f1: F @@ Tags.Dual, f2: => F @@ Tags.Dual) = Tag(F.append(f2, f1))
 }
 
-private[scalaz] trait DualMonoid[F] extends Monoid[F @@ Tags.Dual] with DualSemigroup[F] {
+private trait DualMonoid[F] extends Monoid[F @@ Tags.Dual] with DualSemigroup[F] {
   implicit def F: Monoid[F]
   def zero = Tag(F.zero)
 }

--- a/core/src/main/scala/scalaz/EitherT.scala
+++ b/core/src/main/scala/scalaz/EitherT.scala
@@ -256,13 +256,13 @@ trait EitherTFunctions {
 }
 
 
-private[scalaz] trait EitherTFunctor[F[_], E] extends Functor[({type λ[α]=EitherT[F, E, α]})#λ] {
+private trait EitherTFunctor[F[_], E] extends Functor[({type λ[α]=EitherT[F, E, α]})#λ] {
   implicit def F: Functor[F]
 
   override def map[A, B](fa: EitherT[F, E, A])(f: A => B): EitherT[F, E, B] = fa map f
 }
 
-private[scalaz] trait EitherTMonad[F[_], E] extends Monad[({type λ[α]=EitherT[F, E, α]})#λ] with EitherTFunctor[F, E] {
+private trait EitherTMonad[F[_], E] extends Monad[({type λ[α]=EitherT[F, E, α]})#λ] with EitherTFunctor[F, E] {
   implicit def F: Monad[F]
 
   def point[A](a: => A): EitherT[F, E, A] = EitherT(F.point(\/-(a)))
@@ -270,25 +270,25 @@ private[scalaz] trait EitherTMonad[F[_], E] extends Monad[({type λ[α]=EitherT[
   def bind[A, B](fa: EitherT[F, E, A])(f: A => EitherT[F, E, B]): EitherT[F, E, B] = fa flatMap f
 }
 
-private[scalaz] trait EitherTFoldable[F[_], E] extends Foldable.FromFoldr[({type λ[α]=EitherT[F, E, α]})#λ] {
+private trait EitherTFoldable[F[_], E] extends Foldable.FromFoldr[({type λ[α]=EitherT[F, E, α]})#λ] {
   implicit def F: Foldable[F]
 
   override def foldRight[A, B](fa: EitherT[F, E, A], z: => B)(f: (A, => B) => B): B = fa.foldRight(z)(f)
 }
 
-private[scalaz] trait EitherTTraverse[F[_], E] extends Traverse[({type λ[α]=EitherT[F, E, α]})#λ] with EitherTFoldable[F, E] {
+private trait EitherTTraverse[F[_], E] extends Traverse[({type λ[α]=EitherT[F, E, α]})#λ] with EitherTFoldable[F, E] {
   implicit def F: Traverse[F]
 
   def traverseImpl[G[_]: Applicative, A, B](fa: EitherT[F, E, A])(f: A => G[B]): G[EitherT[F, E, B]] = fa traverse f
 }
 
-private[scalaz] trait EitherTBifunctor[F[_]] extends Bifunctor[({type λ[α, β]=EitherT[F, α, β]})#λ] {
+private trait EitherTBifunctor[F[_]] extends Bifunctor[({type λ[α, β]=EitherT[F, α, β]})#λ] {
   implicit def F: Functor[F]
 
   override def bimap[A, B, C, D](fab: EitherT[F, A, B])(f: A => C, g: B => D): EitherT[F, C, D] = fab.bimap(f, g)
 }
 
-private[scalaz] trait EitherTBitraverse[F[_]] extends Bitraverse[({type λ[α, β] = EitherT[F, α, β]})#λ] with EitherTBifunctor[F] {
+private trait EitherTBitraverse[F[_]] extends Bitraverse[({type λ[α, β] = EitherT[F, α, β]})#λ] with EitherTBifunctor[F] {
   implicit def F: Traverse[F]
 
   def bitraverseImpl[G[_] : Applicative, A, B, C, D](fab: EitherT[F, A, B])
@@ -296,7 +296,7 @@ private[scalaz] trait EitherTBitraverse[F[_]] extends Bitraverse[({type λ[α, �
     fab.bitraverse(f, g)
 }
 
-private[scalaz] trait EitherTHoist[A] extends Hoist[({type λ[α[_], β] = EitherT[α, A, β]})#λ] {
+private trait EitherTHoist[A] extends Hoist[({type λ[α[_], β] = EitherT[α, A, β]})#λ] {
   def hoist[M[_], N[_]](f: M ~> N)(implicit M: Monad[M]) = new (({type λ[α] = EitherT[M, A, α]})#λ ~> ({type λ[α] = EitherT[N, A, α]})#λ) {
     def apply[B](mb: EitherT[M, A, B]): EitherT[N, A, B] = EitherT(f.apply(mb.run))
   }
@@ -306,7 +306,7 @@ private[scalaz] trait EitherTHoist[A] extends Hoist[({type λ[α[_], β] = Eithe
   implicit def apply[M[_] : Monad]: Monad[({type λ[α] = EitherT[M, A, α]})#λ] = EitherT.eitherTMonad
 }
 
-private[scalaz] trait EitherTMonadTell[F[_, _], W, A] extends MonadTell[({type λ[α, β] = EitherT[({type f[x] = F[α, x]})#f, A, β]})#λ, W] with EitherTMonad[({type λ[α] = F[W, α]})#λ, A] with EitherTHoist[A] {
+private trait EitherTMonadTell[F[_, _], W, A] extends MonadTell[({type λ[α, β] = EitherT[({type f[x] = F[α, x]})#f, A, β]})#λ, W] with EitherTMonad[({type λ[α] = F[W, α]})#λ, A] with EitherTHoist[A] {
   def MT: MonadTell[F, W]
 
   implicit def F = MT
@@ -321,7 +321,7 @@ private[scalaz] trait EitherTMonadTell[F[_, _], W, A] extends MonadTell[({type �
     EitherT.right[({type λ[α] = F[W, α]})#λ, A, B](MT.point(v))
 }
 
-private[scalaz] trait EitherTMonadListen[F[_, _], W, A] extends MonadListen[({type λ[α, β] = EitherT[({type f[x] = F[α, x]})#f, A, β]})#λ, W] with EitherTMonadTell[F, W, A] {
+private trait EitherTMonadListen[F[_, _], W, A] extends MonadListen[({type λ[α, β] = EitherT[({type f[x] = F[α, x]})#f, A, β]})#λ, W] with EitherTMonadTell[F, W, A] {
   implicit def MT: MonadListen[F, W]
 
   def listen[B](ma: EitherT[({type λ[α] = F[W, α]})#λ, A, B]): EitherT[({type λ[α] = F[W, α]})#λ, A, (B, W)] = {

--- a/core/src/main/scala/scalaz/Endomorphic.scala
+++ b/core/src/main/scala/scalaz/Endomorphic.scala
@@ -44,7 +44,7 @@ sealed abstract class EndomorphicInstances0 {
 
 }
 
-private[scalaz] trait EndomorphicSemigroup[=>:[_, _], A] extends Semigroup[Endomorphic[=>:, A]] {
+private trait EndomorphicSemigroup[=>:[_, _], A] extends Semigroup[Endomorphic[=>:, A]] {
   implicit def F: Compose[=>:]
   def append(f1: Endomorphic[=>:, A], f2: => Endomorphic[=>:, A]) = Endomorphic(F.compose(f1.run, f2.run))
 }

--- a/core/src/main/scala/scalaz/IdT.scala
+++ b/core/src/main/scala/scalaz/IdT.scala
@@ -71,43 +71,43 @@ object IdT extends IdTInstances with IdTFunctions
 // Implementation traits for type class instances
 //
 
-private[scalaz] trait IdTFunctor[F[_]] extends Functor[({type λ[α] = IdT[F, α]})#λ] {
+private trait IdTFunctor[F[_]] extends Functor[({type λ[α] = IdT[F, α]})#λ] {
   implicit def F: Functor[F]
 
   override def map[A, B](fa: IdT[F, A])(f: A => B) = fa map f
 }
 
-private[scalaz] trait IdTApply[F[_]] extends Apply[({type λ[α] = IdT[F, α]})#λ] with IdTFunctor[F] {
+private trait IdTApply[F[_]] extends Apply[({type λ[α] = IdT[F, α]})#λ] with IdTFunctor[F] {
   implicit def F: Apply[F]
 
   override def ap[A, B](fa: => IdT[F, A])(f: => IdT[F, A => B]): IdT[F, B] = fa ap f
 }
 
-private[scalaz] trait IdTApplicative[F[_]] extends Applicative[({type λ[α] = IdT[F, α]})#λ] with IdTApply[F] {
+private trait IdTApplicative[F[_]] extends Applicative[({type λ[α] = IdT[F, α]})#λ] with IdTApply[F] {
   implicit def F: Applicative[F]
 
   def point[A](a: => A) = new IdT[F, A](F.point(a))
 }
 
-private[scalaz] trait IdTMonad[F[_]] extends Monad[({type λ[α] = IdT[F, α]})#λ] with IdTApplicative[F] {
+private trait IdTMonad[F[_]] extends Monad[({type λ[α] = IdT[F, α]})#λ] with IdTApplicative[F] {
   implicit def F: Monad[F]
 
   def bind[A, B](fa: IdT[F, A])(f: A => IdT[F, B]) = fa flatMap f
 }
 
-private[scalaz] trait IdTFoldable[F[_]] extends Foldable.FromFoldr[({type λ[α] = IdT[F, α]})#λ] {
+private trait IdTFoldable[F[_]] extends Foldable.FromFoldr[({type λ[α] = IdT[F, α]})#λ] {
   implicit def F: Foldable[F]
 
   override def foldRight[A, B](fa: IdT[F, A], z: => B)(f: (A, => B) => B): B = fa.foldRight(z)(f)
 }
 
-private[scalaz] trait IdTTraverse[F[_]] extends Traverse[({type λ[α] = IdT[F, α]})#λ] with IdTFoldable[F] with IdTFunctor[F]{
+private trait IdTTraverse[F[_]] extends Traverse[({type λ[α] = IdT[F, α]})#λ] with IdTFoldable[F] with IdTFunctor[F]{
   implicit def F: Traverse[F]
 
   def traverseImpl[G[_] : Applicative, A, B](fa: IdT[F, A])(f: A => G[B]): G[IdT[F, B]] = fa traverse f
 }
 
-private[scalaz] object IdTHoist extends Hoist[IdT] {
+private object IdTHoist extends Hoist[IdT] {
   def liftM[G[_], A](a: G[A])(implicit G: Monad[G]): IdT[G, A] = new IdT[G, A](a)
 
   def hoist[M[_]: Monad, N[_]](f: M ~> N) = new (({type f[x] = IdT[M, x]})#f ~> ({type f[x] = IdT[N, x]})#f) {

--- a/core/src/main/scala/scalaz/IndexedContsT.scala
+++ b/core/src/main/scala/scalaz/IndexedContsT.scala
@@ -109,26 +109,26 @@ abstract class IndexedContsTInstances extends IndexedContsTInstances0 {
   }
 }
 
-private[scalaz] sealed trait IndexedContsTFunctorLeft[W[_], M[_], O, A0] extends Functor[({type f[r]=IndexedContsT[W, M, r, O, A0]})#f] {
+private sealed trait IndexedContsTFunctorLeft[W[_], M[_], O, A0] extends Functor[({type f[r]=IndexedContsT[W, M, r, O, A0]})#f] {
   implicit val M: Functor[M]
 
   def map[A, B](fa: IndexedContsT[W, M, A, O, A0])(f: A => B): IndexedContsT[W, M, B, O, A0] = fa.imap(f)
 }
 
-private[scalaz] sealed trait IndexedContsTFunctorRight[W[_], M[_], R, O] extends Functor[({type f[a]=IndexedContsT[W, M, R, O, a]})#f] {
+private sealed trait IndexedContsTFunctorRight[W[_], M[_], R, O] extends Functor[({type f[a]=IndexedContsT[W, M, R, O, a]})#f] {
   implicit val W: Functor[W]
 
   override def map[A, B](fa: IndexedContsT[W, M, R, O, A])(f: A => B): IndexedContsT[W, M, R, O, B] = fa.map(f)
 }
 
-private[scalaz] sealed trait IndexedContsTContravariant[W[_], M[_], R, A0] extends Contravariant[({type f[o]=IndexedContsT[W, M, R, o, A0]})#f] {
+private sealed trait IndexedContsTContravariant[W[_], M[_], R, A0] extends Contravariant[({type f[o]=IndexedContsT[W, M, R, o, A0]})#f] {
   implicit val W: Functor[W]
   implicit val M: Functor[M]
 
   def contramap[A, B](fa: IndexedContsT[W, M, R, A, A0])(f: B => A): IndexedContsT[W, M, R, B, A0] = fa.contramap(f)
 }
 
-private[scalaz] sealed trait IndexedContsTBifunctor[W[_], M[_], O] extends Bifunctor[({type f[r, a]=IndexedContsT[W, M, r, O, a]})#f] {
+private sealed trait IndexedContsTBifunctor[W[_], M[_], O] extends Bifunctor[({type f[r, a]=IndexedContsT[W, M, r, O, a]})#f] {
   implicit val W: Functor[W]
   implicit val M: Functor[M]
 
@@ -143,7 +143,7 @@ private[scalaz] sealed trait IndexedContsTBifunctor[W[_], M[_], O] extends Bifun
   override def rightMap[A, B, D](fa: IndexedContsT[W, M, A, O, B])(f: B => D): IndexedContsT[W, M, A, O, D] = fa.map(f)
 }
 
-private[scalaz] sealed trait ContsTMonad[W[_], M[_], R] extends Monad[({type f[a]=ContsT[W, M, R, a]})#f] with IndexedContsTFunctorRight[W, M, R, R] {
+private sealed trait ContsTMonad[W[_], M[_], R] extends Monad[({type f[a]=ContsT[W, M, R, a]})#f] with IndexedContsTFunctorRight[W, M, R, R] {
   implicit val W: Comonad[W]
 
   def point[A](a: => A): ContsT[W, M, R, A] = IndexedContsT.point(a)

--- a/core/src/main/scala/scalaz/Kleisli.scala
+++ b/core/src/main/scala/scalaz/Kleisli.scala
@@ -177,42 +177,42 @@ import Kleisli.kleisli
 // * -> *
 //
 
-private[scalaz] trait KleisliFunctor[F[_], R] extends Functor[({type λ[α] = Kleisli[F, R, α]})#λ] {
+private trait KleisliFunctor[F[_], R] extends Functor[({type λ[α] = Kleisli[F, R, α]})#λ] {
   implicit def F: Functor[F]
 
   override def map[A, B](fa: Kleisli[F, R, A])(f: A => B): Kleisli[F, R, B] = fa map f
 }
 
-private[scalaz] trait KleisliApply[F[_], R] extends Apply[({type λ[α] = Kleisli[F, R, α]})#λ] with KleisliFunctor[F, R] {
+private trait KleisliApply[F[_], R] extends Apply[({type λ[α] = Kleisli[F, R, α]})#λ] with KleisliFunctor[F, R] {
   implicit def F: Apply[F]
   override def ap[A, B](fa: => Kleisli[F, R, A])(f: => Kleisli[F, R, A => B]): Kleisli[F, R, B] = Kleisli[F, R, B](r => F.ap(fa(r))(f(r)))
 }
 
-private[scalaz] trait KleisliDistributive[F[_], R] extends Distributive[({type λ[α] = Kleisli[F, R, α]})#λ] with KleisliFunctor[F, R] {
+private trait KleisliDistributive[F[_], R] extends Distributive[({type λ[α] = Kleisli[F, R, α]})#λ] with KleisliFunctor[F, R] {
   implicit def F: Distributive[F]
 
   override def distributeImpl[G[_]: Functor, A, B](a: G[A])(f: A => Kleisli[F, R, B]): Kleisli[F, R, G[B]] =
     Kleisli(r => F.distribute(a)(f(_) run r))
 }
 
-private[scalaz] trait KleisliApplicative[F[_], R] extends Applicative[({type λ[α] = Kleisli[F, R, α]})#λ] with KleisliApply[F, R] {
+private trait KleisliApplicative[F[_], R] extends Applicative[({type λ[α] = Kleisli[F, R, α]})#λ] with KleisliApply[F, R] {
   implicit def F: Applicative[F]
   def point[A](a: => A): Kleisli[F, R, A] = kleisli((r: R) => F.point(a))
 }
 
-private[scalaz] trait KleisliMonad[F[_], R] extends Monad[({type λ[α] = Kleisli[F, R, α]})#λ] with KleisliApplicative[F, R] {
+private trait KleisliMonad[F[_], R] extends Monad[({type λ[α] = Kleisli[F, R, α]})#λ] with KleisliApplicative[F, R] {
   implicit def F: Monad[F]
   def bind[A, B](fa: Kleisli[F, R, A])(f: A => Kleisli[F, R, B]): Kleisli[F, R, B] = fa flatMap f
 }
 
-private[scalaz] trait KleisliMonadReader[F[_], R] extends MonadReader[({type f[s, a] = Kleisli[F, s, a]})#f, R] with KleisliApplicative[F, R] with KleisliMonad[F, R] {
+private trait KleisliMonadReader[F[_], R] extends MonadReader[({type f[s, a] = Kleisli[F, s, a]})#f, R] with KleisliApplicative[F, R] with KleisliMonad[F, R] {
   implicit def F: Monad[F]
 
   def ask: Kleisli[F, R, R] = Kleisli[F, R, R](r => F.point(r))
   def local[A](f: R => R)(fa: Kleisli[F, R, A]): Kleisli[F, R, A] = Kleisli[F, R, A](r => fa.run(f(r)))
 }
 
-private[scalaz] trait KleisliHoist[R] extends Hoist[({type λ[α[_], β] = Kleisli[α, R, β]})#λ] {
+private trait KleisliHoist[R] extends Hoist[({type λ[α[_], β] = Kleisli[α, R, β]})#λ] {
   def hoist[M[_]: Monad, N[_]](f: M ~> N): ({type f[x] = Kleisli[M, R, x]})#f ~> ({type f[x] = Kleisli[N, R, x]})#f =
     new (({type f[x] = Kleisli[M, R, x]})#f ~> ({type f[x] = Kleisli[N, R, x]})#f) {
       def apply[A](m: Kleisli[M, R, A]): Kleisli[N, R, A] = Kleisli[N, R, A](r => f(m(r)))
@@ -223,11 +223,11 @@ private[scalaz] trait KleisliHoist[R] extends Hoist[({type λ[α[_], β] = Kleis
   implicit def apply[G[_] : Monad]: Monad[({type λ[α] = Kleisli[G, R, α]})#λ] = Kleisli.kleisliMonadReader
 }
 
-private[scalaz] trait KleisliMonadPlus[F[_], R] extends MonadPlus[({type λ[α] = Kleisli[F, R, α]})#λ] with KleisliPlusEmpty[F, R] with KleisliMonad[F, R] {
+private trait KleisliMonadPlus[F[_], R] extends MonadPlus[({type λ[α] = Kleisli[F, R, α]})#λ] with KleisliPlusEmpty[F, R] with KleisliMonad[F, R] {
   implicit def F: MonadPlus[F]
 }
 
-private[scalaz] trait KleisliContravariant[F[_], X] extends Contravariant[({type λ[α] = Kleisli[F, α, X]})#λ] {
+private trait KleisliContravariant[F[_], X] extends Contravariant[({type λ[α] = Kleisli[F, α, X]})#λ] {
   def contramap[A, B](fa: Kleisli[F, A, X])(f: B => A) = fa local f
 }
 
@@ -235,7 +235,7 @@ private[scalaz] trait KleisliContravariant[F[_], X] extends Contravariant[({type
 // (* *) -> *
 //
 
-private[scalaz] trait KleisliArrow[F[_]]
+private trait KleisliArrow[F[_]]
   extends Arrow[({type λ[α, β] = Kleisli[F, α, β]})#λ]
   with Choice[({type λ[α, β] = Kleisli[F, α, β]})#λ] {
 
@@ -264,22 +264,22 @@ private[scalaz] trait KleisliArrow[F[_]]
     }
 }
 
-private[scalaz] trait KleisliSemigroup[F[_], A, B] extends Semigroup[Kleisli[F, A, B]] {
+private trait KleisliSemigroup[F[_], A, B] extends Semigroup[Kleisli[F, A, B]] {
   implicit def FB: Semigroup[F[B]]
   def append(f1: Kleisli[F, A, B], f2: => Kleisli[F, A, B]) = Kleisli[F, A, B](a => FB.append(f1.run(a), f2.run(a)))
 }
 
-private[scalaz] trait KleisliMonoid[F[_], A, B] extends Monoid[Kleisli[F, A, B]] with KleisliSemigroup[F, A, B] {
+private trait KleisliMonoid[F[_], A, B] extends Monoid[Kleisli[F, A, B]] with KleisliSemigroup[F, A, B] {
   implicit def FB: Monoid[F[B]]
   def zero = Kleisli[F, A, B](a => FB.zero)
 }
 
-private[scalaz] trait KleisliPlus[F[_], A] extends Plus[({type λ[α]=Kleisli[F, A, α]})#λ] {
+private trait KleisliPlus[F[_], A] extends Plus[({type λ[α]=Kleisli[F, A, α]})#λ] {
   implicit def F: Plus[F]
   def plus[B](f1: Kleisli[F, A, B], f2: => Kleisli[F, A, B]) = Kleisli[F, A, B](a => F.plus[B](f1.run(a), f2.run(a)))
 }
 
-private[scalaz] trait KleisliPlusEmpty[F[_], A] extends PlusEmpty[({type λ[α]=Kleisli[F, A, α]})#λ] with KleisliPlus[F, A] {
+private trait KleisliPlusEmpty[F[_], A] extends PlusEmpty[({type λ[α]=Kleisli[F, A, α]})#λ] with KleisliPlus[F, A] {
   implicit def F: PlusEmpty[F]
   def empty[B] = Kleisli[F, A, B](a => F.empty[B])
 }

--- a/core/src/main/scala/scalaz/LazyEitherT.scala
+++ b/core/src/main/scala/scalaz/LazyEitherT.scala
@@ -221,13 +221,13 @@ trait LazyEitherTFunctions {
 // Type class implementation traits
 //
 
-private[scalaz] trait LazyEitherTFunctor[F[_], E] extends Functor[({type λ[α]=LazyEitherT[F, E, α]})#λ] {
+private trait LazyEitherTFunctor[F[_], E] extends Functor[({type λ[α]=LazyEitherT[F, E, α]})#λ] {
   implicit def F: Functor[F]
 
   override def map[A, B](fa: LazyEitherT[F, E, A])(f: A => B): LazyEitherT[F, E, B] = fa map (a => f(a))
 }
 
-private[scalaz] trait LazyEitherTMonad[F[_], E] extends Monad[({type λ[α]=LazyEitherT[F, E, α]})#λ] with LazyEitherTFunctor[F, E] {
+private trait LazyEitherTMonad[F[_], E] extends Monad[({type λ[α]=LazyEitherT[F, E, α]})#λ] with LazyEitherTFunctor[F, E] {
   implicit def F: Monad[F]
 
   def point[A](a: => A): LazyEitherT[F, E, A] = LazyEitherT.lazyRightT(a)
@@ -235,13 +235,13 @@ private[scalaz] trait LazyEitherTMonad[F[_], E] extends Monad[({type λ[α]=Lazy
   def bind[A, B](fa: LazyEitherT[F, E, A])(f: A => LazyEitherT[F, E, B]): LazyEitherT[F, E, B] = fa flatMap (a => f(a))
 }
 
-private[scalaz] trait LazyEitherTFoldable[F[_], E] extends Foldable.FromFoldr[({type λ[α]=LazyEitherT[F, E, α]})#λ] {
+private trait LazyEitherTFoldable[F[_], E] extends Foldable.FromFoldr[({type λ[α]=LazyEitherT[F, E, α]})#λ] {
   implicit def F: Foldable[F]
 
   def foldRight[A, B](fa: LazyEitherT[F, E, A], z: => B)(f: (A, => B) => B): B = fa.foldRight(z)(f)
 }
 
-private[scalaz] trait LazyEitherTTraverse[F[_], E] extends Traverse[({type λ[α]=LazyEitherT[F, E, α]})#λ] with LazyEitherTFoldable[F, E] {
+private trait LazyEitherTTraverse[F[_], E] extends Traverse[({type λ[α]=LazyEitherT[F, E, α]})#λ] with LazyEitherTFoldable[F, E] {
   implicit def F: Traverse[F]
 
   def traverseImpl[G[_]: Applicative, A, B](fa: LazyEitherT[F, E, A])(f: A => G[B]): G[LazyEitherT[F, E, B]] = fa traverse f
@@ -249,14 +249,14 @@ private[scalaz] trait LazyEitherTTraverse[F[_], E] extends Traverse[({type λ[α
   override def foldRight[A, B](fa: LazyEitherT[F, E, A], z: => B)(f: (A, => B) => B): B = fa.foldRight(z)(f)
 }
 
-private[scalaz] trait LazyEitherTBifunctor[F[_]] extends Bifunctor[({type λ[α, β] = LazyEitherT[F, α, β]})#λ] {
+private trait LazyEitherTBifunctor[F[_]] extends Bifunctor[({type λ[α, β] = LazyEitherT[F, α, β]})#λ] {
   implicit def F: Functor[F]
 
   def bimap[A, B, C, D](fab: LazyEitherT[F, A, B])(f: A => C, g: B => D) =
     fab.map(x => g(x)).left.map(x => f(x))
 }
 
-private[scalaz] trait LazyEitherTBitraverse[F[_]] extends Bitraverse[({type λ[α, β] = LazyEitherT[F, α, β]})#λ] {
+private trait LazyEitherTBitraverse[F[_]] extends Bitraverse[({type λ[α, β] = LazyEitherT[F, α, β]})#λ] {
   implicit def F: Traverse[F]
 
   def bitraverseImpl[G[_]: Applicative, A, B, C, D](fab: LazyEitherT[F, A, B])(f: A => G[C], g: B => G[D]): G[LazyEitherT[F, C, D]] =

--- a/core/src/main/scala/scalaz/LazyOptionT.scala
+++ b/core/src/main/scala/scalaz/LazyOptionT.scala
@@ -112,31 +112,31 @@ trait LazyOptionTFunctions {
 // Implementation traits for type class instances
 //
 
-private[scalaz] trait LazyOptionTFunctor[F[_]] extends Functor[({type λ[α] = LazyOptionT[F, α]})#λ] {
+private trait LazyOptionTFunctor[F[_]] extends Functor[({type λ[α] = LazyOptionT[F, α]})#λ] {
   implicit def F: Functor[F]
 
   override def map[A, B](fa: LazyOptionT[F, A])(f: A => B): LazyOptionT[F, B] = fa map (a => f(a))
 }
 
-private[scalaz] trait LazyOptionTApply[F[_]] extends Apply[({type λ[α] = LazyOptionT[F, α]})#λ] with LazyOptionTFunctor[F] {
+private trait LazyOptionTApply[F[_]] extends Apply[({type λ[α] = LazyOptionT[F, α]})#λ] with LazyOptionTFunctor[F] {
   implicit def F: Apply[F]
 
   override def ap[A, B](fa: => LazyOptionT[F, A])(f: => LazyOptionT[F, A => B]): LazyOptionT[F, B] =
     LazyOptionT(F.apply2(f.run, fa.run)({ case (ff, aa) => LazyOption.lazyOptionInstance.ap(aa)(ff) }))
 }
 
-private[scalaz] trait LazyOptionTApplicative[F[_]] extends Applicative[({type λ[α] = LazyOptionT[F, α]})#λ] with LazyOptionTApply[F] {
+private trait LazyOptionTApplicative[F[_]] extends Applicative[({type λ[α] = LazyOptionT[F, α]})#λ] with LazyOptionTApply[F] {
   implicit def F: Applicative[F]
   def point[A](a: => A): LazyOptionT[F, A] = LazyOptionT[F, A](F.point(LazyOption.lazySome(a)))
 }
 
-private[scalaz] trait LazyOptionTMonad[F[_]] extends Monad[({type λ[α] = LazyOptionT[F, α]})#λ] with LazyOptionTApplicative[F] {
+private trait LazyOptionTMonad[F[_]] extends Monad[({type λ[α] = LazyOptionT[F, α]})#λ] with LazyOptionTApplicative[F] {
   implicit def F: Monad[F]
 
   def bind[A, B](fa: LazyOptionT[F, A])(f: A => LazyOptionT[F, B]): LazyOptionT[F, B] = fa flatMap (a => f(a))
 }
 
-private[scalaz] trait LazyOptionTHoist extends Hoist[LazyOptionT] {
+private trait LazyOptionTHoist extends Hoist[LazyOptionT] {
   def liftM[G[_], A](a: G[A])(implicit G: Monad[G]): LazyOptionT[G, A] =
     LazyOptionT[G, A](G.map[A, LazyOption[A]](a)((a: A) => LazyOption.lazySome(a)))
 

--- a/core/src/main/scala/scalaz/LazyTuple.scala
+++ b/core/src/main/scala/scalaz/LazyTuple.scala
@@ -89,7 +89,7 @@ sealed abstract class LazyTuple2Instances0 {
     }
   }
 
-  implicit def lazyTuple2Semigroup[A1, A2](implicit A1: Semigroup[A1], A2: Semigroup[A2]) = new LazyTuple2Semigroup[A1, A2] {
+  implicit def lazyTuple2Semigroup[A1, A2](implicit A1: Semigroup[A1], A2: Semigroup[A2]): Semigroup[LazyTuple2[A1, A2]] = new LazyTuple2Semigroup[A1, A2] {
     implicit def _1 = A1
     implicit def _2 = A2
   }
@@ -99,17 +99,17 @@ sealed abstract class LazyTuple2Instances0 {
 
 sealed abstract class LazyTuple2Instances extends LazyTuple2Instances0 {
 
-  implicit def lazyTuple2Show[A1, A2](implicit A1: Show[A1], A2: Show[A2]) = new LazyTuple2Show[A1, A2] {
+  implicit def lazyTuple2Show[A1, A2](implicit A1: Show[A1], A2: Show[A2]): Show[LazyTuple2[A1, A2]] = new LazyTuple2Show[A1, A2] {
     implicit def _1 = A1
     implicit def _2 = A2
   }
 
-  implicit def lazyTuple2Order[A1, A2](implicit A1: Order[A1], A2: Order[A2]) = new LazyTuple2Order[A1, A2] {
+  implicit def lazyTuple2Order[A1, A2](implicit A1: Order[A1], A2: Order[A2]): Order[LazyTuple2[A1, A2]] = new LazyTuple2Order[A1, A2] {
     implicit def _1 = A1
     implicit def _2 = A2
   }
 
-  implicit def lazyTuple2Monoid[A1, A2](implicit A1: Monoid[A1], A2: Monoid[A2]) = new LazyTuple2Monoid[A1, A2] {
+  implicit def lazyTuple2Monoid[A1, A2](implicit A1: Monoid[A1], A2: Monoid[A2]): Monoid[LazyTuple2[A1, A2]] = new LazyTuple2Monoid[A1, A2] {
     implicit def _1 = A1
     implicit def _2 = A2
   }
@@ -120,7 +120,7 @@ sealed abstract class LazyTuple2Instances extends LazyTuple2Instances0 {
 }
 
 sealed abstract class LazyTuple3Instances0 {
-  implicit def lazyTuple3Semigroup[A1, A2, A3](implicit A1: Semigroup[A1], A2: Semigroup[A2], A3: Semigroup[A3]) = new LazyTuple3Semigroup[A1, A2, A3] {
+  implicit def lazyTuple3Semigroup[A1, A2, A3](implicit A1: Semigroup[A1], A2: Semigroup[A2], A3: Semigroup[A3]): Semigroup[LazyTuple3[A1, A2, A3]] = new LazyTuple3Semigroup[A1, A2, A3] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
@@ -128,7 +128,7 @@ sealed abstract class LazyTuple3Instances0 {
 
   implicit def lazyTuple3Functor[A1, A2]: Functor[({type f[x] = LazyTuple3[A1, A2, x]})#f] = new LazyTuple3Functor[A1, A2] {}
 
-  implicit def lazyTuple3Equal[A1, A2, A3](implicit A1: Equal[A1], A2: Equal[A2], A3: Equal[A3]) = new LazyTuple3Equal[A1, A2, A3] {
+  implicit def lazyTuple3Equal[A1, A2, A3](implicit A1: Equal[A1], A2: Equal[A2], A3: Equal[A3]): Equal[LazyTuple3[A1, A2, A3]] = new LazyTuple3Equal[A1, A2, A3] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
@@ -136,19 +136,19 @@ sealed abstract class LazyTuple3Instances0 {
 }
 sealed abstract class LazyTuple3Instances extends LazyTuple3Instances0 {
 
-  implicit def lazyTuple3Show[A1, A2, A3](implicit A1: Show[A1], A2: Show[A2], A3: Show[A3]) = new LazyTuple3Show[A1, A2, A3] {
+  implicit def lazyTuple3Show[A1, A2, A3](implicit A1: Show[A1], A2: Show[A2], A3: Show[A3]): Show[LazyTuple3[A1, A2, A3]] = new LazyTuple3Show[A1, A2, A3] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
   }
 
-  implicit def lazyTuple3Order[A1, A2, A3](implicit A1: Order[A1], A2: Order[A2], A3: Order[A3]) = new LazyTuple3Order[A1, A2, A3] {
+  implicit def lazyTuple3Order[A1, A2, A3](implicit A1: Order[A1], A2: Order[A2], A3: Order[A3]): Order[LazyTuple3[A1, A2, A3]] = new LazyTuple3Order[A1, A2, A3] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
   }
 
-  implicit def lazyTuple3Monoid[A1, A2, A3](implicit A1: Monoid[A1], A2: Monoid[A2], A3: Monoid[A3]) = new LazyTuple3Monoid[A1, A2, A3] {
+  implicit def lazyTuple3Monoid[A1, A2, A3](implicit A1: Monoid[A1], A2: Monoid[A2], A3: Monoid[A3]): Monoid[LazyTuple3[A1, A2, A3]] = new LazyTuple3Monoid[A1, A2, A3] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
@@ -161,7 +161,7 @@ sealed abstract class LazyTuple3Instances extends LazyTuple3Instances0 {
 }
 
 sealed abstract class LazyTuple4Instances0 {
-  implicit def lazyTuple4Semigroup[A1, A2, A3, A4](implicit A1: Semigroup[A1], A2: Semigroup[A2], A3: Semigroup[A3], A4: Semigroup[A4]) = new LazyTuple4Semigroup[A1, A2, A3, A4] {
+  implicit def lazyTuple4Semigroup[A1, A2, A3, A4](implicit A1: Semigroup[A1], A2: Semigroup[A2], A3: Semigroup[A3], A4: Semigroup[A4]): Semigroup[LazyTuple4[A1, A2, A3, A4]] = new LazyTuple4Semigroup[A1, A2, A3, A4] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
@@ -170,7 +170,7 @@ sealed abstract class LazyTuple4Instances0 {
 
   implicit def lazyTuple4Functor[A1, A2, A3]: Functor[({type f[x] = LazyTuple4[A1, A2, A3, x]})#f] = new LazyTuple4Functor[A1, A2, A3] {}
 
-  implicit def lazyTuple4Equal[A1, A2, A3, A4](implicit A1: Equal[A1], A2: Equal[A2], A3: Equal[A3], A4: Equal[A4]) = new LazyTuple4Equal[A1, A2, A3, A4] {
+  implicit def lazyTuple4Equal[A1, A2, A3, A4](implicit A1: Equal[A1], A2: Equal[A2], A3: Equal[A3], A4: Equal[A4]): Equal[LazyTuple4[A1, A2, A3, A4]] = new LazyTuple4Equal[A1, A2, A3, A4] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
@@ -179,21 +179,21 @@ sealed abstract class LazyTuple4Instances0 {
 }
 sealed abstract class LazyTuple4Instances extends LazyTuple4Instances0 {
 
-  implicit def lazyTuple4Show[A1, A2, A3, A4](implicit A1: Show[A1], A2: Show[A2], A3: Show[A3], A4: Show[A4]) = new LazyTuple4Show[A1, A2, A3, A4] {
+  implicit def lazyTuple4Show[A1, A2, A3, A4](implicit A1: Show[A1], A2: Show[A2], A3: Show[A3], A4: Show[A4]): Show[LazyTuple4[A1, A2, A3, A4]] = new LazyTuple4Show[A1, A2, A3, A4] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
     implicit def _4 = A4
   }
 
-  implicit def lazyTuple4Order[A1, A2, A3, A4](implicit A1: Order[A1], A2: Order[A2], A3: Order[A3], A4: Order[A4]) = new LazyTuple4Order[A1, A2, A3, A4] {
+  implicit def lazyTuple4Order[A1, A2, A3, A4](implicit A1: Order[A1], A2: Order[A2], A3: Order[A3], A4: Order[A4]): Order[LazyTuple4[A1, A2, A3, A4]] = new LazyTuple4Order[A1, A2, A3, A4] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
     implicit def _4 = A4
   }
 
-  implicit def lazyTuple4Monoid[A1, A2, A3, A4](implicit A1: Monoid[A1], A2: Monoid[A2], A3: Monoid[A3], A4: Monoid[A4]) = new LazyTuple4Monoid[A1, A2, A3, A4] {
+  implicit def lazyTuple4Monoid[A1, A2, A3, A4](implicit A1: Monoid[A1], A2: Monoid[A2], A3: Monoid[A3], A4: Monoid[A4]): Monoid[LazyTuple4[A1, A2, A3, A4]] = new LazyTuple4Monoid[A1, A2, A3, A4] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
@@ -209,22 +209,22 @@ sealed abstract class LazyTuple4Instances extends LazyTuple4Instances0 {
 
 ////
 
-private[scalaz] trait LazyTuple2Functor[A1] extends Functor[({type f[x] = LazyTuple2[A1, x]})#f] {
+private trait LazyTuple2Functor[A1] extends Functor[({type f[x] = LazyTuple2[A1, x]})#f] {
   override def map[A, B](fa: LazyTuple2[A1, A])(f: A => B) =
     LazyTuple2(fa._1, f(fa._2))
 }
-private[scalaz] trait LazyTuple3Functor[A1, A2] extends Functor[({type f[x] = LazyTuple3[A1, A2, x]})#f] {
+private trait LazyTuple3Functor[A1, A2] extends Functor[({type f[x] = LazyTuple3[A1, A2, x]})#f] {
   override def map[A, B](fa: LazyTuple3[A1, A2, A])(f: A => B) =
     LazyTuple3(fa._1, fa._2, f(fa._3))
 }
-private[scalaz] trait LazyTuple4Functor[A1, A2, A3] extends Functor[({type f[x] = LazyTuple4[A1, A2, A3, x]})#f] {
+private trait LazyTuple4Functor[A1, A2, A3] extends Functor[({type f[x] = LazyTuple4[A1, A2, A3, x]})#f] {
   override def map[A, B](fa: LazyTuple4[A1, A2, A3, A])(f: A => B) =
     LazyTuple4(fa._1, fa._2, fa._3, f(fa._4))
 }
 
 import LazyTuple._
 
-private[scalaz] trait LazyTuple2Semigroup[A1, A2] extends Semigroup[LazyTuple2[A1, A2]] {
+private trait LazyTuple2Semigroup[A1, A2] extends Semigroup[LazyTuple2[A1, A2]] {
   implicit def _1 : Semigroup[A1]
   implicit def _2 : Semigroup[A2]
   def append(f1: LazyTuple2[A1, A2], f2: => LazyTuple2[A1, A2]) = LazyTuple2(
@@ -232,7 +232,7 @@ private[scalaz] trait LazyTuple2Semigroup[A1, A2] extends Semigroup[LazyTuple2[A
     _2.append(f1._2, f2._2)
     )
 }
-private[scalaz] trait LazyTuple3Semigroup[A1, A2, A3] extends Semigroup[LazyTuple3[A1, A2, A3]] {
+private trait LazyTuple3Semigroup[A1, A2, A3] extends Semigroup[LazyTuple3[A1, A2, A3]] {
   implicit def _1 : Semigroup[A1]
   implicit def _2 : Semigroup[A2]
   implicit def _3 : Semigroup[A3]
@@ -242,7 +242,7 @@ private[scalaz] trait LazyTuple3Semigroup[A1, A2, A3] extends Semigroup[LazyTupl
     _3.append(f1._3, f2._3)
     )
 }
-private[scalaz] trait LazyTuple4Semigroup[A1, A2, A3, A4] extends Semigroup[LazyTuple4[A1, A2, A3, A4]] {
+private trait LazyTuple4Semigroup[A1, A2, A3, A4] extends Semigroup[LazyTuple4[A1, A2, A3, A4]] {
   implicit def _1 : Semigroup[A1]
   implicit def _2 : Semigroup[A2]
   implicit def _3 : Semigroup[A3]
@@ -256,20 +256,20 @@ private[scalaz] trait LazyTuple4Semigroup[A1, A2, A3, A4] extends Semigroup[Lazy
 }
 
 
-private[scalaz] trait LazyTuple2Equal[A1, A2] extends Equal[LazyTuple2[A1, A2]] {
+private trait LazyTuple2Equal[A1, A2] extends Equal[LazyTuple2[A1, A2]] {
   implicit def _1 : Equal[A1]
   implicit def _2 : Equal[A2]
   override def equal(f1: LazyTuple2[A1, A2], f2: LazyTuple2[A1, A2]) =
     _1.equal(f1._1, f2._1) && _2.equal(f1._2, f2._2)
 }
-private[scalaz] trait LazyTuple3Equal[A1, A2, A3] extends Equal[LazyTuple3[A1, A2, A3]] {
+private trait LazyTuple3Equal[A1, A2, A3] extends Equal[LazyTuple3[A1, A2, A3]] {
   implicit def _1 : Equal[A1]
   implicit def _2 : Equal[A2]
   implicit def _3 : Equal[A3]
   override def equal(f1: LazyTuple3[A1, A2, A3], f2: LazyTuple3[A1, A2, A3]) =
     _1.equal(f1._1, f2._1) && _2.equal(f1._2, f2._2) && _3.equal(f1._3, f2._3)
 }
-private[scalaz] trait LazyTuple4Equal[A1, A2, A3, A4] extends Equal[LazyTuple4[A1, A2, A3, A4]] {
+private trait LazyTuple4Equal[A1, A2, A3, A4] extends Equal[LazyTuple4[A1, A2, A3, A4]] {
   implicit def _1 : Equal[A1]
   implicit def _2 : Equal[A2]
   implicit def _3 : Equal[A3]
@@ -278,20 +278,20 @@ private[scalaz] trait LazyTuple4Equal[A1, A2, A3, A4] extends Equal[LazyTuple4[A
     _1.equal(f1._1, f2._1) && _2.equal(f1._2, f2._2) && _3.equal(f1._3, f2._3) && _4.equal(f1._4, f2._4)
 }
 
-private[scalaz] trait LazyTuple2Show[A1, A2] extends Show[LazyTuple2[A1, A2]] {
+private trait LazyTuple2Show[A1, A2] extends Show[LazyTuple2[A1, A2]] {
   implicit def _1 : Show[A1]
   implicit def _2 : Show[A2]
   override def show(f: LazyTuple2[A1, A2]) =
     Cord("(", _1.show(f._1), ",", _2.show(f._2), ")")
 }
-private[scalaz] trait LazyTuple3Show[A1, A2, A3] extends Show[LazyTuple3[A1, A2, A3]] {
+private trait LazyTuple3Show[A1, A2, A3] extends Show[LazyTuple3[A1, A2, A3]] {
   implicit def _1 : Show[A1]
   implicit def _2 : Show[A2]
   implicit def _3 : Show[A3]
   override def show(f: LazyTuple3[A1, A2, A3]) =
     Cord("(", _1.show(f._1), ",", _2.show(f._2), ",", _3.show(f._3), ")")
 }
-private[scalaz] trait LazyTuple4Show[A1, A2, A3, A4] extends Show[LazyTuple4[A1, A2, A3, A4]] {
+private trait LazyTuple4Show[A1, A2, A3, A4] extends Show[LazyTuple4[A1, A2, A3, A4]] {
   implicit def _1 : Show[A1]
   implicit def _2 : Show[A2]
   implicit def _3 : Show[A3]
@@ -300,7 +300,7 @@ private[scalaz] trait LazyTuple4Show[A1, A2, A3, A4] extends Show[LazyTuple4[A1,
     Cord("(", _1.show(f._1), ",", _2.show(f._2), ",", _3.show(f._3), ",", _4.show(f._4), ")")
 }
 
-private[scalaz] trait LazyTuple2Order[A1, A2] extends Order[LazyTuple2[A1, A2]] with LazyTuple2Equal[A1, A2] {
+private trait LazyTuple2Order[A1, A2] extends Order[LazyTuple2[A1, A2]] with LazyTuple2Equal[A1, A2] {
   implicit def _1 : Order[A1]
   implicit def _2 : Order[A2]
   import Ordering.EQ
@@ -310,7 +310,7 @@ private[scalaz] trait LazyTuple2Order[A1, A2] extends Order[LazyTuple2[A1, A2]] 
       case (ord, _) => ord
     }
 }
-private[scalaz] trait LazyTuple3Order[A1, A2, A3] extends Order[LazyTuple3[A1, A2, A3]] with LazyTuple3Equal[A1, A2, A3]{
+private trait LazyTuple3Order[A1, A2, A3] extends Order[LazyTuple3[A1, A2, A3]] with LazyTuple3Equal[A1, A2, A3]{
   implicit def _1 : Order[A1]
   implicit def _2 : Order[A2]
   implicit def _3 : Order[A3]
@@ -322,7 +322,7 @@ private[scalaz] trait LazyTuple3Order[A1, A2, A3] extends Order[LazyTuple3[A1, A
       case (ord, _, _) => ord
     }
 }
-private[scalaz] trait LazyTuple4Order[A1, A2, A3, A4] extends Order[LazyTuple4[A1, A2, A3, A4]] with LazyTuple4Equal[A1, A2, A3, A4]{
+private trait LazyTuple4Order[A1, A2, A3, A4] extends Order[LazyTuple4[A1, A2, A3, A4]] with LazyTuple4Equal[A1, A2, A3, A4]{
   implicit def _1 : Order[A1]
   implicit def _2 : Order[A2]
   implicit def _3 : Order[A3]
@@ -337,18 +337,18 @@ private[scalaz] trait LazyTuple4Order[A1, A2, A3, A4] extends Order[LazyTuple4[A
     }
 }
 
-private[scalaz] trait LazyTuple2Monoid[A1, A2] extends Monoid[LazyTuple2[A1, A2]] with LazyTuple2Semigroup[A1, A2] {
+private trait LazyTuple2Monoid[A1, A2] extends Monoid[LazyTuple2[A1, A2]] with LazyTuple2Semigroup[A1, A2] {
   implicit def _1 : Monoid[A1]
   implicit def _2 : Monoid[A2]
   def zero: LazyTuple2[A1, A2] = LazyTuple2(_1.zero, _2.zero)
 }
-private[scalaz] trait LazyTuple3Monoid[A1, A2, A3] extends Monoid[LazyTuple3[A1, A2, A3]] with LazyTuple3Semigroup[A1, A2, A3] {
+private trait LazyTuple3Monoid[A1, A2, A3] extends Monoid[LazyTuple3[A1, A2, A3]] with LazyTuple3Semigroup[A1, A2, A3] {
   implicit def _1 : Monoid[A1]
   implicit def _2 : Monoid[A2]
   implicit def _3 : Monoid[A3]
   def zero: LazyTuple3[A1, A2, A3] = LazyTuple3(_1.zero, _2.zero, _3.zero)
 }
-private[scalaz] trait LazyTuple4Monoid[A1, A2, A3, A4] extends Monoid[LazyTuple4[A1, A2, A3, A4]] with LazyTuple4Semigroup[A1, A2, A3, A4] {
+private trait LazyTuple4Monoid[A1, A2, A3, A4] extends Monoid[LazyTuple4[A1, A2, A3, A4]] with LazyTuple4Semigroup[A1, A2, A3, A4] {
   implicit def _1 : Monoid[A1]
   implicit def _2 : Monoid[A2]
   implicit def _3 : Monoid[A3]
@@ -358,7 +358,7 @@ private[scalaz] trait LazyTuple4Monoid[A1, A2, A3, A4] extends Monoid[LazyTuple4
 
 // LazyTupleN forms a Monad if the element types other than the last are Monoids.
 
-private[scalaz] trait LazyTuple2Monad[A1] extends Monad[({type f[x] = LazyTuple2[A1, x]})#f] with LazyTuple2Functor[A1] {
+private trait LazyTuple2Monad[A1] extends Monad[({type f[x] = LazyTuple2[A1, x]})#f] with LazyTuple2Functor[A1] {
   implicit def _1 : Monoid[A1]
   def bind[A, B](fa: LazyTuple2[A1, A])(f: A => LazyTuple2[A1, B]) = {
     val t = f(fa._2)
@@ -367,7 +367,7 @@ private[scalaz] trait LazyTuple2Monad[A1] extends Monad[({type f[x] = LazyTuple2
   }
   def point[A](a: => A) = lazyTuple2(_1.zero, a)
 }
-private[scalaz] trait LazyTuple3Monad[A1, A2] extends Monad[({type f[x] = LazyTuple3[A1, A2, x]})#f] with LazyTuple3Functor[A1, A2] {
+private trait LazyTuple3Monad[A1, A2] extends Monad[({type f[x] = LazyTuple3[A1, A2, x]})#f] with LazyTuple3Functor[A1, A2] {
   implicit def _1 : Monoid[A1]
   implicit def _2 : Monoid[A2]
   def bind[A, B](fa: LazyTuple3[A1, A2, A])(f: A => LazyTuple3[A1, A2, B]) = {
@@ -378,7 +378,7 @@ private[scalaz] trait LazyTuple3Monad[A1, A2] extends Monad[({type f[x] = LazyTu
 
   def point[A](a: => A) = lazyTuple3(_1.zero, _2.zero, a)
 }
-private[scalaz] trait LazyTuple4Monad[A1, A2, A3] extends Monad[({type f[x] = LazyTuple4[A1, A2, A3, x]})#f] with LazyTuple4Functor[A1, A2, A3] {
+private trait LazyTuple4Monad[A1, A2, A3] extends Monad[({type f[x] = LazyTuple4[A1, A2, A3, x]})#f] with LazyTuple4Functor[A1, A2, A3] {
   implicit def _1 : Monoid[A1]
   implicit def _2 : Monoid[A2]
   implicit def _3 : Monoid[A3]

--- a/core/src/main/scala/scalaz/ListT.scala
+++ b/core/src/main/scala/scalaz/ListT.scala
@@ -103,23 +103,23 @@ object ListT extends ListTInstances {
 // Implementation traits for type class instances
 //
 
-private[scalaz] trait ListTFunctor[F[_]] extends Functor[({type λ[α] = ListT[F, α]})#λ] {
+private trait ListTFunctor[F[_]] extends Functor[({type λ[α] = ListT[F, α]})#λ] {
  implicit def F: Functor[F]
  override def map[A, B](fa: ListT[F, A])(f: A => B): ListT[F, B] = fa map f
 }
 
-private[scalaz] trait ListTSemigroup[F[_], A] extends Semigroup[ListT[F, A]] {
+private trait ListTSemigroup[F[_], A] extends Semigroup[ListT[F, A]] {
  implicit def F: Bind[F]
  def append(f1: ListT[F, A], f2: => ListT[F, A]): ListT[F, A] = f1 ++ f2
 }
 
-private[scalaz] trait ListTMonoid[F[_], A] extends Monoid[ListT[F, A]] with ListTSemigroup[F, A] {
+private trait ListTMonoid[F[_], A] extends Monoid[ListT[F, A]] with ListTSemigroup[F, A] {
   implicit def F: Monad[F]
 
   def zero: ListT[F, A] = ListT.empty[F, A]
 }
 
-private[scalaz] trait ListTMonadPlus[F[_]] extends MonadPlus[({type λ[α] = ListT[F, α]})#λ] with ListTFunctor[F] {
+private trait ListTMonadPlus[F[_]] extends MonadPlus[({type λ[α] = ListT[F, α]})#λ] with ListTFunctor[F] {
   implicit def F: Monad[F]
 
   def bind[A, B](fa: ListT[F, A])(f: A => ListT[F, B]): ListT[F, B] = fa flatMap f
@@ -131,7 +131,7 @@ private[scalaz] trait ListTMonadPlus[F[_]] extends MonadPlus[({type λ[α] = Lis
   def plus[A](a: ListT[F, A], b: => ListT[F, A]): ListT[F, A] = a ++ b
 }
 
-private[scalaz] trait ListTHoist extends Hoist[ListT] {
+private trait ListTHoist extends Hoist[ListT] {
   import ListT._
   
   implicit def apply[G[_] : Monad]: Monad[({type λ[α] = ListT[G, α]})#λ] = listTMonadPlus[G]

--- a/core/src/main/scala/scalaz/Monoid.scala
+++ b/core/src/main/scala/scalaz/Monoid.scala
@@ -98,7 +98,7 @@ object Monoid {
     def append(x: F[M], y: => F[M]): F[M] = F.lift2[M, M, M]((m1, m2) => M.append(m1, m2))(x, y)
   }
 
-  private[scalaz] trait ApplicativeMonoid[F[_], M] extends Monoid[F[M]] with Semigroup.ApplySemigroup[F, M] {
+  private trait ApplicativeMonoid[F[_], M] extends Monoid[F[M]] with Semigroup.ApplySemigroup[F, M] {
     implicit def F: Applicative[F]
     implicit def M: Monoid[M]
     val zero = F.point(M.zero)

--- a/core/src/main/scala/scalaz/NullArgument.scala
+++ b/core/src/main/scala/scalaz/NullArgument.scala
@@ -153,14 +153,14 @@ sealed abstract class NullArgumentInstances extends NullArgumentInstances0 {
 
 }
 
-private[scalaz] trait NullArgumentSemigroup[A, B] extends Semigroup[NullArgument[A, B]] {
+private trait NullArgumentSemigroup[A, B] extends Semigroup[NullArgument[A, B]] {
   implicit val M: Semigroup[B]
 
   override def append(a1: NullArgument[A, B], a2: => NullArgument[A, B]) =
     a1 |+| a2
 }
 
-private[scalaz] trait NullArgumentMonoid[A, B] extends Monoid[NullArgument[A, B]] with NullArgumentSemigroup[A, B] {
+private trait NullArgumentMonoid[A, B] extends Monoid[NullArgument[A, B]] with NullArgumentSemigroup[A, B] {
   implicit val M: Monoid[B]
 
   override def zero =

--- a/core/src/main/scala/scalaz/NullResult.scala
+++ b/core/src/main/scala/scalaz/NullResult.scala
@@ -194,14 +194,14 @@ sealed abstract class NullResultInstances extends NullResultInstances0 {
 
 }
 
-private[scalaz] trait NullResultSemigroup[A, B] extends Semigroup[NullResult[A, B]] {
+private trait NullResultSemigroup[A, B] extends Semigroup[NullResult[A, B]] {
   implicit val M: Semigroup[B]
 
   override def append(a1: NullResult[A, B], a2: => NullResult[A, B]) =
     a1 |+| a2
 }
 
-private[scalaz] trait NullResultMonoid[A, B] extends Monoid[NullResult[A, B]] with NullResultSemigroup[A, B] {
+private trait NullResultMonoid[A, B] extends Monoid[NullResult[A, B]] with NullResultSemigroup[A, B] {
   implicit val M: Monoid[B]
 
   override def zero =

--- a/core/src/main/scala/scalaz/OneAnd.scala
+++ b/core/src/main/scala/scalaz/OneAnd.scala
@@ -6,7 +6,7 @@ import scalaz.Ordering.orderingInstance
 
 final case class OneAnd[F[_], A](head: A, tail: F[A])
 
-private[scalaz] sealed trait OneAndFunctor[F[_]]
+private sealed trait OneAndFunctor[F[_]]
     extends Functor[({type λ[α] = OneAnd[F, α]})#λ] {
   def F: Functor[F]
 
@@ -14,7 +14,7 @@ private[scalaz] sealed trait OneAndFunctor[F[_]]
     OneAnd(f(fa.head), F.map(fa.tail)(f))
 }
 
-private[scalaz] sealed trait OneAndApply[F[_]] extends Apply[({type λ[α] = OneAnd[F, α]})#λ] with OneAndFunctor[F] {
+private sealed trait OneAndApply[F[_]] extends Apply[({type λ[α] = OneAnd[F, α]})#λ] with OneAndFunctor[F] {
   def F: Applicative[F]
   def G: Plus[F]
 
@@ -26,13 +26,13 @@ private[scalaz] sealed trait OneAndApply[F[_]] extends Apply[({type λ[α] = One
   }
 }
 
-private[scalaz] sealed trait OneAndApplicative[F[_]] extends Applicative[({type λ[α] = OneAnd[F, α]})#λ] with OneAndApply[F] {
+private sealed trait OneAndApplicative[F[_]] extends Applicative[({type λ[α] = OneAnd[F, α]})#λ] with OneAndApply[F] {
   def F: ApplicativePlus[F]
 
   def point[A](a: => A): OneAnd[F, A] = OneAnd(a, F.empty)
 }
 
-private[scalaz] sealed trait OneAndBind[F[_]] extends Bind[({type λ[α] = OneAnd[F, α]})#λ] with OneAndApply[F] {
+private sealed trait OneAndBind[F[_]] extends Bind[({type λ[α] = OneAnd[F, α]})#λ] with OneAndApply[F] {
   def F: Monad[F]
   def G: Plus[F]
 
@@ -48,7 +48,7 @@ private[scalaz] sealed trait OneAndBind[F[_]] extends Bind[({type λ[α] = OneAn
   )
 }
 
-private[scalaz] sealed trait OneAndPlus[F[_]] extends Plus[({type λ[α] = OneAnd[F, α]})#λ] {
+private sealed trait OneAndPlus[F[_]] extends Plus[({type λ[α] = OneAnd[F, α]})#λ] {
   def F: Applicative[F]
   def G: Plus[F]
 
@@ -56,12 +56,12 @@ private[scalaz] sealed trait OneAndPlus[F[_]] extends Plus[({type λ[α] = OneAn
     OneAnd(a.head, G.plus(G.plus(a.tail, F.point(b.head)), b.tail))
 }
 
-private[scalaz] sealed trait OneAndMonad[F[_]] extends Monad[({type λ[α] = OneAnd[F, α]})#λ] with OneAndBind[F] with OneAndApplicative[F] {
+private sealed trait OneAndMonad[F[_]] extends Monad[({type λ[α] = OneAnd[F, α]})#λ] with OneAndBind[F] with OneAndApplicative[F] {
   def F: MonadPlus[F]
   def G = F
 }
 
-private[scalaz] sealed trait OneAndFoldable[F[_]]
+private sealed trait OneAndFoldable[F[_]]
     extends Foldable1[({type λ[α] = OneAnd[F, α]})#λ] {
   def F: Foldable[F]
 
@@ -85,7 +85,7 @@ private[scalaz] sealed trait OneAndFoldable[F[_]]
     F.foldLeft(fa.tail, f(z, fa.head))(f)
 }
 
-private[scalaz] sealed trait OneAndFoldable1[F[_]] extends OneAndFoldable[F] {
+private sealed trait OneAndFoldable1[F[_]] extends OneAndFoldable[F] {
   def F: Foldable1[F]
 
   override def foldMap1[A, B](fa: OneAnd[F, A])(f: A => B)(implicit S: Semigroup[B]) =
@@ -95,7 +95,7 @@ private[scalaz] sealed trait OneAndFoldable1[F[_]] extends OneAndFoldable[F] {
     f(fa.head, F.foldRight1(fa.tail)(f))
 }
 
-private[scalaz] sealed trait OneAndTraverse[F[_]]
+private sealed trait OneAndTraverse[F[_]]
     extends Traverse1[({type λ[α] = OneAnd[F, α]})#λ]
     with OneAndFunctor[F] with OneAndFoldable[F] {
   def F: Traverse[F]
@@ -109,7 +109,7 @@ private[scalaz] sealed trait OneAndTraverse[F[_]]
     G.apply2(f(fa.head), F.traverseImpl(fa.tail)(f)(G))(OneAnd.apply)
 }
 
-private[scalaz] sealed trait OneAndTraverse1[F[_]]
+private sealed trait OneAndTraverse1[F[_]]
     extends OneAndTraverse[F] with OneAndFoldable1[F] {
   def F: Traverse1[F]
 
@@ -160,8 +160,7 @@ sealed abstract class OneAndInstances1 extends OneAndInstances2 {
     }
 }
 
-private[scalaz]
-sealed trait OneAndEqual[F[_], A] extends Equal[OneAnd[F, A]] {
+private sealed trait OneAndEqual[F[_], A] extends Equal[OneAnd[F, A]] {
   def OA: Equal[A]
   def OFA: Equal[F[A]]
 

--- a/core/src/main/scala/scalaz/OneOr.scala
+++ b/core/src/main/scala/scalaz/OneOr.scala
@@ -108,7 +108,7 @@ final case class OneOr[F[_], A](run: F[A] \/ A) {
 
 }
 
-private[scalaz] sealed trait OneOrFunctor[F[_]]
+private sealed trait OneOrFunctor[F[_]]
     extends Functor[({type λ[α] = OneOr[F, α]})#λ] {
   implicit def F: Functor[F]
 
@@ -116,7 +116,7 @@ private[scalaz] sealed trait OneOrFunctor[F[_]]
     fa map f
 }
 
-private[scalaz] sealed trait OneOrCobind[F[_]]
+private sealed trait OneOrCobind[F[_]]
     extends OneOrFunctor[F] with Cobind[({type λ[α] = OneOr[F, α]})#λ] {
   implicit def F: Cobind[F]
 
@@ -124,7 +124,7 @@ private[scalaz] sealed trait OneOrCobind[F[_]]
     fa cobind f
 }
 
-private[scalaz] sealed trait OneOrComonad[F[_]]
+private sealed trait OneOrComonad[F[_]]
     extends OneOrCobind[F] with Comonad[({type λ[α] = OneOr[F, α]})#λ] {
   implicit def F: Comonad[F]
 
@@ -135,7 +135,7 @@ private[scalaz] sealed trait OneOrComonad[F[_]]
     fa.copoint
 }
 
-private[scalaz] sealed trait OneOrApplicative[F[_]]
+private sealed trait OneOrApplicative[F[_]]
     extends OneOrFunctor[F] with Applicative[({type λ[α] = OneOr[F, α]})#λ] {
   implicit def F: Apply[F]
 
@@ -146,7 +146,7 @@ private[scalaz] sealed trait OneOrApplicative[F[_]]
     OneOr(\/-(a))
 }
 
-private[scalaz] sealed trait OneOrFoldable[F[_]]
+private sealed trait OneOrFoldable[F[_]]
   extends Foldable[({type λ[α] = OneOr[F, α]})#λ] {
 
   implicit def F: Foldable[F]
@@ -161,7 +161,7 @@ private[scalaz] sealed trait OneOrFoldable[F[_]]
     fa.foldLeft(z)(f)
 }
 
-private[scalaz] sealed trait OneOrFoldable1[F[_]]
+private sealed trait OneOrFoldable1[F[_]]
   extends OneOrFoldable[F] with Foldable1[({type λ[α] = OneOr[F, α]})#λ] {
 
   implicit def F: Foldable1[F]
@@ -176,7 +176,7 @@ private[scalaz] sealed trait OneOrFoldable1[F[_]]
     fa.foldLeft1(f)
 }
 
-private[scalaz] sealed trait OneOrTraverse[F[_]]
+private sealed trait OneOrTraverse[F[_]]
   extends OneOrFunctor[F] with OneOrFoldable[F] with Traverse[({type λ[α] = OneOr[F, α]})#λ] {
 
   implicit def F: Traverse[F]
@@ -189,7 +189,7 @@ private[scalaz] sealed trait OneOrTraverse[F[_]]
 
 }
 
-private[scalaz] sealed trait OneOrTraverse1[F[_]]
+private sealed trait OneOrTraverse1[F[_]]
   extends OneOrFoldable1[F] with OneOrTraverse[F] with Traverse1[({type λ[α] = OneOr[F, α]})#λ] {
 
   implicit def F: Traverse1[F]
@@ -198,7 +198,7 @@ private[scalaz] sealed trait OneOrTraverse1[F[_]]
     fa traverse1 f
 }
 
-private[scalaz] sealed trait OneOrEqual[F[_], A] extends Equal[OneOr[F, A]] {
+private sealed trait OneOrEqual[F[_], A] extends Equal[OneOr[F, A]] {
   implicit def OA: Equal[A]
   implicit def OFA: Equal[F[A]]
 
@@ -208,7 +208,7 @@ private[scalaz] sealed trait OneOrEqual[F[_], A] extends Equal[OneOr[F, A]] {
   override def equalIsNatural = OA.equalIsNatural && OFA.equalIsNatural
 }
 
-private[scalaz] sealed trait OneOrOrder[F[_], A] extends Order[OneOr[F, A]] {
+private sealed trait OneOrOrder[F[_], A] extends Order[OneOr[F, A]] {
   implicit def OA: Order[A]
   implicit def OFA: Order[F[A]]
 
@@ -216,7 +216,7 @@ private[scalaz] sealed trait OneOrOrder[F[_], A] extends Order[OneOr[F, A]] {
     a1.run compare a2.run
 }
 
-private[scalaz] sealed trait OneOrShow[F[_], A] extends Show[OneOr[F, A]] {
+private sealed trait OneOrShow[F[_], A] extends Show[OneOr[F, A]] {
   implicit def OA: Show[A]
   implicit def OFA: Show[F[A]]
 

--- a/core/src/main/scala/scalaz/OptionT.scala
+++ b/core/src/main/scala/scalaz/OptionT.scala
@@ -117,11 +117,11 @@ trait OptionTFunctions {
     def apply[A](a: M[Option[A]]) = new OptionT[M, A](a)
   }
 
-  def monadTell[F[_, _], W, A](implicit MT0: MonadTell[F, W]) = new OptionTMonadTell[F, W] {
+  def monadTell[F[_, _], W, A](implicit MT0: MonadTell[F, W]): MonadTell[({type λ[α, β]=OptionT[({type f[x]=F[α, x]})#f, β] })#λ, W] = new OptionTMonadTell[F, W] {
     def MT = MT0
   }
 
-  def monadListen[F[_, _], W, A](implicit ML0: MonadListen[F, W]) = new OptionTMonadListen[F, W] {
+  def monadListen[F[_, _], W, A](implicit ML0: MonadListen[F, W]): MonadListen[({type λ[α, β]=OptionT[({type f[x]=F[α, x]})#f, β] })#λ, W] = new OptionTMonadListen[F, W] {
     def MT = ML0
   }
 }
@@ -132,44 +132,44 @@ object OptionT extends OptionTInstances with OptionTFunctions
 // Implementation traits for type class instances
 //
 
-private[scalaz] trait OptionTFunctor[F[_]] extends Functor[({type λ[α] = OptionT[F, α]})#λ] {
+private trait OptionTFunctor[F[_]] extends Functor[({type λ[α] = OptionT[F, α]})#λ] {
   implicit def F: Functor[F]
 
   override def map[A, B](fa: OptionT[F, A])(f: A => B): OptionT[F, B] = fa map f
 }
 
-private[scalaz] trait OptionTApply[F[_]] extends Apply[({type λ[α] = OptionT[F, α]})#λ] with OptionTFunctor[F] {
+private trait OptionTApply[F[_]] extends Apply[({type λ[α] = OptionT[F, α]})#λ] with OptionTFunctor[F] {
   implicit def F: Apply[F]
 
   override def ap[A, B](fa: => OptionT[F, A])(f: => OptionT[F, A => B]): OptionT[F, B] = fa ap f
 }
 
-private[scalaz] trait OptionTApplicative[F[_]] extends Applicative[({type λ[α] = OptionT[F, α]})#λ] with OptionTApply[F] {
+private trait OptionTApplicative[F[_]] extends Applicative[({type λ[α] = OptionT[F, α]})#λ] with OptionTApply[F] {
   implicit def F: Applicative[F]
 
   def point[A](a: => A): OptionT[F, A] = OptionT[F, A](F.point(some(a)))
 }
 
-private[scalaz] trait OptionTMonad[F[_]] extends Monad[({type λ[α] = OptionT[F, α]})#λ] with OptionTApplicative[F] {
+private trait OptionTMonad[F[_]] extends Monad[({type λ[α] = OptionT[F, α]})#λ] with OptionTApplicative[F] {
   implicit def F: Monad[F]
 
   def bind[A, B](fa: OptionT[F, A])(f: A => OptionT[F, B]): OptionT[F, B] = fa flatMap f
 
 }
 
-private[scalaz] trait OptionTFoldable[F[_]] extends Foldable.FromFoldr[({type λ[α] = OptionT[F, α]})#λ] {
+private trait OptionTFoldable[F[_]] extends Foldable.FromFoldr[({type λ[α] = OptionT[F, α]})#λ] {
   implicit def F: Foldable[F]
 
   override def foldRight[A, B](fa: OptionT[F, A], z: => B)(f: (A, => B) => B): B = fa.foldRight(z)(f)
 }
 
-private[scalaz] trait OptionTTraverse[F[_]] extends Traverse[({type λ[α] = OptionT[F, α]})#λ] with OptionTFoldable[F] with OptionTFunctor[F]{
+private trait OptionTTraverse[F[_]] extends Traverse[({type λ[α] = OptionT[F, α]})#λ] with OptionTFoldable[F] with OptionTFunctor[F]{
   implicit def F: Traverse[F]
 
   def traverseImpl[G[_] : Applicative, A, B](fa: OptionT[F, A])(f: A => G[B]): G[OptionT[F, B]] = fa traverse f
 }
 
-private[scalaz] trait OptionTHoist extends Hoist[OptionT] {
+private trait OptionTHoist extends Hoist[OptionT] {
   def liftM[G[_], A](a: G[A])(implicit G: Monad[G]): OptionT[G, A] =
     OptionT[G, A](G.map[A, Option[A]](a)((a: A) => some(a)))
 
@@ -180,14 +180,14 @@ private[scalaz] trait OptionTHoist extends Hoist[OptionT] {
   implicit def apply[G[_] : Monad]: Monad[({type λ[α] = OptionT[G, α]})#λ] = OptionT.optionTMonadPlus[G]
 }
 
-private[scalaz] trait OptionTMonadPlus[F[_]] extends MonadPlus[({type λ[α] = OptionT[F, α]})#λ] with OptionTMonad[F] {
+private trait OptionTMonadPlus[F[_]] extends MonadPlus[({type λ[α] = OptionT[F, α]})#λ] with OptionTMonad[F] {
   implicit def F: Monad[F]
 
   def empty[A]: OptionT[F, A] = OptionT(F point none[A])
   def plus[A](a: OptionT[F, A], b: => OptionT[F, A]): OptionT[F, A] = a orElse b
 }
 
-private[scalaz] trait OptionTMonadTell[F[_, _], W] extends MonadTell[({ type λ[α, β] = OptionT[({ type f[x] = F[α, x] })#f, β] })#λ, W] with OptionTMonad[({ type λ[α] = F[W, α] })#λ] with OptionTHoist {
+private trait OptionTMonadTell[F[_, _], W] extends MonadTell[({ type λ[α, β] = OptionT[({ type f[x] = F[α, x] })#f, β] })#λ, W] with OptionTMonad[({ type λ[α] = F[W, α] })#λ] with OptionTHoist {
   def MT: MonadTell[F, W]
 
   implicit def F = MT
@@ -202,7 +202,7 @@ private[scalaz] trait OptionTMonadTell[F[_, _], W] extends MonadTell[({ type λ[
     OptionT.optionT[({ type λ[α] = F[W, α] })#λ].apply[A](MT.point(None))
 }
 
-private[scalaz] trait OptionTMonadListen[F[_, _], W] extends MonadListen[({ type λ[α, β] = OptionT[({ type f[x] = F[α, x] })#f, β] })#λ, W] with OptionTMonadTell[F, W] {
+private trait OptionTMonadListen[F[_, _], W] extends MonadListen[({ type λ[α, β] = OptionT[({ type f[x] = F[α, x] })#f, β] })#λ, W] with OptionTMonadTell[F, W] {
   def MT: MonadListen[F, W]
 
   def listen[A](ma: OptionT[({ type λ[α] = F[W, α] })#λ, A]): OptionT[({ type λ[α] = F[W, α] })#λ, (A, W)] = {

--- a/core/src/main/scala/scalaz/Product.scala
+++ b/core/src/main/scala/scalaz/Product.scala
@@ -2,7 +2,7 @@ package scalaz
 
 import std.option.cata
 
-private[scalaz] trait ProductFunctor[F[_], G[_]] extends Functor[({type λ[α] = (F[α], G[α])})#λ] {
+private trait ProductFunctor[F[_], G[_]] extends Functor[({type λ[α] = (F[α], G[α])})#λ] {
   implicit def F: Functor[F]
 
   implicit def G: Functor[G]
@@ -10,7 +10,7 @@ private[scalaz] trait ProductFunctor[F[_], G[_]] extends Functor[({type λ[α] =
   override def map[A, B](fa: (F[A], G[A]))(f: A => B): (F[B], G[B]) = (F.map(fa._1)(f), G.map(fa._2)(f))
 }
 
-private[scalaz] trait ProductApply[F[_], G[_]] extends Apply[({type λ[α] = (F[α], G[α])})#λ] with ProductFunctor[F, G] {
+private trait ProductApply[F[_], G[_]] extends Apply[({type λ[α] = (F[α], G[α])})#λ] with ProductFunctor[F, G] {
   implicit def F: Apply[F]
 
   implicit def G: Apply[G]
@@ -19,7 +19,7 @@ private[scalaz] trait ProductApply[F[_], G[_]] extends Apply[({type λ[α] = (F[
     (F.ap(fa._1)(f._1), G.ap(fa._2)(f._2))
 }
 
-private[scalaz] trait ProductApplicative[F[_], G[_]] extends Applicative[({type λ[α] = (F[α], G[α])})#λ] with ProductApply[F, G] {
+private trait ProductApplicative[F[_], G[_]] extends Applicative[({type λ[α] = (F[α], G[α])})#λ] with ProductApply[F, G] {
   implicit def F: Applicative[F]
 
   implicit def G: Applicative[G]
@@ -27,7 +27,7 @@ private[scalaz] trait ProductApplicative[F[_], G[_]] extends Applicative[({type 
   def point[A](a: => A): (F[A], G[A]) = (F.point(a), G.point(a))
 }
 
-private[scalaz] trait ProductPlus[F[_], G[_]] extends Plus[({type λ[α] = (F[α], G[α])})#λ] {
+private trait ProductPlus[F[_], G[_]] extends Plus[({type λ[α] = (F[α], G[α])})#λ] {
   implicit def F: Plus[F]
 
   implicit def G: Plus[G]
@@ -36,7 +36,7 @@ private[scalaz] trait ProductPlus[F[_], G[_]] extends Plus[({type λ[α] = (F[α
     (F.plus(a._1, b._1), G.plus(a._2, b._2))
 }
 
-private[scalaz] trait ProductPlusEmpty[F[_], G[_]] extends PlusEmpty[({type λ[α] = (F[α], G[α])})#λ] with ProductPlus[F, G] {
+private trait ProductPlusEmpty[F[_], G[_]] extends PlusEmpty[({type λ[α] = (F[α], G[α])})#λ] with ProductPlus[F, G] {
   implicit def F: PlusEmpty[F]
 
   implicit def G: PlusEmpty[G]
@@ -44,13 +44,13 @@ private[scalaz] trait ProductPlusEmpty[F[_], G[_]] extends PlusEmpty[({type λ[�
   def empty[A]: (F[A], G[A]) = (F.empty[A], G.empty[A])
 }
 
-private[scalaz] trait ProductApplicativePlus[F[_], G[_]] extends ApplicativePlus[({type λ[α] = (F[α], G[α])})#λ] with ProductApplicative[F, G] with ProductPlusEmpty[F, G] {
+private trait ProductApplicativePlus[F[_], G[_]] extends ApplicativePlus[({type λ[α] = (F[α], G[α])})#λ] with ProductApplicative[F, G] with ProductPlusEmpty[F, G] {
   implicit def F: ApplicativePlus[F]
 
   implicit def G: ApplicativePlus[G]
 }
 
-private[scalaz] trait ProductFoldable[F[_], G[_]] extends Foldable[({type λ[α] = (F[α], G[α])})#λ] {
+private trait ProductFoldable[F[_], G[_]] extends Foldable[({type λ[α] = (F[α], G[α])})#λ] {
   implicit def F: Foldable[F]
 
   implicit def G: Foldable[G]
@@ -65,7 +65,7 @@ private[scalaz] trait ProductFoldable[F[_], G[_]] extends Foldable[({type λ[α]
     G.foldLeft(fa._2, F.foldLeft(fa._1, z)(f))(f)
 }
 
-private[scalaz] trait ProductFoldable1L[F[_], G[_]] extends Foldable1[({type λ[α] = (F[α], G[α])})#λ] with ProductFoldable[F, G] {
+private trait ProductFoldable1L[F[_], G[_]] extends Foldable1[({type λ[α] = (F[α], G[α])})#λ] with ProductFoldable[F, G] {
   implicit def F: Foldable1[F]
 
   override def foldRight1[A](fa: (F[A], G[A]))(f: (A, => A) => A): A =
@@ -80,7 +80,7 @@ private[scalaz] trait ProductFoldable1L[F[_], G[_]] extends Foldable1[({type λ[
     G.foldLeft(fa._2, F.foldLeft1(fa._1)(f))(f)
 }
 
-private[scalaz] trait ProductFoldable1R[F[_], G[_]] extends Foldable1[({type λ[α] = (F[α], G[α])})#λ] with ProductFoldable[F, G] {
+private trait ProductFoldable1R[F[_], G[_]] extends Foldable1[({type λ[α] = (F[α], G[α])})#λ] with ProductFoldable[F, G] {
   implicit def G: Foldable1[G]
 
   override def foldRight1[A](fa: (F[A], G[A]))(f: (A, => A) => A): A =
@@ -95,7 +95,7 @@ private[scalaz] trait ProductFoldable1R[F[_], G[_]] extends Foldable1[({type λ[
     cata(F.foldLeft1Opt(fa._1)(f))(G.foldLeft(fa._2, _)(f), G.foldLeft1(fa._2)(f))
 }
 
-private[scalaz] trait ProductFoldable1[F[_], G[_]] extends Foldable1[({type λ[α] = (F[α], G[α])})#λ] with ProductFoldable[F, G] {
+private trait ProductFoldable1[F[_], G[_]] extends Foldable1[({type λ[α] = (F[α], G[α])})#λ] with ProductFoldable[F, G] {
   implicit def F: Foldable1[F]
 
   implicit def G: Foldable1[G]
@@ -110,7 +110,7 @@ private[scalaz] trait ProductFoldable1[F[_], G[_]] extends Foldable1[({type λ[�
     G.foldLeft(fa._2, F.foldLeft1(fa._1)(f))(f)
 }
 
-private[scalaz] trait ProductTraverse[F[_], G[_]] extends Traverse[({type λ[α] = (F[α], G[α])})#λ] with ProductFunctor[F, G] with ProductFoldable[F, G] {
+private trait ProductTraverse[F[_], G[_]] extends Traverse[({type λ[α] = (F[α], G[α])})#λ] with ProductFunctor[F, G] with ProductFoldable[F, G] {
   implicit def F: Traverse[F]
 
   implicit def G: Traverse[G]
@@ -119,7 +119,7 @@ private[scalaz] trait ProductTraverse[F[_], G[_]] extends Traverse[({type λ[α]
     Applicative[X].apply2(F.traverse(a._1)(f), G.traverse(a._2)(f))((a, b) => (a, b))
 }
 
-private[scalaz] trait ProductTraverse1L[F[_], G[_]] extends Traverse1[({type λ[α] = (F[α], G[α])})#λ] with ProductFoldable1L[F, G] with ProductTraverse[F, G] {
+private trait ProductTraverse1L[F[_], G[_]] extends Traverse1[({type λ[α] = (F[α], G[α])})#λ] with ProductFoldable1L[F, G] with ProductTraverse[F, G] {
   implicit def F: Traverse1[F]
 
   def traverse1Impl[X[_], A, B](a: (F[A], G[A]))(f: A => X[B])(implicit X0: Apply[X]): X[(F[B], G[B])] = {
@@ -133,7 +133,7 @@ private[scalaz] trait ProductTraverse1L[F[_], G[_]] extends Traverse1[({type λ[
     super[ProductTraverse].traverseImpl(a)(f)
 }
 
-private[scalaz] trait ProductTraverse1R[F[_], G[_]] extends Traverse1[({type λ[α] = (F[α], G[α])})#λ] with ProductFoldable1R[F, G] with ProductTraverse[F, G] {
+private trait ProductTraverse1R[F[_], G[_]] extends Traverse1[({type λ[α] = (F[α], G[α])})#λ] with ProductFoldable1R[F, G] with ProductTraverse[F, G] {
   implicit def G: Traverse1[G]
 
   def traverse1Impl[X[_], A, B](a: (F[A], G[A]))(f: A => X[B])(implicit X0: Apply[X]): X[(F[B], G[B])] = {
@@ -147,7 +147,7 @@ private[scalaz] trait ProductTraverse1R[F[_], G[_]] extends Traverse1[({type λ[
     super[ProductTraverse].traverseImpl(a)(f)
 }
 
-private[scalaz] trait ProductTraverse1[F[_], G[_]] extends Traverse1[({type λ[α] = (F[α], G[α])})#λ] with ProductFoldable1[F, G] with ProductTraverse[F, G] {
+private trait ProductTraverse1[F[_], G[_]] extends Traverse1[({type λ[α] = (F[α], G[α])})#λ] with ProductFoldable1[F, G] with ProductTraverse[F, G] {
   implicit def F: Traverse1[F]
 
   implicit def G: Traverse1[G]
@@ -159,7 +159,7 @@ private[scalaz] trait ProductTraverse1[F[_], G[_]] extends Traverse1[({type λ[�
     super[ProductTraverse].traverseImpl(a)(f)
 }
 
-private[scalaz] trait ProductDistributive[F[_], G[_]] extends Distributive[({type λ[α] = (F[α], G[α])})#λ] with ProductFunctor[F, G] {
+private trait ProductDistributive[F[_], G[_]] extends Distributive[({type λ[α] = (F[α], G[α])})#λ] with ProductFunctor[F, G] {
   implicit def F: Distributive[F]
 
   implicit def G: Distributive[G]
@@ -168,7 +168,7 @@ private[scalaz] trait ProductDistributive[F[_], G[_]] extends Distributive[({typ
     (F.distribute(a)(x => f(x)._1), G.distribute(a)(x => f(x)._2))
 }
 
-private[scalaz] trait ProductZip[F[_], G[_]] extends Zip[({type λ[α] = (F[α], G[α])})#λ] {
+private trait ProductZip[F[_], G[_]] extends Zip[({type λ[α] = (F[α], G[α])})#λ] {
   implicit def F: Zip[F]
 
   implicit def G: Zip[G]
@@ -177,7 +177,7 @@ private[scalaz] trait ProductZip[F[_], G[_]] extends Zip[({type λ[α] = (F[α],
     (F.zip(a._1, b._1), G.zip(a._2, b._2))
 }
 
-private[scalaz] trait ProductUnzip[F[_], G[_]] extends Unzip[({type λ[α] = (F[α], G[α])})#λ] {
+private trait ProductUnzip[F[_], G[_]] extends Unzip[({type λ[α] = (F[α], G[α])})#λ] {
   implicit def F: Unzip[F]
 
   implicit def G: Unzip[G]
@@ -189,7 +189,7 @@ private[scalaz] trait ProductUnzip[F[_], G[_]] extends Unzip[({type λ[α] = (F[
   }
 }
 
-private[scalaz] trait ProductBifunctor[F[_, _], G[_, _]] extends Bifunctor[({type λ[α, β]=(F[α, β], G[α, β])})#λ] {
+private trait ProductBifunctor[F[_, _], G[_, _]] extends Bifunctor[({type λ[α, β]=(F[α, β], G[α, β])})#λ] {
   implicit def F: Bifunctor[F]
 
   implicit def G: Bifunctor[G]
@@ -198,7 +198,7 @@ private[scalaz] trait ProductBifunctor[F[_, _], G[_, _]] extends Bifunctor[({typ
     (F.bimap(fab._1)(f, g), G.bimap(fab._2)(f, g))
 }
 
-private[scalaz] trait ProductBifoldable[F[_, _], G[_, _]] extends Bifoldable[({type λ[α, β]=(F[α, β], G[α, β])})#λ] {
+private trait ProductBifoldable[F[_, _], G[_, _]] extends Bifoldable[({type λ[α, β]=(F[α, β], G[α, β])})#λ] {
   implicit def F: Bifoldable[F]
 
   implicit def G: Bifoldable[G]
@@ -212,7 +212,7 @@ private[scalaz] trait ProductBifoldable[F[_, _], G[_, _]] extends Bifoldable[({t
 
 }
 
-private[scalaz] trait ProductBitraverse[F[_, _], G[_, _]]
+private trait ProductBitraverse[F[_, _], G[_, _]]
   extends Bitraverse[({type λ[α, β]=(F[α, β], G[α, β])})#λ] with ProductBifunctor[F, G] with ProductBifoldable[F, G] {
 
   implicit def F: Bitraverse[F]

--- a/core/src/main/scala/scalaz/ReaderWriterStateT.scala
+++ b/core/src/main/scala/scalaz/ReaderWriterStateT.scala
@@ -62,13 +62,13 @@ abstract class ReaderWriterStateTInstances extends IndexedReaderWriterStateTInst
 
 }
 
-private[scalaz] trait IndexedReaderWriterStateTFunctor[F[_], R, W, S1, S2] extends Functor[({type λ[α]=IndexedReaderWriterStateT[F, R, W, S1, S2, α]})#λ] {
+private trait IndexedReaderWriterStateTFunctor[F[_], R, W, S1, S2] extends Functor[({type λ[α]=IndexedReaderWriterStateT[F, R, W, S1, S2, α]})#λ] {
   implicit def F: Functor[F]
 
   override def map[A, B](fa: IndexedReaderWriterStateT[F, R, W, S1, S2, A])(f: A => B): IndexedReaderWriterStateT[F, R, W, S1, S2, B] = fa map f
 }
 
-private[scalaz] trait ReaderWriterStateTMonad[F[_], R, W, S]
+private trait ReaderWriterStateTMonad[F[_], R, W, S]
   extends MonadReader[({type λ[r, α]=ReaderWriterStateT[F, r, W, S, α]})#λ, R]
   with MonadState[({type f[s, α] = ReaderWriterStateT[F, R, W, s, α]})#f, S]
   with MonadListen[({type f[w, α] = ReaderWriterStateT[F, R, w, S, α]})#f, W]
@@ -104,7 +104,7 @@ private[scalaz] trait ReaderWriterStateTMonad[F[_], R, W, S]
     ReaderWriterStateT((r, s) => F.map(ma.run(r, s)) { case (w, a, s1) => (w, (a, w), s1)})
 }
 
-private[scalaz] trait ReaderWriterStateTHoist[R, W, S] extends Hoist[({type λ[α[_], β] = ReaderWriterStateT[α, R, W, S, β]})#λ] {
+private trait ReaderWriterStateTHoist[R, W, S] extends Hoist[({type λ[α[_], β] = ReaderWriterStateT[α, R, W, S, β]})#λ] {
   implicit def W: Monoid[W]
   
   def hoist[M[_], N[_]](f: M ~> N)(implicit M: Monad[M]) = new (({type λ[α] = ReaderWriterStateT[M, R, W, S, α]})#λ ~> ({type λ[α] = ReaderWriterStateT[N, R, W, S, α]})#λ) {

--- a/core/src/main/scala/scalaz/Semigroup.scala
+++ b/core/src/main/scala/scalaz/Semigroup.scala
@@ -22,7 +22,7 @@ trait Semigroup[F]  { self =>
   def append(f1: F, f2: => F): F
 
   // derived functions
-  private[scalaz] trait SemigroupCompose extends Compose[({type λ[α, β]=F})#λ] {
+  protected[this] trait SemigroupCompose extends Compose[({type λ[α, β]=F})#λ] {
     def compose[A, B, C](f: F, g: F) = append(f, g)
   }
 
@@ -33,7 +33,7 @@ trait Semigroup[F]  { self =>
     */
   final def compose: Compose[({type λ[α, β]=F})#λ] = new SemigroupCompose {}
 
-  private[scalaz] trait SemigroupApply extends Apply[({type λ[α]=F})#λ] {
+  protected[this] trait SemigroupApply extends Apply[({type λ[α]=F})#λ] {
     override def map[A, B](fa: F)(f: A => B) = fa
     def ap[A, B](fa: => F)(f: => F) = append(f, fa)
   }

--- a/core/src/main/scala/scalaz/StateT.scala
+++ b/core/src/main/scala/scalaz/StateT.scala
@@ -147,29 +147,29 @@ trait StateTFunctions extends IndexedStateTFunctions {
 // Implementation traits for type class instances
 //
 
-private[scalaz] trait IndexedStateTContravariant[S2, A0, F[_]] extends Contravariant[({type f[a] = IndexedStateT[F, a, S2, A0]})#f] {
+private trait IndexedStateTContravariant[S2, A0, F[_]] extends Contravariant[({type f[a] = IndexedStateT[F, a, S2, A0]})#f] {
   override def contramap[A, B](fa: IndexedStateT[F, A, S2, A0])(f: B => A): IndexedStateT[F, B, S2, A0] = fa.contramap(f)
 }
 
-private[scalaz] trait IndexedStateTBifunctor[S1, F[_]] extends Bifunctor[({type f[a, b] = IndexedStateT[F, S1, a, b]})#f] {
+private trait IndexedStateTBifunctor[S1, F[_]] extends Bifunctor[({type f[a, b] = IndexedStateT[F, S1, a, b]})#f] {
   implicit def F: Functor[F]
 
   override def bimap[A, B, C, D](fab: IndexedStateT[F, S1, A, B])(f: A => C, g: B => D): IndexedStateT[F, S1, C, D] = fab.bimap(f)(g)
 }
 
-private[scalaz] trait IndexedStateTFunctorLeft[S1, A0, F[_]] extends Functor[({type f[a] = IndexedStateT[F, S1, a, A0]})#f] {
+private trait IndexedStateTFunctorLeft[S1, A0, F[_]] extends Functor[({type f[a] = IndexedStateT[F, S1, a, A0]})#f] {
   implicit def F: Functor[F]
 
   override def map[A, B](fa: IndexedStateT[F, S1, A, A0])(f: A => B): IndexedStateT[F, S1, B, A0] = fa.imap(f)
 }
 
-private[scalaz] trait IndexedStateTFunctorRight[S1, S2, F[_]] extends Functor[({type f[a] = IndexedStateT[F, S1, S2, a]})#f] {
+private trait IndexedStateTFunctorRight[S1, S2, F[_]] extends Functor[({type f[a] = IndexedStateT[F, S1, S2, a]})#f] {
   implicit def F: Functor[F]
 
   override def map[A, B](fa: IndexedStateT[F, S1, S2, A])(f: A => B): IndexedStateT[F, S1, S2, B] = fa.map(f)
 }
 
-private[scalaz] trait StateTMonadState[S, F[_]] extends MonadState[({type f[s, a] = StateT[F, s, a]})#f, S] {
+private trait StateTMonadState[S, F[_]] extends MonadState[({type f[s, a] = StateT[F, s, a]})#f, S] {
   implicit def F: Monad[F]
 
   def bind[A, B](fa: StateT[F, S, A])(f: A => StateT[F, S, B]): StateT[F, S, B] = fa.flatMap(f)
@@ -190,7 +190,7 @@ private[scalaz] trait StateTMonadState[S, F[_]] extends MonadState[({type f[s, a
   override def gets[A](f: S => A): StateT[F, S, A] = StateT(s => F.point((s, f(s))))
 }
 
-private[scalaz] trait StateTHoist[S] extends Hoist[({type f[g[_], a] = StateT[g, S, a]})#f] {
+private trait StateTHoist[S] extends Hoist[({type f[g[_], a] = StateT[g, S, a]})#f] {
 
   type StateTF[G[_], S] = {
     type f[x] = StateT[G, S, x]

--- a/core/src/main/scala/scalaz/StoreT.scala
+++ b/core/src/main/scala/scalaz/StoreT.scala
@@ -132,38 +132,38 @@ abstract class StoreTInstances extends StoreTInstances0 {
   implicit def storeTCohoist[S]: Cohoist[({type f[g[_], a] = StoreT[g, S, a]})#f] = new StoreTCohoist[S] {}
 }
 
-private[scalaz] trait IndexedStoreTFunctorLeft[F[_], A0, B0] extends Functor[({type λ[α]=IndexedStoreT[F, α, A0, B0]})#λ]{
+private trait IndexedStoreTFunctorLeft[F[_], A0, B0] extends Functor[({type λ[α]=IndexedStoreT[F, α, A0, B0]})#λ]{
   override def map[A, B](fa: IndexedStoreT[F, A, A0, B0])(f: A => B): IndexedStoreT[F, B, A0, B0] = fa imap f
 }
 
-private[scalaz] trait IndexedStoreTFunctorRight[F[_], I0, A0] extends Functor[({type λ[α]=IndexedStoreT[F, I0, A0, α]})#λ]{
+private trait IndexedStoreTFunctorRight[F[_], I0, A0] extends Functor[({type λ[α]=IndexedStoreT[F, I0, A0, α]})#λ]{
   implicit def F: Functor[F]
   override def map[A, B](fa: IndexedStoreT[F, I0, A0, A])(f: A => B): IndexedStoreT[F, I0, A0, B] = fa map f
 }
 
-private[scalaz] trait IndexedStoreTContravariant[F[_], I0, B0] extends Contravariant[({type λ[-α]=IndexedStoreT[F, I0, α, B0]})#λ] {
+private trait IndexedStoreTContravariant[F[_], I0, B0] extends Contravariant[({type λ[-α]=IndexedStoreT[F, I0, α, B0]})#λ] {
   implicit def F: Functor[F]
   override def contramap[A, B](fa: IndexedStoreT[F, I0, A, B0])(f: B => A): IndexedStoreT[F, I0, B, B0] = fa contramap f
 }
 
-private[scalaz] trait IndexedStoreTBifunctor[F[_], A0] extends Bifunctor[({type λ[α, β]=IndexedStoreT[F, α, A0, β]})#λ] {
+private trait IndexedStoreTBifunctor[F[_], A0] extends Bifunctor[({type λ[α, β]=IndexedStoreT[F, α, A0, β]})#λ] {
   implicit def F: Functor[F]
   override def bimap[A, B, C, D](fab: IndexedStoreT[F, A, A0, B])(f: A => C, g: B => D): IndexedStoreT[F, C, A0, D] = (fab bimap f)(g)
 }
 
-private[scalaz] trait StoreTCobind[F[_], A0] extends Cobind[({type λ[α]=StoreT[F, A0, α]})#λ] with IndexedStoreTFunctorRight[F, A0, A0] {
+private trait StoreTCobind[F[_], A0] extends Cobind[({type λ[α]=StoreT[F, A0, α]})#λ] with IndexedStoreTFunctorRight[F, A0, A0] {
   implicit def F: Cobind[F]
   def cobind[A, B](fa: StoreT[F, A0, A])(f: (StoreT[F, A0, A]) => B) = fa cobind f
 }
 
-private[scalaz] trait StoreTComonad[F[_], A0] extends Comonad[({type λ[α]=StoreT[F, A0, α]})#λ] with StoreTCobind[F, A0] {
+private trait StoreTComonad[F[_], A0] extends Comonad[({type λ[α]=StoreT[F, A0, α]})#λ] with StoreTCobind[F, A0] {
   implicit def F: Comonad[F]
   override def cojoin[A](a: StoreT[F, A0, A]) = a.duplicate
   def copoint[A](p: StoreT[F, A0, A]) = p.copoint
 
 }
 
-private[scalaz] trait StoreTComonadStore[F[_], S] extends ComonadStore[({type λ[σ, α]=StoreT[F, σ, α]})#λ, S] with StoreTComonad[F, S] {
+private trait StoreTComonadStore[F[_], S] extends ComonadStore[({type λ[σ, α]=StoreT[F, σ, α]})#λ, S] with StoreTComonad[F, S] {
   def pos[A](w: StoreT[F, S, A]): S = w.pos
   def peek[A](s: S, w: StoreT[F, S, A]): A = w peek s
   override def peeks[A](s: S => S, w: StoreT[F, S, A]): A = w peeks s
@@ -172,7 +172,7 @@ private[scalaz] trait StoreTComonadStore[F[_], S] extends ComonadStore[({type λ
   override def experiment[G[_], A](s: S => G[S], w: StoreT[F, S, A])(implicit FG: Functor[G]): G[A] = w experiment s
 }
 
-private[scalaz] trait StoreTCohoist[S] extends Cohoist[({type f[g[_], a] = StoreT[g, S, a]})#f] {
+private trait StoreTCohoist[S] extends Cohoist[({type f[g[_], a] = StoreT[g, S, a]})#f] {
   def lower[G[_] : Cobind, A](a: StoreT[G, S, A]) =
     Cobind[G].map(a.run._1)((z: S => A) => z(a.run._2))
 

--- a/core/src/main/scala/scalaz/StreamT.scala
+++ b/core/src/main/scala/scalaz/StreamT.scala
@@ -235,25 +235,25 @@ object StreamT extends StreamTInstances {
 // Implementation traits for type class instances
 //
 
-private[scalaz] trait StreamTFunctor[F[_]] extends Functor[({type λ[α] = StreamT[F, α]})#λ] {
+private trait StreamTFunctor[F[_]] extends Functor[({type λ[α] = StreamT[F, α]})#λ] {
   implicit def F: Functor[F]
 
   override def map[A, B](fa: StreamT[F, A])(f: A => B): StreamT[F, B] = fa map f
 }
 
-private[scalaz] trait StreamTSemigroup[F[_], A] extends Semigroup[StreamT[F, A]] {
+private trait StreamTSemigroup[F[_], A] extends Semigroup[StreamT[F, A]] {
   implicit def F: Functor[F]
 
   def append(f1: StreamT[F, A], f2: => StreamT[F, A]): StreamT[F, A] = f1 ++ f2
 }
 
-private[scalaz] trait StreamTMonoid[F[_], A] extends Monoid[StreamT[F, A]] with StreamTSemigroup[F, A] {
+private trait StreamTMonoid[F[_], A] extends Monoid[StreamT[F, A]] with StreamTSemigroup[F, A] {
   implicit def F: Applicative[F]
 
   def zero: StreamT[F, A] = StreamT.empty[F, A]
 }
 
-private[scalaz] trait StreamTMonadPlus[F[_]] extends MonadPlus[({type λ[α] = StreamT[F, α]})#λ] with StreamTFunctor[F] {
+private trait StreamTMonadPlus[F[_]] extends MonadPlus[({type λ[α] = StreamT[F, α]})#λ] with StreamTFunctor[F] {
   implicit def F: Applicative[F]
 
   def point[A](a: => A): StreamT[F, A] = a :: StreamT.empty[F, A]
@@ -265,7 +265,7 @@ private[scalaz] trait StreamTMonadPlus[F[_]] extends MonadPlus[({type λ[α] = S
   def bind[A, B](fa: StreamT[F, A])(f: A => StreamT[F, B]): StreamT[F, B] = fa flatMap f
 }
 
-private[scalaz] trait StreamTHoist extends Hoist[StreamT] {
+private trait StreamTHoist extends Hoist[StreamT] {
   import StreamT._
   
   implicit def apply[G[_] : Monad]: Monad[({type λ[α] = StreamT[G, α]})#λ] = StreamTMonadPlus[G]

--- a/core/src/main/scala/scalaz/UnwriterT.scala
+++ b/core/src/main/scala/scalaz/UnwriterT.scala
@@ -158,62 +158,62 @@ trait UnwriterTFunctions {
 // Type class implementation traits
 //
 
-private[scalaz] trait UnwriterTFunctor[F[_], W] extends Functor[({type λ[α]=UnwriterT[F, W, α]})#λ] {
+private trait UnwriterTFunctor[F[_], W] extends Functor[({type λ[α]=UnwriterT[F, W, α]})#λ] {
   implicit def F: Functor[F]
 
   override def map[A, B](fa: UnwriterT[F, W, A])(f: A => B) = fa map f
 }
 
-private[scalaz] trait UnwriterTApply[F[_], W] extends Apply[({type λ[α]=UnwriterT[F, W, α]})#λ] with UnwriterTFunctor[F, W] {
+private trait UnwriterTApply[F[_], W] extends Apply[({type λ[α]=UnwriterT[F, W, α]})#λ] with UnwriterTFunctor[F, W] {
   implicit def F: Apply[F]
 
   override def ap[A, B](fa: => UnwriterT[F, W, A])(f: => UnwriterT[F, W, A => B]) = fa ap f
 }
 
-private[scalaz] trait UnwriterTEach[F[_], W] extends Each[({type λ[α]=UnwriterT[F, W, α]})#λ] {
+private trait UnwriterTEach[F[_], W] extends Each[({type λ[α]=UnwriterT[F, W, α]})#λ] {
   implicit def F: Each[F]
 
   def each[A](fa: UnwriterT[F, W, A])(f: A => Unit) = fa foreach f
 }
 
 // TODO does Index it make sense for F other than Id?
-private[scalaz] trait UnwriterTIndex[W] extends Index[({type λ[α]=UnwriterT[Id, W, α]})#λ] {
+private trait UnwriterTIndex[W] extends Index[({type λ[α]=UnwriterT[Id, W, α]})#λ] {
   def index[A](fa: UnwriterT[Id, W, A], i: Int) = if(i == 0) Some(fa.value) else None
 }
 
-private[scalaz] trait UnwriterTBind[F[_], W] extends Bind[({type λ[α]=UnwriterT[F, W, α]})#λ] with UnwriterTApply[F, W] {
+private trait UnwriterTBind[F[_], W] extends Bind[({type λ[α]=UnwriterT[F, W, α]})#λ] with UnwriterTApply[F, W] {
   implicit def F: Bind[F]
 
   def bind[A, B](fa: UnwriterT[F, W, A])(f: A => UnwriterT[F, W, B]) = fa flatMap f
 }
 
-private[scalaz] trait UnwriterTFoldable[F[_], W] extends Foldable.FromFoldr[({type λ[α]=UnwriterT[F, W, α]})#λ] {
+private trait UnwriterTFoldable[F[_], W] extends Foldable.FromFoldr[({type λ[α]=UnwriterT[F, W, α]})#λ] {
   implicit def F: Foldable[F]
 
   override def foldRight[A, B](fa: UnwriterT[F, W, A], z: => B)(f: (A, => B) => B) = fa.foldRight(z)(f)
 }
 
-private[scalaz] trait UnwriterTTraverse[F[_], W] extends Traverse[({type λ[α]=UnwriterT[F, W, α]})#λ] with UnwriterTFoldable[F, W] {
+private trait UnwriterTTraverse[F[_], W] extends Traverse[({type λ[α]=UnwriterT[F, W, α]})#λ] with UnwriterTFoldable[F, W] {
   implicit def F: Traverse[F]
 
   def traverseImpl[G[_]: Applicative, A, B](fa: UnwriterT[F, W, A])(f: A => G[B]) = fa traverse f
 }
 
-private[scalaz] trait UnwriterTBifunctor[F[_]] extends Bifunctor[({type λ[α, β]=UnwriterT[F, α, β]})#λ] {
+private trait UnwriterTBifunctor[F[_]] extends Bifunctor[({type λ[α, β]=UnwriterT[F, α, β]})#λ] {
   implicit def F: Functor[F]
 
   override def bimap[A, B, C, D](fab: UnwriterT[F, A, B])(f: A => C, g: B => D) =
     fab.bimap(f, g)
 }
 
-private[scalaz] trait UnwriterTBitraverse[F[_]] extends Bitraverse[({type λ[α, β]=UnwriterT[F, α, β]})#λ] with UnwriterTBifunctor[F] {
+private trait UnwriterTBitraverse[F[_]] extends Bitraverse[({type λ[α, β]=UnwriterT[F, α, β]})#λ] with UnwriterTBifunctor[F] {
   implicit def F: Traverse[F]
 
   def bitraverseImpl[G[_]: Applicative, A, B, C, D](fab: UnwriterT[F, A, B])(f: A => G[C], g: B => G[D]) =
     fab.bitraverse(f, g)
 }
 
-private[scalaz] trait UnwriterComonad[W] extends Comonad[({type λ[α] = Unwriter[W, α]})#λ] with UnwriterTFunctor[Id, W] {
+private trait UnwriterComonad[W] extends Comonad[({type λ[α] = Unwriter[W, α]})#λ] with UnwriterTFunctor[Id, W] {
 
   override def cojoin[A](fa: Unwriter[W, A]): Unwriter[W, Unwriter[W, A]] =
     Unwriter(fa.unwritten, fa)

--- a/core/src/main/scala/scalaz/WriterT.scala
+++ b/core/src/main/scala/scalaz/WriterT.scala
@@ -239,69 +239,69 @@ trait WriterTFunctions {
 //
 import WriterT.writerT
 
-private[scalaz] trait WriterTFunctor[F[_], W] extends Functor[({type λ[α]=WriterT[F, W, α]})#λ] {
+private trait WriterTFunctor[F[_], W] extends Functor[({type λ[α]=WriterT[F, W, α]})#λ] {
   implicit def F: Functor[F]
 
   override def map[A, B](fa: WriterT[F, W, A])(f: A => B) = fa map f
 }
 
-private[scalaz] trait WriterTApply[F[_], W] extends Apply[({type λ[α]=WriterT[F, W, α]})#λ] with WriterTFunctor[F, W] {
+private trait WriterTApply[F[_], W] extends Apply[({type λ[α]=WriterT[F, W, α]})#λ] with WriterTFunctor[F, W] {
   implicit def F: Apply[F]
   implicit def W: Semigroup[W]
 
   override def ap[A, B](fa: => WriterT[F, W, A])(f: => WriterT[F, W, A => B]) = fa ap f
 }
 
-private[scalaz] trait WriterTApplicative[F[_], W] extends Applicative[({type λ[α]=WriterT[F, W, α]})#λ] with WriterTApply[F, W] {
+private trait WriterTApplicative[F[_], W] extends Applicative[({type λ[α]=WriterT[F, W, α]})#λ] with WriterTApply[F, W] {
   implicit def F: Applicative[F]
   implicit def W: Monoid[W]
   def point[A](a: => A) = writerT(F.point((W.zero, a)))
 }
 
-private[scalaz] trait WriterTEach[F[_], W] extends Each[({type λ[α]=WriterT[F, W, α]})#λ] {
+private trait WriterTEach[F[_], W] extends Each[({type λ[α]=WriterT[F, W, α]})#λ] {
   implicit def F: Each[F]
 
   def each[A](fa: WriterT[F, W, A])(f: A => Unit) = fa foreach f
 }
 
 // TODO does Index it make sense for F other than Id?
-private[scalaz] trait WriterIndex[W] extends Index[({type λ[α]=Writer[W, α]})#λ] {
+private trait WriterIndex[W] extends Index[({type λ[α]=Writer[W, α]})#λ] {
   def index[A](fa: Writer[W, A], i: Int) = if(i == 0) Some(fa.value) else None
 }
 
-private[scalaz] trait WriterTMonad[F[_], W] extends Monad[({type λ[α]=WriterT[F, W, α]})#λ] with WriterTApplicative[F, W] {
+private trait WriterTMonad[F[_], W] extends Monad[({type λ[α]=WriterT[F, W, α]})#λ] with WriterTApplicative[F, W] {
   implicit def F: Monad[F]
 
   def bind[A, B](fa: WriterT[F, W, A])(f: A => WriterT[F, W, B]) = fa flatMap f
 }
 
-private[scalaz] trait WriterTFoldable[F[_], W] extends Foldable.FromFoldr[({type λ[α]=WriterT[F, W, α]})#λ] {
+private trait WriterTFoldable[F[_], W] extends Foldable.FromFoldr[({type λ[α]=WriterT[F, W, α]})#λ] {
   implicit def F: Foldable[F]
 
   override def foldRight[A, B](fa: WriterT[F, W, A], z: => B)(f: (A, => B) => B) = fa.foldRight(z)(f)
 }
 
-private[scalaz] trait WriterTTraverse[F[_], W] extends Traverse[({type λ[α]=WriterT[F, W, α]})#λ] with WriterTFoldable[F, W] {
+private trait WriterTTraverse[F[_], W] extends Traverse[({type λ[α]=WriterT[F, W, α]})#λ] with WriterTFoldable[F, W] {
   implicit def F: Traverse[F]
 
   def traverseImpl[G[_]: Applicative, A, B](fa: WriterT[F, W, A])(f: A => G[B]) = fa traverse f
 }
 
-private[scalaz] trait WriterTBifunctor[F[_]] extends Bifunctor[({type λ[α, β]=WriterT[F, α, β]})#λ] {
+private trait WriterTBifunctor[F[_]] extends Bifunctor[({type λ[α, β]=WriterT[F, α, β]})#λ] {
   implicit def F: Functor[F]
 
   override def bimap[A, B, C, D](fab: WriterT[F, A, B])(f: A => C, g: B => D) =
     fab.bimap(f, g)
 }
 
-private[scalaz] trait WriterTBitraverse[F[_]] extends Bitraverse[({type λ[α, β]=WriterT[F, α, β]})#λ] with WriterTBifunctor[F] {
+private trait WriterTBitraverse[F[_]] extends Bitraverse[({type λ[α, β]=WriterT[F, α, β]})#λ] with WriterTBifunctor[F] {
   implicit def F: Traverse[F]
 
   def bitraverseImpl[G[_]: Applicative, A, B, C, D](fab: WriterT[F, A, B])(f: A => G[C], g: B => G[D]) =
     fab.bitraverse(f, g)
 }
 
-private[scalaz] trait WriterComonad[W] extends Comonad[({type λ[α] = Writer[W, α]})#λ] with WriterTFunctor[Id, W] {
+private trait WriterComonad[W] extends Comonad[({type λ[α] = Writer[W, α]})#λ] with WriterTFunctor[Id, W] {
   def copoint[A](p: Writer[W, A]): A = p.value
 
   override def cojoin[A](fa: Writer[W, A]): Writer[W, Writer[W, A]] =
@@ -311,7 +311,7 @@ private[scalaz] trait WriterComonad[W] extends Comonad[({type λ[α] = Writer[W,
     Writer(fa.written, f(fa))
 }
 
-private[scalaz] trait WriterTMonadTrans[W] extends MonadTrans[({type λ[α[_], β] = WriterT[α, W, β]})#λ] {
+private trait WriterTMonadTrans[W] extends MonadTrans[({type λ[α[_], β] = WriterT[α, W, β]})#λ] {
   def liftM[M[_], B](mb: M[B])(implicit M: Monad[M]): WriterT[M, W, B] =
     WriterT(M.map(mb)((W.zero, _)))
 
@@ -320,7 +320,7 @@ private[scalaz] trait WriterTMonadTrans[W] extends MonadTrans[({type λ[α[_], �
   implicit def apply[M[_]: Monad]: Monad[({type λ[α]=WriterT[M, W, α]})#λ] = WriterT.writerTMonad
 }
 
-private[scalaz] trait WriterTMonadListen[F[_], W] extends MonadListen[({type λ[α, β] = WriterT[F, α, β]})#λ, W] with WriterTMonad[F, W] {
+private trait WriterTMonadListen[F[_], W] extends MonadListen[({type λ[α, β] = WriterT[F, α, β]})#λ, W] with WriterTMonad[F, W] {
   implicit def F: Monad[F]
   implicit def W: Monoid[W]
 

--- a/core/src/main/scala/scalaz/std/Either.scala
+++ b/core/src/main/scala/scalaz/std/Either.scala
@@ -300,7 +300,7 @@ trait EitherInstances extends EitherInstances0 {
 object either extends EitherInstances
 
 
-private[scalaz] trait EitherRightEqual[X, A] extends Equal[RightProjection[X, A]] {
+private trait EitherRightEqual[X, A] extends Equal[RightProjection[X, A]] {
   implicit def A: Equal[A]
 
   def equal(a1: RightProjection[X, A], a2: RightProjection[X, A]) = (a1.toOption, a2.toOption) match {
@@ -311,7 +311,7 @@ private[scalaz] trait EitherRightEqual[X, A] extends Equal[RightProjection[X, A]
   override val equalIsNatural: Boolean = A.equalIsNatural
 }
 
-private[scalaz] trait EitherLeftEqual[A, X] extends Equal[LeftProjection[A, X]] {
+private trait EitherLeftEqual[A, X] extends Equal[LeftProjection[A, X]] {
   implicit def A: Equal[A]
 
   def equal(a1: LeftProjection[A, X], a2: LeftProjection[A, X]) = (a1.toOption, a2.toOption) match {
@@ -322,7 +322,7 @@ private[scalaz] trait EitherLeftEqual[A, X] extends Equal[LeftProjection[A, X]] 
   override val equalIsNatural: Boolean = A.equalIsNatural
 }
 
-private[scalaz] trait EitherFirstRightEqual[X, A] extends Equal[RightProjection[X, A] @@ First] {
+private trait EitherFirstRightEqual[X, A] extends Equal[RightProjection[X, A] @@ First] {
   implicit def A: Equal[A]
 
   def equal(a1: RightProjection[X, A] @@ First, a2: RightProjection[X, A] @@ First) = (a1.toOption, a2.toOption) match {
@@ -333,7 +333,7 @@ private[scalaz] trait EitherFirstRightEqual[X, A] extends Equal[RightProjection[
   override val equalIsNatural: Boolean = A.equalIsNatural
 }
 
-private[scalaz] trait EitherFirstLeftEqual[A, X] extends Equal[LeftProjection[A, X] @@ First] {
+private trait EitherFirstLeftEqual[A, X] extends Equal[LeftProjection[A, X] @@ First] {
   implicit def A: Equal[A]
 
   def equal(a1: LeftProjection[A, X] @@ First, a2: LeftProjection[A, X] @@ First) = (a1.toOption, a2.toOption) match {
@@ -345,7 +345,7 @@ private[scalaz] trait EitherFirstLeftEqual[A, X] extends Equal[LeftProjection[A,
 }
 
 
-private[scalaz] trait EitherLastRightEqual[X, A] extends Equal[RightProjection[X, A] @@ Last] {
+private trait EitherLastRightEqual[X, A] extends Equal[RightProjection[X, A] @@ Last] {
   implicit def A: Equal[A]
 
   def equal(a1: RightProjection[X, A] @@ Last, a2: RightProjection[X, A] @@ Last) = (a1.toOption, a2.toOption) match {
@@ -356,7 +356,7 @@ private[scalaz] trait EitherLastRightEqual[X, A] extends Equal[RightProjection[X
   override val equalIsNatural: Boolean = A.equalIsNatural
 }
 
-private[scalaz] trait EitherLastLeftEqual[A, X] extends Equal[LeftProjection[A, X] @@ Last] {
+private trait EitherLastLeftEqual[A, X] extends Equal[LeftProjection[A, X] @@ Last] {
   implicit def A: Equal[A]
 
   def equal(a1: LeftProjection[A, X] @@ Last, a2: LeftProjection[A, X] @@ Last) = (a1.toOption, a2.toOption) match {
@@ -367,7 +367,7 @@ private[scalaz] trait EitherLastLeftEqual[A, X] extends Equal[LeftProjection[A, 
   override val equalIsNatural: Boolean = A.equalIsNatural
 }
 
-private[scalaz] trait EitherEqual[A, B] extends Equal[Either[A, B]] {
+private trait EitherEqual[A, B] extends Equal[Either[A, B]] {
   implicit def A: Equal[A]
   implicit def B: Equal[B]
 
@@ -379,23 +379,23 @@ private[scalaz] trait EitherEqual[A, B] extends Equal[Either[A, B]] {
   override val equalIsNatural: Boolean = A.equalIsNatural
 }
 
-private[scalaz] trait EitherFirstLeftSemigroup[A, X] extends Semigroup[LeftProjection[A, X] @@ First] {
+private trait EitherFirstLeftSemigroup[A, X] extends Semigroup[LeftProjection[A, X] @@ First] {
   def append(f1: LeftProjection[A, X] @@ First, f2: => LeftProjection[A, X] @@ First) = if (f1.e.isLeft) f1 else f2
 }
 
-private[scalaz] trait EitherFirstRightSemigroup[X, A] extends Semigroup[RightProjection[X, A] @@ First] {
+private trait EitherFirstRightSemigroup[X, A] extends Semigroup[RightProjection[X, A] @@ First] {
   def append(f1: RightProjection[X, A] @@ First, f2: => RightProjection[X, A] @@ First) = if (f1.e.isRight) f1 else f2
 }
 
-private[scalaz] trait EitherLastLeftSemigroup[A, X] extends Semigroup[LeftProjection[A, X] @@ Last] {
+private trait EitherLastLeftSemigroup[A, X] extends Semigroup[LeftProjection[A, X] @@ Last] {
   def append(f1: LeftProjection[A, X] @@ Last, f2: => LeftProjection[A, X] @@ Last) = if (f1.e.isLeft) f1 else f2
 }
 
-private[scalaz] trait EitherLastRightSemigroup[X, A] extends Semigroup[RightProjection[X, A] @@ Last] {
+private trait EitherLastRightSemigroup[X, A] extends Semigroup[RightProjection[X, A] @@ Last] {
   def append(f1: RightProjection[X, A] @@ Last, f2: => RightProjection[X, A] @@ Last) = if (f1.e.isRight) f1 else f2
 }
 
-private[scalaz] trait EitherLeftSemigroup[A, X] extends Semigroup[LeftProjection[A, X]] {
+private trait EitherLeftSemigroup[A, X] extends Semigroup[LeftProjection[A, X]] {
   implicit def A: Semigroup[A]
   implicit def X: Monoid[X]
 
@@ -407,7 +407,7 @@ private[scalaz] trait EitherLeftSemigroup[A, X] extends Semigroup[LeftProjection
   }
 }
 
-private[scalaz] trait EitherRightSemigroup[X, A] extends Semigroup[RightProjection[X, A]] {
+private trait EitherRightSemigroup[X, A] extends Semigroup[RightProjection[X, A]] {
   implicit def X: Monoid[X]
   implicit def A: Semigroup[A]
 
@@ -420,43 +420,43 @@ private[scalaz] trait EitherRightSemigroup[X, A] extends Semigroup[RightProjecti
 }
 
 
-private[scalaz] trait EitherFirstLeftMonoid[A, X] extends Monoid[LeftProjection[A, X] @@ First] with EitherFirstLeftSemigroup[A, X] {
+private trait EitherFirstLeftMonoid[A, X] extends Monoid[LeftProjection[A, X] @@ First] with EitherFirstLeftSemigroup[A, X] {
   implicit def X: Monoid[X]
 
   def zero = First(Right(Monoid[X].zero).left)
 }
 
-private[scalaz] trait EitherLastLeftMonoid[A, X] extends Monoid[LeftProjection[A, X] @@ Last] with EitherLastLeftSemigroup[A, X] {
+private trait EitherLastLeftMonoid[A, X] extends Monoid[LeftProjection[A, X] @@ Last] with EitherLastLeftSemigroup[A, X] {
   implicit def X: Monoid[X]
 
   def zero = Last(Right(Monoid[X].zero).left)
 }
 
-private[scalaz] trait EitherLeftMonoid[A, X] extends Monoid[LeftProjection[A, X]] with EitherLeftSemigroup[A, X] {
+private trait EitherLeftMonoid[A, X] extends Monoid[LeftProjection[A, X]] with EitherLeftSemigroup[A, X] {
   implicit def X: Monoid[X]
 
   def zero: LeftProjection[A, X] = Right(Monoid[X].zero).left
 }
 
-private[scalaz] trait EitherFirstRightMonoid[X, A] extends Monoid[RightProjection[X, A] @@ First] with EitherFirstRightSemigroup[X, A] {
+private trait EitherFirstRightMonoid[X, A] extends Monoid[RightProjection[X, A] @@ First] with EitherFirstRightSemigroup[X, A] {
   implicit def X: Monoid[X]
 
   def zero = First(Left(Monoid[X].zero).right)
 }
 
-private[scalaz] trait EitherLastRightMonoid[X, A] extends Monoid[RightProjection[X, A] @@ Last] with EitherLastRightSemigroup[X, A] {
+private trait EitherLastRightMonoid[X, A] extends Monoid[RightProjection[X, A] @@ Last] with EitherLastRightSemigroup[X, A] {
   implicit def X: Monoid[X]
 
   def zero = Last(Left(Monoid[X].zero).right)
 }
 
-private[scalaz] trait EitherRightMonoid[X, A] extends Monoid[RightProjection[X, A]] with EitherRightSemigroup[X, A] {
+private trait EitherRightMonoid[X, A] extends Monoid[RightProjection[X, A]] with EitherRightSemigroup[X, A] {
   implicit def X: Monoid[X]
 
   def zero: RightProjection[X, A] = Left(Monoid[X].zero).right
 }
 
-private[scalaz] trait EitherOrder[A, B] extends Order[Either[A, B]] {
+private trait EitherOrder[A, B] extends Order[Either[A, B]] {
   implicit def A: Order[A]
   implicit def B: Order[B]
 
@@ -470,7 +470,7 @@ private[scalaz] trait EitherOrder[A, B] extends Order[Either[A, B]] {
   }
 }
 
-private[scalaz] trait EitherLeftOrder[A, X] extends Order[LeftProjection[A, X]] {
+private trait EitherLeftOrder[A, X] extends Order[LeftProjection[A, X]] {
   implicit def A: Order[A]
 
   import Ordering._
@@ -483,7 +483,7 @@ private[scalaz] trait EitherLeftOrder[A, X] extends Order[LeftProjection[A, X]] 
   }
 }
 
-private[scalaz] trait EitherRightOrder[X, A] extends Order[RightProjection[X, A]] {
+private trait EitherRightOrder[X, A] extends Order[RightProjection[X, A]] {
   implicit def A: Order[A]
 
   import Ordering._
@@ -496,7 +496,7 @@ private[scalaz] trait EitherRightOrder[X, A] extends Order[RightProjection[X, A]
   }
 }
 
-private[scalaz] trait EitherFirstLeftOrder[A, X] extends Order[LeftProjection[A, X] @@ First] {
+private trait EitherFirstLeftOrder[A, X] extends Order[LeftProjection[A, X] @@ First] {
   implicit def A: Order[A]
 
   import Ordering._
@@ -509,7 +509,7 @@ private[scalaz] trait EitherFirstLeftOrder[A, X] extends Order[LeftProjection[A,
   }
 }
 
-private[scalaz] trait EitherFirstRightOrder[X, A] extends Order[RightProjection[X, A] @@ First] {
+private trait EitherFirstRightOrder[X, A] extends Order[RightProjection[X, A] @@ First] {
   implicit def A: Order[A]
 
   import Ordering._
@@ -523,7 +523,7 @@ private[scalaz] trait EitherFirstRightOrder[X, A] extends Order[RightProjection[
 }
 
 
-private[scalaz] trait EitherLastLeftOrder[A, X] extends Order[LeftProjection[A, X] @@ Last] {
+private trait EitherLastLeftOrder[A, X] extends Order[LeftProjection[A, X] @@ Last] {
   implicit def A: Order[A]
 
   import Ordering._
@@ -536,7 +536,7 @@ private[scalaz] trait EitherLastLeftOrder[A, X] extends Order[LeftProjection[A, 
   }
 }
 
-private[scalaz] trait EitherLastRightOrder[X, A] extends Order[RightProjection[X, A] @@ Last] {
+private trait EitherLastRightOrder[X, A] extends Order[RightProjection[X, A] @@ Last] {
   implicit def A: Order[A]
 
   import Ordering._

--- a/core/src/main/scala/scalaz/std/Function.scala
+++ b/core/src/main/scala/scalaz/std/Function.scala
@@ -2,7 +2,7 @@ package scalaz
 package std
 
 sealed trait FunctionInstances1 {
-  implicit def function1Semigroup[A, R](implicit R0: Semigroup[R]) = new Function1Semigroup[A, R] {
+  implicit def function1Semigroup[A, R](implicit R0: Semigroup[R]): Semigroup[A => R] = new Function1Semigroup[A, R] {
     implicit def R = R0
   }
   implicit def function1Cobind[A, R](implicit A0: Semigroup[A]): Cobind[({type λ[α]=(A => α)})#λ] = new Function1Cobind[A, R] {
@@ -11,7 +11,7 @@ sealed trait FunctionInstances1 {
 }
 
 sealed trait FunctionInstances0 extends FunctionInstances1 {
-  implicit def function1Monoid[A, R](implicit R0: Monoid[R]) = new Function1Monoid[A, R] {
+  implicit def function1Monoid[A, R](implicit R0: Monoid[R]): Monoid[A => R] = new Function1Monoid[A, R] {
     implicit def R = R0
   }
   implicit def function1Comonad[A, R](implicit A0: Monoid[A]): Comonad[({type λ[α]=(A => α)})#λ] = new Function1Comonad[A, R] {
@@ -146,25 +146,25 @@ object function extends FunctionFunctions with FunctionInstances
 // Type class implementation traits
 //
 
-private[scalaz] trait Function1Semigroup[A, R] extends Semigroup[A => R] {
+private trait Function1Semigroup[A, R] extends Semigroup[A => R] {
   implicit def R: Semigroup[R]
 
   def append(f1: A => R, f2: => A => R) = a => R.append(f1(a), f2(a))
 }
 
-private[scalaz] trait Function1Monoid[A, R] extends Monoid[A => R] with Function1Semigroup[A, R] {
+private trait Function1Monoid[A, R] extends Monoid[A => R] with Function1Semigroup[A, R] {
   implicit def R: Monoid[R]
   def zero = a => R.zero
 }
 
-private[scalaz] trait Function1Cobind[M, R] extends Cobind[({type λ[α]=(M => α)})#λ] {
+private trait Function1Cobind[M, R] extends Cobind[({type λ[α]=(M => α)})#λ] {
   implicit def M: Semigroup[M]
   override def cojoin[A](a: M => A) = (m1: M) => (m2: M) => a(M.append(m1, m2))
   def cobind[A, B](fa: M => A)(f: (M => A) => B) = (m1: M) => f((m2: M) => fa(M.append(m1, m2)))
   override def map[A, B](fa: M => A)(f: A => B) = fa andThen f
 }
 
-private[scalaz] trait Function1Comonad[M, R] extends Comonad[({type λ[α]=(M => α)})#λ] with Function1Cobind[M, R]{
+private trait Function1Comonad[M, R] extends Comonad[({type λ[α]=(M => α)})#λ] with Function1Cobind[M, R]{
   implicit def M: Monoid[M]
   def copoint[A](p: M => A) = p(M.zero)
 }

--- a/core/src/main/scala/scalaz/std/IndexedSeq.scala
+++ b/core/src/main/scala/scalaz/std/IndexedSeq.scala
@@ -238,7 +238,7 @@ object indexedSeq extends IndexedSeqInstances with IndexedSeqSubFunctions with I
   object indexedSeqSyntax extends scalaz.syntax.std.ToIndexedSeqOps
 }
 
-trait IndexedSeqEqual[A, Coll <: IndexedSeq[A]] extends Equal[Coll] {
+private trait IndexedSeqEqual[A, Coll <: IndexedSeq[A]] extends Equal[Coll] {
   implicit def A: Equal[A]
 
   override def equalIsNatural: Boolean = A.equalIsNatural
@@ -246,7 +246,7 @@ trait IndexedSeqEqual[A, Coll <: IndexedSeq[A]] extends Equal[Coll] {
   override def equal(a1: Coll, a2: Coll) = (a1 corresponds a2)(Equal[A].equal)
 }
 
-trait IndexedSeqSubOrder[A, Coll <: IndexedSeq[A] with IndexedSeqLike[A, Coll]] extends Order[Coll] with IndexedSeqEqual[A, Coll] {
+private trait IndexedSeqSubOrder[A, Coll <: IndexedSeq[A] with IndexedSeqLike[A, Coll]] extends Order[Coll] with IndexedSeqEqual[A, Coll] {
   implicit def A: Order[A]
 
   import Ordering._

--- a/core/src/main/scala/scalaz/std/List.scala
+++ b/core/src/main/scala/scalaz/std/List.scala
@@ -4,8 +4,8 @@ package std
 import scalaz.Id._
 import annotation.tailrec
 
-sealed trait ListInstances0 {
-  implicit def listEqual[A](implicit A0: Equal[A]) = new ListEqual[A] {
+trait ListInstances0 {
+  implicit def listEqual[A](implicit A0: Equal[A]): Equal[List[A]] = new ListEqual[A] {
     implicit def A = A0
   }
 }
@@ -264,7 +264,7 @@ object list extends ListInstances with ListFunctions {
 }
 
 
-trait ListEqual[A] extends Equal[List[A]] {
+private trait ListEqual[A] extends Equal[List[A]] {
   implicit def A: Equal[A]
 
   override def equalIsNatural: Boolean = A.equalIsNatural
@@ -272,7 +272,7 @@ trait ListEqual[A] extends Equal[List[A]] {
   override def equal(a1: List[A], a2: List[A]) = (a1 corresponds a2)(Equal[A].equal)
 }
 
-trait ListOrder[A] extends Order[List[A]] with ListEqual[A] {
+private trait ListOrder[A] extends Order[List[A]] with ListEqual[A] {
   implicit def A: Order[A]
 
   import Ordering._

--- a/core/src/main/scala/scalaz/std/Option.scala
+++ b/core/src/main/scala/scalaz/std/Option.scala
@@ -2,7 +2,7 @@ package scalaz
 package std
 
 sealed trait OptionInstances0 {
-  implicit def optionEqual[A](implicit A0: Equal[A]) = new OptionEqual[A] {
+  implicit def optionEqual[A](implicit A0: Equal[A]): Equal[Option[A]] = new OptionEqual[A] {
     implicit def A = A0
   }
 }
@@ -225,7 +225,7 @@ object option extends OptionInstances with OptionFunctions {
 // Type class implementation traits
 //
 
-trait OptionEqual[A] extends Equal[Option[A]] {
+private trait OptionEqual[A] extends Equal[Option[A]] {
   implicit def A: Equal[A]
 
   override def equalIsNatural: Boolean = A.equalIsNatural
@@ -239,7 +239,7 @@ trait OptionEqual[A] extends Equal[Option[A]] {
 }
 
 
-trait OptionOrder[A] extends Order[Option[A]] with OptionEqual[A] {
+private trait OptionOrder[A] extends Order[Option[A]] with OptionEqual[A] {
   implicit def A: Order[A]
 
   import Ordering._

--- a/core/src/main/scala/scalaz/std/Tuple.scala
+++ b/core/src/main/scala/scalaz/std/Tuple.scala
@@ -9,32 +9,32 @@ sealed trait TupleInstances0 {
       Applicative[G].apply2(f(fab._1), g(fab._2))((_, _))
   }
 
-  implicit def tuple1Semigroup[A1](implicit A1: Semigroup[A1]) = new Tuple1Semigroup[A1] {
+  implicit def tuple1Semigroup[A1](implicit A1: Semigroup[A1]): Semigroup[Tuple1[A1]] = new Tuple1Semigroup[A1] {
     implicit def _1: Semigroup[A1] = A1
   }
-  implicit def tuple2Semigroup[A1, A2](implicit A1: Semigroup[A1], A2: Semigroup[A2]) = new Tuple2Semigroup[A1, A2] {
+  implicit def tuple2Semigroup[A1, A2](implicit A1: Semigroup[A1], A2: Semigroup[A2]): Semigroup[(A1, A2)] = new Tuple2Semigroup[A1, A2] {
     implicit def _1 = A1
     implicit def _2 = A2
   }
-  implicit def tuple3Semigroup[A1, A2, A3](implicit A1: Semigroup[A1], A2: Semigroup[A2], A3: Semigroup[A3]) = new Tuple3Semigroup[A1, A2, A3] {
+  implicit def tuple3Semigroup[A1, A2, A3](implicit A1: Semigroup[A1], A2: Semigroup[A2], A3: Semigroup[A3]): Semigroup[(A1, A2, A3)] = new Tuple3Semigroup[A1, A2, A3] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
   }
-  implicit def tuple4Semigroup[A1, A2, A3, A4](implicit A1: Semigroup[A1], A2: Semigroup[A2], A3: Semigroup[A3], A4: Semigroup[A4]) = new Tuple4Semigroup[A1, A2, A3, A4] {
+  implicit def tuple4Semigroup[A1, A2, A3, A4](implicit A1: Semigroup[A1], A2: Semigroup[A2], A3: Semigroup[A3], A4: Semigroup[A4]): Semigroup[(A1, A2, A3, A4)] = new Tuple4Semigroup[A1, A2, A3, A4] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
     implicit def _4 = A4
   }
-  implicit def tuple5Semigroup[A1, A2, A3, A4, A5](implicit A1: Semigroup[A1], A2: Semigroup[A2], A3: Semigroup[A3], A4: Semigroup[A4], A5: Semigroup[A5]) = new Tuple5Semigroup[A1, A2, A3, A4, A5] {
+  implicit def tuple5Semigroup[A1, A2, A3, A4, A5](implicit A1: Semigroup[A1], A2: Semigroup[A2], A3: Semigroup[A3], A4: Semigroup[A4], A5: Semigroup[A5]): Semigroup[(A1, A2, A3, A4, A5)] = new Tuple5Semigroup[A1, A2, A3, A4, A5] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
     implicit def _4 = A4
     implicit def _5 = A5
   }
-  implicit def tuple6Semigroup[A1, A2, A3, A4, A5, A6](implicit A1: Semigroup[A1], A2: Semigroup[A2], A3: Semigroup[A3], A4: Semigroup[A4], A5: Semigroup[A5], A6: Semigroup[A6]) = new Tuple6Semigroup[A1, A2, A3, A4, A5, A6] {
+  implicit def tuple6Semigroup[A1, A2, A3, A4, A5, A6](implicit A1: Semigroup[A1], A2: Semigroup[A2], A3: Semigroup[A3], A4: Semigroup[A4], A5: Semigroup[A5], A6: Semigroup[A6]): Semigroup[(A1, A2, A3, A4, A5, A6)] = new Tuple6Semigroup[A1, A2, A3, A4, A5, A6] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
@@ -42,7 +42,7 @@ sealed trait TupleInstances0 {
     implicit def _5 = A5
     implicit def _6 = A6
   }
-  implicit def tuple7Semigroup[A1, A2, A3, A4, A5, A6, A7](implicit A1: Semigroup[A1], A2: Semigroup[A2], A3: Semigroup[A3], A4: Semigroup[A4], A5: Semigroup[A5], A6: Semigroup[A6], A7: Semigroup[A7]) = new Tuple7Semigroup[A1, A2, A3, A4, A5, A6, A7] {
+  implicit def tuple7Semigroup[A1, A2, A3, A4, A5, A6, A7](implicit A1: Semigroup[A1], A2: Semigroup[A2], A3: Semigroup[A3], A4: Semigroup[A4], A5: Semigroup[A5], A6: Semigroup[A6], A7: Semigroup[A7]): Semigroup[(A1, A2, A3, A4, A5, A6, A7)] = new Tuple7Semigroup[A1, A2, A3, A4, A5, A6, A7] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
@@ -51,7 +51,7 @@ sealed trait TupleInstances0 {
     implicit def _6 = A6
     implicit def _7 = A7
   }
-  implicit def tuple8Semigroup[A1, A2, A3, A4, A5, A6, A7, A8](implicit A1: Semigroup[A1], A2: Semigroup[A2], A3: Semigroup[A3], A4: Semigroup[A4], A5: Semigroup[A5], A6: Semigroup[A6], A7: Semigroup[A7], A8: Semigroup[A8]) = new Tuple8Semigroup[A1, A2, A3, A4, A5, A6, A7, A8] {
+  implicit def tuple8Semigroup[A1, A2, A3, A4, A5, A6, A7, A8](implicit A1: Semigroup[A1], A2: Semigroup[A2], A3: Semigroup[A3], A4: Semigroup[A4], A5: Semigroup[A5], A6: Semigroup[A6], A7: Semigroup[A7], A8: Semigroup[A8]): Semigroup[(A1, A2, A3, A4, A5, A6, A7, A8)] = new Tuple8Semigroup[A1, A2, A3, A4, A5, A6, A7, A8] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
@@ -82,32 +82,32 @@ sealed trait TupleInstances0 {
   implicit def tuple7Functor[A1, A2, A3, A4, A5, A6]: Traverse[({type f[x] = (A1, A2, A3, A4, A5, A6, x)})#f] = new Tuple7Functor[A1, A2, A3, A4, A5, A6] {}
   implicit def tuple8Functor[A1, A2, A3, A4, A5, A6, A7]: Traverse[({type f[x] = (A1, A2, A3, A4, A5, A6, A7, x)})#f] = new Tuple8Functor[A1, A2, A3, A4, A5, A6, A7] {}
 
-  implicit def tuple1Equal[A1](implicit A1: Equal[A1]) = new Tuple1Equal[A1] {
+  implicit def tuple1Equal[A1](implicit A1: Equal[A1]): Equal[Tuple1[A1]] = new Tuple1Equal[A1] {
     implicit def _1 = A1
   }
-  implicit def tuple2Equal[A1, A2](implicit A1: Equal[A1], A2: Equal[A2]) = new Tuple2Equal[A1, A2] {
+  implicit def tuple2Equal[A1, A2](implicit A1: Equal[A1], A2: Equal[A2]): Equal[(A1, A2)] = new Tuple2Equal[A1, A2] {
     implicit def _1 = A1
     implicit def _2 = A2
   }
-  implicit def tuple3Equal[A1, A2, A3](implicit A1: Equal[A1], A2: Equal[A2], A3: Equal[A3]) = new Tuple3Equal[A1, A2, A3] {
+  implicit def tuple3Equal[A1, A2, A3](implicit A1: Equal[A1], A2: Equal[A2], A3: Equal[A3]): Equal[(A1, A2, A3)] = new Tuple3Equal[A1, A2, A3] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
   }
-  implicit def tuple4Equal[A1, A2, A3, A4](implicit A1: Equal[A1], A2: Equal[A2], A3: Equal[A3], A4: Equal[A4]) = new Tuple4Equal[A1, A2, A3, A4] {
+  implicit def tuple4Equal[A1, A2, A3, A4](implicit A1: Equal[A1], A2: Equal[A2], A3: Equal[A3], A4: Equal[A4]): Equal[(A1, A2, A3, A4)] = new Tuple4Equal[A1, A2, A3, A4] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
     implicit def _4 = A4
   }
-  implicit def tuple5Equal[A1, A2, A3, A4, A5](implicit A1: Equal[A1], A2: Equal[A2], A3: Equal[A3], A4: Equal[A4], A5: Equal[A5]) = new Tuple5Equal[A1, A2, A3, A4, A5] {
+  implicit def tuple5Equal[A1, A2, A3, A4, A5](implicit A1: Equal[A1], A2: Equal[A2], A3: Equal[A3], A4: Equal[A4], A5: Equal[A5]): Equal[(A1, A2, A3, A4, A5)] = new Tuple5Equal[A1, A2, A3, A4, A5] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
     implicit def _4 = A4
     implicit def _5 = A5
   }
-  implicit def tuple6Equal[A1, A2, A3, A4, A5, A6](implicit A1: Equal[A1], A2: Equal[A2], A3: Equal[A3], A4: Equal[A4], A5: Equal[A5], A6: Equal[A6]) = new Tuple6Equal[A1, A2, A3, A4, A5, A6] {
+  implicit def tuple6Equal[A1, A2, A3, A4, A5, A6](implicit A1: Equal[A1], A2: Equal[A2], A3: Equal[A3], A4: Equal[A4], A5: Equal[A5], A6: Equal[A6]): Equal[(A1, A2, A3, A4, A5, A6)] = new Tuple6Equal[A1, A2, A3, A4, A5, A6] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
@@ -115,7 +115,7 @@ sealed trait TupleInstances0 {
     implicit def _5 = A5
     implicit def _6 = A6
   }
-  implicit def tuple7Equal[A1, A2, A3, A4, A5, A6, A7](implicit A1: Equal[A1], A2: Equal[A2], A3: Equal[A3], A4: Equal[A4], A5: Equal[A5], A6: Equal[A6], A7: Equal[A7]) = new Tuple7Equal[A1, A2, A3, A4, A5, A6, A7] {
+  implicit def tuple7Equal[A1, A2, A3, A4, A5, A6, A7](implicit A1: Equal[A1], A2: Equal[A2], A3: Equal[A3], A4: Equal[A4], A5: Equal[A5], A6: Equal[A6], A7: Equal[A7]): Equal[(A1, A2, A3, A4, A5, A6, A7)] = new Tuple7Equal[A1, A2, A3, A4, A5, A6, A7] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
@@ -124,7 +124,7 @@ sealed trait TupleInstances0 {
     implicit def _6 = A6
     implicit def _7 = A7
   }
-  implicit def tuple8Equal[A1, A2, A3, A4, A5, A6, A7, A8](implicit A1: Equal[A1], A2: Equal[A2], A3: Equal[A3], A4: Equal[A4], A5: Equal[A5], A6: Equal[A6], A7: Equal[A7], A8: Equal[A8]) = new Tuple8Equal[A1, A2, A3, A4, A5, A6, A7, A8] {
+  implicit def tuple8Equal[A1, A2, A3, A4, A5, A6, A7, A8](implicit A1: Equal[A1], A2: Equal[A2], A3: Equal[A3], A4: Equal[A4], A5: Equal[A5], A6: Equal[A6], A7: Equal[A7], A8: Equal[A8]): Equal[(A1, A2, A3, A4, A5, A6, A7, A8)] = new Tuple8Equal[A1, A2, A3, A4, A5, A6, A7, A8] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
@@ -137,32 +137,32 @@ sealed trait TupleInstances0 {
 }
 sealed trait TupleInstances1 extends TupleInstances0 {
 
-  implicit def tuple1Show[A1](implicit A1: Show[A1]) = new Tuple1Show[A1] {
+  implicit def tuple1Show[A1](implicit A1: Show[A1]): Show[Tuple1[A1]] = new Tuple1Show[A1] {
     implicit def _1 = A1
   }
-  implicit def tuple2Show[A1, A2](implicit A1: Show[A1], A2: Show[A2]) = new Tuple2Show[A1, A2] {
+  implicit def tuple2Show[A1, A2](implicit A1: Show[A1], A2: Show[A2]): Show[(A1, A2)]  = new Tuple2Show[A1, A2] {
     implicit def _1 = A1
     implicit def _2 = A2
   }
-  implicit def tuple3Show[A1, A2, A3](implicit A1: Show[A1], A2: Show[A2], A3: Show[A3]) = new Tuple3Show[A1, A2, A3] {
+  implicit def tuple3Show[A1, A2, A3](implicit A1: Show[A1], A2: Show[A2], A3: Show[A3]): Show[(A1, A2, A3)]  = new Tuple3Show[A1, A2, A3] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
   }
-  implicit def tuple4Show[A1, A2, A3, A4](implicit A1: Show[A1], A2: Show[A2], A3: Show[A3], A4: Show[A4]) = new Tuple4Show[A1, A2, A3, A4] {
+  implicit def tuple4Show[A1, A2, A3, A4](implicit A1: Show[A1], A2: Show[A2], A3: Show[A3], A4: Show[A4]): Show[(A1, A2, A3, A4)]  = new Tuple4Show[A1, A2, A3, A4] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
     implicit def _4 = A4
   }
-  implicit def tuple5Show[A1, A2, A3, A4, A5](implicit A1: Show[A1], A2: Show[A2], A3: Show[A3], A4: Show[A4], A5: Show[A5]) = new Tuple5Show[A1, A2, A3, A4, A5] {
+  implicit def tuple5Show[A1, A2, A3, A4, A5](implicit A1: Show[A1], A2: Show[A2], A3: Show[A3], A4: Show[A4], A5: Show[A5]): Show[(A1, A2, A3, A4, A5)]  = new Tuple5Show[A1, A2, A3, A4, A5] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
     implicit def _4 = A4
     implicit def _5 = A5
   }
-  implicit def tuple6Show[A1, A2, A3, A4, A5, A6](implicit A1: Show[A1], A2: Show[A2], A3: Show[A3], A4: Show[A4], A5: Show[A5], A6: Show[A6]) = new Tuple6Show[A1, A2, A3, A4, A5, A6] {
+  implicit def tuple6Show[A1, A2, A3, A4, A5, A6](implicit A1: Show[A1], A2: Show[A2], A3: Show[A3], A4: Show[A4], A5: Show[A5], A6: Show[A6]): Show[(A1, A2, A3, A4, A5, A6)]  = new Tuple6Show[A1, A2, A3, A4, A5, A6] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
@@ -170,7 +170,7 @@ sealed trait TupleInstances1 extends TupleInstances0 {
     implicit def _5 = A5
     implicit def _6 = A6
   }
-  implicit def tuple7Show[A1, A2, A3, A4, A5, A6, A7](implicit A1: Show[A1], A2: Show[A2], A3: Show[A3], A4: Show[A4], A5: Show[A5], A6: Show[A6], A7: Show[A7]) = new Tuple7Show[A1, A2, A3, A4, A5, A6, A7] {
+  implicit def tuple7Show[A1, A2, A3, A4, A5, A6, A7](implicit A1: Show[A1], A2: Show[A2], A3: Show[A3], A4: Show[A4], A5: Show[A5], A6: Show[A6], A7: Show[A7]): Show[(A1, A2, A3, A4, A5, A6, A7)]  = new Tuple7Show[A1, A2, A3, A4, A5, A6, A7] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
@@ -179,7 +179,7 @@ sealed trait TupleInstances1 extends TupleInstances0 {
     implicit def _6 = A6
     implicit def _7 = A7
   }
-  implicit def tuple8Show[A1, A2, A3, A4, A5, A6, A7, A8](implicit A1: Show[A1], A2: Show[A2], A3: Show[A3], A4: Show[A4], A5: Show[A5], A6: Show[A6], A7: Show[A7], A8: Show[A8]) = new Tuple8Show[A1, A2, A3, A4, A5, A6, A7, A8] {
+  implicit def tuple8Show[A1, A2, A3, A4, A5, A6, A7, A8](implicit A1: Show[A1], A2: Show[A2], A3: Show[A3], A4: Show[A4], A5: Show[A5], A6: Show[A6], A7: Show[A7], A8: Show[A8]): Show[(A1, A2, A3, A4, A5, A6, A7, A8)] = new Tuple8Show[A1, A2, A3, A4, A5, A6, A7, A8] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
@@ -190,32 +190,32 @@ sealed trait TupleInstances1 extends TupleInstances0 {
     implicit def _8 = A8
   }
 
-  implicit def tuple1Order[A1](implicit A1: Order[A1]) = new Tuple1Order[A1] {
+  implicit def tuple1Order[A1](implicit A1: Order[A1]): Order[Tuple1[A1]] = new Tuple1Order[A1] {
     implicit def _1 = A1
   }
-  implicit def tuple2Order[A1, A2](implicit A1: Order[A1], A2: Order[A2]) = new Tuple2Order[A1, A2] {
+  implicit def tuple2Order[A1, A2](implicit A1: Order[A1], A2: Order[A2]): Order[(A1, A2)] = new Tuple2Order[A1, A2] {
     implicit def _1 = A1
     implicit def _2 = A2
   }
-  implicit def tuple3Order[A1, A2, A3](implicit A1: Order[A1], A2: Order[A2], A3: Order[A3]) = new Tuple3Order[A1, A2, A3] {
+  implicit def tuple3Order[A1, A2, A3](implicit A1: Order[A1], A2: Order[A2], A3: Order[A3]): Order[(A1, A2, A3)] = new Tuple3Order[A1, A2, A3] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
   }
-  implicit def tuple4Order[A1, A2, A3, A4](implicit A1: Order[A1], A2: Order[A2], A3: Order[A3], A4: Order[A4]) = new Tuple4Order[A1, A2, A3, A4] {
+  implicit def tuple4Order[A1, A2, A3, A4](implicit A1: Order[A1], A2: Order[A2], A3: Order[A3], A4: Order[A4]): Order[(A1, A2, A3, A4)] = new Tuple4Order[A1, A2, A3, A4] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
     implicit def _4 = A4
   }
-  implicit def tuple5Order[A1, A2, A3, A4, A5](implicit A1: Order[A1], A2: Order[A2], A3: Order[A3], A4: Order[A4], A5: Order[A5]) = new Tuple5Order[A1, A2, A3, A4, A5] {
+  implicit def tuple5Order[A1, A2, A3, A4, A5](implicit A1: Order[A1], A2: Order[A2], A3: Order[A3], A4: Order[A4], A5: Order[A5]): Order[(A1, A2, A3, A4, A5)] = new Tuple5Order[A1, A2, A3, A4, A5] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
     implicit def _4 = A4
     implicit def _5 = A5
   }
-  implicit def tuple6Order[A1, A2, A3, A4, A5, A6](implicit A1: Order[A1], A2: Order[A2], A3: Order[A3], A4: Order[A4], A5: Order[A5], A6: Order[A6]) = new Tuple6Order[A1, A2, A3, A4, A5, A6] {
+  implicit def tuple6Order[A1, A2, A3, A4, A5, A6](implicit A1: Order[A1], A2: Order[A2], A3: Order[A3], A4: Order[A4], A5: Order[A5], A6: Order[A6]): Order[(A1, A2, A3, A4, A5, A6)] = new Tuple6Order[A1, A2, A3, A4, A5, A6] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
@@ -223,7 +223,7 @@ sealed trait TupleInstances1 extends TupleInstances0 {
     implicit def _5 = A5
     implicit def _6 = A6
   }
-  implicit def tuple7Order[A1, A2, A3, A4, A5, A6, A7](implicit A1: Order[A1], A2: Order[A2], A3: Order[A3], A4: Order[A4], A5: Order[A5], A6: Order[A6], A7: Order[A7]) = new Tuple7Order[A1, A2, A3, A4, A5, A6, A7] {
+  implicit def tuple7Order[A1, A2, A3, A4, A5, A6, A7](implicit A1: Order[A1], A2: Order[A2], A3: Order[A3], A4: Order[A4], A5: Order[A5], A6: Order[A6], A7: Order[A7]): Order[(A1, A2, A3, A4, A5, A6, A7)] = new Tuple7Order[A1, A2, A3, A4, A5, A6, A7] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
@@ -232,7 +232,7 @@ sealed trait TupleInstances1 extends TupleInstances0 {
     implicit def _6 = A6
     implicit def _7 = A7
   }
-  implicit def tuple8Order[A1, A2, A3, A4, A5, A6, A7, A8](implicit A1: Order[A1], A2: Order[A2], A3: Order[A3], A4: Order[A4], A5: Order[A5], A6: Order[A6], A7: Order[A7], A8: Order[A8]) = new Tuple8Order[A1, A2, A3, A4, A5, A6, A7, A8] {
+  implicit def tuple8Order[A1, A2, A3, A4, A5, A6, A7, A8](implicit A1: Order[A1], A2: Order[A2], A3: Order[A3], A4: Order[A4], A5: Order[A5], A6: Order[A6], A7: Order[A7], A8: Order[A8]): Order[(A1, A2, A3, A4, A5, A6, A7, A8)] = new Tuple8Order[A1, A2, A3, A4, A5, A6, A7, A8] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
@@ -242,32 +242,32 @@ sealed trait TupleInstances1 extends TupleInstances0 {
     implicit def _7 = A7
     implicit def _8 = A8
   }
-  implicit def tuple1Monoid[A1](implicit A1: Monoid[A1]) = new Tuple1Monoid[A1] {
+  implicit def tuple1Monoid[A1](implicit A1: Monoid[A1]): Monoid[Tuple1[A1]] = new Tuple1Monoid[A1] {
       implicit def _1 = A1
   }
-  implicit def tuple2Monoid[A1, A2](implicit A1: Monoid[A1], A2: Monoid[A2]) = new Tuple2Monoid[A1, A2] {
+  implicit def tuple2Monoid[A1, A2](implicit A1: Monoid[A1], A2: Monoid[A2]): Monoid[(A1, A2)] = new Tuple2Monoid[A1, A2] {
     implicit def _1 = A1
     implicit def _2 = A2
   }
-  implicit def tuple3Monoid[A1, A2, A3](implicit A1: Monoid[A1], A2: Monoid[A2], A3: Monoid[A3]) = new Tuple3Monoid[A1, A2, A3] {
+  implicit def tuple3Monoid[A1, A2, A3](implicit A1: Monoid[A1], A2: Monoid[A2], A3: Monoid[A3]): Monoid[(A1, A2, A3)] = new Tuple3Monoid[A1, A2, A3] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
   }
-  implicit def tuple4Monoid[A1, A2, A3, A4](implicit A1: Monoid[A1], A2: Monoid[A2], A3: Monoid[A3], A4: Monoid[A4]) = new Tuple4Monoid[A1, A2, A3, A4] {
+  implicit def tuple4Monoid[A1, A2, A3, A4](implicit A1: Monoid[A1], A2: Monoid[A2], A3: Monoid[A3], A4: Monoid[A4]): Monoid[(A1, A2, A3, A4)] = new Tuple4Monoid[A1, A2, A3, A4] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
     implicit def _4 = A4
   }
-  implicit def tuple5Monoid[A1, A2, A3, A4, A5](implicit A1: Monoid[A1], A2: Monoid[A2], A3: Monoid[A3], A4: Monoid[A4], A5: Monoid[A5]) = new Tuple5Monoid[A1, A2, A3, A4, A5] {
+  implicit def tuple5Monoid[A1, A2, A3, A4, A5](implicit A1: Monoid[A1], A2: Monoid[A2], A3: Monoid[A3], A4: Monoid[A4], A5: Monoid[A5]): Monoid[(A1, A2, A3, A4, A5)] = new Tuple5Monoid[A1, A2, A3, A4, A5] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
     implicit def _4 = A4
     implicit def _5 = A5
   }
-  implicit def tuple6Monoid[A1, A2, A3, A4, A5, A6](implicit A1: Monoid[A1], A2: Monoid[A2], A3: Monoid[A3], A4: Monoid[A4], A5: Monoid[A5], A6: Monoid[A6]) = new Tuple6Monoid[A1, A2, A3, A4, A5, A6] {
+  implicit def tuple6Monoid[A1, A2, A3, A4, A5, A6](implicit A1: Monoid[A1], A2: Monoid[A2], A3: Monoid[A3], A4: Monoid[A4], A5: Monoid[A5], A6: Monoid[A6]): Monoid[(A1, A2, A3, A4, A5, A6)] = new Tuple6Monoid[A1, A2, A3, A4, A5, A6] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
@@ -275,7 +275,7 @@ sealed trait TupleInstances1 extends TupleInstances0 {
     implicit def _5 = A5
     implicit def _6 = A6
   }
-  implicit def tuple7Monoid[A1, A2, A3, A4, A5, A6, A7](implicit A1: Monoid[A1], A2: Monoid[A2], A3: Monoid[A3], A4: Monoid[A4], A5: Monoid[A5], A6: Monoid[A6], A7: Monoid[A7]) = new Tuple7Monoid[A1, A2, A3, A4, A5, A6, A7] {
+  implicit def tuple7Monoid[A1, A2, A3, A4, A5, A6, A7](implicit A1: Monoid[A1], A2: Monoid[A2], A3: Monoid[A3], A4: Monoid[A4], A5: Monoid[A5], A6: Monoid[A6], A7: Monoid[A7]): Monoid[(A1, A2, A3, A4, A5, A6, A7)] = new Tuple7Monoid[A1, A2, A3, A4, A5, A6, A7] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
@@ -284,7 +284,7 @@ sealed trait TupleInstances1 extends TupleInstances0 {
     implicit def _6 = A6
     implicit def _7 = A7
   }
-  implicit def tuple8Monoid[A1, A2, A3, A4, A5, A6, A7, A8](implicit A1: Monoid[A1], A2: Monoid[A2], A3: Monoid[A3], A4: Monoid[A4], A5: Monoid[A5], A6: Monoid[A6], A7: Monoid[A7], A8: Monoid[A8]) = new Tuple8Monoid[A1, A2, A3, A4, A5, A6, A7, A8] {
+  implicit def tuple8Monoid[A1, A2, A3, A4, A5, A6, A7, A8](implicit A1: Monoid[A1], A2: Monoid[A2], A3: Monoid[A3], A4: Monoid[A4], A5: Monoid[A5], A6: Monoid[A6], A7: Monoid[A7], A8: Monoid[A8]): Monoid[(A1, A2, A3, A4, A5, A6, A7, A8)] = new Tuple8Monoid[A1, A2, A3, A4, A5, A6, A7, A8] {
     implicit def _1 = A1
     implicit def _2 = A2
     implicit def _3 = A3
@@ -355,14 +355,14 @@ object tuple extends TupleInstances {
   object tupleSyntax extends scalaz.syntax.std.ToTupleOps
 }
 
-private[scalaz] trait Tuple1Semigroup[A1] extends Semigroup[Tuple1[A1]] {
+private trait Tuple1Semigroup[A1] extends Semigroup[Tuple1[A1]] {
   implicit def _1 : Semigroup[A1]
   def append(f1: Tuple1[A1], f2: => Tuple1[A1]) = (
     Tuple1(Semigroup[A1].append(f1._1, f2._1))
     )
 }
 
-private[scalaz] trait Tuple2Semigroup[A1, A2] extends Semigroup[(A1, A2)] {
+private trait Tuple2Semigroup[A1, A2] extends Semigroup[(A1, A2)] {
   implicit def _1 : Semigroup[A1]
   implicit def _2 : Semigroup[A2]
   def append(f1: (A1, A2), f2: => (A1, A2)) = (
@@ -370,7 +370,7 @@ private[scalaz] trait Tuple2Semigroup[A1, A2] extends Semigroup[(A1, A2)] {
     _2.append(f1._2, f2._2)
     )
 }
-private[scalaz] trait Tuple3Semigroup[A1, A2, A3] extends Semigroup[(A1, A2, A3)] {
+private trait Tuple3Semigroup[A1, A2, A3] extends Semigroup[(A1, A2, A3)] {
   implicit def _1 : Semigroup[A1]
   implicit def _2 : Semigroup[A2]
   implicit def _3 : Semigroup[A3]
@@ -380,7 +380,7 @@ private[scalaz] trait Tuple3Semigroup[A1, A2, A3] extends Semigroup[(A1, A2, A3)
     _3.append(f1._3, f2._3)
     )
 }
-private[scalaz] trait Tuple4Semigroup[A1, A2, A3, A4] extends Semigroup[(A1, A2, A3, A4)] {
+private trait Tuple4Semigroup[A1, A2, A3, A4] extends Semigroup[(A1, A2, A3, A4)] {
   implicit def _1 : Semigroup[A1]
   implicit def _2 : Semigroup[A2]
   implicit def _3 : Semigroup[A3]
@@ -392,7 +392,7 @@ private[scalaz] trait Tuple4Semigroup[A1, A2, A3, A4] extends Semigroup[(A1, A2,
     _4.append(f1._4, f2._4)
     )
 }
-private[scalaz] trait Tuple5Semigroup[A1, A2, A3, A4, A5] extends Semigroup[(A1, A2, A3, A4, A5)] {
+private trait Tuple5Semigroup[A1, A2, A3, A4, A5] extends Semigroup[(A1, A2, A3, A4, A5)] {
   implicit def _1 : Semigroup[A1]
   implicit def _2 : Semigroup[A2]
   implicit def _3 : Semigroup[A3]
@@ -406,7 +406,7 @@ private[scalaz] trait Tuple5Semigroup[A1, A2, A3, A4, A5] extends Semigroup[(A1,
     _5.append(f1._5, f2._5)
     )
 }
-private[scalaz] trait Tuple6Semigroup[A1, A2, A3, A4, A5, A6] extends Semigroup[(A1, A2, A3, A4, A5, A6)] {
+private trait Tuple6Semigroup[A1, A2, A3, A4, A5, A6] extends Semigroup[(A1, A2, A3, A4, A5, A6)] {
   implicit def _1 : Semigroup[A1]
   implicit def _2 : Semigroup[A2]
   implicit def _3 : Semigroup[A3]
@@ -422,7 +422,7 @@ private[scalaz] trait Tuple6Semigroup[A1, A2, A3, A4, A5, A6] extends Semigroup[
     _6.append(f1._6, f2._6)
     )
 }
-private[scalaz] trait Tuple7Semigroup[A1, A2, A3, A4, A5, A6, A7] extends Semigroup[(A1, A2, A3, A4, A5, A6, A7)] {
+private trait Tuple7Semigroup[A1, A2, A3, A4, A5, A6, A7] extends Semigroup[(A1, A2, A3, A4, A5, A6, A7)] {
   implicit def _1 : Semigroup[A1]
   implicit def _2 : Semigroup[A2]
   implicit def _3 : Semigroup[A3]
@@ -440,7 +440,7 @@ private[scalaz] trait Tuple7Semigroup[A1, A2, A3, A4, A5, A6, A7] extends Semigr
     _7.append(f1._7, f2._7)
     )
 }
-private[scalaz] trait Tuple8Semigroup[A1, A2, A3, A4, A5, A6, A7, A8] extends Semigroup[(A1, A2, A3, A4, A5, A6, A7, A8)] {
+private trait Tuple8Semigroup[A1, A2, A3, A4, A5, A6, A7, A8] extends Semigroup[(A1, A2, A3, A4, A5, A6, A7, A8)] {
   implicit def _1 : Semigroup[A1]
   implicit def _2 : Semigroup[A2]
   implicit def _3 : Semigroup[A3]
@@ -460,101 +460,101 @@ private[scalaz] trait Tuple8Semigroup[A1, A2, A3, A4, A5, A6, A7, A8] extends Se
     _8.append(f1._8, f2._8)
     )
 }
-private[scalaz] trait Tuple1Functor extends Traverse[Tuple1] {
+private trait Tuple1Functor extends Traverse[Tuple1] {
   override def map[A, B](fa: Tuple1[A])(f: A => B) =
     Tuple1(f(fa._1))
   def traverseImpl[G[_], A, B](fa: Tuple1[A])(f: A => G[B])(implicit G: Applicative[G]) =
     G.map(f(fa._1))(Tuple1.apply)
 }
-private[scalaz] trait Tuple2Functor[A1] extends Traverse[({type f[x] = (A1, x)})#f] {
+private trait Tuple2Functor[A1] extends Traverse[({type f[x] = (A1, x)})#f] {
   override def map[A, B](fa: (A1, A))(f: A => B) =
     (fa._1, f(fa._2))
   def traverseImpl[G[_], A, B](fa: (A1, A))(f: A => G[B])(implicit G: Applicative[G]) =
     G.map(f(fa._2))((fa._1, _))
 }
-private[scalaz] trait Tuple3Functor[A1, A2] extends Traverse[({type f[x] = (A1, A2, x)})#f] {
+private trait Tuple3Functor[A1, A2] extends Traverse[({type f[x] = (A1, A2, x)})#f] {
   override def map[A, B](fa: (A1, A2, A))(f: A => B) =
     (fa._1, fa._2, f(fa._3))
   def traverseImpl[G[_], A, B](fa: (A1, A2, A))(f: A => G[B])(implicit G: Applicative[G]) =
     G.map(f(fa._3))((fa._1, fa._2, _))
 }
-private[scalaz] trait Tuple4Functor[A1, A2, A3] extends Traverse[({type f[x] = (A1, A2, A3, x)})#f] {
+private trait Tuple4Functor[A1, A2, A3] extends Traverse[({type f[x] = (A1, A2, A3, x)})#f] {
   override def map[A, B](fa: (A1, A2, A3, A))(f: A => B) =
     (fa._1, fa._2, fa._3, f(fa._4))
   def traverseImpl[G[_], A, B](fa: (A1, A2, A3, A))(f: A => G[B])(implicit G: Applicative[G]) =
     G.map(f(fa._4))((fa._1, fa._2, fa._3, _))
 }
-private[scalaz] trait Tuple5Functor[A1, A2, A3, A4] extends Traverse[({type f[x] = (A1, A2, A3, A4, x)})#f] {
+private trait Tuple5Functor[A1, A2, A3, A4] extends Traverse[({type f[x] = (A1, A2, A3, A4, x)})#f] {
   override def map[A, B](fa: (A1, A2, A3, A4, A))(f: A => B) =
     (fa._1, fa._2, fa._3, fa._4, f(fa._5))
   def traverseImpl[G[_], A, B](fa: (A1, A2, A3, A4, A))(f: A => G[B])(implicit G: Applicative[G]) =
     G.map(f(fa._5))((fa._1, fa._2, fa._3, fa._4, _))
 }
-private[scalaz] trait Tuple6Functor[A1, A2, A3, A4, A5] extends Traverse[({type f[x] = (A1, A2, A3, A4, A5, x)})#f] {
+private trait Tuple6Functor[A1, A2, A3, A4, A5] extends Traverse[({type f[x] = (A1, A2, A3, A4, A5, x)})#f] {
   override def map[A, B](fa: (A1, A2, A3, A4, A5, A))(f: A => B) =
     (fa._1, fa._2, fa._3, fa._4, fa._5, f(fa._6))
   def traverseImpl[G[_], A, B](fa: (A1, A2, A3, A4, A5, A))(f: A => G[B])(implicit G: Applicative[G]) =
     G.map(f(fa._6))((fa._1, fa._2, fa._3, fa._4, fa._5, _))
 }
-private[scalaz] trait Tuple7Functor[A1, A2, A3, A4, A5, A6] extends Traverse[({type f[x] = (A1, A2, A3, A4, A5, A6, x)})#f] {
+private trait Tuple7Functor[A1, A2, A3, A4, A5, A6] extends Traverse[({type f[x] = (A1, A2, A3, A4, A5, A6, x)})#f] {
   override def map[A, B](fa: (A1, A2, A3, A4, A5, A6, A))(f: A => B) =
     (fa._1, fa._2, fa._3, fa._4, fa._5, fa._6, f(fa._7))
   def traverseImpl[G[_], A, B](fa: (A1, A2, A3, A4, A5, A6, A))(f: A => G[B])(implicit G: Applicative[G]) =
     G.map(f(fa._7))((fa._1, fa._2, fa._3, fa._4, fa._5, fa._6, _))
 }
-private[scalaz] trait Tuple8Functor[A1, A2, A3, A4, A5, A6, A7] extends Traverse[({type f[x] = (A1, A2, A3, A4, A5, A6, A7, x)})#f] {
+private trait Tuple8Functor[A1, A2, A3, A4, A5, A6, A7] extends Traverse[({type f[x] = (A1, A2, A3, A4, A5, A6, A7, x)})#f] {
   override def map[A, B](fa: (A1, A2, A3, A4, A5, A6, A7, A))(f: A => B) =
     (fa._1, fa._2, fa._3, fa._4, fa._5, fa._6, fa._7, f(fa._8))
   def traverseImpl[G[_], A, B](fa: (A1, A2, A3, A4, A5, A6, A7, A))(f: A => G[B])(implicit G: Applicative[G]) =
     G.map(f(fa._8))((fa._1, fa._2, fa._3, fa._4, fa._5, fa._6, fa._7, _))
 }
 
-private[scalaz] trait Tuple1Cozip extends Cozip[Tuple1] {
+private trait Tuple1Cozip extends Cozip[Tuple1] {
   override def cozip[A, B](x: Tuple1[A \/ B]) =
     x._1.bimap(Tuple1(_), Tuple1(_))
 }
-private[scalaz] trait Tuple2Cozip[A1] extends Cozip[({type f[x] = (A1, x)})#f] {
+private trait Tuple2Cozip[A1] extends Cozip[({type f[x] = (A1, x)})#f] {
   override def cozip[A, B](x: (A1, A \/ B)) =
     x._2.bimap((x._1, _), (x._1, _))
 }
-private[scalaz] trait Tuple3Cozip[A1, A2] extends Cozip[({type f[x] = (A1, A2, x)})#f] {
+private trait Tuple3Cozip[A1, A2] extends Cozip[({type f[x] = (A1, A2, x)})#f] {
   override def cozip[A, B](x: (A1, A2, A \/ B)) =
     x._3.bimap((x._1, x._2, _), (x._1, x._2, _))
 }
-private[scalaz] trait Tuple4Cozip[A1, A2, A3] extends Cozip[({type f[x] = (A1, A2, A3, x)})#f] {
+private trait Tuple4Cozip[A1, A2, A3] extends Cozip[({type f[x] = (A1, A2, A3, x)})#f] {
   override def cozip[A, B](x: (A1, A2, A3, A \/ B)) =
     x._4.bimap((x._1, x._2, x._3, _), (x._1, x._2, x._3, _))
 }
-private[scalaz] trait Tuple5Cozip[A1, A2, A3, A4] extends Cozip[({type f[x] = (A1, A2, A3, A4, x)})#f] {
+private trait Tuple5Cozip[A1, A2, A3, A4] extends Cozip[({type f[x] = (A1, A2, A3, A4, x)})#f] {
   override def cozip[A, B](x: (A1, A2, A3, A4, A \/ B)) =
     x._5.bimap((x._1, x._2, x._3, x._4, _), (x._1, x._2, x._3, x._4, _))
 }
-private[scalaz] trait Tuple6Cozip[A1, A2, A3, A4, A5] extends Cozip[({type f[x] = (A1, A2, A3, A4, A5, x)})#f] {
+private trait Tuple6Cozip[A1, A2, A3, A4, A5] extends Cozip[({type f[x] = (A1, A2, A3, A4, A5, x)})#f] {
   override def cozip[A, B](x: (A1, A2, A3, A4, A5, A \/ B)) =
     x._6.bimap((x._1, x._2, x._3, x._4, x._5, _), (x._1, x._2, x._3, x._4, x._5, _))
 }
-private[scalaz] trait Tuple7Cozip[A1, A2, A3, A4, A5, A6] extends Cozip[({type f[x] = (A1, A2, A3, A4, A5, A6, x)})#f] {
+private trait Tuple7Cozip[A1, A2, A3, A4, A5, A6] extends Cozip[({type f[x] = (A1, A2, A3, A4, A5, A6, x)})#f] {
   override def cozip[A, B](x: (A1, A2, A3, A4, A5, A6, A \/ B)) =
     x._7.bimap((x._1, x._2, x._3, x._4, x._5, x._6, _), (x._1, x._2, x._3, x._4, x._5, x._6, _))
 }
-private[scalaz] trait Tuple8Cozip[A1, A2, A3, A4, A5, A6, A7] extends Cozip[({type f[x] = (A1, A2, A3, A4, A5, A6, A7, x)})#f] {
+private trait Tuple8Cozip[A1, A2, A3, A4, A5, A6, A7] extends Cozip[({type f[x] = (A1, A2, A3, A4, A5, A6, A7, x)})#f] {
   override def cozip[A, B](x: (A1, A2, A3, A4, A5, A6, A7, A \/ B)) =
     x._8.bimap((x._1, x._2, x._3, x._4, x._5, x._6, x._7, _), (x._1, x._2, x._3, x._4, x._5, x._6, x._7, _))
 }
 
-private[scalaz] trait Tuple1Equal[A1] extends Equal[Tuple1[A1]] {
+private trait Tuple1Equal[A1] extends Equal[Tuple1[A1]] {
   implicit def _1 : Equal[A1]
   override def equal(f1: Tuple1[A1], f2: Tuple1[A1]) = _1.equal(f1._1, f2._1)
   override val equalIsNatural: Boolean = _1.equalIsNatural
 }
-private[scalaz] trait Tuple2Equal[A1, A2] extends Equal[(A1, A2)] {
+private trait Tuple2Equal[A1, A2] extends Equal[(A1, A2)] {
   implicit def _1 : Equal[A1]
   implicit def _2 : Equal[A2]
   override def equal(f1: (A1, A2), f2: (A1, A2)) =
     _1.equal(f1._1, f2._1) && _2.equal(f1._2, f2._2)
   override val equalIsNatural: Boolean = _1.equalIsNatural && _2.equalIsNatural
 }
-private[scalaz] trait Tuple3Equal[A1, A2, A3] extends Equal[(A1, A2, A3)] {
+private trait Tuple3Equal[A1, A2, A3] extends Equal[(A1, A2, A3)] {
   implicit def _1 : Equal[A1]
   implicit def _2 : Equal[A2]
   implicit def _3 : Equal[A3]
@@ -562,7 +562,7 @@ private[scalaz] trait Tuple3Equal[A1, A2, A3] extends Equal[(A1, A2, A3)] {
     _1.equal(f1._1, f2._1) && _2.equal(f1._2, f2._2) && _3.equal(f1._3, f2._3)
   override val equalIsNatural: Boolean = _1.equalIsNatural && _2.equalIsNatural && _3.equalIsNatural
 }
-private[scalaz] trait Tuple4Equal[A1, A2, A3, A4] extends Equal[(A1, A2, A3, A4)] {
+private trait Tuple4Equal[A1, A2, A3, A4] extends Equal[(A1, A2, A3, A4)] {
   implicit def _1 : Equal[A1]
   implicit def _2 : Equal[A2]
   implicit def _3 : Equal[A3]
@@ -571,7 +571,7 @@ private[scalaz] trait Tuple4Equal[A1, A2, A3, A4] extends Equal[(A1, A2, A3, A4)
     _1.equal(f1._1, f2._1) && _2.equal(f1._2, f2._2) && _3.equal(f1._3, f2._3) && _4.equal(f1._4, f2._4)
   override val equalIsNatural: Boolean = _1.equalIsNatural && _2.equalIsNatural && _3.equalIsNatural && _4.equalIsNatural
 }
-private[scalaz] trait Tuple5Equal[A1, A2, A3, A4, A5] extends Equal[(A1, A2, A3, A4, A5)] {
+private trait Tuple5Equal[A1, A2, A3, A4, A5] extends Equal[(A1, A2, A3, A4, A5)] {
   implicit def _1 : Equal[A1]
   implicit def _2 : Equal[A2]
   implicit def _3 : Equal[A3]
@@ -581,7 +581,7 @@ private[scalaz] trait Tuple5Equal[A1, A2, A3, A4, A5] extends Equal[(A1, A2, A3,
     _1.equal(f1._1, f2._1) && _2.equal(f1._2, f2._2) && _3.equal(f1._3, f2._3) && _4.equal(f1._4, f2._4) && _5.equal(f1._5, f2._5)
   override val equalIsNatural: Boolean = _1.equalIsNatural && _2.equalIsNatural && _3.equalIsNatural && _4.equalIsNatural && _5.equalIsNatural
 }
-private[scalaz] trait Tuple6Equal[A1, A2, A3, A4, A5, A6] extends Equal[(A1, A2, A3, A4, A5, A6)] {
+private trait Tuple6Equal[A1, A2, A3, A4, A5, A6] extends Equal[(A1, A2, A3, A4, A5, A6)] {
   implicit def _1 : Equal[A1]
   implicit def _2 : Equal[A2]
   implicit def _3 : Equal[A3]
@@ -592,7 +592,7 @@ private[scalaz] trait Tuple6Equal[A1, A2, A3, A4, A5, A6] extends Equal[(A1, A2,
     _1.equal(f1._1, f2._1) && _2.equal(f1._2, f2._2) && _3.equal(f1._3, f2._3) && _4.equal(f1._4, f2._4) && _5.equal(f1._5, f2._5) && _6.equal(f1._6, f2._6)
   override val equalIsNatural: Boolean = _1.equalIsNatural && _2.equalIsNatural && _3.equalIsNatural && _4.equalIsNatural && _5.equalIsNatural && _6.equalIsNatural
 }
-private[scalaz] trait Tuple7Equal[A1, A2, A3, A4, A5, A6, A7] extends Equal[(A1, A2, A3, A4, A5, A6, A7)] {
+private trait Tuple7Equal[A1, A2, A3, A4, A5, A6, A7] extends Equal[(A1, A2, A3, A4, A5, A6, A7)] {
   implicit def _1 : Equal[A1]
   implicit def _2 : Equal[A2]
   implicit def _3 : Equal[A3]
@@ -604,7 +604,7 @@ private[scalaz] trait Tuple7Equal[A1, A2, A3, A4, A5, A6, A7] extends Equal[(A1,
     _1.equal(f1._1, f2._1) && _2.equal(f1._2, f2._2) && _3.equal(f1._3, f2._3) && _4.equal(f1._4, f2._4) && _5.equal(f1._5, f2._5) && _6.equal(f1._6, f2._6) && _7.equal(f1._7, f2._7)
   override val equalIsNatural: Boolean = _1.equalIsNatural && _2.equalIsNatural && _3.equalIsNatural && _4.equalIsNatural && _5.equalIsNatural && _6.equalIsNatural && _7.equalIsNatural
 }
-private[scalaz] trait Tuple8Equal[A1, A2, A3, A4, A5, A6, A7, A8] extends Equal[(A1, A2, A3, A4, A5, A6, A7, A8)] {
+private trait Tuple8Equal[A1, A2, A3, A4, A5, A6, A7, A8] extends Equal[(A1, A2, A3, A4, A5, A6, A7, A8)] {
   implicit def _1 : Equal[A1]
   implicit def _2 : Equal[A2]
   implicit def _3 : Equal[A3]
@@ -617,25 +617,25 @@ private[scalaz] trait Tuple8Equal[A1, A2, A3, A4, A5, A6, A7, A8] extends Equal[
     _1.equal(f1._1, f2._1) && _2.equal(f1._2, f2._2) && _3.equal(f1._3, f2._3) && _4.equal(f1._4, f2._4) && _5.equal(f1._5, f2._5) && _6.equal(f1._6, f2._6) && _7.equal(f1._7, f2._7) && _8.equal(f1._8, f2._8)
   override val equalIsNatural: Boolean = _1.equalIsNatural && _2.equalIsNatural && _3.equalIsNatural && _4.equalIsNatural && _5.equalIsNatural && _6.equalIsNatural && _7.equalIsNatural && _8.equalIsNatural
 }
-private[scalaz] trait Tuple1Show[A1] extends Show[Tuple1[A1]] {
+private trait Tuple1Show[A1] extends Show[Tuple1[A1]] {
   implicit def _1 : Show[A1]
   override def show(f: Tuple1[A1]) =
     Cord("(", _1.show(f._1), ")")
 }
-private[scalaz] trait Tuple2Show[A1, A2] extends Show[(A1, A2)] {
+private trait Tuple2Show[A1, A2] extends Show[(A1, A2)] {
   implicit def _1 : Show[A1]
   implicit def _2 : Show[A2]
   override def show(f: (A1, A2)) =
     Cord("(", _1.show(f._1), ",", _2.show(f._2), ")")
 }
-private[scalaz] trait Tuple3Show[A1, A2, A3] extends Show[(A1, A2, A3)] {
+private trait Tuple3Show[A1, A2, A3] extends Show[(A1, A2, A3)] {
   implicit def _1 : Show[A1]
   implicit def _2 : Show[A2]
   implicit def _3 : Show[A3]
   override def show(f: (A1, A2, A3)) =
     Cord("(", _1.show(f._1), ",", _2.show(f._2), ",", _3.show(f._3), ")")
 }
-private[scalaz] trait Tuple4Show[A1, A2, A3, A4] extends Show[(A1, A2, A3, A4)] {
+private trait Tuple4Show[A1, A2, A3, A4] extends Show[(A1, A2, A3, A4)] {
   implicit def _1 : Show[A1]
   implicit def _2 : Show[A2]
   implicit def _3 : Show[A3]
@@ -643,7 +643,7 @@ private[scalaz] trait Tuple4Show[A1, A2, A3, A4] extends Show[(A1, A2, A3, A4)] 
   override def show(f: (A1, A2, A3, A4)) =
     Cord("(", _1.show(f._1), ",", _2.show(f._2), ",", _3.show(f._3), ",", _4.show(f._4), ")")
 }
-private[scalaz] trait Tuple5Show[A1, A2, A3, A4, A5] extends Show[(A1, A2, A3, A4, A5)] {
+private trait Tuple5Show[A1, A2, A3, A4, A5] extends Show[(A1, A2, A3, A4, A5)] {
   implicit def _1 : Show[A1]
   implicit def _2 : Show[A2]
   implicit def _3 : Show[A3]
@@ -652,7 +652,7 @@ private[scalaz] trait Tuple5Show[A1, A2, A3, A4, A5] extends Show[(A1, A2, A3, A
   override def show(f: (A1, A2, A3, A4, A5)) =
     Cord("(", _1.show(f._1), ",", _2.show(f._2), ",", _3.show(f._3), ",", _4.show(f._4), ",", _5.show(f._5), ")")
 }
-private[scalaz] trait Tuple6Show[A1, A2, A3, A4, A5, A6] extends Show[(A1, A2, A3, A4, A5, A6)] {
+private trait Tuple6Show[A1, A2, A3, A4, A5, A6] extends Show[(A1, A2, A3, A4, A5, A6)] {
   implicit def _1 : Show[A1]
   implicit def _2 : Show[A2]
   implicit def _3 : Show[A3]
@@ -662,7 +662,7 @@ private[scalaz] trait Tuple6Show[A1, A2, A3, A4, A5, A6] extends Show[(A1, A2, A
   override def show(f: (A1, A2, A3, A4, A5, A6)) =
     Cord("(", _1.show(f._1), ",", _2.show(f._2), ",", _3.show(f._3), ",", _4.show(f._4), ",", _5.show(f._5), ",", _6.show(f._6), ")")
 }
-private[scalaz] trait Tuple7Show[A1, A2, A3, A4, A5, A6, A7] extends Show[(A1, A2, A3, A4, A5, A6, A7)] {
+private trait Tuple7Show[A1, A2, A3, A4, A5, A6, A7] extends Show[(A1, A2, A3, A4, A5, A6, A7)] {
   implicit def _1 : Show[A1]
   implicit def _2 : Show[A2]
   implicit def _3 : Show[A3]
@@ -673,7 +673,7 @@ private[scalaz] trait Tuple7Show[A1, A2, A3, A4, A5, A6, A7] extends Show[(A1, A
   override def show(f: (A1, A2, A3, A4, A5, A6, A7)) =
     Cord("(", _1.show(f._1), ",", _2.show(f._2), ",", _3.show(f._3), ",", _4.show(f._4), ",", _5.show(f._5), ",", _6.show(f._6), ",", _7.show(f._7), ")")
 }
-private[scalaz] trait Tuple8Show[A1, A2, A3, A4, A5, A6, A7, A8] extends Show[(A1, A2, A3, A4, A5, A6, A7, A8)] {
+private trait Tuple8Show[A1, A2, A3, A4, A5, A6, A7, A8] extends Show[(A1, A2, A3, A4, A5, A6, A7, A8)] {
   implicit def _1 : Show[A1]
   implicit def _2 : Show[A2]
   implicit def _3 : Show[A3]
@@ -686,11 +686,11 @@ private[scalaz] trait Tuple8Show[A1, A2, A3, A4, A5, A6, A7, A8] extends Show[(A
     Cord("(", _1.show(f._1), ",", _2.show(f._2), ",", _3.show(f._3), ",", _4.show(f._4), ",", _5.show(f._5), ",", _6.show(f._6), ",", _7.show(f._7), ",", _8.show(f._8), ")")
 }
 
-private[scalaz] trait Tuple1Order[A1] extends Order[Tuple1[A1]] with Tuple1Equal[A1] {
+private trait Tuple1Order[A1] extends Order[Tuple1[A1]] with Tuple1Equal[A1] {
   implicit def _1 : Order[A1]
   def order(f1: Tuple1[A1], f2: Tuple1[A1]) = _1.order(f1._1, f2._1)
 }
-private[scalaz] trait Tuple2Order[A1, A2] extends Order[(A1, A2)] with Tuple2Equal[A1, A2] {
+private trait Tuple2Order[A1, A2] extends Order[(A1, A2)] with Tuple2Equal[A1, A2] {
   implicit def _1 : Order[A1]
   implicit def _2 : Order[A2]
   import Ordering.EQ
@@ -700,7 +700,7 @@ private[scalaz] trait Tuple2Order[A1, A2] extends Order[(A1, A2)] with Tuple2Equ
       case (ord, _) => ord
     }
 }
-private[scalaz] trait Tuple3Order[A1, A2, A3] extends Order[(A1, A2, A3)] with Tuple3Equal[A1, A2, A3]{
+private trait Tuple3Order[A1, A2, A3] extends Order[(A1, A2, A3)] with Tuple3Equal[A1, A2, A3]{
   implicit def _1 : Order[A1]
   implicit def _2 : Order[A2]
   implicit def _3 : Order[A3]
@@ -712,7 +712,7 @@ private[scalaz] trait Tuple3Order[A1, A2, A3] extends Order[(A1, A2, A3)] with T
       case (ord, _, _) => ord
     }
 }
-private[scalaz] trait Tuple4Order[A1, A2, A3, A4] extends Order[(A1, A2, A3, A4)] with Tuple4Equal[A1, A2, A3, A4]{
+private trait Tuple4Order[A1, A2, A3, A4] extends Order[(A1, A2, A3, A4)] with Tuple4Equal[A1, A2, A3, A4]{
   implicit def _1 : Order[A1]
   implicit def _2 : Order[A2]
   implicit def _3 : Order[A3]
@@ -726,7 +726,7 @@ private[scalaz] trait Tuple4Order[A1, A2, A3, A4] extends Order[(A1, A2, A3, A4)
       case (ord, _, _, _) => ord
     }
 }
-private[scalaz] trait Tuple5Order[A1, A2, A3, A4, A5] extends Order[(A1, A2, A3, A4, A5)] with Tuple5Equal[A1, A2, A3, A4, A5] {
+private trait Tuple5Order[A1, A2, A3, A4, A5] extends Order[(A1, A2, A3, A4, A5)] with Tuple5Equal[A1, A2, A3, A4, A5] {
   implicit def _1 : Order[A1]
   implicit def _2 : Order[A2]
   implicit def _3 : Order[A3]
@@ -742,7 +742,7 @@ private[scalaz] trait Tuple5Order[A1, A2, A3, A4, A5] extends Order[(A1, A2, A3,
       case (ord, _, _, _, _) => ord
     }
 }
-private[scalaz] trait Tuple6Order[A1, A2, A3, A4, A5, A6] extends Order[(A1, A2, A3, A4, A5, A6)] with Tuple6Equal[A1, A2, A3, A4, A5, A6] {
+private trait Tuple6Order[A1, A2, A3, A4, A5, A6] extends Order[(A1, A2, A3, A4, A5, A6)] with Tuple6Equal[A1, A2, A3, A4, A5, A6] {
   implicit def _1 : Order[A1]
   implicit def _2 : Order[A2]
   implicit def _3 : Order[A3]
@@ -760,7 +760,7 @@ private[scalaz] trait Tuple6Order[A1, A2, A3, A4, A5, A6] extends Order[(A1, A2,
       case (ord, _, _, _, _, _) => ord
     }
 }
-private[scalaz] trait Tuple7Order[A1, A2, A3, A4, A5, A6, A7] extends Order[(A1, A2, A3, A4, A5, A6, A7)] with Tuple7Equal[A1, A2, A3, A4, A5, A6, A7]{
+private trait Tuple7Order[A1, A2, A3, A4, A5, A6, A7] extends Order[(A1, A2, A3, A4, A5, A6, A7)] with Tuple7Equal[A1, A2, A3, A4, A5, A6, A7]{
   implicit def _1 : Order[A1]
   implicit def _2 : Order[A2]
   implicit def _3 : Order[A3]
@@ -780,7 +780,7 @@ private[scalaz] trait Tuple7Order[A1, A2, A3, A4, A5, A6, A7] extends Order[(A1,
       case (ord, _, _, _, _, _, _) => ord
     }
 }
-private[scalaz] trait Tuple8Order[A1, A2, A3, A4, A5, A6, A7, A8] extends Order[(A1, A2, A3, A4, A5, A6, A7, A8)] with Tuple8Equal[A1, A2, A3, A4, A5, A6, A7, A8] {
+private trait Tuple8Order[A1, A2, A3, A4, A5, A6, A7, A8] extends Order[(A1, A2, A3, A4, A5, A6, A7, A8)] with Tuple8Equal[A1, A2, A3, A4, A5, A6, A7, A8] {
   implicit def _1 : Order[A1]
   implicit def _2 : Order[A2]
   implicit def _3 : Order[A3]
@@ -803,29 +803,29 @@ private[scalaz] trait Tuple8Order[A1, A2, A3, A4, A5, A6, A7, A8] extends Order[
     }
 }
 
-private[scalaz] trait Tuple1Monoid[A1] extends Monoid[Tuple1[A1]] with Tuple1Semigroup[A1] {
+private trait Tuple1Monoid[A1] extends Monoid[Tuple1[A1]] with Tuple1Semigroup[A1] {
   implicit def _1 : Monoid[A1]
   def zero: Tuple1[A1] = Tuple1(_1.zero)
 }
-private[scalaz] trait Tuple2Monoid[A1, A2] extends Monoid[(A1, A2)] with Tuple2Semigroup[A1, A2] {
+private trait Tuple2Monoid[A1, A2] extends Monoid[(A1, A2)] with Tuple2Semigroup[A1, A2] {
   implicit def _1 : Monoid[A1]
   implicit def _2 : Monoid[A2]
   def zero: (A1, A2) = (_1.zero, _2.zero)
 }
-private[scalaz] trait Tuple3Monoid[A1, A2, A3] extends Monoid[(A1, A2, A3)] with Tuple3Semigroup[A1, A2, A3] {
+private trait Tuple3Monoid[A1, A2, A3] extends Monoid[(A1, A2, A3)] with Tuple3Semigroup[A1, A2, A3] {
   implicit def _1 : Monoid[A1]
   implicit def _2 : Monoid[A2]
   implicit def _3 : Monoid[A3]
   def zero: (A1, A2, A3) = (_1.zero, _2.zero, _3.zero)
 }
-private[scalaz] trait Tuple4Monoid[A1, A2, A3, A4] extends Monoid[(A1, A2, A3, A4)] with Tuple4Semigroup[A1, A2, A3, A4] {
+private trait Tuple4Monoid[A1, A2, A3, A4] extends Monoid[(A1, A2, A3, A4)] with Tuple4Semigroup[A1, A2, A3, A4] {
   implicit def _1 : Monoid[A1]
   implicit def _2 : Monoid[A2]
   implicit def _3 : Monoid[A3]
   implicit def _4 : Monoid[A4]
   def zero: (A1, A2, A3, A4) = (_1.zero, _2.zero, _3.zero, _4.zero)
 }
-private[scalaz] trait Tuple5Monoid[A1, A2, A3, A4, A5] extends Monoid[(A1, A2, A3, A4, A5)] with Tuple5Semigroup[A1, A2, A3, A4, A5] {
+private trait Tuple5Monoid[A1, A2, A3, A4, A5] extends Monoid[(A1, A2, A3, A4, A5)] with Tuple5Semigroup[A1, A2, A3, A4, A5] {
   implicit def _1 : Monoid[A1]
   implicit def _2 : Monoid[A2]
   implicit def _3 : Monoid[A3]
@@ -833,7 +833,7 @@ private[scalaz] trait Tuple5Monoid[A1, A2, A3, A4, A5] extends Monoid[(A1, A2, A
   implicit def _5 : Monoid[A5]
   def zero: (A1, A2, A3, A4, A5) = (_1.zero, _2.zero, _3.zero, _4.zero, _5.zero)
 }
-private[scalaz] trait Tuple6Monoid[A1, A2, A3, A4, A5, A6] extends Monoid[(A1, A2, A3, A4, A5, A6)] with Tuple6Semigroup[A1, A2, A3, A4, A5, A6] {
+private trait Tuple6Monoid[A1, A2, A3, A4, A5, A6] extends Monoid[(A1, A2, A3, A4, A5, A6)] with Tuple6Semigroup[A1, A2, A3, A4, A5, A6] {
   implicit def _1 : Monoid[A1]
   implicit def _2 : Monoid[A2]
   implicit def _3 : Monoid[A3]
@@ -842,7 +842,7 @@ private[scalaz] trait Tuple6Monoid[A1, A2, A3, A4, A5, A6] extends Monoid[(A1, A
   implicit def _6 : Monoid[A6]
   def zero: (A1, A2, A3, A4, A5, A6) = (_1.zero, _2.zero, _3.zero, _4.zero, _5.zero, _6.zero)
 }
-private[scalaz] trait Tuple7Monoid[A1, A2, A3, A4, A5, A6, A7] extends Monoid[(A1, A2, A3, A4, A5, A6, A7)] with Tuple7Semigroup[A1, A2, A3, A4, A5, A6, A7] {
+private trait Tuple7Monoid[A1, A2, A3, A4, A5, A6, A7] extends Monoid[(A1, A2, A3, A4, A5, A6, A7)] with Tuple7Semigroup[A1, A2, A3, A4, A5, A6, A7] {
   implicit def _1 : Monoid[A1]
   implicit def _2 : Monoid[A2]
   implicit def _3 : Monoid[A3]
@@ -852,7 +852,7 @@ private[scalaz] trait Tuple7Monoid[A1, A2, A3, A4, A5, A6, A7] extends Monoid[(A
   implicit def _7 : Monoid[A7]
   def zero: (A1, A2, A3, A4, A5, A6, A7) = (_1.zero, _2.zero, _3.zero, _4.zero, _5.zero, _6.zero, _7.zero)
 }
-private[scalaz] trait Tuple8Monoid[A1, A2, A3, A4, A5, A6, A7, A8] extends Monoid[(A1, A2, A3, A4, A5, A6, A7, A8)] with Tuple8Semigroup[A1, A2, A3, A4, A5, A6, A7, A8] {
+private trait Tuple8Monoid[A1, A2, A3, A4, A5, A6, A7, A8] extends Monoid[(A1, A2, A3, A4, A5, A6, A7, A8)] with Tuple8Semigroup[A1, A2, A3, A4, A5, A6, A7, A8] {
   implicit def _1 : Monoid[A1]
   implicit def _2 : Monoid[A2]
   implicit def _3 : Monoid[A3]
@@ -864,7 +864,7 @@ private[scalaz] trait Tuple8Monoid[A1, A2, A3, A4, A5, A6, A7, A8] extends Monoi
   def zero: (A1, A2, A3, A4, A5, A6, A7, A8) = (_1.zero, _2.zero, _3.zero, _4.zero, _5.zero, _6.zero, _7.zero, _8.zero)
 }
 
-private[scalaz] trait Tuple1Monad extends Monad[Tuple1] {
+private trait Tuple1Monad extends Monad[Tuple1] {
   def bind[A, B](fa: Tuple1[A])(f: A => Tuple1[B]) = f(fa._1)
   def point[A](a: => A) = Tuple1(a)
 }
@@ -873,7 +873,7 @@ private[scalaz] trait Tuple1Monad extends Monad[Tuple1] {
 // TupleN forms a Monad if the element types other than the last are Monoids.
 
 
-private[scalaz] trait Tuple2Monad[A1] extends Monad[({type f[x] = (A1, x)})#f] with Tuple2Functor[A1] {
+private trait Tuple2Monad[A1] extends Monad[({type f[x] = (A1, x)})#f] with Tuple2Functor[A1] {
   implicit def _1 : Monoid[A1]
   def bind[A, B](fa: (A1, A))(f: A => (A1, B)) = {
     val t = f(fa._2)
@@ -882,7 +882,7 @@ private[scalaz] trait Tuple2Monad[A1] extends Monad[({type f[x] = (A1, x)})#f] w
   }
   def point[A](a: => A) = (_1.zero, a)
 }
-private[scalaz] trait Tuple3Monad[A1, A2] extends Monad[({type f[x] = (A1, A2, x)})#f] with Tuple3Functor[A1, A2] {
+private trait Tuple3Monad[A1, A2] extends Monad[({type f[x] = (A1, A2, x)})#f] with Tuple3Functor[A1, A2] {
   implicit def _1 : Monoid[A1]
   implicit def _2 : Monoid[A2]
   def bind[A, B](fa: (A1, A2, A))(f: A => (A1, A2, B)) = {
@@ -893,7 +893,7 @@ private[scalaz] trait Tuple3Monad[A1, A2] extends Monad[({type f[x] = (A1, A2, x
 
   def point[A](a: => A) = (_1.zero, _2.zero, a)
 }
-private[scalaz] trait Tuple4Monad[A1, A2, A3] extends Monad[({type f[x] = (A1, A2, A3, x)})#f] with Tuple4Functor[A1, A2, A3] {
+private trait Tuple4Monad[A1, A2, A3] extends Monad[({type f[x] = (A1, A2, A3, x)})#f] with Tuple4Functor[A1, A2, A3] {
   implicit def _1 : Monoid[A1]
   implicit def _2 : Monoid[A2]
   implicit def _3 : Monoid[A3]
@@ -904,7 +904,7 @@ private[scalaz] trait Tuple4Monad[A1, A2, A3] extends Monad[({type f[x] = (A1, A
   }
   def point[A](a: => A) = (_1.zero, _2.zero, _3.zero, a)
 }
-private[scalaz] trait Tuple5Monad[A1, A2, A3, A4] extends Monad[({type f[x] = (A1, A2, A3, A4, x)})#f] with Tuple5Functor[A1, A2, A3, A4] {
+private trait Tuple5Monad[A1, A2, A3, A4] extends Monad[({type f[x] = (A1, A2, A3, A4, x)})#f] with Tuple5Functor[A1, A2, A3, A4] {
   implicit def _1 : Monoid[A1]
   implicit def _2 : Monoid[A2]
   implicit def _3 : Monoid[A3]
@@ -916,7 +916,7 @@ private[scalaz] trait Tuple5Monad[A1, A2, A3, A4] extends Monad[({type f[x] = (A
   }
   def point[A](a: => A) = (_1.zero, _2.zero, _3.zero, _4.zero, a)
 }
-private[scalaz] trait Tuple6Monad[A1, A2, A3, A4, A5] extends Monad[({type f[x] = (A1, A2, A3, A4, A5, x)})#f] with Tuple6Functor[A1, A2, A3, A4, A5] {
+private trait Tuple6Monad[A1, A2, A3, A4, A5] extends Monad[({type f[x] = (A1, A2, A3, A4, A5, x)})#f] with Tuple6Functor[A1, A2, A3, A4, A5] {
   implicit def _1 : Monoid[A1]
   implicit def _2 : Monoid[A2]
   implicit def _3 : Monoid[A3]
@@ -929,7 +929,7 @@ private[scalaz] trait Tuple6Monad[A1, A2, A3, A4, A5] extends Monad[({type f[x] 
   }
   def point[A](a: => A) = (_1.zero, _2.zero, _3.zero, _4.zero, _5.zero, a)
 }
-private[scalaz] trait Tuple7Monad[A1, A2, A3, A4, A5, A6] extends Monad[({type f[x] = (A1, A2, A3, A4, A5, A6, x)})#f] with Tuple7Functor[A1, A2, A3, A4, A5, A6] {
+private trait Tuple7Monad[A1, A2, A3, A4, A5, A6] extends Monad[({type f[x] = (A1, A2, A3, A4, A5, A6, x)})#f] with Tuple7Functor[A1, A2, A3, A4, A5, A6] {
   implicit def _1 : Monoid[A1]
   implicit def _2 : Monoid[A2]
   implicit def _3 : Monoid[A3]
@@ -944,7 +944,7 @@ private[scalaz] trait Tuple7Monad[A1, A2, A3, A4, A5, A6] extends Monad[({type f
 
   def point[A](a: => A) = (_1.zero, _2.zero, _3.zero, _4.zero, _5.zero, _6.zero, a)
 }
-private[scalaz] trait Tuple8Monad[A1, A2, A3, A4, A5, A6, A7] extends Monad[({type f[x] = (A1, A2, A3, A4, A5, A6, A7, x)})#f] with Tuple8Functor[A1, A2, A3, A4, A5, A6, A7] {
+private trait Tuple8Monad[A1, A2, A3, A4, A5, A6, A7] extends Monad[({type f[x] = (A1, A2, A3, A4, A5, A6, A7, x)})#f] with Tuple8Functor[A1, A2, A3, A4, A5, A6, A7] {
   implicit def _1 : Monoid[A1]
   implicit def _2 : Monoid[A2]
   implicit def _3 : Monoid[A3]

--- a/effect/src/main/scala/scalaz/effect/KleisliEffect.scala
+++ b/effect/src/main/scala/scalaz/effect/KleisliEffect.scala
@@ -25,13 +25,13 @@ sealed abstract class KleisliEffectInstances extends KleisliEffectInstances0 {
     }
 }
 
-trait KleisliLiftIO[M[_], R] extends LiftIO[({type λ[α] = Kleisli[M, R, α]})#λ] {
+private trait KleisliLiftIO[M[_], R] extends LiftIO[({type λ[α] = Kleisli[M, R, α]})#λ] {
   implicit def L: LiftIO[M]
     
   def liftIO[A](ioa: IO[A]) = Kleisli(_ => L.liftIO(ioa))
 }
 
-trait KleisliCatchIO[M[_], R] extends MonadCatchIO[({type λ[α] = Kleisli[M, R, α]})#λ] with KleisliLiftIO[M, R] with KleisliMonadReader[M, R] {
+private trait KleisliCatchIO[M[_], R] extends MonadCatchIO[({type λ[α] = Kleisli[M, R, α]})#λ] with KleisliLiftIO[M, R] with KleisliMonadReader[M, R] {
   implicit def F: MonadCatchIO[M]
 
   def except[A](k: Kleisli[M, R, A])(h: Throwable ⇒ Kleisli[M, R, A]) = 

--- a/iteratee/src/main/scala/scalaz/iteratee/EnumeratorT.scala
+++ b/iteratee/src/main/scala/scalaz/iteratee/EnumeratorT.scala
@@ -231,7 +231,7 @@ object EnumeratorT extends EnumeratorTFunctions with EnumeratorTInstances
 // Type class implementation traits
 //
 
-private[scalaz] trait EnumeratorTSemigroup[E, F[_]] extends Semigroup[EnumeratorT[E, F]] {
+private trait EnumeratorTSemigroup[E, F[_]] extends Semigroup[EnumeratorT[E, F]] {
   implicit def F: Bind[F]
 
   def append(f1: EnumeratorT[E, F], f2: => EnumeratorT[E, F]) =
@@ -240,7 +240,7 @@ private[scalaz] trait EnumeratorTSemigroup[E, F[_]] extends Semigroup[Enumerator
     }
 }
 
-private[scalaz] trait EnumeratorTMonoid[E, F[_]] extends Monoid[EnumeratorT[E, F]] with EnumeratorTSemigroup[E, F] {
+private trait EnumeratorTMonoid[E, F[_]] extends Monoid[EnumeratorT[E, F]] with EnumeratorTSemigroup[E, F] {
   implicit def F: Monad[F]
 
   def zero = new EnumeratorT[E, F] {
@@ -248,12 +248,12 @@ private[scalaz] trait EnumeratorTMonoid[E, F[_]] extends Monoid[EnumeratorT[E, F
   }
 }
 
-private[scalaz] trait EnumeratorTFunctor[F[_]] extends Functor[({type λ[α]=EnumeratorT[α, F]})#λ] {
+private trait EnumeratorTFunctor[F[_]] extends Functor[({type λ[α]=EnumeratorT[α, F]})#λ] {
   implicit def M: Monad[F]
   abstract override def map[A, B](fa: EnumeratorT[A, F])(f: A => B): EnumeratorT[B, F] = fa.map(f)
 }
 
-private [scalaz] trait EnumeratorTMonad[F[_]] extends Monad[({type λ[α]=EnumeratorT[α, F]})#λ] with EnumeratorTFunctor[F] {
+private trait EnumeratorTMonad[F[_]] extends Monad[({type λ[α]=EnumeratorT[α, F]})#λ] with EnumeratorTFunctor[F] {
   def bind[A, B](fa: EnumeratorT[A, F])(f: A => EnumeratorT[B, F]) = fa.flatMap(f)
   def point[E](e: => E) = EnumeratorT.enumOne[E, F](e)
 }

--- a/iteratee/src/main/scala/scalaz/iteratee/IterateeT.scala
+++ b/iteratee/src/main/scala/scalaz/iteratee/IterateeT.scala
@@ -345,7 +345,7 @@ trait IterateeTFunctions {
 // Type class implementation traits
 //
 
-private[scalaz] trait IterateeTMonad[E, F[_]] extends Monad[({type λ[α] = IterateeT[E, F, α]})#λ] {
+private trait IterateeTMonad[E, F[_]] extends Monad[({type λ[α] = IterateeT[E, F, α]})#λ] {
   implicit def F: Monad[F]
 
   def point[A](a: => A) = StepT.sdone(a, emptyInput).pointI
@@ -353,7 +353,7 @@ private[scalaz] trait IterateeTMonad[E, F[_]] extends Monad[({type λ[α] = Iter
   def bind[A, B](fa: IterateeT[E, F, A])(f: A => IterateeT[E, F, B]): IterateeT[E, F, B] = fa flatMap f
 }
 
-private[scalaz] trait IterateeTHoist[E] extends Hoist[({type λ[β[_], α] = IterateeT[E, β, α]})#λ] {
+private trait IterateeTHoist[E] extends Hoist[({type λ[β[_], α] = IterateeT[E, β, α]})#λ] {
   trait IterateeTF[F[_]] {
     type λ[α] = IterateeT[E, F, α]
   }
@@ -368,13 +368,13 @@ private[scalaz] trait IterateeTHoist[E] extends Hoist[({type λ[β[_], α] = Ite
   implicit def apply[G[_] : Monad]: Monad[IterateeTF[G]#λ] = IterateeT.IterateeTMonad[E, G]
 }
 
-private[scalaz] trait IterateeTMonadIO[E, F[_]] extends MonadIO[({type λ[α] = IterateeT[E, F, α]})#λ] with IterateeTMonad[E, F] {
+private trait IterateeTMonadIO[E, F[_]] extends MonadIO[({type λ[α] = IterateeT[E, F, α]})#λ] with IterateeTMonad[E, F] {
   implicit def F: MonadIO[F]
   
   def liftIO[A](ioa: IO[A]) = MonadTrans[({type λ[α[_], β] = IterateeT[E, α, β]})#λ].liftM(F.liftIO(ioa))
 }
 
-private[scalaz] trait IterateeTMonadTransT[E, H[_[_], _]] extends MonadTrans[({type λ0[α[_], β] = IterateeT[E, ({type λ1[x] = H[α, x]})#λ1, β]})#λ0] {
+private trait IterateeTMonadTransT[E, H[_[_], _]] extends MonadTrans[({type λ0[α[_], β] = IterateeT[E, ({type λ1[x] = H[α, x]})#λ1, β]})#λ0] {
   implicit def T: MonadTrans[H]
 
   def liftM[G[_]: Monad, A](ga: G[A]): IterateeT[E, ({type λ[α] = H[G, α]})#λ, A] =
@@ -384,7 +384,7 @@ private[scalaz] trait IterateeTMonadTransT[E, H[_[_], _]] extends MonadTrans[({t
     IterateeT.IterateeTMonad[E, ({type λ[α] = H[G, α]})#λ](T[G])
 }
 
-private[scalaz] trait IterateeTHoistT[E, H[_[_], _]] extends Hoist[({type λ0[α[_], β] = IterateeT[E, ({type λ1[x] = H[α, x]})#λ1, β]})#λ0] with IterateeTMonadTransT[E, H] {
+private trait IterateeTHoistT[E, H[_[_], _]] extends Hoist[({type λ0[α[_], β] = IterateeT[E, ({type λ1[x] = H[α, x]})#λ1, β]})#λ0] with IterateeTMonadTransT[E, H] {
   implicit def T: Hoist[H]
 
   def hoist[M[_]: Monad, N[_]](f: M ~> N) = new (({type λ0[α0] = IterateeT[E, ({type λ1[α1] = H[M, α1]})#λ1, α0]})#λ0 ~> ({type λ0[α0] = IterateeT[E, ({type λ1[α1] = H[N, α1]})#λ1, α0]})#λ0) {


### PR DESCRIPTION
for more binary compatibility. `private` modifier is more strong restriction than `private[scalaz]`.

`private[scalaz]`

``` scala
sealed abstract class FooInstances{
  // NOT compile errer
  implicit def fooInstance = new FooEqual{

  }
}

private[scalaz] trait FooEqual extends Equal[Foo]{
  // something code
}
```

just `private`

``` scala
sealed abstract class FooInstances{
  // compile errer! compiler says
  // "private trait FooEqual escapes its defining scope as part of type FooEqual"
  implicit def fooInstance = new FooEqual{

  }
}

private trait FooEqual extends Equal[Foo]{
  // something code
}
```

I think type class implementation traits are internal implementation detail. always need explicit return type annotation.
