### PR TITLE
Add getOrAdd to Map

### DIFF
--- a/core/src/main/scala/scalaz/std/Map.scala
+++ b/core/src/main/scala/scalaz/std/Map.scala
@@ -194,6 +194,12 @@ trait MapSubFunctions extends MapSub {
     */
   final def insertWith[K:BuildKeyConstraint,A](m1: XMap[K, A], k: K, v: A)(f: (A, A) => A): XMap[K, A] =
     if(m1 contains k) ab_+(m1, k, f(m1(k), v)) else ab_+(m1, k, v)
+
+  /** Grab a value out of Map if it's present. Otherwise evaluate
+    * a value to be placed at that key in the Map.
+    */
+  final def getOrAdd[F[_],K,A](m: XMap[K, A], k: K)(fa: => F[A])(implicit F: Applicative[F], K: BuildKeyConstraint[K]): F[(XMap[K, A], A)] =
+    (m get k).map(a => F.point(m, a)).getOrElse(F.map(fa)(a => (ab_+(m, k, a), a)))
 }
 
 trait MapInstances extends MapSubInstances with MapSubMap

--- a/core/src/main/scala/scalaz/syntax/std/MapOps.scala
+++ b/core/src/main/scala/scalaz/syntax/std/MapOps.scala
@@ -14,6 +14,7 @@ final class MapOps[Map[_, _], BKC[_], K, A](self: Map[K, A])
   final def unionWithKey(m: Map[K, A])(f: (K, A, A) => A)(implicit bk: BKC[K]): Map[K, A] = dict.unionWithKey(self, m)(f)
   final def unionWith(m: Map[K, A])(f: (A, A) => A)(implicit bk: BKC[K]): Map[K, A] = dict.unionWith(self, m)(f)
   final def insertWith(k: K, v: A)(f: (A, A) => A)(implicit bk: BKC[K]): Map[K, A] = dict.insertWith(self, k, v)(f)
+  final def getOrAdd[F[_]](k: K)(fa: => F[A])(implicit F: Applicative[F], bk: BKC[K]): F[(Map[K, A], A)] = dict.getOrAdd(self, k)(fa)
 }
 
 trait ToMapOps {

--- a/tests/src/test/scala/scalaz/std/MapTest.scala
+++ b/tests/src/test/scala/scalaz/std/MapTest.scala
@@ -74,6 +74,25 @@ abstract class XMapTest[Map[K, V] <: SMap[K, V] with MapLike[K, V, Map[K, V]], B
     x.filter(_._2.isThis) must_=== F.map(a.filter{case (k, _) => ! keysB(k)})(This(_))
     x.filter(_._2.isThat) must_=== F.map(b.filter{case (k, _) => ! keysA(k)})(That(_))
   }
+
+  "getOrAdd" ! forAll { (m0: Map[Int, Long], k: Int, vOld: Long, vNew: Long) =>
+    import std.tuple._, std.anyVal._, std.map._
+
+    val mWithout = m0 - k
+    val mWithOld = m0 + (k -> vOld)
+    val mWithNew = m0 + (k -> vNew)
+
+    // not already in map
+    getOrAdd[Id.Id, Int, Long](mWithout, k)(vNew) must_=== (mWithNew, vNew)
+
+    // already in map
+    getOrAdd[Id.Id, Int, Long](mWithOld, k)(vNew) must_=== (mWithOld, vOld)
+
+    // lazy
+    var evaluated = false
+    getOrAdd[Id.Id, Int, Long](mWithOld, k)({evaluated = true; vNew}) must_=== (mWithOld, vOld)
+    evaluated must_=== false
+  }
 }
 
 private object DIContravariant extends Contravariant[({type λ[α] = DummyImplicit})#λ] {


### PR DESCRIPTION
This seemed useful when using a State with a Map for memoization. It's possible there's a more elegant solution that I wasn't aware of.

If there's interest, I could also add this to `==>>` and/or `InsertionMap`.
