### PR TITLE
implement apply method for Writer compatible to WriterT

### DIFF
--- a/core/src/main/scala/scalaz/package.scala
+++ b/core/src/main/scala/scalaz/package.scala
@@ -124,6 +124,7 @@ package object scalaz {
 
   object Writer {
     def apply[W, A](w: W, a: A): WriterT[Id, W, A] = WriterT[Id, W, A]((w, a))
+    def apply[W, A](wa: (W, A)): WriterT[Id, W, A] = WriterT[Id, W,A](wa)
   }
 
   object Unwriter {


### PR DESCRIPTION
apply in WriterT takes a tuple whereas apply in Writer takes two parameters.
Added apply(wa:(W,A)) in Writer to have more compatibility.
