### PR TITLE
Use ~O(min(m,n)) time append v O(n+m) for Vector

### DIFF
--- a/core/src/main/scala/scalaz/std/Vector.scala
+++ b/core/src/main/scala/scalaz/std/Vector.scala
@@ -19,7 +19,14 @@ trait VectorInstances extends VectorInstances0 {
 
   implicit val vectorInstance = generic.ixSqInstance
 
-  implicit def vectorMonoid[A]: Monoid[Vector[A]] = generic.ixSqMonoid
+  implicit def vectorMonoid[A]: Monoid[Vector[A]] = new Monoid[Vector[A]] {
+    def zero: Vector[A] = Vector.empty[A]
+    def append(as: Vector[A], bs0: => Vector[A]) = {
+      val bs = bs0
+      if (as.size < bs.size) as.reverseIterator.foldLeft(bs) { (acc, a) => a +: acc }
+      else bs.foldLeft(as)(_ :+ _)
+    }
+  }
 
   implicit def vectorShow[A: Show]: Show[Vector[A]] = generic.ixSqShow
 


### PR DESCRIPTION
The problem is that something like xs.map(Vector(_)).suml is O(n^2).
This would make it O(n), as expected... ignoring factors of log_32(n).
