### PR TITLE
Mark threads as Daemon in DefaultTimeoutScheduler in scalaz-concurrent

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Strategy.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Strategy.scala
@@ -18,25 +18,32 @@ trait Strategy {
 object Strategy extends Strategys
 
 trait Strategys extends StrategysLow {
+
+  /**
+   * Default thread factory to mark all threads as daemon
+   */
+  val DefaultDaemonThreadFactory = new ThreadFactory {
+    val defaultThreadFactory = Executors.defaultThreadFactory()
+    def newThread(r: Runnable) = {
+      val t = defaultThreadFactory.newThread(r)
+      t.setDaemon(true)
+      t
+    }
+  }
+
   /**
    * The default executor service is a fixed thread pool with N daemon threads,
    * where N is equal to the number of available processors.
    */
   val DefaultExecutorService: ExecutorService = {
-    Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors, new ThreadFactory {
-      val defaultThreadFactory = Executors.defaultThreadFactory()
-      def newThread(r: Runnable) = {
-        val t = defaultThreadFactory.newThread(r)
-        t.setDaemon(true)
-        t
-      }
-    })
+    Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors, DefaultDaemonThreadFactory)
   }
 
   /**
    * Default scheduler used for scheduling the tasks like timeout.
    */
-  val DefaultTimeoutScheduler: ScheduledExecutorService =  Executors.newScheduledThreadPool(1)
+  val DefaultTimeoutScheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(1,
+    DefaultDaemonThreadFactory)
 
   /**
    * A strategy that executes its arguments on `DefaultExecutorService`


### PR DESCRIPTION
Fixing DefaultTimeoutScheduler in concurrent Strategy so threads are marked as daemon allowing JVM to shutdown properly without explicitly shutting down the scheduler pool
