### PR TITLE
Foldable short circuiting

### DIFF
--- a/core/src/main/scala/scalaz/IList.scala
+++ b/core/src/main/scala/scalaz/IList.scala
@@ -592,6 +592,14 @@ sealed abstract class IListInstances extends IListInstance0 {
         }
         loop(fa)
       }
+
+      override def all[A](fa: IList[A])(p: A => Boolean): Boolean = {
+        @tailrec def loop(fa: IList[A]): Boolean = fa match {
+          case INil() => true
+          case ICons(h, t) => p(h) && loop(t)
+        }
+        loop(fa)
+      }
     }
 
 

--- a/core/src/main/scala/scalaz/std/Iterable.scala
+++ b/core/src/main/scala/scalaz/std/Iterable.scala
@@ -65,6 +65,9 @@ trait IterableInstances {
 
     override def any[A](fa: I[A])(p: A => Boolean): Boolean =
       fa.exists(p)
+
+    override def all[A](fa: I[A])(p: A => Boolean): Boolean =
+      fa.forall(p)
   }
 }
 

--- a/core/src/main/scala/scalaz/std/List.scala
+++ b/core/src/main/scala/scalaz/std/List.scala
@@ -98,6 +98,9 @@ trait ListInstances extends ListInstances0 {
 
     override def any[A](fa: List[A])(p: A => Boolean): Boolean =
       fa.exists(p)
+
+    override def all[A](fa: List[A])(p: A => Boolean): Boolean =
+      fa.forall(p)
   }
 
   implicit def listMonoid[A]: Monoid[List[A]] = new Monoid[List[A]] {

--- a/tests/src/test/scala/scalaz/FoldableTest.scala
+++ b/tests/src/test/scala/scalaz/FoldableTest.scala
@@ -138,4 +138,14 @@ object FoldableTests {
     val expected = if (fa.empty) 0 else 1
     i === expected
   }
+
+  def allIsLazy[F[_], A](implicit F: Foldable[F], arb: Arbitrary[F[A]]) = forAll { fa: F[A] =>
+    var i = 0
+    fa all { x =>
+      i = i + 1
+      false
+    }
+    val expected = if (fa.empty) 0 else 1
+    i === expected
+  }
 }

--- a/tests/src/test/scala/scalaz/IListTest.scala
+++ b/tests/src/test/scala/scalaz/IListTest.scala
@@ -405,4 +405,6 @@ object IListTest extends SpecLite {
 
   "any is lazy" ! FoldableTests.anyIsLazy[IList, Int]
 
+  "all is lazy" ! FoldableTests.allIsLazy[IList, Int]
+
 }

--- a/tests/src/test/scala/scalaz/std/IterableTest.scala
+++ b/tests/src/test/scala/scalaz/std/IterableTest.scala
@@ -12,4 +12,6 @@ object IterableTest extends SpecLite {
   checkAll(order.laws[Iterable[Boolean]].withProp("benchmark", order.scalaOrdering[Iterable[Boolean]]))
 
   "any is lazy" ! FoldableTests.anyIsLazy[Iterable, Int]
+
+  "all is lazy" ! FoldableTests.allIsLazy[Iterable, Int]
 }

--- a/tests/src/test/scala/scalaz/std/ListTest.scala
+++ b/tests/src/test/scala/scalaz/std/ListTest.scala
@@ -160,4 +160,6 @@ object ListTest extends SpecLite {
 
   "any is lazy" ! FoldableTests.anyIsLazy[List, Int]
 
+  "all is lazy" ! FoldableTests.allIsLazy[List, Int]
+
 }


### PR DESCRIPTION
`Foldable.any` and `Foldable.all` can stop iterating through elements if they find an element that matches the right condition.

I've made them short-circuit evaluation for List, Iterable, and IList. It's possible there are other instances that could also have similar logic.

Is there a more general way to do this? In Haskell I think defining `any` and `all` in terms of `foldr` would be enough. But in the Scala world, it doesn't seem like we can do the same with `foldRight` (except for perhaps on lazy structures like `Stream`).

Let me know if there is a preferred alternative to what I've done with the `FoldableTests` object. These seemed more like useful traits than laws, so it didn't seem like mixing them in with the law declarations was the right thing to do.
