### PR TITLE
Added LiftTask <: LiftIO typeclass

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/LiftTask.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/LiftTask.scala
@@ -1,0 +1,50 @@
+package scalaz
+package concurrent
+
+import scalaz.effect.{LiftIO, IO}
+
+trait LiftTask[F[_]] extends LiftIO[F] {
+  
+  // what we're saying here is that Task is basically the same as IO
+  def liftIO[A](ioa: IO[A]): F[A] =
+    liftTask(Task delay { ioa.unsafePerformIO() })
+  
+  def liftTask[A](task: Task[A]): F[A]
+}
+
+object LiftTask {
+  @inline
+  def apply[F[_]](implicit F: LiftTask[F]): LiftTask[F] = F
+  
+  implicit def idTLiftTask[F[_]: LiftTask] = new LiftTask[({type λ[α]=IdT[F, α]})#λ] {
+    def liftTask[A](task: Task[A]) = IdT(LiftTask[F].liftTask(task))
+  }
+
+  implicit def listTLiftTask[F[_]: LiftTask] = new LiftTask[({type λ[α]=ListT[F, α]})#λ] {
+    def liftTask[A](task: Task[A]) = ListT(LiftTask[F].liftTask(task.map(_ :: Nil)))
+  }
+
+  implicit def optionTLiftTask[F[_]: LiftTask] = new LiftTask[({type λ[α]=OptionT[F, α]})#λ] {
+    def liftTask[A](task: Task[A]) = OptionT(LiftTask[F].liftTask(task.map(Some(_): Option[A])))
+  }
+
+  implicit def eitherTLiftTask[F[_]: LiftTask, E] = new LiftTask[({type λ[α]=EitherT[F, E, α]})#λ] {
+    def liftTask[A](task: Task[A]) = EitherT(LiftTask[F].liftTask(task.map(\/.right)))
+  }
+
+  implicit def streamTLiftTask[F[_]: LiftTask: Applicative] = new LiftTask[({type λ[α]=StreamT[F, α]})#λ] {
+    def liftTask[A](task: Task[A]) = StreamT(LiftTask[F].liftTask(task.map(StreamT.Yield(_, StreamT.empty))))
+  }
+
+  implicit def kleisliLiftTask[F[_]: LiftTask, E] = new LiftTask[({type λ[α]=Kleisli[F, E, α]})#λ] {
+    def liftTask[A](task: Task[A]) = Kleisli(_ => LiftTask[F].liftTask(task))
+  }
+
+  implicit def writerTLiftTask[F[_]: LiftTask, W: Monoid] = new LiftTask[({type λ[α]=WriterT[F, W, α]})#λ] {
+    def liftTask[A](task: Task[A]) = WriterT(LiftTask[F].liftTask(task.map((Monoid[W].zero, _))))
+  }
+
+  implicit def stateTLiftTask[F[_]: LiftTask, S] = new LiftTask[({type λ[α]=StateT[F, S, α]})#λ] {
+    def liftTask[A](task: Task[A]) = StateT(s => LiftTask[F].liftTask(task.map((s, _))))
+  }
+}

--- a/concurrent/src/main/scala/scalaz/concurrent/Task.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Task.scala
@@ -237,6 +237,10 @@ object Task {
     def fail[A](e: Throwable): Task[A] = new Task(Future.now(-\/(e)))
     def attempt[A](a: Task[A]): Task[Throwable \/ A] = a.attempt
   }
+  
+  implicit val taskLiftTask: LiftTask[Task] = new LiftTask[Task] {
+    def liftTask[A](task: Task[A]): Task[A] = task
+  }
 
   /** signals task was interrupted **/
   case object TaskInterrupted extends InterruptedException {


### PR DESCRIPTION
I didn't generate this with the typeclass scaffolding stuff, so it might need to be revised/rewritten.  I think it's important to have a `LiftTask` though, given the way that scalaz-stream basically forces users to treat `Task` as `IO`.  `Task` also has the notable distinction of being one of two monads in scalaz which have no "greater" monads, and thus make sense as lift predicates (`IO` being the other).
