### PR TITLE
`apply` methods for Unapply companion & friends.

### DIFF
--- a/core/src/main/scala/scalaz/Unapply.scala
+++ b/core/src/main/scala/scalaz/Unapply.scala
@@ -227,6 +227,12 @@ sealed trait Unapply_0 extends Unapply_1 {
 }
 
 object Unapply extends Unapply_0 {
+  /** Fetch a well-typed `Unapply` for the given typeclass and type. */
+  def apply[TC[_[_]], MA](implicit U: Unapply[TC, MA]): U.type {
+    type M[A] = U.M[A]
+    type A = U.A
+  } = U
+
   /** Unpack a value of type `M0[A0]` into types `M0` and `A0`, given a instance of `TC` */
   implicit def unapplyMA[TC[_[_]], M0[_], A0](implicit TC0: TC[M0]): Unapply[TC, M0[A0]] {
     type M[X] = M0[X]
@@ -278,6 +284,13 @@ sealed trait Unapply2_0 {
 }
 
 object Unapply2 extends Unapply2_0 {
+  /** Fetch a well-typed `Unapply2` for the given typeclass and type. */
+  def apply[TC[_[_, _]], MAB](implicit U: Unapply2[TC, MAB]): U.type {
+    type M[X, Y] = U.M[X, Y]
+    type A = U.A
+    type B = U.B
+  } = U
+
   /**Unpack a value of type `M0[A0, B0]` into types `M0`, `A`, and 'B', given an instance of `TC` */
   implicit def unapplyMAB[TC[_[_, _]], M0[_, _], A0, B0](implicit TC0: TC[M0]): Unapply2[TC, M0[A0, B0]] {
     type M[X, Y] = M0[X, Y]
@@ -303,6 +316,13 @@ trait Unapply21[TC[_[_, _], _], MAB]{
 }
 
 object Unapply21 {
+  /** Fetch a well-typed `Unapply21` for the given typeclass and type. */
+  def apply[TC[_[_, _], _], MAB](implicit U: Unapply21[TC, MAB]): U.type {
+    type M[X, Y] = U.M[X, Y]
+    type A = U.A
+    type B = U.B
+  } = U
+
   implicit def unapply210MFABC[TC[_[_, _], _], F[_,_], M0[_[_], _, _], A0, B0, C](implicit TC0: TC[({type f[a, b] = M0[({type m[x] = F[a, x]})#m, C, b]})#f, A0]): Unapply21[TC, M0[({type f[x] = F[A0, x]})#f, C, B0]]{
     type M[X, Y] = M0[({type f[a] = F[X, a]})#f, C, Y]
     type A = A0

--- a/tests/src/test/scala/scalaz/UnapplyTest.scala
+++ b/tests/src/test/scala/scalaz/UnapplyTest.scala
@@ -1,0 +1,29 @@
+package scalaz
+
+import Leibniz.===
+
+import org.scalacheck.{Prop, Gen}
+import org.scalacheck.Prop.forAll
+
+object UnapplyTest extends SpecLite {
+  object unapply {
+    val ue = Unapply[Monad, Int \/ String]
+    def mequiv[A] = implicitly[ue.M[A] === (Int \/ A)]
+      implicitly[ue.A === String]
+
+    // needs only transient stable type
+    Unapply[Monad, Int \/ String].TC : Monad[({type λ[α] = Int \/ α})#λ]
+  }
+
+  object unapply2 {
+    import std.function._
+    val ue = Unapply2[Arrow, Kleisli[NonEmptyList, Int, String]]
+    def mequiv[A,B] = implicitly[ue.M[A,B] === Kleisli[NonEmptyList, A, B]]
+    implicitly[ue.A === Int]
+    implicitly[ue.B === String]
+
+    // needs only transient stable type
+    Unapply2[Arrow, Kleisli[NonEmptyList, Int, String]].TC
+        : Arrow[({type λ[α,β] = Kleisli[NonEmptyList, α, β]})#λ]
+  }
+}


### PR DESCRIPTION
A fun REPL toy for discovering instances & avoiding type lambdas.

``` scala
scala> Unapply[Monad, EitherT[NonEmptyList, Int, String]]
res0: U.type{type M[A] = scalaz.EitherT[scalaz.NonEmptyList,Int,A]; type A = String} = scalaz.Unapply_2$$anon$5@2609c830

scala> Unapply[Monad, EitherT[NonEmptyList, Int, String]].TC.point(42)
res1: scalaz.EitherT[scalaz.NonEmptyList,Int,Int] = EitherT(NonEmptyList(\/-(42)))
```

I would think `U.type` would be a sufficient result type for the methods, but that's not how it works out, for whatever reason.
