### PR TITLE
Unapply version of traverse_

### DIFF
--- a/core/src/main/scala/scalaz/Foldable.scala
+++ b/core/src/main/scala/scalaz/Foldable.scala
@@ -64,6 +64,10 @@ trait Foldable[F[_]]  { self =>
   def traverse_[M[_], A, B](fa: F[A])(f: A => M[B])(implicit a: Applicative[M]): M[Unit] =
     foldLeft(fa, a.pure(()))((x, y) => a.ap(f(y))(a.map(x)(_ => _ => ())))
 
+  /** A version of `traverse_` that infers the type constructor `M`. */
+  final def traverseU_[A, GB](fa: F[A])(f: A => GB)(implicit G: Unapply[Applicative, GB]): G.M[Unit] =
+    traverse_[G.M, A, G.A](fa)(G.leibniz.subst[({type λ[α] = A => α})#λ](f))(G.TC)
+
   /** `traverse_` specialized to `State` **/
   def traverseS_[S, A, B](fa: F[A])(f: A => State[S, B]): State[S, Unit] =
     traverse_[({type λ[α]=State[S, α]})#λ, A, B](fa)(f)

--- a/core/src/main/scala/scalaz/syntax/FoldableSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/FoldableSyntax.scala
@@ -57,6 +57,8 @@ final class FoldableOps[F[_],A] private[syntax](val self: F[A])(implicit val F: 
   final def concatenate(implicit A: Monoid[A]): A = F.fold(self)
   final def intercalate(a: A)(implicit A: Monoid[A]): A = F.intercalate(self, a)
   final def traverse_[M[_]:Applicative](f: A => M[Unit]): M[Unit] = F.traverse_(self)(f)
+  final def traverseU_[GB](f: A => GB)(implicit G: Unapply[Applicative, GB]): G.M[Unit] =
+    F.traverseU_[A, GB](self)(f)(G)
   final def traverseS_[S, B](f: A => State[S, B]): State[S, Unit] = F.traverseS_(self)(f)
   final def sequence_[G[_], B](implicit ev: A === G[B], G: Applicative[G]): G[Unit] = F.sequence_(ev.subst[F](self))(G)
   final def sequenceS_[S, B](implicit ev: A === State[S,B]): State[S,Unit] = F.sequenceS_(ev.subst[F](self))


### PR DESCRIPTION
This is a version of `traverse_` which uses `Unapply` to infer the type constructor in the result.

I've found this useful when working with effects in `ST` and `Free`, for example.
