### PR TITLE
Make Task's map and flatMap exception-safe

### DIFF
--- a/tests/src/test/scala/scalaz/concurrent/TaskTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/TaskTest.scala
@@ -48,6 +48,36 @@ class TaskTest extends Spec with AnyMatchers {
     -\/(FailWhale)
   }
 
+  "catches exceptions in a mapped function" ! check {
+    Task { Thread.sleep(10); 42 }.map(_ => throw FailWhale).attemptRun ==
+    -\/(FailWhale)
+  }
+
+  "catches exceptions in a mapped function, created by delay" ! check {
+    Task.delay { Thread.sleep(10); 42 }.map(_ => throw FailWhale).attemptRun ==
+    -\/(FailWhale)
+  }
+
+  "catches exceptions in a mapped function, created with now" ! check {
+    Task.now { Thread.sleep(10); 42 }.map(_ => throw FailWhale).attemptRun ==
+    -\/(FailWhale)
+  }
+
+  "catches exceptions in a flatMapped function" ! check {
+    Task { Thread.sleep(10); 42 }.flatMap(_ => throw FailWhale).attemptRun ==
+    -\/(FailWhale)
+  }
+
+  "catches exceptions in a flatMapped function, created with delay" ! check {
+    Task.delay { Thread.sleep(10); 42 }.flatMap(_ => throw FailWhale).attemptRun ==
+    -\/(FailWhale)
+  }
+
+  "catches exceptions in a flatMapped function, created with now" ! check {
+    Task.now { Thread.sleep(10); 42 }.flatMap(_ => throw FailWhale).attemptRun ==
+    -\/(FailWhale)
+  }
+
   "catches exceptions in parallel execution" ! prop { (x: Int, y: Int) =>
     val t1 = Task { Thread.sleep(10); throw FailWhale; 42 }
     val t2 = Task { 43 }


### PR DESCRIPTION
If a function passed into map or flatMap throws an exception,
this is now converted into a returned exception.

Tests check that this works for tasks created by Task.apply,
delay, and now. Note that the failing case for these tests is
that they never terminate. Before this change, throwing an
exception causes thread termination, and another thread waits
on it forever.

This resolves #573
