### PR TITLE
Add MonadState.{state, constantState} to parallel equivalents in StateFunctions; add basic tests

### DIFF
--- a/core/src/main/scala/scalaz/MonadState.scala
+++ b/core/src/main/scala/scalaz/MonadState.scala
@@ -4,11 +4,13 @@ package scalaz
   * [[scalaz.State]].
   */
 trait MonadState[F[_,_],S] extends Monad[({type f[x]=F[S,x]})#f] {
-  def init: F[S,S]
+  def state[A](a: A): F[S, A] = bind(init)(s => point(a))
+  def constantState[A](a: A, s: => S): F[S, A] = bind(put(s))(_ => point(a))
+  def init: F[S, S]
   def get: F[S, S]
-  def put(s: S): F[S,Unit]
-  def modify(f: S => S): F[S, Unit] = bind(init)(s => put(f(s)))
   def gets[A](f: S => A): F[S, A] = bind(init)(s => point(f(s)))
+  def put(s: S): F[S, Unit]
+  def modify(f: S => S): F[S, Unit] = bind(init)(s => put(f(s)))
 }
 
 object MonadState {

--- a/tests/src/test/scala/scalaz/StateTTest.scala
+++ b/tests/src/test/scala/scalaz/StateTTest.scala
@@ -27,4 +27,28 @@ class StateTTest extends Spec {
     // checking absence of ambiguity
     def functor[S, F[_] : Monad] = Functor[({type λ[α] = StateT[F, S, α]})#λ]
   }
+
+  "monadState.state" in {
+    instances.monadState[Boolean].state(42).run(true) must be_===((true, 42))
+  }
+
+  "monadState.constantState" in {
+    instances.monadState[Boolean].constantState(42, false).run(true) must be_===((false, 42))
+  }
+
+  "monadState.get" in {
+    instances.monadState[Boolean].get.run(true) must be_===((true, true))
+  }
+
+  "monadState.gets" in {
+    instances.monadState[Int].gets { _ + 1 }.run(10) must be_===((10, 11))
+  }
+
+  "monadState.put" in {
+    instances.monadState[Int].put(20).run(10) must be_===((20, ()))
+  }
+
+  "monadState.modify" in {
+    instances.monadState[Int].modify { _ + 1 }.run(10) must be_===((11, ()))
+  }
 }


### PR DESCRIPTION
This PR adds `state` and `constantState` to `MonadState`. A basic test was added for each method on `MonadState` in lieu of proper law checking. The tests were added to `StateTTest` but if they should be in a new MonadStateTest, I can move them.
