### PR TITLE
optimize NonEmptyList#traverse1. avoid stack overflow

### DIFF
--- a/core/src/main/scala/scalaz/NonEmptyList.scala
+++ b/core/src/main/scala/scalaz/NonEmptyList.scala
@@ -42,10 +42,13 @@ final class NonEmptyList[+A] private[scalaz](val head: A, val tail: List[A]) {
     nel(bb.head, bb.tail)
   }
 
-  def traverse1[F[_], B](f: A => F[B])(implicit F: Apply[F]): F[NonEmptyList[B]] = tail match {
-    case Nil => F.map(f(head))(nel(_, Nil))
-    case b :: bs => F.apply2(f(head), nel(b, bs).traverse1(f)) {
-      case (h, t) => nel(h, t.head :: t.tail)
+  def traverse1[F[_], B](f: A => F[B])(implicit F: Apply[F]): F[NonEmptyList[B]] = {
+    import std.list._
+    tail match {
+      case Nil => F.map(f(head))(nel(_, Nil))
+      case b :: bs => F.apply2(f(head), OneAnd.oneAndTraverse[List].traverse1(OneAnd(b, bs))(f)) {
+        case (h, t) => nel(h, t.head :: t.tail)
+      }
     }
   }
 

--- a/tests/src/test/scala/scalaz/NonEmptyListTest.scala
+++ b/tests/src/test/scala/scalaz/NonEmptyListTest.scala
@@ -42,4 +42,9 @@ class NonEmptyListTest extends Spec {
     import syntax.foldable1._
     nel(0, List.fill(10000000)(1)).foldRight1(_ + _) must_== 10000000
   }
+  "no stack overflow large list traverse" in {
+    import syntax.traverse._
+    val largeNel = NonEmptyList.nel(0, (1 to 100000).toList)
+    (largeNel map Option.apply).sequence must be_===(Option(largeNel))
+  }
 }


### PR DESCRIPTION
`scalaz.OneAnd` is so useful :)
