### PR TITLE
separate deprecated methods

### DIFF
--- a/core/src/main/scala/scalaz/syntax/IdOps.scala
+++ b/core/src/main/scala/scalaz/syntax/IdOps.scala
@@ -3,7 +3,22 @@ package syntax
 
 import annotation.tailrec
 
-final class IdOps[A](self: A) {
+final class IdOpsDeprecated[A](self: A) extends IdOps[A](self){
+
+  @deprecated("use scalaz.syntax.either._", "7.1")
+  def left[B]: (A \/ B) =
+    \/.left(self)
+
+  @deprecated("use scalaz.syntax.either._", "7.1")
+  def right[B]: (B \/ A) =
+    \/.right(self)
+
+  @deprecated("use scalaz.syntax.nel._", "7.1")
+  final def wrapNel: NonEmptyList[A] =
+    NonEmptyList(self)
+}
+
+sealed class IdOps[A](self: A) {
   /**Returns `self` if it is non-null, otherwise returns `d`. */
   final def ??(d: => A)(implicit ev: Null <:< A): A =
     if (self == null) d else self
@@ -25,18 +40,6 @@ final class IdOps[A](self: A) {
 
   final def squared: (A, A) =
     (self, self)
-
-  @deprecated("use scalaz.syntax.either._", "7.1")
-  def left[B]: (A \/ B) =
-    \/.left(self)
-
-  @deprecated("use scalaz.syntax.either._", "7.1")
-  def right[B]: (B \/ A) =
-    \/.right(self)
-
-  @deprecated("use scalaz.syntax.nel._", "7.1")
-  final def wrapNel: NonEmptyList[A] =
-    NonEmptyList(self)
 
   /**
    * @return the result of pf(value) if defined, otherwise the the Zero element of type B.
@@ -77,4 +80,8 @@ final class IdOps[A](self: A) {
 
 trait ToIdOps {
   implicit def ToIdOps[A](a: A): IdOps[A] = new IdOps(a)
+}
+
+trait ToIdOpsDeprecated {
+  implicit def ToIdOpsDeprecated[A](a: A): IdOpsDeprecated[A] = new IdOpsDeprecated(a)
 }

--- a/core/src/main/scala/scalaz/syntax/Syntax.scala
+++ b/core/src/main/scala/scalaz/syntax/Syntax.scala
@@ -108,7 +108,7 @@ trait Syntaxes {
   // Data
   //
 
-  object id extends ToIdOps
+  object id extends ToIdOpsDeprecated
 
   object tree extends ToTreeOps
 
@@ -142,10 +142,8 @@ trait ToDataOps
   with ToStateOps
   with ToValidationOps
   with ToKleisliOps
-  // TODO those are not yet included because of ambiguities when importing all syntax
-  // can be included again when the @deprecated methods are being removed
-  // with ToEitherOps
-  // with ToNelOps
+  with ToEitherOps
+  with ToNelOps
 
 trait ToTypeClassOps
   extends ToSemigroupOps with ToMonoidOps with ToEqualOps with ToLengthOps with ToShowOps


### PR DESCRIPTION
this changes does not break source compatibility,
and fix unnecesary deprecation warnings when using `import Scalaz._`
#### before

``` scala
scala> import scalaz._,Scalaz._
import scalaz._
import Scalaz._

scala> 1.wrapNel
warning: there were 1 deprecation warning(s); re-run with -deprecation for details
res0: scalaz.NonEmptyList[Int] = NonEmptyList(1)
```
#### after

``` scala
scala> import scalaz._,Scalaz._
import scalaz._
import Scalaz._

scala> 1.wrapNel
res0: scalaz.NonEmptyList[Int] = NonEmptyList(1) // no warnings
```
