### PR TITLE
fix ImmutableArray#++

### DIFF
--- a/core/src/main/scala/scalaz/ImmutableArray.scala
+++ b/core/src/main/scala/scalaz/ImmutableArray.scala
@@ -25,7 +25,7 @@ sealed abstract class ImmutableArray[+A] {
   def copyToArray[B >: A](xs: Array[B], start: Int, len: Int)
   def slice(from: Int, until: Int): ImmutableArray[A]
 
-  def ++[B >: A](other: ImmutableArray[B]): ImmutableArray[A]
+  def ++[B >: A: ClassManifest](other: ImmutableArray[B]): ImmutableArray[B]
 }
 
 
@@ -111,10 +111,10 @@ object ImmutableArray extends ImmutableArrayFunctions {
     def slice(from: Int, until: Int) = fromArray(arr.slice(from, until))
 
     // TODO can do O(1) for primitives
-    override def ++[B >: A](other: ImmutableArray[B]) = {
-      val newArr = elemManifest.newArray(length + other.length)
+    override def ++[B >: A: ClassManifest](other: ImmutableArray[B]) = {
+      val newArr = new Array(length + other.length)
       this.copyToArray(newArr, 0, length)
-      other.copyToArray(newArr.asInstanceOf[Array[B]], length, other.length)
+      other.copyToArray(newArr, length, other.length)
       fromArray(newArr)
     }
   }
@@ -174,13 +174,13 @@ object ImmutableArray extends ImmutableArrayFunctions {
 
     def slice(from: Int, until: Int) = new StringArray(str.slice(from, until))
 
-    def ++[B >: Char](other: ImmutableArray[B]) =
+    def ++[B >: Char: ClassManifest](other: ImmutableArray[B]) =
       other match {
         case other: StringArray => new StringArray(str + other.str)
         case _ => {
-          val newArr = new Array[Char](length + other.length)
+          val newArr = new Array[B](length + other.length)
           this.copyToArray(newArr, 0, length)
-          other.copyToArray(newArr.asInstanceOf[Array[B]], length, other.length)
+          other.copyToArray(newArr, length, other.length)
           fromArray(newArr)
         }
       }


### PR DESCRIPTION
`ClassCastException` when different element type

``` scala
scala> scalaz.ImmutableArray.fromArray(Array(1))
res0: scalaz.ImmutableArray[Int] = scalaz.ImmutableArrayFunctions$ofInt@4b95b26

scala> scalaz.ImmutableArray.fromArray(Array("a"))
res1: scalaz.ImmutableArray[String] = scalaz.ImmutableArrayFunctions$ofRef@5facd7f

scala> res0 ++ res1
java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Integer
        at scala.runtime.BoxesRunTime.unboxToInt(BoxesRunTime.java:106)
        at scala.runtime.ScalaRunTime$.array_update(ScalaRunTime.scala:95)
        at scala.Array$.slowcopy(Array.scala:81)
        at scala.Array$.copy(Array.scala:107)
        at scala.collection.mutable.ArrayOps$class.copyToArray(ArrayOps.scala:44)
        at scala.collection.mutable.ArrayOps$ofRef.copyToArray(ArrayOps.scala:108)
        at scalaz.ImmutableArrayFunctions$ImmutableArray1.copyToArray(ImmutableArray.scala:106)
        at scalaz.ImmutableArrayFunctions$ImmutableArray1.$plus$plus(ImmutableArray.scala:114)
```
