### PR TITLE
Implementing the :<: (inject) type class

### DIFF
--- a/core/src/main/scala/scalaz/package.scala
+++ b/core/src/main/scala/scalaz/package.scala
@@ -271,8 +271,11 @@ package object scalaz {
     def apply[R, A](f: (A => R) => R): Cont[R, A] = IndexedContsT[Id, Id, R, R, A](f)
   }
 
-  /** [[scalaz.:<:]][F, G] */
-  type :≺:[F[_], G[_]] = F :<: G
+  /** [[scalaz.Inject]][F, G] */
+  type :<:[F[_], G[_]] = Inject[F, G]
+
+  /** [[scalaz.Inject]][F, G] */
+  type :≺:[F[_], G[_]] = Inject[F, G]
 
   @deprecated("Cojoin has been merged into Cobind", "7.1")
   type Cojoin[F[_]] = Cobind[F]

--- a/tests/src/test/scala/scalaz/InjectTest.scala
+++ b/tests/src/test/scala/scalaz/InjectTest.scala
@@ -1,7 +1,7 @@
 package scalaz
 
 import syntax.all._
-import :<:._, Free.Return
+import Inject._, Free.Return
 
 class InjectTest extends Spec {
   import std.AllInstances._
@@ -103,5 +103,15 @@ class InjectTest extends Spec {
       distr(test1[T](Seq("a")) >> test2[T](Seq("b")) >> test3[T](Seq("c")))
 
     (res == Some(Return[T, Int](3))) must be_===(true)
+  }
+
+  "apply in left" in {
+    val fa = Test1(Seq("a"), Return[Test1Algebra, Int](_))
+    (Inject[Test1Algebra, C0].inj(fa) == Coproduct(-\/(fa))) must be_===(true)
+  }
+
+  "apply in right" in {
+    val fa = Test2(Seq("a"), Return[Test2Algebra, Int](_))
+    (Inject[Test2Algebra, C0].inj(fa) == Coproduct(\/-(fa))) must be_===(true)
   }
 }


### PR DESCRIPTION
Please consider this request to add the `:<:` type class to Scalaz. If this is of interest to be included, I am happy to make any changes necessary to better accommodate the library.

Best,
 -Eric
