### PR TITLE
Change DList's underlying data structure from List to IList.

### DIFF
--- a/core/src/main/scala/scalaz/DList.scala
+++ b/core/src/main/scala/scalaz/DList.scala
@@ -62,7 +62,7 @@ final class DList[A] private[scalaz](f: (IList[A]) => Trampoline[IList[A]]) {
 }
 
 object DList extends DListInstances with DListFunctions {
-  def apply[A](xs: A*): DList[A] = fromList(xs.toList)
+  def apply[A](xs: A*): DList[A] = fromIList(IList(xs: _*))
 }
 
 sealed abstract class DListInstances {


### PR DESCRIPTION
Since scalaz has IList, it seems to be a better choice than the standard library List for DList's underlying data structure.  Using the original foldRight and map methods were causing OOM with IList however so I moved to something more suitable for how IList works (no OOM or SO now). 
