### PR TITLE
Account for tighter definition of private in Scala 2.11.0-SNAPSHOT

### DIFF
--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -370,7 +370,7 @@ sealed abstract class ==>>[A, B] {
         (r._1._2, r._2).some
     }
 
-  private def merge(other: A ==>> B): A ==>> B =
+  protected def merge(other: A ==>> B): A ==>> B =
     (this, other) match {
       case (Tip(), r) =>
         r
@@ -841,7 +841,7 @@ sealed abstract class ==>>[A, B] {
         }
     }
 
-  private def join(kx: A, x: B, other: A ==>> B)(implicit o: Order[A]): A ==>> B =
+  protected def join(kx: A, x: B, other: A ==>> B)(implicit o: Order[A]): A ==>> B =
     (this, other) match {
       case (Tip(), r) =>
         r.insertMin(kx, x)


### PR DESCRIPTION
SI-7475 fixed a hole in the the compiler, which does not allow:

```
class C {
  private def foo: Any = 0
  def test(d: D) = d.foo
}

class D extends C
```

This was in line with:

> The private modifier can be used with any definition or declaration
> in a template. Such members can be accessed only from within the
> directly enclosing template and its companion module or companion
> class (§5.4). They are not inherited by subclasses,

Two choices here to comply: we could either ascribe to `==>[A, B]`,
which does have the member, or make it protected so it will be a
member of the subclass. I chose the latter in this commit.

Review by @larsrh
