### PR TITLE
Syntax support for scala.Either[A,B] => Validation[A,B]

### DIFF
--- a/core/src/main/scala/scalaz/syntax/std/EitherOps.scala
+++ b/core/src/main/scala/scalaz/syntax/std/EitherOps.scala
@@ -5,6 +5,8 @@ package std
 final class EitherOps[A, B](self: Either[A, B]) {
 
   final def disjunction: A \/ B = \/ fromEither self
+
+  final def validation: Validation[A, B] = Validation fromEither self
 }
 
 trait ToEitherOps {


### PR DESCRIPTION
Found this nicer then `Validation fromEither e` or `e.disjunction.validation`
