### PR TITLE
Add fromTryCatchNonFatal to \/, EitherT, and Validation

### DIFF
--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -1,5 +1,6 @@
 package scalaz
 
+import scala.util.control.NonFatal
 import Liskov.<~<
 
 /** Represents a disjunction: a result that is either an `A` or a `B`.
@@ -457,7 +458,7 @@ trait DisjunctionFunctions {
     e fold (left, right)
 
   /** Evaluate the given value, which might throw an exception. */
-  @deprecated("catches fatal exceptions, use fromTryCatchThrowable", "7.1.0")
+  @deprecated("catches fatal exceptions, use fromTryCatchThrowable or fromTryCatchNonFatal", "7.1.0")
   def fromTryCatch[T](a: => T): Throwable \/ T = try {
     \/-(a)
   } catch {
@@ -468,5 +469,11 @@ trait DisjunctionFunctions {
     \/-(a)
   } catch {
     case e if ex.erasure.isInstance(e) => -\/(e.asInstanceOf[E])
+  }
+
+  def fromTryCatchNonFatal[T](a: => T): Throwable \/ T = try {
+    \/-(a)
+  } catch {
+    case NonFatal(t) => -\/(t)
   }
 }

--- a/core/src/main/scala/scalaz/EitherT.scala
+++ b/core/src/main/scala/scalaz/EitherT.scala
@@ -1,5 +1,7 @@
 package scalaz
 
+import scala.util.control.NonFatal
+
 /**
  * Represents a computation of type `F[A \/ B]`.
  *
@@ -208,7 +210,7 @@ object EitherT extends EitherTInstances with EitherTFunctions {
     apply(F.map(e)(_ fold (\/.left, \/.right)))
 
   /** Evaluate the given value, which might throw an exception. */
-  @deprecated("catches fatal exceptions, use fromTryCatchThrowable", "7.1.0")
+  @deprecated("catches fatal exceptions, use fromTryCatchThrowable or fromTryCatchNonFatal", "7.1.0")
   def fromTryCatch[F[_], A](a: => F[A])(implicit F: Applicative[F]): EitherT[F, Throwable, A] = try {
     right(a)
   } catch {
@@ -221,6 +223,14 @@ object EitherT extends EitherTInstances with EitherTFunctions {
     } catch {
       case e if ex.erasure.isInstance(e) => left(F.point(e.asInstanceOf[B]))
     }
+
+  def fromTryCatchNonFatal[F[_], A](a: => F[A])(implicit F: Applicative[F]): EitherT[F, Throwable, A] =
+    try {
+      right(a)
+    } catch {
+      case NonFatal(t) => left(F.point(t))
+    }
+
 }
 
 sealed abstract class EitherTInstances2 {

--- a/core/src/main/scala/scalaz/Validation.scala
+++ b/core/src/main/scala/scalaz/Validation.scala
@@ -1,5 +1,6 @@
 package scalaz
 
+import scala.util.control.NonFatal
 
 /**
  * Represents either:
@@ -489,7 +490,7 @@ trait ValidationFunctions {
     Failure(NonEmptyList(e))
 
   /** Evaluate the given value, which might throw an exception. */
-  @deprecated("catches fatal exceptions, use fromTryCatchThrowable", "7.1.0")
+  @deprecated("catches fatal exceptions, use fromTryCatchThrowable or fromTryCatchNonFatal", "7.1.0")
   def fromTryCatch[T](a: => T): Validation[Throwable, T] = try {
     Success(a)
   } catch {
@@ -500,6 +501,12 @@ trait ValidationFunctions {
     Success(a)
   } catch {
     case e if ex.erasure.isInstance(e) => Failure(e.asInstanceOf[E])
+  }
+
+  def fromTryCatchNonFatal[T](a: => T): Validation[Throwable, T] = try {
+    Success(a)
+  } catch {
+    case NonFatal(t) => Failure(t)
   }
 
   /** Construct a `Validation` from an `Either`. */


### PR DESCRIPTION
fromTryCatchThrowable is a great addition but it does not work nicely
with type inference -- Nothing is often inferred and when not using
inference, clients must specify both the exception type _and_ the result
type.

This PR adds a safer version of fromTryCatch that only catches non-fatal
exceptions, using scala.util.control.NonFatal. Note that suc.NonFatal is
included in Scala 2.9.3, as part of the SIP-14 backport.
