### PR TITLE
Add `dimap` to Profunctor

### DIFF
--- a/core/src/main/scala/scalaz/Profunctor.scala
+++ b/core/src/main/scala/scalaz/Profunctor.scala
@@ -13,6 +13,10 @@ trait Profunctor[=>:[_, _]]  { self =>
   /** Functor map on `B`. */
   def mapsnd[A, B, C](fab: (A =>: B))(f: B => C): (A =>: C)
 
+  /** Functor map on `A` and `B`. */
+  def dimap[A, B, C, D](fab: (A =>: B))(f: C => A)(g: B => D): (C =>: D) =
+    mapsnd(mapfst(fab)(f))(g)
+
   protected[this] trait SndCovariant[C] extends Functor[({type λ[α] = C =>: α})#λ] {
     override def map[A, B](fa: C =>: A)(f: A => B) = mapsnd(fa)(f)
   }

--- a/core/src/main/scala/scalaz/syntax/ProfunctorSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/ProfunctorSyntax.scala
@@ -17,6 +17,9 @@ final class ProfunctorOps[F[_, _],A, B] private[syntax](val self: F[A, B])(impli
   final def mapsnd[C](f: B => C): F[A, C] =
     F.mapsnd(self)(f)
 
+  final def dimap[C, D](f: C => A, g: B => D): F[C, D] =
+    F.dimap(self)(f)(g)
+
   ////
 }
 


### PR DESCRIPTION
Example:

```
scala> val example = (((_: Int) + 1) dimap ((_: MyInt).a, MyInt))(MyInt(100))
example: MyInt = MyInt(101)
```
