### PR TITLE
Add Functor.widen

### DIFF
--- a/core/src/main/scala/scalaz/Functor.scala
+++ b/core/src/main/scala/scalaz/Functor.scala
@@ -15,6 +15,7 @@ package scalaz
 ////
 trait Functor[F[_]] extends InvariantFunctor[F] { self =>
   ////
+  import Liskov.<~<
 
   /** Lift `f` into `F` and apply to `F[A]`. */
   def map[A, B](fa: F[A])(f: A => B): F[B]
@@ -86,6 +87,13 @@ trait Functor[F[_]] extends InvariantFunctor[F] { self =>
 
     implicit def G = G0
   }
+
+  /**
+   * Functors are covariant by nature, so we can treat an `F[A]` as
+   * an `F[B]` if `A` is a subtype of `B`.
+   */
+  def widen[A, B](fa: F[A])(implicit ev: A <~< B): F[B] =
+    map(fa)(ev.apply)
 
   trait FunctorLaw extends InvariantFunctorLaw {
     /** The identity function, lifted, is a no-op. */

--- a/core/src/main/scala/scalaz/IList.scala
+++ b/core/src/main/scala/scalaz/IList.scala
@@ -603,6 +603,9 @@ sealed abstract class IListInstances extends IListInstance0 {
         }
         loop(fa)
       }
+
+      override def widen[A, B](fa: IList[A])(implicit ev: A <~< B): IList[B] =
+        fa.widen[B]
     }
 
 

--- a/core/src/main/scala/scalaz/syntax/FunctorSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/FunctorSyntax.scala
@@ -5,6 +5,7 @@ package syntax
 final class FunctorOps[F[_],A] private[syntax](val self: F[A])(implicit val F: Functor[F]) extends Ops[F[A]] {
   ////
   import Leibniz.===
+  import Liskov.<~<
 
   final def map[B](f: A => B): F[B] = F.map(self)(f)
   final def distribute[G[_], B](f: A => G[B])(implicit D: Distributive[G]): G[F[B]] = D.distribute(self)(f)
@@ -19,6 +20,7 @@ final class FunctorOps[F[_],A] private[syntax](val self: F[A])(implicit val F: F
   final def fpoint[G[_]: Applicative]: F[G[A]] = F.map(self)(a => Applicative[G].point(a))
   final def >|[B](b: => B): F[B] = F.map(self)(_ => b)
   final def as[B](b: => B): F[B] = F.map(self)(_ => b)
+  final def widen[B](implicit ev: A <~< B): F[B] = F.widen(self)
   ////
 }
 

--- a/tests/src/test/scala/scalaz/FunctorTest.scala
+++ b/tests/src/test/scala/scalaz/FunctorTest.scala
@@ -23,4 +23,10 @@ object FunctorTest extends SpecLite {
   "fpair" in {
     some(1).fpair must_===(some((1, 1)))
   }
+
+  "widen" ! forAll { ola: Option[List[Int]] =>
+    import std.iterable._
+    val oia: Option[Iterable[Int]] = ola
+    ola.widen[Iterable[Int]] must_===(oia)
+  }
 }


### PR DESCRIPTION
I have implemented this via `map` and `Liskov.apply`. In many cases,
we could probably cheat by using `Liskov.subst` along with a variance
hack (such as in `IList.widen`) or `asInstanceOf`, which may be more
performant than using `map`. However, this would be a dirty hack, and
usually those are accompanied with bugs.

Can anyone recommend a safe yet more performant way to write this
generally? If not, we probably will want to consider overriding the
implementation for more instances for the sake of performance. At this
point I have only overridden the implementation for `IList`.
