### PR TITLE
Remove utilM overloading

### DIFF
--- a/core/src/main/scala/scalaz/syntax/MonadSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadSyntax.scala
@@ -13,7 +13,7 @@ final class MonadOps[F[_],A] private[syntax](val self: F[A])(implicit val F: Mon
 
   def untilM[G[_]](p: => F[Boolean])(implicit G: MonadPlus[G]): F[G[A]] = F.untilM(self, p)
 
-  def untilM(p: => F[Boolean]): F[Unit] = F.untilM_(self, p)
+  def untilM_(p: => F[Boolean]): F[Unit] = F.untilM_(self, p)
 
   def iterateWhile(p: A => Boolean): F[A] = F.iterateWhile(self)(p)
 


### PR DESCRIPTION
Looks like it should be utilM_ instead. I didn't hit any problems with
this, just noticed that it was very strange to be overloading on whether
an implicit was found.
