### PR TITLE
Prevent an unnecessary allocation on Either.getOrElse

### DIFF
--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -169,7 +169,10 @@ sealed abstract class \/[+A, +B] extends Product with Serializable {
 
   /** Return the right value of this disjunction or the given default if left. Alias for `|` */
   def getOrElse[BB >: B](x: => BB): BB =
-    toOption getOrElse x
+    this match {
+      case -\/(_) => x
+      case \/-(b) => b
+    }
 
   /** Return the right value of this disjunction or the given default if left. Alias for `getOrElse` */
   def |[BB >: B](x: => BB): BB =


### PR DESCRIPTION
Not a big deal but `\/-.getOrElse` was creating a new `Some` only to throw it away immediately.
