### PR TITLE
Correct issue with ==>>#union. Fixes #501

### DIFF
--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -523,8 +523,8 @@ sealed abstract class ==>>[A, B] {
         (l filterGt cmpLo).join(kx, x, r filterLt cmpHi)
       case (Bin(kx, x, l, r), t2) =>
         val cmpkx = (k: A) =>  o.order(kx, k)
-        val a = l.hedgeUnionL(cmpLo, cmpHi, t2.trim(cmpLo, cmpkx))
-        val b = r.hedgeUnionL(cmpLo, cmpHi, t2.trim(cmpkx, cmpHi))
+        val a = l.hedgeUnionL(cmpLo, cmpkx, t2.trim(cmpLo, cmpkx))
+        val b = r.hedgeUnionL(cmpkx, cmpHi, t2.trim(cmpkx, cmpHi))
         a.join(kx, x, b)
     }
 


### PR DESCRIPTION
Union was incorrectly using the wrong bounds as it descended down the internal tree. My mistake.

Thanks to @S11001001 for reporting, and to @xuwei-k for pointing out the error.

Signed-off-by: Gary Pamparà gpampara@gmail.com
