### PR TITLE
Added jetbrains support note

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,3 +304,7 @@ type Id[A] = A
 ## Contributing
 
 [Documentation for contributors](https://github.com/scalaz/scalaz/blob/scalaz-seven/doc/DeveloperGuide.md)
+
+## Credits
+
+Support for Scalaz development is provided by [Jetbrains](http://www.jetbrains.com/idea/).


### PR DESCRIPTION
Jetbrains provide an IntelliJ licence for us to use on Scalaz & have been doing so for several years. I've just renewed this licence for another year, and they requested we add a link to them noting this. So this is it.
