### PR TITLE
made catchable ops importable

### DIFF
--- a/core/src/main/scala/scalaz/syntax/Syntax.scala
+++ b/core/src/main/scala/scalaz/syntax/Syntax.scala
@@ -80,6 +80,8 @@ trait Syntaxes {
 
   object optional extends ToOptionalOps
 
+  object catchable extends ToCatchableOps
+
   //
   // Type classes over * * -> *
   //
@@ -162,4 +164,4 @@ trait ToTypeClassOps
   with ToPlusOps with ToApplicativePlusOps with ToMonadPlusOps with ToTraverseOps with ToBifunctorOps
   with ToBitraverseOps with ToComposeOps with ToCategoryOps
   with ToArrowOps with ToFoldableOps with ToChoiceOps with ToSplitOps with ToZipOps with ToUnzipOps with ToMonadTellOps with ToMonadListenOps
-  with ToFoldable1Ops with ToTraverse1Ops with ToOptionalOps with ToAlignOps
+  with ToFoldable1Ops with ToTraverse1Ops with ToOptionalOps with ToCatchableOps with ToAlignOps


### PR DESCRIPTION
Added `Catchable` ops to syntax package and blanket import. I realize this is a janky typeclass but we either need to make it usable or remove it.
