### PR TITLE
Added "inverse attempt" function to Task

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Task.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Task.scala
@@ -9,6 +9,7 @@ import scalaz.std.list._
 import scalaz.Free.Trampoline
 import scalaz.Trampoline
 import scalaz.\/._
+import scalaz.Liskov._
 
 import collection.JavaConversions._
 import scala.concurrent.duration._
@@ -47,6 +48,10 @@ class Task[+A](val get: Future[Throwable \/ A]) {
       case -\/(e) => \/-(-\/(e))
       case \/-(a) => \/-(\/-(a))
     })
+
+  /** 'Rethrows' exceptions in the given task.  The inverse of attempt. */
+  def rethrow[B](implicit subst: A <~< (Throwable \/ B)): Task[B] =
+    new Task(get map { _ flatMap subst.apply })
 
   /**
    * Returns a new `Task` in which `f` is scheduled to be run on completion.

--- a/tests/src/test/scala/scalaz/concurrent/TaskTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/TaskTest.scala
@@ -125,7 +125,12 @@ object TaskTest extends SpecLite {
     Task { Thread.sleep(10); throw FailWhale; 42 }.handleWith { case FailWhale => Task.delay(throw SadTrombone) }.attemptRun ==
       -\/(SadTrombone)
   }
-  
+
+  "rethrows exceptions after catch" ! {
+    val t: Task[Int] = Task { Thread.sleep(10); throw FailWhale; 42}.attempt.rethrow
+    t.attemptRun == -\/(FailWhale)
+  }
+
   "evalutes Monad[Task].point lazily" in {
     val M = implicitly[Monad[Task]]
     var x = 0


### PR DESCRIPTION
I got tired of reimplementing this function (inefficiently) over and over again.  If there's a pre-existing way of doing this, please let me know.

Basically, this PR adds a `rethrow` function to `Task`, which serves as the direct inverse of `attempt`.  This is enormously useful whenever you want to have a "try/finally-style" pattern inside bind chain.  For example:

```scala
for {
  either <- somethingDangerous.attempt
  _ <- cleanup(resources)
  back <- either.rethrow
} yield back
```