### PR TITLE
Add Validation.failNel for creating a ValidationNel

### DIFF
--- a/core/src/main/scala/scalaz/Validation.scala
+++ b/core/src/main/scala/scalaz/Validation.scala
@@ -484,6 +484,10 @@ trait ValidationFunctions {
   def failure[E, A]: E => Validation[E, A] =
     Failure(_)
 
+  /** Wrap a value in a `NonEmptyList` and construct a failure validation out of it. */
+  def failureNel[E, A](e: E): ValidationNel[E, A] =
+    Failure(NonEmptyList(e))
+
   /** Evaluate the given value, which might throw an exception. */
   @deprecated("catches fatal exceptions, use fromTryCatchThrowable", "7.1.0")
   def fromTryCatch[T](a: => T): Validation[Throwable, T] = try {

--- a/core/src/main/scala/scalaz/syntax/ValidationOps.scala
+++ b/core/src/main/scala/scalaz/syntax/ValidationOps.scala
@@ -10,7 +10,7 @@ final class ValidationOps[A](self: A) {
 
   def fail[X]: Validation[A, X] = failure[X]
 
-  def failureNel[X]: ValidationNel[A, X] = Validation.failure[NonEmptyList[A], X](NonEmptyList(self))
+  def failureNel[X]: ValidationNel[A, X] = Validation.failureNel[A, X](self)
 
   def failNel[X]: ValidationNel[A, X] = failureNel[X]
 }


### PR DESCRIPTION
Because Validation.failure(NonEmptyList(x)) just feels so verbose
