### PR TITLE
Use Future.successful for std Future's point

### DIFF
--- a/core/src/main/scala/scalaz/std/Future.scala
+++ b/core/src/main/scala/scalaz/std/Future.scala
@@ -25,11 +25,11 @@ trait FutureInstances extends FutureInstances1 {
 }
 
 private class FutureInstance(implicit ec: ExecutionContext) extends Monad[Future] with Cobind[Future] {
-  def point[A](a: => A): Future[A] = Future(a)
+  def point[A](a: => A): Future[A] = Future.successful(a)
   def bind[A, B](fa: Future[A])(f: A => Future[B]): Future[B] = fa flatMap f
   override def map[A, B](fa: Future[A])(f: A => B): Future[B] = fa map f
-  def cobind[A, B](fa: Future[A])(f: Future[A] => B): Future[B] = Future(f(fa))
-  override def cojoin[A](a: Future[A]): Future[Future[A]] = Future(a)
+  def cobind[A, B](fa: Future[A])(f: Future[A] => B): Future[B] = Future.successful(f(fa))
+  override def cojoin[A](a: Future[A]): Future[Future[A]] = Future.successful(a)
 
   // override for actual parallel execution
   override def ap[A, B](fa: => Future[A])(fab: => Future[A => B]) =


### PR DESCRIPTION
Previously Future.apply was used, which uses an implicit
ExecutionContext and has the side effect of beginning the execution of
the Future in a separate thread. This side effect is probably unexpected
from a seemingly-benign point method, and it has quite a bit of
performance overhead.

At first glance, it might appear that a benefit of Future.apply over
Future.successful is that apply is call-by-name while successful is
strict. However, apply is only call-by-name so it can evaluate the
argument in a separate thread. It still (nearly) immediately evaluates
the argument, since standard lib futures immediately begin execution as
opposed to using a run method.

Example of current behavior:

```
scala> Applicative[Future].point(println("hello"))
hello
res9: scala.concurrent.Future[Unit] = scala.concurrent.impl.Promise$DefaultPromise@1d2f62b6

scala> Applicative[Future].point({Thread.sleep(400); println("hi")})
res10: scala.concurrent.Future[Unit] = scala.concurrent.impl.Promise$DefaultPromise@10032b3e

scala> hi
```

While we will still have immediate execution with Future.successful, at
least we will avoid some overhead and won't execute a side-effect as
part of a point call.

I believe this is a candidate for back-porting to 7.1.x.
