### PR TITLE
Add MonadError and Catchable for Scala Futures.

### DIFF
--- a/core/src/main/scala/scalaz/std/Future.scala
+++ b/core/src/main/scala/scalaz/std/Future.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration.Duration
 import scala.util.{ Try, Success => TSuccess }
 
 trait FutureInstances1 {
-  implicit def futureInstance(implicit ec: ExecutionContext): Nondeterminism[Future] with Cobind[Future] =
+  implicit def futureInstance(implicit ec: ExecutionContext): Nondeterminism[Future] with Cobind[Future] with MonadError[({type λ[α,β] = Future[β]})#λ, Throwable] with Catchable[Future] =
     new FutureInstance
 
   implicit def futureSemigroup[A](implicit m: Semigroup[A], ec: ExecutionContext): Semigroup[Future[A]] =
@@ -27,7 +27,7 @@ trait FutureInstances extends FutureInstances1 {
     Monoid.liftMonoid[Future, A]
 }
 
-private class FutureInstance(implicit ec: ExecutionContext) extends Nondeterminism[Future] with Cobind[Future] {
+private class FutureInstance(implicit ec: ExecutionContext) extends Nondeterminism[Future] with Cobind[Future] with MonadError[({type λ[α,β] = Future[β]})#λ, Throwable] with Catchable[Future] {
   def point[A](a: => A): Future[A] = Future(a)
   def bind[A, B](fa: Future[A])(f: A => Future[B]): Future[B] = fa flatMap f
   override def map[A, B](fa: Future[A])(f: A => B): Future[B] = fa map f
@@ -68,6 +68,18 @@ private class FutureInstance(implicit ec: ExecutionContext) extends Nondetermini
   // override for actual parallel execution
   override def ap[A, B](fa: => Future[A])(fab: => Future[A => B]) =
     fa zip fab map { case (a, fa) => fa(a) }
+
+  def attempt[A](f: Future[A]): Future[Throwable \/ A] =
+    f.map(\/-(_)).recover { case e => -\/(e) }
+
+  def fail[A](e: Throwable): Future[A] =
+    Future.failed(e)
+
+  def raiseError[A](e: Throwable): Future[A] =
+    fail(e)
+
+  def handleError[A](fa: Future[A])(f: Throwable => Future[A]): Future[A] =
+    fa.recoverWith(PartialFunction(f))
 }
 
 object scalaFuture extends FutureInstances


### PR DESCRIPTION
This adds MonadError and Catchable instances for Scala futures, similar
to Task. The major difference, of course, is that Futures are eager.
