### PR TITLE
Squish `Unapply` implicitNotFound msg into 1 line. #555

### DIFF
--- a/core/src/main/scala/scalaz/Unapply.scala
+++ b/core/src/main/scala/scalaz/Unapply.scala
@@ -49,11 +49,7 @@ import Leibniz.{===, refl}
  *
  * Credits to Miles Sabin.
  */
-@implicitNotFound(
-"""Unable to unapply type `${MA}` into a type constructor of kind `M[_]` that is classified by the type class `${TC}`
-1) Check that the type class is defined by compiling `implicitly[${TC}[<type constructor>]]`.
-2) Review the implicits in object Unapply, which only cover common type 'shapes'
-(implicit not found: scalaz.Unapply[${TC}, ${MA}])""")
+@implicitNotFound("Implicit not found: scalaz.Unapply[${TC}, ${MA}]. Unable to unapply type `${MA}` into a type constructor of kind `M[_]` that is classified by the type class `${TC}`. Check that the type class is defined by compiling `implicitly[${TC}[type constructor]]` and review the implicits in object Unapply, which only cover common type 'shapes.'")
 trait Unapply[TC[_[_]], MA] {
 
   /** The type constructor */


### PR DESCRIPTION
I hit this issue when trying to generate a
[Kapeli Dash](http://kapeli.com/dash) docset for Scalaz
using [this](https://bitbucket.org/inkytonik/mkscaladocset).

Issue: [Scaladoc generation](https://github.com/scalaz/scalaz/issues/555#issuecomment-25765209) first checks to see if the
message is >= 36 characters long - if so, instead of
showing a big whopping message in the HTML it shoves
it into a tag attribute instead with the motivation being
you can hover your mouse over it to read the full message.

However, the generation process will also replace any
newlines with the HTML newline, `<br />`. When it goes
to turn `Unapply`'s `implicitNotFound` message (which is

> = 36 characters long _and_ multi-line) it translates
> the end of each line into `<br />`, then puts it into a
> tag attribute. As far as I know, angle brackets are not
> allowed in HTML tag attributes, but Scaladoc generation
> will gladly generate it anyways.

My proposed solution is simply - squash it all down into
one line.
