### PR TITLE
Add Show instances for EitherT

### DIFF
--- a/core/src/main/scala/scalaz/EitherT.scala
+++ b/core/src/main/scala/scalaz/EitherT.scala
@@ -283,6 +283,8 @@ sealed abstract class EitherTInstances extends EitherTInstances0 {
   implicit def eitherTHoist[A]: Hoist[({type λ[α[_], β] = EitherT[α, A, β]})#λ] = new EitherTHoist[A] {}
 
   implicit def eitherTEqual[F[_], A, B](implicit F0: Equal[F[A \/ B]]): Equal[EitherT[F, A, B]] = F0.contramap((_: EitherT[F, A, B]).run)
+
+  implicit def eitherTShow[F[_], A, B](implicit F0: Show[F[A \/ B]]): Show[EitherT[F, A, B]] = Contravariant[Show].contramap(F0)(_.run)
 }
 
 trait EitherTFunctions {

--- a/tests/src/test/scala/scalaz/EitherTTest.scala
+++ b/tests/src/test/scala/scalaz/EitherTTest.scala
@@ -26,6 +26,10 @@ object EitherTTest extends SpecLite {
     Bifoldable[EitherTList].bifoldMap(a)(_ :: Nil)(_ :: Nil) must_=== F.bifoldMap(a)(_ :: Nil)(_ :: Nil)
   }
 
+  "show" ! forAll { a: EitherTList[Int, Int] =>
+    Show[EitherTList[Int, Int]].show(a) must_=== Show[List[Int \/ Int]].show(a.run)
+  }
+
   object instances {
     def functor[F[_] : Functor, A] = Functor[({type λ[α] = EitherT[F, A, α]})#λ]
     def monad[F[_] : Monad, A] = Monad[({type λ[α] = EitherT[F, A, α]})#λ]


### PR DESCRIPTION
This just shows the underlying instance, as opposed to wrapping it in
"EitherT(...)" or something. This follows the precedent set by ListT.
