### PR TITLE
Add explicit return types for {Y,Coy}oneda.apply

### DIFF
--- a/core/src/main/scala/scalaz/Coyoneda.scala
+++ b/core/src/main/scala/scalaz/Coyoneda.scala
@@ -46,7 +46,7 @@ abstract class Coyoneda[F[_], A] { coyo =>
 object Coyoneda extends CoyonedaInstances {
 
   /** `F[A]` converts to `Coyoneda[F,A]` for any `F` */
-  def apply[F[_],A](fa: F[A]) = new Coyoneda[F,A] {
+  def apply[F[_],A](fa: F[A]): Coyoneda[F, A] = new Coyoneda[F, A] {
     type I = A
     def k(a: A) = a
     val fi = fa

--- a/core/src/main/scala/scalaz/Yoneda.scala
+++ b/core/src/main/scala/scalaz/Yoneda.scala
@@ -41,7 +41,7 @@ object Yoneda {
     }
 
   /** `F[A]` converts to `Yoneda[F,A]` for any functor `F` */
-  def apply[F[_]:Functor,A](fa: F[A]) = new Yoneda[F,A] {
+  def apply[F[_]:Functor,A](fa: F[A]): Yoneda[F, A] = new Yoneda[F, A] {
     def apply[B](f: A => B) = Functor[F].map(fa)(f)
   }
 


### PR DESCRIPTION
Before this patch: :hurtrealbad: 

```
scala> import scalaz._, Scalaz._
import scalaz._
import Scalaz._

scala> Free.liftFU(Coyoneda(Set(4)))
<console>:14: error: Implicit not found: scalaz.Unapply[scalaz.Functor, scalaz.Coyoneda[scala.collection.immutable.Set,Int]{type I = Int; val fi: scala.collection.immutable.Set[Int]}]. Unable to unapply type `scalaz.Coyoneda[scala.collection.immutable.Set,Int]{type I = Int; val fi: scala.collection.immutable.Set[Int]}` into a type constructor of kind `M[_]` that is classified by the type class `scalaz.Functor`. Check that the type class is defined by compiling `implicitly[scalaz.Functor[type constructor]]` and review the implicits in object Unapply, which only cover common type 'shapes.'
              Free.liftFU(Coyoneda(Set(4)))
                         ^
```

After this patch: :hibiscus: 

```
scala> import scalaz._, Scalaz._
import scalaz._
import Scalaz._

scala> Free.liftFU(Coyoneda(Set(4)))
res0: scalaz.Free[scalaz.Unapply[scalaz.Functor,scalaz.Coyoneda[scala.collection.immutable.Set,Int]]{type M[X] = scalaz.Coyoneda[scala.collection.immutable.Set,X]; type A = Int}#M,Int] = Suspend(scalaz.Coyoneda$$anon$21@b016515)
```
