### PR TITLE
memoised the result of the unzip method for Function1

### DIFF
--- a/core/src/main/scala/scalaz/std/Function.scala
+++ b/core/src/main/scala/scalaz/std/Function.scala
@@ -77,8 +77,10 @@ trait FunctionInstances extends FunctionInstances0 {
     def zip[A, B](a: => T => A, b: => T => B) =
       t => (a(t), b(t))
 
-    def unzip[A, B](a: T => (A, B)) =
-      (a(_)._1, a(_)._2)
+    def unzip[A, B](a: T => (A, B)) = {
+      lazy val result = Memo.immutableHashMapMemo((t: T) => a(t))
+      (result(_)._1, result(_)._2)
+    }
 
     def distributeImpl[G[_]:Functor,A,B](fa: G[A])(f: A => T => B): T => G[B] =
       t => Functor[G].map(fa)(a => f(a)(t))

--- a/tests/src/test/scala/scalaz/std/FunctionTest.scala
+++ b/tests/src/test/scala/scalaz/std/FunctionTest.scala
@@ -63,6 +63,15 @@ class FunctionTest extends Spec {
     mappedCall() must be_===(number + 4)
   }
 
+  "Function1 unzip must only evaluate the function once" ! {
+    var sideEffect = 0
+    val f: Int => (Int, Int) = (i: Int) => ({ sideEffect += 1; i + 1}, i + 2)
+    val (unzipped1, unzipped2) = function1Covariant[Int].unzip(f)
+
+    (unzipped1(1), unzipped2(1)) must be_===((2, 3))
+    sideEffect must be_===(1)
+  }
+
   "fix" ! prop{(n: Int) =>
     fix[Int](_ => n) must be_===(n)
     (fix[Stream[Int]](ns => n #:: (2*n) #:: ns).take(4).toList


### PR DESCRIPTION
I want to avoid a function to be called twice when unzipped. 

The test uses a side-effect to show that the fix is working.
