### PR TITLE
Revised Monad[Task].point to evaluate lazily

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Task.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Task.scala
@@ -222,7 +222,7 @@ object Task {
 
   implicit val taskInstance: Nondeterminism[Task] with Catchable[Task] = new Nondeterminism[Task] with Catchable[Task] {
     val F = Nondeterminism[Future]
-    def point[A](a: => A) = new Task(Future.now(Try(a)))
+    def point[A](a: => A) = new Task(Future.delay(Try(a)))
     def bind[A,B](a: Task[A])(f: A => Task[B]): Task[B] =
       a flatMap f
     def chooseAny[A](h: Task[A], t: Seq[Task[A]]): Task[(A, Seq[Task[A]])] =

--- a/tests/src/test/scala/scalaz/concurrent/TaskTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/TaskTest.scala
@@ -126,6 +126,13 @@ object TaskTest extends SpecLite {
     Task { Thread.sleep(10); throw FailWhale; 42 }.handleWith { case FailWhale => Task.delay(throw SadTrombone) }.attemptRun ==
       -\/(SadTrombone)
   }
+  
+  "evalutes Monad[Task].point lazily" in {
+    val M = implicitly[Monad[Task]]
+    var x = 0
+    M point { x += 1 }
+    x must_== 0
+  }
 
 
   "Nondeterminism[Task]" should {


### PR DESCRIPTION
@pchiusano said he had a reason for `Monad[Task].point` evaluating eagerly, but he couldn't remember what it was.  Submitting PR for further review.

For the purposes of discussion, bear in mind that `Monad[IO].point` is lazy.
