### PR TITLE
Add Nondeterminism[scala.concurrent.Future].

### DIFF
--- a/tests/src/test/scala/scalaz/std/FutureTest.scala
+++ b/tests/src/test/scala/scalaz/std/FutureTest.scala
@@ -1,8 +1,11 @@
 package scalaz
 package std
 
+import _root_.java.util.concurrent.Executors
+
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
+import org.scalacheck.Prop.forAll
 
 import scalaz.scalacheck.ScalazProperties._
 import scalaz.scalacheck.ScalazArbitrary._
@@ -34,4 +37,34 @@ class FutureTest extends SpecLite {
     checkAll(comonad.laws[Future])
   }
 
+  "Nondeterminism[Future]" should {
+    implicit val es: ExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(1))
+
+    "fetch first completed future in chooseAny" ! forAll { (xs: Vector[Int]) =>
+      val promises = Vector.fill(xs.size)(Promise[Int]())
+      def loop(is: List[Int], fs: Seq[Future[Int]], acc: Vector[Int]): Future[Vector[Int]] =
+        is match {
+          case i :: is0 =>
+            promises(i).complete(scala.util.Try(xs(i)))
+            Nondeterminism[Future].chooseAny(fs).get.flatMap { case (x, fs0) =>
+              loop(is0, fs0, acc :+ x)
+            }
+          case Nil =>
+            Future(acc)
+        }
+
+      val sorted = xs.zipWithIndex.sorted
+      val sortedF = loop(sorted.map(_._2).toList, promises.map(_.future), Vector.empty)
+      Await.result(sortedF, duration) must_== sorted.map(_._1)
+    }
+
+    "gather maintains order" ! forAll { (xs: List[Int]) =>
+      val promises = Vector.fill(xs.size)(Promise[Int]())
+      val f = Nondeterminism[Future].gather(promises.map(_.future))
+      (promises zip xs).reverseIterator.foreach { case (p, x) =>
+        p.complete(scala.util.Try(x))
+      }
+      Await.result(f, duration) must_== xs
+    }
+  }
 }


### PR DESCRIPTION
This adds a `Nondeterminism` instance for Scala's Future.

One (maybe) controversial choice is that `chooseAny` attempts to select the first successful `Future`, and not just the first `Future` that actually completed. Does anyone have any strong opinions on which behaviour should be followed?
