### PR TITLE
use foldLeft which is faster in Iterable Foldable

### DIFF
--- a/core/src/main/scala/scalaz/std/Iterable.scala
+++ b/core/src/main/scala/scalaz/std/Iterable.scala
@@ -47,7 +47,7 @@ trait IterableInstances {
   }
 
   implicit def iterableSubtypeFoldable[I[X] <: Iterable[X]]: Foldable[I] = new Foldable[I] {
-    def foldMap[A,B](fa: I[A])(f: A => B)(implicit F: Monoid[B]) = foldRight(fa, F.zero)((x,y) => Monoid[B].append(f(x), y))
+    def foldMap[A,B](fa: I[A])(f: A => B)(implicit F: Monoid[B]) = foldLeft(fa, F.zero)((x,y) => Monoid[B].append(x, f(y)))
 
     def foldRight[A, B](fa: I[A], b: => B)(f: (A, => B) => B) = fa.foldRight(b)(f(_, _))
 


### PR DESCRIPTION
foldRight does a reverse which foldLeft does not need to do. Ran the tests and they pass. Not sure how to test individual laws though. The description here  http://eed3si9n.com/learning-scalaz/Combined+Pages.html#Functor+Laws now longer seems to work.
The document should tell more about this https://github.com/scalaz/scalaz/blob/series/7.2.x/CONTRIBUTING.md
