### PR TITLE
Improve IterateeTTest for fold in constant stack space

### DIFF
--- a/tests/src/test/scala/scalaz/iteratee/IterateeTTest.scala
+++ b/tests/src/test/scala/scalaz/iteratee/IterateeTTest.scala
@@ -2,6 +2,7 @@ package scalaz
 package iteratee
 
 import std.AllInstances._
+import Free.Trampoline
 import Iteratee._
 import effect._
 import Id._
@@ -16,10 +17,11 @@ object IterateeTTest extends SpecLite {
     (consume[Int, Id, List] &= enumStream(Stream(1, 2, 3))).run must_===(List(1, 2, 3))
   }
 
-//  "fold in constant stack space" in {
-//    skipped("TODO")
-//    (fold[Int, Id, Int](0){ case (a,v) => a + v } &= enumStream[Int, Id](Stream.fill(10000)(1))).run must_===(10000)
-//  }
+  "fold in constant stack space" in {
+    val iter = fold[Int, Id, Int](0){ case (a,v) => a + v }.up[Trampoline]
+    val enum = enumStream[Int, Trampoline](Stream.fill(10000)(1))
+    (iter &= enum).run.run must_===(10000)
+  }
 
   object instances {
     object iterateet {


### PR DESCRIPTION
This test was disabled 2 years ago.
I don't think something will change in implementation of fold itself, so it would be nice to delete that test completely or change it to demonstrate how to use fold in constant stack space using trampolines.
I believe second approach is better because I seen people having this problem before, and it would be nice to document solution somewhere.
