### PR TITLE
Task: Catch Throwable, not just Exception

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Task.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Task.scala
@@ -306,6 +306,6 @@ object Task {
 
   /** Utility function - evaluate `a` and catch and return any exceptions. */
   def Try[A](a: => A): Throwable \/ A =
-    try \/-(a) catch { case e: Exception => -\/(e) }
+    try \/-(a) catch { case e: Throwable => -\/(e) }
 }
 

--- a/tests/src/test/scala/scalaz/concurrent/TaskTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/TaskTest.scala
@@ -42,9 +42,18 @@ object TaskTest extends SpecLite {
     override def fillInStackTrace = this
   }
 
+  case object FailTurkey extends Error {
+    override def fillInStackTrace = this
+  }
+
   "catches exceptions" ! {
     Task { Thread.sleep(10); throw FailWhale; 42 }.map(_ + 1).attemptRun ==
     -\/(FailWhale)
+  }
+
+  "catches errors" ! {
+    Task { Thread.sleep(10); throw FailTurkey; 42 }.map(_ + 1).attemptRun ==
+    -\/(FailTurkey)
   }
 
   "catches exceptions in a mapped function" ! {


### PR DESCRIPTION
Task.Try catches Exception, but not Throwable.
The consequence is that when trampolining, if a Throwable pops up then the thread dies and the program never terminates.

It's a good rule of thumb to never catch Throwable, but this is an exception. If the intention of "Don't catch Throwable" is "Let the program die", then it is more useful to wrap the Throwable, give it back to the other thread, and throw it again there. 
As it is, the contents of the Throwable are lost in the aether of the dying thread, never to be diagnosed.

Paul says:  it should catch all Throwables, that is a bug. It's up to the consumer of `Task` to rethrow any non-Exception Throwables if that's the behavior they want. 

from discussion:
https://groups.google.com/forum/#!topic/scalaz/D3ZyY1Xu_PQ
