### PR TITLE
Prevent an unnecessary allocation in Validation.getOrElse

### DIFF
--- a/core/src/main/scala/scalaz/Validation.scala
+++ b/core/src/main/scala/scalaz/Validation.scala
@@ -195,7 +195,10 @@ sealed abstract class Validation[+E, +A] extends Product with Serializable {
 
   /** Return the success value of this validation or the given default if failure. Alias for `|` */
   def getOrElse[AA >: A](x: => AA): AA =
-    toOption getOrElse x
+    this match {
+      case Failure(_) => x
+      case Success(a) => a
+    }
 
   /** Return the success value of this validation or the given default if failure. Alias for `getOrElse` */
   def |[AA >: A](x: => AA): AA =


### PR DESCRIPTION
Instance of `Some` being created only to be thrown away.
