### PR TITLE
Remove useless try-catch block

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Task.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Task.scala
@@ -100,7 +100,7 @@ class Task[+A](val get: Future[Throwable \/ A]) {
 
   /** Like `run`, but returns exceptions as values. */
   def attemptRun: Throwable \/ A =
-    try get.run catch { case t: Throwable => -\/(t) }
+    get.run
 
   /**
    * Run this computation to obtain an `A`, so long as `cancel` remains false.


### PR DESCRIPTION
This check should never be necessary if this class is implemented correctly and it is being used properly (as documented).