### PR TITLE
update sbt 0.13.2 and sbt plugins versions

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,11 @@
 scalacOptions += "-deprecation"
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.2")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.7.1")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.3")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.6.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.7.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.2.5")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.3.1")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.2.0")


### PR DESCRIPTION
sbt 0.13.2 has been released.
Let's bump up version!
But I didn't update `sbt-unidoc` plugin.
`sbt-unidoc` plugin 0.3.0 contains breaking changes as follows:

> String-based **excludedProjects** is now replaced with **unidocProjectFilter**. 

see more detail: http://notes.implicit.ly/post/63162383096/sbt-unidoc-0-3-0

Using `sbt-unidoc` 0.3.0 for scalaz, it need more work....
