### PR TITLE
Tidying up Foldable.collapse

### DIFF
--- a/core/src/main/scala/scalaz/Foldable.scala
+++ b/core/src/main/scala/scalaz/Foldable.scala
@@ -243,8 +243,8 @@ trait Foldable[F[_]]  { self =>
       }
     })._1
 
-  def collapse[X[_], A](x: F[A])(implicit F: Foldable[F], A: ApplicativePlus[X]): X[A] =
-    F.foldRight(x, A.empty[A])((a, b) => A.plus(A.point(a), b))
+  def collapse[X[_], A](x: F[A])(implicit A: ApplicativePlus[X]): X[A] =
+    foldRight(x, A.empty[A])((a, b) => A.plus(A.point(a), b))
 
   trait FoldableLaw {
     import std.vector._


### PR DESCRIPTION
This PR removes `Foldable.collapse{2-7}` in favor of clients calling collapse on composed Foldables themselves. It also removes the unnecessary requirement of implicit Foldable evidence from the signature of `Foldable.collapse`.
