### PR TITLE
Deprecate fail and failNel

### DIFF
--- a/core/src/main/scala/scalaz/syntax/ValidationOps.scala
+++ b/core/src/main/scala/scalaz/syntax/ValidationOps.scala
@@ -8,10 +8,12 @@ final class ValidationOps[A](self: A) {
 
   def failure[X]: Validation[A, X] = Validation.failure[A, X](self)
 
+  @deprecated("use `failure` instead", "7.1")
   def fail[X]: Validation[A, X] = failure[X]
 
   def failureNel[X]: ValidationNel[A, X] = Validation.failureNel[A, X](self)
 
+  @deprecated("use `failureNel` instead", "7.1")
   def failNel[X]: ValidationNel[A, X] = failureNel[X]
 }
 

--- a/tests/src/test/scala/scalaz/ValidationTest.scala
+++ b/tests/src/test/scala/scalaz/ValidationTest.scala
@@ -89,20 +89,20 @@ object ValidationTest extends SpecLite {
     def errmsg(i: Int) = "Int must be positive: " + i
     (List("1", "2", "3") map (_.parseInt.leftMap(_.toString) excepting { case i if i < 0 => errmsg(i) })) must_===(List(1.success[String], 2.success[String], 3.success[String]))
 
-    (List("1", "-2", "3") map (_.parseInt.leftMap(_.toString) excepting { case i if i < 0 => errmsg(i) })) must_===(List(1.success[String], errmsg(-2).fail[Int], 3.success[String]))
+    (List("1", "-2", "3") map (_.parseInt.leftMap(_.toString) excepting { case i if i < 0 => errmsg(i) })) must_===(List(1.success[String], errmsg(-2).failure[Int], 3.success[String]))
 
     implicit val ShowAny: Show[Any] = Show.showA; implicit val EqualAny: Equal[Any] = Equal.equalA
     def errmsgA(i: Int): Any = errmsg(i)
     (List("1", "2", "3") map (_.parseInt.leftMap(_.toString) excepting { case i if i < 0 => errmsgA(i) })) must_===(List(1.success[Any], 2.success[Any], 3.success[Any]))
 
-    (List("1", "-2", "3") map (_.parseInt.leftMap(_.toString) excepting { case i if i < 0 => errmsgA(i) })) must_===(List(1.success[Any], errmsgA(-2).fail[Int], 3.success[Any]))
+    (List("1", "-2", "3") map (_.parseInt.leftMap(_.toString) excepting { case i if i < 0 => errmsgA(i) })) must_===(List(1.success[Any], errmsgA(-2).failure[Int], 3.success[Any]))
   }
 
   "ensure" in {
     import syntax.std.string._
     import syntax.validation._
     List("1", "2") map (_.parseInt.leftMap(_.toString).ensure("Fail")(_ >= 0)) must_===(List(1.success[String], 2.success[String]))
-    List("1", "-2") map (_.parseInt.leftMap(_.toString).ensure("Fail")(_ >= 0)) must_===(List(1.success[String], "Fail".fail[Int]))
+    List("1", "-2") map (_.parseInt.leftMap(_.toString).ensure("Fail")(_ >= 0)) must_===(List(1.success[String], "Fail".failure[Int]))
   }
 
   object instances {


### PR DESCRIPTION
As discussed in #720, `failure` and `failureNel` are preferred.

cc @LeifW
