### PR TITLE
Use typesafe equality in an example

### DIFF
--- a/example/src/main/scala/scalaz/example/TraverseUsage.scala
+++ b/example/src/main/scala/scalaz/example/TraverseUsage.scala
@@ -97,8 +97,8 @@ object TraverseUsage extends App {
   val res1: List[Boolean] = nonRepeating.traverseS(checkForRepeats).eval(None)
   val res2: List[Boolean] = repeating.traverseS(checkForRepeats).eval(None)
 
-  assert(Tag.unwrap(res1.foldMap(Tags.Disjunction(_))) == false)
-  assert(Tag.unwrap(res2.foldMap(Tags.Disjunction(_))) == true)
+  assert(Tag.unwrap(res1.foldMap(Tags.Disjunction(_))) === false)
+  assert(Tag.unwrap(res2.foldMap(Tags.Disjunction(_))) === true)
 
   // Here's a variation of above which might be a bit of a head
   // scratcher, but this works because a Monoid gives rise to an
@@ -106,6 +106,6 @@ object TraverseUsage extends App {
   // constructor, we need traverseU instead of traverse to find the
   // Applicative.
   import scalaz.Applicative.monoidApplicative
-  assert(Tag.unwrap(res1.traverseU(Tags.Disjunction(_))) == false)
-  assert(Tag.unwrap(res2.traverseU(Tags.Disjunction(_))) == true)
+  assert(Tag.unwrap(res1.traverseU(Tags.Disjunction(_))) === false)
+  assert(Tag.unwrap(res2.traverseU(Tags.Disjunction(_))) === true)
 }


### PR DESCRIPTION
This prevents the sort of breakage in
c5980d619dd624288180383125a5dc09ed6b997e (which fixed a (spurious)
warning which should have been an error).

Fixing all usage of == seems a bigger task than I can manage right away.
