### PR TITLE
More in-depth ScalaDoc for `\/`

### DIFF
--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -2,8 +2,25 @@ package scalaz
 
 import Liskov.<~<
 
-/**
- * Represents disjunction. Isomorphic to `scala.Either`. Does not have left/right projections, instead right-bias and use `swap` or `swapped`.
+/** Represents a disjunction: a result that is either an `A` or a `B`.
+ * 
+ * An instance of `A` [[\/]] B is either a [[-\/]]`[A]` (aka a "left") or a [[\/-]]`[B]` (aka a "right").
+ *
+ * A common use of a disjunction is to explicitly represent the possibility of failure in a result as opposed to
+ * throwing an exception. By convention, the left is used for errors and the right is reserved for successes.
+ * For example, a function that attempts to parse an integer from a string may have a return type of
+ * `NumberFormatException` [[\/]] `Int`. However, since there is no need to actually throw an exception, the type (`A`)
+ * chosen for the "left" could be any type representing an error and has no need to actually extend `Exception`.
+ *
+ * `A` [[\/]] `B` is isomorphic to `scala.Either[A, B]`, but [[\/]] is right-biased, so methods such as `map` and
+ * `flatMap` apply only in the context of the "right" case. This right bias makes [[\/]] more convenient to use
+ * than `scala.Either` in a monadic context. Methods such as `swap`, `swapped`, and `leftMap` provide functionality
+ * that `scala.Either` exposes through left projections.
+ *
+ * `A` [[\/]] `B` is also isomorphic to [[Validation]]`[A, B]`. The subtle but important difference is that [[Applicative]]
+ * instances for [[Validation]] accumulates errors ("lefts") while [[Applicative]] instances for [[\/]] fail fast on the
+ * first "left" they evaluate. This fail-fast behavior allows [[\/]] to have lawful [[Monad]] instances that are consistent
+ * with their [[Applicative]] instances, while [[Validation]] cannot.
  */
 sealed abstract class \/[+A, +B] extends Product with Serializable {
   final class SwitchingDisjunction[X](r: => X) {
@@ -284,7 +301,17 @@ sealed abstract class \/[+A, +B] extends Product with Serializable {
     }
 
 }
+
+/** A left disjunction
+ *
+ * Often used to represent the failure case of a result
+ */
 final case class -\/[+A](a: A) extends (A \/ Nothing)
+
+/** A right disjunction
+ *
+ * Often used to represent the success case of a result
+ */
 final case class \/-[+B](b: B) extends (Nothing \/ B)
 
 object \/ extends DisjunctionInstances with DisjunctionFunctions {


### PR DESCRIPTION
I'm hoping to start adding to ScalaDoc descriptions that seem sparse as I encounter them. This is my first attempt.

I'm not quite sure of the right level of detail and what should be accomplished through blog posts, examples, etc. However, I think discoverability of Scalaz features is an issue currently (I've gotten this feedback from multiple sources), so I'd rather err on the side of too much detail than not enough.
