### PR TITLE
Make `ValidationFlatMap.self` public to avoid issues with inlining.

### DIFF
--- a/core/src/main/scala/scalaz/Validation.scala
+++ b/core/src/main/scala/scalaz/Validation.scala
@@ -405,7 +405,7 @@ sealed abstract class ValidationInstances0 extends ValidationInstances1 {
     }
 }
 
-final class ValidationFlatMap[E, A] private[scalaz](self: Validation[E, A]) {
+final class ValidationFlatMap[E, A] private[scalaz](val self: Validation[E, A]) {
   /** Bind through the success of this validation. */
   def flatMap[EE >: E, B](f: A => Validation[EE, B]): Validation[EE, B] =
     self match {


### PR DESCRIPTION
Without this one might get compilation error saying that the field is not accessible, it's because in situation where the method call got inlined the generate closure refer to `self`.

I don't think we should hope for a compiler fix.

(spotted and fixed by @ijuma in our codebase)
