### PR TITLE
Add `IMap` alias for `scalaz.==>>`

### DIFF
--- a/core/src/main/scala/scalaz/package.scala
+++ b/core/src/main/scala/scalaz/package.scala
@@ -285,4 +285,7 @@ package object scalaz {
 
   @deprecated("Cojoin has been merged into Cobind", "7.1")
   val Cojoin = Cobind
+
+  type IMap[A, B] = ==>>[A, B]
+  val IMap = ==>>
 }


### PR DESCRIPTION
Consistent with `IList` and `ISet`.
