### PR TITLE
fix EitherRightEqual, EitherLeftEqual

### DIFF
--- a/core/src/main/scala/scalaz/std/Either.scala
+++ b/core/src/main/scala/scalaz/std/Either.scala
@@ -292,7 +292,6 @@ private trait EitherRightEqual[X, A] extends Equal[RightProjection[X, A]] {
     case (None, None)       => true
     case _                  => false
   }
-  override val equalIsNatural: Boolean = A.equalIsNatural
 }
 
 private trait EitherLeftEqual[A, X] extends Equal[LeftProjection[A, X]] {
@@ -303,7 +302,6 @@ private trait EitherLeftEqual[A, X] extends Equal[LeftProjection[A, X]] {
     case (None, None)       => true
     case _                  => false
   }
-  override val equalIsNatural: Boolean = A.equalIsNatural
 }
 
 private trait EitherEqual[A, B] extends Equal[Either[A, B]] {


### PR DESCRIPTION
does not satisfy the [`naturality law`](https://github.com/scalaz/scalaz/blob/v7.1.0-M2/core/src/main/scala/scalaz/Equal.scala#L30)

``` scala
scala> import scalaz._,Scalaz._
import scalaz._
import Scalaz._

scala> scalaz.std.either.eitherRightEqual[Int, String]
res0: scalaz.Equal[Either.RightProjection[Int,String]] = scalaz.std.EitherInstances0$$anon$39@34a266b5

scala> val e1 = Left[Int,String](1).right
e1: scala.util.Either.RightProjection[Int,String] = RightProjection(Left(1))

scala> val e2 = Left[Int,String](2).right
e2: scala.util.Either.RightProjection[Int,String] = RightProjection(Left(2))

scala> e1 == e2
res1: Boolean = false

scala> res0.equal(e1, e2)
res2: Boolean = true

scala> res0.equalLaw.naturality(e1, e2)
res3: Boolean = false                                 
```
