### PR TITLE
LiftF methods for StateT and Kleisli to make life easier

### DIFF
--- a/core/src/main/scala/scalaz/Kleisli.scala
+++ b/core/src/main/scala/scalaz/Kleisli.scala
@@ -70,7 +70,7 @@ final case class Kleisli[M[_], A, B](run: A => M[B]) { self =>
   def endo(implicit M: Functor[M], ev: A >~> B): Endomorphic[({type λ[α, β] = Kleisli[M, α, β]})#λ, A] =
     Endomorphic[({type λ[α, β] = Kleisli[M, α, β]})#λ, A](map(ev.apply))
   
-  def liftF(implicit S: Functor[({ type l[a] = Kleisli[M, A, a]})#l]) = Free.liftF[({ type l[a] = Kleisli[M, A,a]})#l,B](self)
+  def liftF(implicit F: Functor[({ type l[a] = Kleisli[M, A, a]})#l]) = Free.liftF[({ type l[a] = Kleisli[M, A,a]})#l,B](self)
 
 }
 

--- a/core/src/main/scala/scalaz/StateT.scala
+++ b/core/src/main/scala/scalaz/StateT.scala
@@ -86,7 +86,7 @@ trait IndexedStateT[F[_], -S1, S2, A] { self =>
     }
   }
   
-  def liftF[S <: S1](implicit GG: Functor[({ type l[a] = IndexedStateT[F, S, S2, a]})#l]) = Free.liftF[({ type l[a] = IndexedStateT[F, S, S2, a]})#l, A](self)
+  def liftF[S <: S1](implicit F: Functor[({ type l[a] = IndexedStateT[F, S, S2, a]})#l]) = Free.liftF[({ type l[a] = IndexedStateT[F, S, S2, a]})#l, A](self)
 
 }
 


### PR DESCRIPTION
It's a little ugly to call the raw liftf function on Free with multiple parameter monads, so this should make things a little nicer.  It's quite often preferable to work with a Free[M,A] over an M[A] due to stack issues.  Hope this is helpful.  
