### PR TITLE
Strategy.DefaultExecutorService creates threads as if they're each in a different pool

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Strategy.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Strategy.scala
@@ -23,8 +23,8 @@ trait Strategys extends StrategysLow {
    * where N is equal to the number of available processors.
    */
   val DefaultExecutorService: ExecutorService = {
-    import Executors._
-    newFixedThreadPool(Runtime.getRuntime.availableProcessors, new ThreadFactory {
+    Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors, new ThreadFactory {
+      val defaultThreadFactory = Executors.defaultThreadFactory()
       def newThread(r: Runnable) = {
         val t = defaultThreadFactory.newThread(r)
         t.setDaemon(true)
@@ -34,7 +34,7 @@ trait Strategys extends StrategysLow {
   }
 
   /**
-   * Default scheduler used for scheduling the tasks like timeout. 
+   * Default scheduler used for scheduling the tasks like timeout.
    */
   val DefaultTimeoutScheduler: ScheduledExecutorService =  Executors.newScheduledThreadPool(1)
 


### PR DESCRIPTION
The previous Strategy.DefaultExecutorService asked for a new thread
factory for each new thread created. The result was threads with names
like (on a 4-cpu machine)
pool-6-thread-1
pool-7-thread-1
pool-8-thread-1
pool-9-thread-1
This change saves one defaultThreadFactory and reuses it for thread
creation, so that the threads come out named
pool-6-thread-1
pool-6-thread-2
pool-6-thread-3
pool-6-thread-4
This makes debugging easier, because one can see which threads are
grouped into the same pool.
