### PR TITLE
Use ASCII arrows

### DIFF
--- a/core/src/main/scala/scalaz/LazyOption.scala
+++ b/core/src/main/scala/scalaz/LazyOption.scala
@@ -163,7 +163,7 @@ sealed abstract class LazyOptionInstances {
     }
 
   implicit def lazyOptionShow[A](implicit S: Show[A]): Show[LazyOption[A]] =
-    Show.shows(_.fold(a ⇒ "LazySome(%s)".format(S.shows(a)), "LazyNone"))
+    Show.shows(_.fold(a => "LazySome(%s)".format(S.shows(a)), "LazyNone"))
 
   /* TODO
 implicit def LazyOptionOrder[A: Order]: Order[LazyOption[A]] =

--- a/core/src/main/scala/scalaz/std/NodeSeq.scala
+++ b/core/src/main/scala/scalaz/std/NodeSeq.scala
@@ -6,7 +6,7 @@ import scala.xml.{ NodeSeq, PrettyPrinter }
 trait NodeSeqInstances {
   implicit val nodeSeqInstance: Monoid[NodeSeq] with Show[NodeSeq] with Equal[NodeSeq] = new Monoid[NodeSeq] with Show[NodeSeq] with Equal[NodeSeq] {
     def zero = NodeSeq.Empty
-    def append(f1: NodeSeq, f2: ⇒ NodeSeq) = f1 ++ f2
+    def append(f1: NodeSeq, f2: => NodeSeq) = f1 ++ f2
     override def shows(as: NodeSeq) = new PrettyPrinter(80, 2) formatNodes as
     def equal(a1: NodeSeq, a2: NodeSeq): Boolean = a1 == a2
   }

--- a/effect/src/main/scala/scalaz/effect/IO.scala
+++ b/effect/src/main/scala/scalaz/effect/IO.scala
@@ -174,7 +174,7 @@ private trait IOLiftIO extends LiftIO[IO] {
 }
 
 private trait IOMonadCatchIO extends MonadCatchIO[IO] {
-  def except[A](io: IO[A])(h: Throwable ⇒ IO[A]): IO[A] = io.except(h)
+  def except[A](io: IO[A])(h: Throwable => IO[A]): IO[A] = io.except(h)
 }
 
 /** IO Actions for writing to standard output and and reading from standard input */

