### PR TITLE
Explicit return types for type class instances for Future/Task

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Future.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Future.scala
@@ -218,7 +218,7 @@ object Future {
   // NB: considered implementing Traverse and Comonad, but these would have
   // to run the Future; leaving out for now
 
-  implicit val futureInstance = new Nondeterminism[Future] {
+  implicit val futureInstance: Nondeterminism[Future] = new Nondeterminism[Future] {
     def bind[A,B](fa: Future[A])(f: A => Future[B]): Future[B] =
       fa flatMap f
     def point[A](a: => A): Future[A] = now(a)

--- a/concurrent/src/main/scala/scalaz/concurrent/Task.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Task.scala
@@ -177,7 +177,7 @@ class Task[+A](val get: Future[Throwable \/ A]) {
 
 object Task {
 
-  implicit val taskInstance = new Nondeterminism[Task] with Catchable[Task] {
+  implicit val taskInstance: Nondeterminism[Task] with Catchable[Task] = new Nondeterminism[Task] with Catchable[Task] {
     val F = Nondeterminism[Future]
     def point[A](a: => A) = new Task(Future.now(Try(a)))
     def bind[A,B](a: Task[A])(f: A => Task[B]): Task[B] =

--- a/iteratee/src/main/scala/scalaz/iteratee/Input.scala
+++ b/iteratee/src/main/scala/scalaz/iteratee/Input.scala
@@ -82,7 +82,7 @@ object Input extends InputFunctions with InputInstances {
 trait InputInstances {
   import Input._
 
-  implicit val input = new Traverse[Input] with MonadPlus[Input] with Each[Input] with Length[Input] {
+  implicit val input: Traverse[Input] with MonadPlus[Input] with Each[Input] with Length[Input] = new Traverse[Input] with MonadPlus[Input] with Each[Input] with Length[Input] {
      override def length[A](fa: Input[A]): Int = fa.fold(
        empty = 0
        , el = _ => 1
@@ -109,7 +109,7 @@ trait InputInstances {
      def empty[A]: Input[A] = emptyInput
    }
 
-   implicit def inputMonoid[A](implicit A: Monoid[A]) = new Monoid[Input[A]] {
+   implicit def inputMonoid[A](implicit A: Monoid[A]): Monoid[Input[A]] = new Monoid[Input[A]] {
      def append(a1: Input[A], a2: => Input[A]): Input[A] = a1.fold(
        empty = a2.fold(
          empty = emptyInput
@@ -127,7 +127,7 @@ trait InputInstances {
      def zero: Input[A] = emptyInput
    }
 
-   implicit def inputEqual[A](implicit A: Equal[A]) = new Equal[Input[A]] {
+   implicit def inputEqual[A](implicit A: Equal[A]): Equal[Input[A]] = new Equal[Input[A]] {
      def equal(a1: Input[A], a2: Input[A]): Boolean = a1.fold(
        empty = a2.isEmpty
        , el = a => a2.exists(z => A.equal(a, z))
@@ -135,7 +135,7 @@ trait InputInstances {
      )
    }
 
-   implicit def inputShow[A](implicit A: Show[A]) = new Show[Input[A]] {
+   implicit def inputShow[A](implicit A: Show[A]): Show[Input[A]] = new Show[Input[A]] {
      override def shows(f: Input[A]) = f.fold(
        empty = "empty-input"
        , el = a => "el-input(" + A.shows(a) + ")"


### PR DESCRIPTION
Explicit return types for type class instances for Future/Task/Input …
Works around a bug in Scala 2.10.3-RC1, which is will be fixed
shortly in https://github.com/scala/scala/pull/2860.

But it's a good practice to annotate these types in any case.

Will close #376.

Review by @larsrh 
