### PR TITLE
Free.runFC

### DIFF
--- a/core/src/main/scala/scalaz/Free.scala
+++ b/core/src/main/scala/scalaz/Free.scala
@@ -315,7 +315,7 @@ trait FreeFunctions {
     liftFU(Coyoneda lift s)
 
   /** Interpret a free monad over a free functor of `S` via natural transformation to monad `M`. */
-  def runFC[S[_], A, M[_]](sa: FreeC[S, A])(interp: S ~> M)(implicit M: Monad[M]): M[A] =
+  def runFC[S[_], M[_], A](sa: FreeC[S, A])(interp: S ~> M)(implicit M: Monad[M]): M[A] =
     sa.foldMap[M](new (({type λ[α] = Coyoneda[S, α]})#λ ~> M) {
       def apply[A](cy: Coyoneda[S, A]): M[A] =
         M.map(interp(cy.fi))(cy.k)


### PR DESCRIPTION
Added `Free.runFC` to interpret a free monad over a free functor via natural transformation to another monad. I did not invent this; it's distilled from this [snippet](http://scastie.org/5436) by @larsrh and seems generally useful for anyone using `FreeC`.
