### PR TITLE
Test binary compatibility with releases after 7.0.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ jdk:
   - oraclejdk7
   - openjdk6
 
-script: sbt ++$TRAVIS_SCALA_VERSION ';test;mima-report-binary-issues;set scalazMimaBasis in ThisBuild := "7.0.1";mima-report-binary-issues;set scalazMimaBasis in ThisBuild := "7.0.2";mima-report-binary-issues;set scalazMimaBasis in ThisBuild := "7.0.3";mima-report-binary-issues'
+script: sbt ++$TRAVIS_SCALA_VERSION ";test;mima-report-binary-issues"

--- a/project/build.scala
+++ b/project/build.scala
@@ -177,7 +177,6 @@ object build extends Build {
       ) map exclude[MissingMethodProblem]
     }
   ) ++ Seq[Sett](
-    scalazMimaBasis in ThisBuild := "7.0.0",
     previousArtifact <<= (organization, name, scalaBinaryVersion, scalazMimaBasis) { (o, n, sbv, bas) => Some(o % (n + "_" + sbv) % bas) }
   )
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,4 @@
 
 version in ThisBuild := "7.0.4-SNAPSHOT"
+
+scalazMimaBasis in ThisBuild := "7.0.3"


### PR DESCRIPTION
It's possible to introduce a change binary-incompatible with, say, 7.0.3, but not 7.0.0.  This change catches those too.

Assuming I'm guessing right about travis syntax.  It works great in Bash.
