### PR TITLE
Add Maybe.apply for null -> Empty

### DIFF
--- a/core/src/main/scala/scalaz/Maybe.scala
+++ b/core/src/main/scala/scalaz/Maybe.scala
@@ -162,6 +162,10 @@ object Maybe extends MaybeInstances with MaybeFunctions {
 sealed trait MaybeFunctions {
   import Maybe._
 
+  /** Wrap a value in Just, or return Empty if the value is null */
+  final def fromNullable[A](a: A): Maybe[A] =
+    if (null == a) empty else just(a)
+
   final def empty[A]: Maybe[A] = Empty()
 
   final def just[A](a: A): Maybe[A] = Just(a)

--- a/tests/src/test/scala/scalaz/MaybeTests.scala
+++ b/tests/src/test/scala/scalaz/MaybeTests.scala
@@ -9,6 +9,7 @@ object MaybeTest extends SpecLite {
   import scalaz.scalacheck.ScalazProperties._
   import scalaz.scalacheck.ScalazArbitrary._
   import std.anyVal._
+  import std.string._
   import syntax.equal._
 
   import Maybe._
@@ -81,6 +82,13 @@ object MaybeTest extends SpecLite {
   "empty to option is none" ! check(empty.toOption.isEmpty)
 
   "just orElse is just" ! forAll { (x: Int, m: Maybe[Int]) => just(x).orElse(m).isJust }
+
+  "fromNullable(null) is Empty" ! check {
+    val s: String = null
+    Maybe.fromNullable(s).isEmpty
+  }
+
+  "fromNullable(notNull) is just" ! forAll { (s: String) => Maybe.fromNullable(s) must_=== just(s) }
 
   object instances {
     def equal[A: Equal] = Equal[Maybe[A]]


### PR DESCRIPTION
I consider it a major oversight that I failed to address Java interop
where `null` is a possibility in my original implementation of Maybe. This
commit adds `Maybe.apply` which works similarly to `Option.apply`. If it is
passed `null` it returns `Empty` but otherwise just wraps a value in
`Just`.

`Maybe.apply` seemed like a natural choice to mirror `Option.apply`, but
I'm open to other method name suggestions. Since Scalaz generally
assumes reasonable expectations like no nulls, I can see an argument for
a more explicit method name such as `Maybe.noNull` or something.

This is probably a candidate for backporting. @larsrh please let me know what to do on that front.