--- a/effect/src/main/scala/scalaz/effect/KleisliEffect.scala
+++ b/effect/src/main/scala/scalaz/effect/KleisliEffect.scala
@@ -38,6 +38,6 @@ private trait KleisliLiftIO[M[_], R] extends LiftIO[({type λ[α] = Kleisli[M, R
 private trait KleisliCatchIO[M[_], R] extends MonadCatchIO[({type λ[α] = Kleisli[M, R, α]})#λ] with KleisliLiftIO[M, R] with KleisliMonadReader[M, R] {
   implicit def F: MonadCatchIO[M]
 
-  def except[A](k: Kleisli[M, R, A])(h: Throwable ⇒ Kleisli[M, R, A]) = 
-    Kleisli(r ⇒ F.except(k.run(r))(t ⇒ h(t).run(r)))
+  def except[A](k: Kleisli[M, R, A])(h: Throwable => Kleisli[M, R, A]) = 
+    Kleisli(r => F.except(k.run(r))(t => h(t).run(r)))
 }

--- a/effect/src/main/scala/scalaz/effect/MonadCatchIO.scala
+++ b/effect/src/main/scala/scalaz/effect/MonadCatchIO.scala
@@ -3,17 +3,17 @@ package effect
 
 trait MonadCatchIO[M[_]] extends MonadIO[M] {
   /** Executes the handler if an exception is raised. */
-  def except[A](ma: M[A])(handler: Throwable ⇒ M[A]): M[A]
-}     
+  def except[A](ma: M[A])(handler: Throwable => M[A]): M[A]
+}
 
 object MonadCatchIO extends MonadCatchIOFunctions {
   @inline def apply[M[_]](implicit M: MonadCatchIO[M]): MonadCatchIO[M] = M
 }
 
 sealed trait MonadCatchIOFunctions {
-  def except[M[_], A](ma: M[A])(handler: Throwable ⇒ M[A])(implicit M: MonadCatchIO[M]): M[A] =
+  def except[M[_], A](ma: M[A])(handler: Throwable => M[A])(implicit M: MonadCatchIO[M]): M[A] =
     M.except(ma)(handler)
-          
+
   import scalaz.syntax.monad._
 
  /**
@@ -38,37 +38,37 @@ sealed trait MonadCatchIOFunctions {
     catchLeft(ma) map (_.leftMap(e => p(e).getOrElse(throw e)))
 
   /**Like "finally", but only performs the final action if there was an exception. */
-  def onException[M[_]: MonadCatchIO, A, B](ma: M[A], action: M[B]): M[A] = 
-    except(ma)(e ⇒
+  def onException[M[_]: MonadCatchIO, A, B](ma: M[A], action: M[B]): M[A] =
+    except(ma)(e =>
       for {
-        _ ← action
-        a ← (throw e): M[A]
+        _ <- action
+        a <- (throw e): M[A]
       } yield a)
-                 
-  def bracket[M[_]: MonadCatchIO, A, B, C](before: M[A])(after: A ⇒ M[B])(during: A ⇒ M[C]): M[C] =
+
+  def bracket[M[_]: MonadCatchIO, A, B, C](before: M[A])(after: A => M[B])(during: A => M[C]): M[C] =
     for {
-      a ← before
-      r ← onException(during(a), after(a))
-      _ ← after(a)
+      a <- before
+      r <- onException(during(a), after(a))
+      _ <- after(a)
     } yield r
 
   /**Like "bracket", but takes only a computation to run afterward. Generalizes "finally". */
-  def ensuring[M[_]: MonadCatchIO, A, B](ma: M[A], sequel: M[B]): M[A] = 
+  def ensuring[M[_]: MonadCatchIO, A, B](ma: M[A], sequel: M[B]): M[A] =
     for {
-      r ← onException(ma, sequel)
-      _ ← sequel
+      r <- onException(ma, sequel)
+      _ <- sequel
     } yield r
 
   /**A variant of "bracket" where the return value of this computation is not needed. */
   def bracket_[M[_]: MonadCatchIO, A, B, C](before: M[A])(after: M[B])(during: M[C]): M[C] =
-    bracket(before)(_ ⇒ after)(_ ⇒ during)
-                             
+    bracket(before)(_ => after)(_ => during)
+
   /**A variant of "bracket" that performs the final action only if there was an error. */
-  def bracketOnError[M[_]: MonadCatchIO, A, B, C](before: M[A])(after: A ⇒ M[B])(during: A ⇒ M[C]): M[C] = 
+  def bracketOnError[M[_]: MonadCatchIO, A, B, C](before: M[A])(after: A => M[B])(during: A => M[C]): M[C] =
     for {
-      a ← before
-      r ← onException(during(a), after(a))
-    } yield r      
+      a <- before
+      r <- onException(during(a), after(a))
+    } yield r
 
   /** An automatic resource management. */
   def using[M[_], A, B](ma: M[A])(f: A => M[B])(implicit M: MonadCatchIO[M], resource: Resource[A]) =
@@ -78,8 +78,8 @@ sealed trait MonadCatchIOFunctions {
     new MonadCatchIO[({type λ[α] = Kleisli[F, R, α]})#λ] with MonadIO.FromLiftIO[({type λ[α] = Kleisli[F, R, α]})#λ] {
       def FM = MonadIO.kleisliMonadIO[F, R]
       def FLO = MonadIO.kleisliMonadIO[F, R]
-      def except[A](k: Kleisli[F, R, A])(h: Throwable ⇒ Kleisli[F, R, A]) =
-        Kleisli(r ⇒ F.except(k.run(r))(t ⇒ h(t).run(r)))
+      def except[A](k: Kleisli[F, R, A])(h: Throwable => Kleisli[F, R, A]) =
+        Kleisli(r => F.except(k.run(r))(t => h(t).run(r)))
     }
 
 }

--- a/effect/src/main/scala/scalaz/syntax/effect/MonadCatchIOSyntax.scala
+++ b/effect/src/main/scala/scalaz/syntax/effect/MonadCatchIOSyntax.scala
@@ -9,17 +9,17 @@ import scalaz.effect.Resource
 sealed abstract class MonadCatchIOOps[F[_],A] extends Ops[F[A]] {
   implicit def F: MonadCatchIO[F]
   ////
-  def except(handler: Throwable ⇒ F[A]): F[A] = F.except(self)(handler)
+  def except(handler: Throwable => F[A]): F[A] = F.except(self)(handler)
   def catchSome[B](p: Throwable => Option[B], handler: B => F[A]): F[A] = MonadCatchIO.catchSome(self)(p, handler)
   def catchLeft: F[Throwable \/ A] = MonadCatchIO.catchLeft(self)
   def catchSomeLeft[B](p: Throwable => Option[B]): F[B \/ A] = MonadCatchIO.catchSomeLeft(self)(p)
   def onException[B](action: F[B]): F[A] = MonadCatchIO.onException(self, action)
-  def bracket[B, C](after: A ⇒ F[B])(during: A ⇒ F[C]): F[C] = 
+  def bracket[B, C](after: A => F[B])(during: A => F[C]): F[C] = 
     MonadCatchIO.bracket(self)(after)(during)
   def ensuring[B](sequel: F[B]): F[A] = MonadCatchIO.ensuring(self, sequel)
   def bracket_[B, C](after: F[B])(during: F[C]): F[C] =
     MonadCatchIO.bracket_(self)(after)(during)
-  def bracketOnError[B, C](after: A ⇒ F[B])(during: A ⇒ F[C]): F[C] =
+  def bracketOnError[B, C](after: A => F[B])(during: A => F[C]): F[C] =
     MonadCatchIO.bracketOnError(self)(after)(during)
   def using[B](f: A => F[B])(implicit resource: Resource[A]) = MonadCatchIO.using(self)(f)
   ////

--- a/example/src/main/scala/scalaz/example/FoldableUsage.scala
+++ b/example/src/main/scala/scalaz/example/FoldableUsage.scala
@@ -25,7 +25,7 @@ object FoldableUsage extends App {
   // which traverses the stream from left to right lazily, so, given a
   // function which is lazy in the right argument, we can use a foldr
   // on an infinite stream.
-  def lazyOr(x: Boolean)(y: ⇒ Boolean) = x || y
+  def lazyOr(x: Boolean)(y: => Boolean) = x || y
   assert(Foldable[Stream].foldr(trues, false)(lazyOr))
 
   // when we have an available Monoid for the parameterized type, we
@@ -36,12 +36,12 @@ object FoldableUsage extends App {
   // we can also map the structure to values for which we have a
   // monoid, we can collapse the list, as we can see, this one is also
   // properly lazy, allowing us to collapse our infinite stream again
-  assert(Foldable[Stream].foldMap(trues)((b: Boolean) ⇒ Tags.Disjunction(b)))
+  assert(Foldable[Stream].foldMap(trues)((b: Boolean) => Tags.Disjunction(b)))
 
   // We can import syntax for foldable, allowing us to "enhance" the foldable with the new methods:
   import scalaz.syntax.foldable._
   assert(trues.foldr(false)(lazyOr))
-  assert(trues.foldMap((b: Boolean) ⇒ Tags.Disjunction(b)))
+  assert(trues.foldMap((b: Boolean) => Tags.Disjunction(b)))
   assert(digits.map(_.toString).intercalate(",") === "0,1,2,3,4,5,6,7,8,9")
   assert(digits.maximum === Some(9))
   assert(digits.minimum === Some(0))
@@ -70,7 +70,7 @@ object FoldableUsage extends App {
 
   // Monadic Folds: we can fold over a structure with a function
   // which returns its value in a Monad, 
-  val sumEvens: (Int,Int) ⇒ Option[Int] = { (x, y) ⇒
+  val sumEvens: (Int,Int) => Option[Int] = { (x, y) =>
     // if the right int is even, add it to the left
     // otherwise return None
     if((y % 2) == 0) Some(x+y) else None

--- a/example/src/main/scala/scalaz/example/IsomorphismUsage.scala
+++ b/example/src/main/scala/scalaz/example/IsomorphismUsage.scala
@@ -10,8 +10,8 @@ import syntax.traverse._
 
 object IsomorphismUsage extends App {
   def isoSet[A] = new IsoSet[Seq[A], List[A]] {
-    def to: Seq[A] ⇒ List[A] = _.toList
-    def from: List[A] ⇒ Seq[A] = _.toSeq
+    def to: Seq[A] => List[A] = _.toList
+    def from: List[A] => Seq[A] = _.toSeq
   }
   def isoFunctor = new IsoFunctorTemplate[Seq, List] {
     def to[A](sa: Seq[A]): List[A] = sa.toList
@@ -33,8 +33,8 @@ object IsomorphismUsage extends App {
 
   assert((Seq(1, 2) |+| Seq(3, 4)).toList === List(1, 2, 3, 4))
   assert {
-    val seq = Seq(1, 2, 3) >>= {x ⇒ Seq(x, x+1)}
-    val lst = List(1, 2, 3) >>= {x ⇒ List(x, x+1)}
+    val seq = Seq(1, 2, 3) >>= {x => Seq(x, x+1)}
+    val lst = List(1, 2, 3) >>= {x => List(x, x+1)}
     seq.toList === lst
   }
   assert(List(Seq(1, 2), Seq(3, 4)).sequence.toList === List(List(1, 2), List(3, 4)).sequence)

--- a/example/src/main/scala/scalaz/example/ReaderWriterStateTUsage.scala
+++ b/example/src/main/scala/scalaz/example/ReaderWriterStateTUsage.scala
@@ -31,9 +31,9 @@ object Token {
   implicit val euqalsRef: Equal[Token] = Equal.equalRef
   implicit val showTok: Show[Token] = new Show[Token] {
     override def show(t: Token) = t match {
-      case A ⇒ Cord("A")
-      case B ⇒ Cord("B")
-      case C ⇒ Cord("C")
+      case A => Cord("A")
+      case B => Cord("B")
+      case C => Cord("C")
     }
   }
 }
@@ -85,12 +85,12 @@ object CABRunLengthEncoder {
   type RunLength[A] = ReaderWriterStateT[Trampoline, RunLengthConfig, Cord, RunLengthState, A]
 
   // At its essence the RWST monad transformer is a wrap around a function with the following shape:
-  // (ReaderType, StateType) ⇒ Monad[WriterType, Result, StateType]
+  // (ReaderType, StateType) => Monad[WriterType, Result, StateType]
   // we can directly wrap a function of this shape:
   /**
     *  read a token from the input
     */
-  val readToken: RunLength[Token] = ReaderWriterStateT { (config: RunLengthConfig, oldState: RunLengthState) ⇒ 
+  val readToken: RunLength[Token] = ReaderWriterStateT { (config: RunLengthConfig, oldState: RunLengthState) => 
     val (nextTok, newState) = oldState.uncons
     Applicative[Trampoline].point((Monoid[Cord].zero, nextTok, newState))
   }
@@ -112,19 +112,19 @@ object CABRunLengthEncoder {
     */
   val readToken2: RunLength[Token] = 
     for {
-      oldState ← get            // fetch the current state
+      oldState <- get            // fetch the current state
 
                                 // take a token off the input, getting
                                 // a token and a new state
       (nextTok, newState) = oldState.uncons
-      _ ← put(newState)         // store the new state
+      _ <- put(newState)         // store the new state
     } yield nextTok             // return the token
 
   /**
     have we exhausted the input?
     */
   def done: RunLength[Boolean] =
-    get flatMap { state ⇒
+    get flatMap { state =>
       if(state.input.isEmpty)
         // we have, better emit whatever tokens are stored in the
         // current state
@@ -148,9 +148,9 @@ object CABRunLengthEncoder {
     */
   def emit: RunLength[Unit] =
     for {
-       state ← get
-      config ← ask
-           _ ← state.lastToken.cata(none = point(),  // nothing to emit
+       state <- get
+      config <- ask
+           _ <- state.lastToken.cata(none = point(),  // nothing to emit
                                     some = writeOutput(_, state.length, config.minRun))
     } yield ()
 
@@ -160,9 +160,9 @@ object CABRunLengthEncoder {
     */ 
   def maybeEmit: RunLength[Unit] =
     for {
-      state ← get
-       next ← readToken
-           _ ← { if(state.lastToken.map(_ == next) getOrElse(false))
+      state <- get
+       next <- readToken
+           _ <- { if(state.lastToken.map(_ == next) getOrElse(false))
                  // Same token as last, so we just increment our counter 
                  modify(_.incLength)
                else

--- a/example/src/main/scala/scalaz/example/STUsage.scala
+++ b/example/src/main/scala/scalaz/example/STUsage.scala
@@ -11,8 +11,8 @@ object STUsage extends App {
 
   // Creates a new mutable reference and mutates it
   def e1[A] = for {
-    r ← newVar[A](0)
-    x ← r.mod(_ + 1)
+    r <- newVar[A](0)
+    x <- r.mod(_ + 1)
   } yield x
 
   // Creates a new mutable reference, mutates it, and reads its value.
@@ -36,8 +36,8 @@ object STUsage extends App {
 
   // Bin-sort a list into an immutable array.
   // Uses a non-observable mutable array in the background.
-  def binSort[A: Manifest](size: Int, key: A ⇒ Int, as: List[A]): ImmutableArray[List[A]] =
-    accumArray(size, (vs: List[A], v: A) ⇒ v :: vs, List(), for { a ← as } yield (key(a), a))
+  def binSort[A: Manifest](size: Int, key: A => Int, as: List[A]): ImmutableArray[List[A]] =
+    accumArray(size, (vs: List[A], v: A) => v :: vs, List(), for { a <- as } yield (key(a), a))
 
   assert(binSort(12, (_: String).length, List("twenty four", "one", "")).toList.flatten === List("", "one", "twenty four"))
   assert(compiles === 1)

--- a/tests/src/test/scala/scalaz/RopeTest.scala
+++ b/tests/src/test/scala/scalaz/RopeTest.scala
@@ -105,16 +105,16 @@ object RopeTest extends SpecLite {
     for (i <- 0 until rope.size) elems(i) must_===(rope(i))
   }
 
-  "concatenating ropes work correctly" ! forAll {(t1: Rope[Int], t2: Rope[Int]) ⇒
+  "concatenating ropes work correctly" ! forAll {(t1: Rope[Int], t2: Rope[Int]) =>
     (!t1.isEmpty && !t2.isEmpty) ==>
       ((t1 ++ t2).toStream must_===(t1.toStream ++ t2.toStream))
   }
 
-  "chunk append works correctly" ! forAll {(tree: Rope[Int], arr: ImmutableArray[Int]) ⇒
+  "chunk append works correctly" ! forAll {(tree: Rope[Int], arr: ImmutableArray[Int]) =>
     (tree ::+ arr).toStream must_===(tree.toStream ++ arr.toStream)
   }
 
-  "chunk prepend works correctly" ! forAll {(tree: Rope[Int], arr: ImmutableArray[Int]) ⇒
+  "chunk prepend works correctly" ! forAll {(tree: Rope[Int], arr: ImmutableArray[Int]) =>
     (arr +:: tree).toStream must_===(arr.toStream ++ tree.toStream)
   }
 
@@ -128,11 +128,11 @@ object RopeTest extends SpecLite {
 //    (splitTree._1.toStream, splitTree._2.toStream) === asStream.splitAt(index)
 //  }
 
-  "head works correctly" ! forAll {(tree: Rope[Int]) ⇒
+  "head works correctly" ! forAll {(tree: Rope[Int]) =>
     !tree.isEmpty ==> (tree.head must_===(tree.toStream.head))
   }
 
-  "last works correctly" ! forAll {(tree: Rope[Int]) ⇒
+  "last works correctly" ! forAll {(tree: Rope[Int]) =>
     !tree.isEmpty ==> (tree.last must_===(tree.toStream.last))
   }
 

--- a/tests/src/test/scala/scalaz/std/NodeSeqTest.scala
+++ b/tests/src/test/scala/scalaz/std/NodeSeqTest.scala
@@ -16,7 +16,7 @@ object NodeSeqTest extends SpecLite {
 
     val genNode = ^ (
       nonEmptyAlphaStr, nonEmptyAlphaStr
-    ) { (s1, s2) ⇒ XML.loadString("<" + s1 + ">" + s2 + "</" + s1 + ">") }
+    ) { (s1, s2) => XML.loadString("<" + s1 + ">" + s2 + "</" + s1 + ">") }
 
     val genNodeSeq = Gen.containerOf[Array, Node](genNode)
     implicit val NodeSeqArb = Arbitrary[NodeSeq](genNodeSeq map (_.toSeq))


### PR DESCRIPTION
This is just a cosmetic change. I noticed that there were a few occurrences of `⇒` and `←`, whereas usually the ASCII symbols are used throughout the code base.
