### PR TITLE
Reduce memory footprint of actors, change strategies to be more efficient & safe for actors and async calculations

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Strategy.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Strategy.scala
@@ -19,7 +19,7 @@ trait Strategy {
   /**
    * Number of messages that will be handled in batch by actors.
    */
-  private[concurrent] def batch: Long = 10
+  private[concurrent] def batch: Int = 10
 }
 
 object Strategy extends Strategys
@@ -87,7 +87,7 @@ trait StrategysLow {
 
     def apply(a: => Unit): Unit = a
 
-    private[concurrent] override val batch: Long = -1 // maximize batch size to avoid stack overflow in actors
+    private[concurrent] override val batch: Int = -1
   }
 
   /**
@@ -107,7 +107,7 @@ trait StrategysLow {
    *                    before next actor will handle own messages in the same thread,
    *                    set to 1 for as fair as possible
    */
-  def Executor(execService: ExecutorService, batchSize: Long): Strategy = execService match {
+  def Executor(execService: ExecutorService, batchSize: Int): Strategy = execService match {
     case pool: scala.concurrent.forkjoin.ForkJoinPool => new Strategy {
       def apply[A](a: => A): () => A = {
         val task = new ScalaForkJoinTask[A](pool) {
@@ -127,7 +127,7 @@ trait StrategysLow {
           }
         }
 
-      private[concurrent] override val batch: Long = batchSize
+      private[concurrent] override val batch: Int = batchSize
     }
     case pool: ForkJoinPool => new Strategy {
       def apply[A](a: => A): () => A = {
@@ -148,7 +148,7 @@ trait StrategysLow {
           }
         }
 
-      private[concurrent] override val batch: Long = batchSize
+      private[concurrent] override val batch: Int = batchSize
     }
     case pool => new Strategy {
       def apply[A](a: => A): () => A = {
@@ -162,7 +162,7 @@ trait StrategysLow {
         def run(): Unit = a
       })
 
-      private[concurrent] override val batch: Long = batchSize
+      private[concurrent] override val batch: Int = batchSize
     }
   }
 
@@ -194,7 +194,7 @@ trait StrategysLow {
       def run(): Unit = a
     }).start()
 
-    private[concurrent] override val batch: Long = -1 // maximize batch size to minimize forking of threads
+    private[concurrent] override val batch: Int = -1
   }
 
   /**

--- a/concurrent/src/main/scala/scalaz/concurrent/Strategy.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Strategy.scala
@@ -45,12 +45,19 @@ trait Strategys extends StrategysLow {
     Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors, DefaultDaemonThreadFactory)
 
   /**
+   * Default fork-join pool with LIFO scheduling mode for forked tasks,
+   * where parallelism is equal to the number of available processors.
+   * This pool is suitable for parallel algorithms where tasks are joined.
+   */
+  lazy val DefaultLIFOForkJoinPool: ForkJoinPool =
+    new ForkJoinPool(Runtime.getRuntime.availableProcessors, ForkJoinPool.defaultForkJoinWorkerThreadFactory, null, true)
+
+  /**
    * Default fork-join pool with FIFO scheduling mode for forked tasks,
    * where parallelism is equal to the number of available processors.
-   * This pool is more efficient for actors than a fixed thread pool backed by
-   * `java.util.concurrent.LinkedBlockingQueue` as in `DefaultExecutorService`.
+   * This pool is suitable for actors and other message-passing systems.
    */
-  lazy val DefaultForkJoinPool: ForkJoinPool =
+  lazy val DefaultFIFOForkJoinPool: ForkJoinPool =
     new ForkJoinPool(Runtime.getRuntime.availableProcessors, ForkJoinPool.defaultForkJoinWorkerThreadFactory, null, true)
 
   /**
@@ -145,7 +152,7 @@ trait StrategysLow {
     case pool => new Strategy {
       def apply[A](a: => A) = {
         val future = pool.submit(new Callable[A] {
-          def call = a
+          def call: A = a
         })
         () => future.get
       }

--- a/tests/src/test/scala/scalaz/concurrent/ActorTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/ActorTest.scala
@@ -71,16 +71,17 @@ object ActorTest extends SpecLite {
       assertCountDown(latch, "Should exchange " + n + " messages")
     }
 
-    "send messages to itself and process them" in {
+    "create chain of actors and send message through it" in {
       val latch = new CountDownLatch(1)
-      var actor: Actor[Int] = null
-      actor = Actor[Int] {
+
+      def actor: Actor[Int] = Actor[Int] {
         (i: Int) =>
           if (i > 0) actor ! i - 1
           else latch.countDown()
       }
-      actor ! n
-      assertCountDown(latch, "Should send & process " + n + " messages")
+
+      actor ! (if (s eq  Strategy.Sequential) 100 else n)
+      assertCountDown(latch, "Should send message through chain of " + n + " actors")
     }
 
     "handle messages in order of sending by each thread" in {

--- a/tests/src/test/scala/scalaz/concurrent/ActorTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/ActorTest.scala
@@ -96,14 +96,15 @@ object ActorTest extends SpecLite {
     }
 
     "handle messages in order of sending by each thread" in {
-      val latch = new CountDownLatch(n)
+      val nRounded = (n / NumOfThreads) * NumOfThreads
+      val latch = new CountDownLatch(nRounded)
       val actor = countingDownActor(latch)
       for (j <- 1 to NumOfThreads) fork {
-        for (i <- 1 to n / NumOfThreads) {
+        for (i <- 1 to nRounded / NumOfThreads) {
           actor !(j, i)
         }
       }
-      assertCountDown(latch, "Should process " + n + " messages")
+      assertCountDown(latch, "Should process " + nRounded + " messages")
     }
 
     "redirect unhandled errors to uncaught exception handler of thread" in {

--- a/tests/src/test/scala/scalaz/concurrent/ActorTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/ActorTest.scala
@@ -5,7 +5,7 @@ import java.util.concurrent._
 import ConcurrentTest._
 
 object ActorTest extends SpecLite {
-  val NumOfMessages = 100000
+  val NumOfMessages = 10000
   val NumOfThreads = 4
 
   "actor with sequential strategy" should {

--- a/tests/src/test/scala/scalaz/concurrent/ActorTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/ActorTest.scala
@@ -4,53 +4,111 @@ package concurrent
 import collection.mutable
 import java.util.concurrent._
 import ConcurrentTest._
-import org.scalacheck.Prop.forAll
 
 object ActorTest extends SpecLite {
   val NumOfMessages = 1000
   val NumOfThreads = 4
   val NumOfMessagesPerThread = NumOfMessages / NumOfThreads
-  implicit val executor = Executors.newFixedThreadPool(NumOfThreads)
+  val executor = Executors.newFixedThreadPool(NumOfThreads)
+  implicit val strategy = Actor.strategy(executor)
 
-  "code executes async" in {
-    val latch = new CountDownLatch(1)
-    val actor = Actor[Int]((i: Int) => latch.countDown())
-    actor ! 1
-    assertCountDown(latch, "Should process a message")
-  }
-
-  "code errors are catched and can be handled" in {
-    val latch = new CountDownLatch(1)
-    val actor = Actor[Int]((i: Int) => 100 / i, (ex: Throwable) => latch.countDown())
-    actor ! 0
-    assertCountDown(latch, "Should catch an exception")
-  }
-
-  "actors exchange messages without loss" in {
-    val latch = new CountDownLatch(NumOfMessages)
-    var actor1: Actor[Int] = null
-    val actor2 = Actor[Int]((i: Int) => actor1 ! i - 1)
-    actor1 = Actor[Int] {
-      (i: Int) =>
-        if (i == latch.getCount) {
-          if (i != 0) actor2 ! i - 1
-          latch.countDown()
-          latch.countDown()
-        }
+  "actor" should {
+    "execute code async" in {
+      val latch = new CountDownLatch(1)
+      val actor = Actor[Int]((i: Int) => latch.countDown())
+      actor ! 1
+      assertCountDown(latch, "Should process a message")
     }
-    actor1 ! NumOfMessages
-    assertCountDown(latch, "Should exchange " + NumOfMessages + " messages")
-  }
 
-  "actor handles messages in order of sending by each thread" in {
-    val latch = new CountDownLatch(NumOfMessages)
-    val actor = countingDownActor(latch)
-    for (j <- 1 to NumOfThreads) fork {
-      for (i <- 1 to NumOfMessagesPerThread) {
-        actor ! (j, i)
+    "catch code errors that can be handled" in {
+      val latch = new CountDownLatch(1)
+      val actor = Actor[Int]((i: Int) => 100 / i, (ex: Throwable) => latch.countDown())
+      actor ! 0
+      assertCountDown(latch, "Should catch an exception")
+    }
+
+    "exchange messages with another actor without loss" in {
+      val latch = new CountDownLatch(NumOfMessages)
+      var actor1: Actor[Int] = null
+      val actor2 = Actor[Int]((i: Int) => actor1 ! i - 1)
+      actor1 = Actor[Int] {
+        (i: Int) =>
+          if (i == latch.getCount) {
+            if (i != 0) actor2 ! i - 1
+            latch.countDown()
+            latch.countDown()
+          }
       }
+      actor1 ! NumOfMessages
+      assertCountDown(latch, "Should exchange " + NumOfMessages + " messages")
     }
-    assertCountDown(latch, "Should process " + NumOfMessages + " messages")
+
+    "handle messages in order of sending by each thread" in {
+      val latch = new CountDownLatch(NumOfMessages)
+      val actor = countingDownActor(latch)
+      for (j <- 1 to NumOfThreads) fork {
+        for (i <- 1 to NumOfMessagesPerThread) {
+          actor !(j, i)
+        }
+      }
+      assertCountDown(latch, "Should process " + NumOfMessages + " messages")
+    }
+  }
+
+  "actor strategy" should {
+    "execute code async for different pools" in {
+      val l = new CountDownLatch(2/*3*/)
+      val f = (_: Int) => l.countDown()
+      Actor(f) {
+        import scala.concurrent.forkjoin._
+        Actor.strategy(new ForkJoinPool(NumOfThreads))
+      } ! 1
+// TODO uncomment if Java 6 support will be discarded or add dependency on JSR166 classes compiled for Java 6
+/*
+      Actor(f) {
+        Actor.strategy(new ForkJoinPool(NumOfThreads))
+      } ! 1
+*/
+      Actor(f) {
+        Actor.strategy(Executors.newFixedThreadPool(NumOfThreads))
+      } ! 1
+      assertCountDown(l, "Should execute on all pools")
+    }
+
+    "redirect unhandled errors to thread's uncaught exception handler of different pools" in {
+      val l = new CountDownLatch(2/*3*/)
+      val f = (_: Int) => throw new RuntimeException()
+      val h = new java.lang.Thread.UncaughtExceptionHandler() {
+        override def uncaughtException(t: Thread, e: Throwable): Unit = l.countDown()
+      }
+      Actor(f) {
+        import scala.concurrent.forkjoin._
+        Actor.strategy(new ForkJoinPool(NumOfThreads, new ForkJoinPool.ForkJoinWorkerThreadFactory() {
+          override def newThread(pool: ForkJoinPool): ForkJoinWorkerThread = new ForkJoinWorkerThread(pool) {
+            setUncaughtExceptionHandler(h)
+          }
+        }, null, true))
+      } ! 1
+// TODO uncomment if Java 6 support will be discarded or add dependency on JSR166 classes compiled for Java 6
+/*
+      Actor(f) {
+        Actor.strategy(new ForkJoinPool(NumOfThreads, new ForkJoinPool.ForkJoinWorkerThreadFactory() {
+          override def newThread(pool: ForkJoinPool): ForkJoinWorkerThread = new ForkJoinWorkerThread(pool) {
+            setUncaughtExceptionHandler(h)
+          }
+        }, null, true))
+      } ! 1
+*/
+      Actor(f) {
+        Actor.strategy(new ThreadPoolExecutor(NumOfThreads, NumOfThreads, 0L, TimeUnit.MILLISECONDS,
+          new LinkedBlockingQueue[Runnable], new ThreadFactory {
+            override def newThread(r: Runnable): Thread = new Thread(r) {
+              setUncaughtExceptionHandler(h)
+            }
+          }))
+      } ! 1
+      assertCountDown(l, "Should handle all uncaught exceptions")
+    }
   }
 
   def countingDownActor(latch: CountDownLatch): Actor[(Int, Int)] = Actor[(Int, Int)] {

--- a/tests/src/test/scala/scalaz/concurrent/ActorTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/ActorTest.scala
@@ -1,18 +1,58 @@
 package scalaz
 package concurrent
 
-import collection.mutable
 import java.util.concurrent._
 import ConcurrentTest._
 
 object ActorTest extends SpecLite {
-  val NumOfMessages = 1000
+  val NumOfMessages = 100000
   val NumOfThreads = 4
-  val NumOfMessagesPerThread = NumOfMessages / NumOfThreads
-  val executor = Executors.newFixedThreadPool(NumOfThreads)
-  implicit val strategy = Actor.strategy(executor)
 
-  "actor" should {
+  "actor with sequential strategy" should {
+    actorTests(NumOfMessages)(Strategy.Sequential)
+  }
+
+  "actor with default strategy" should {
+    actorTests(NumOfMessages)(Strategy.DefaultStrategy)
+  }
+
+  "actor with executor strategy backed by Scala fork-join pool" should {
+    actorTests(NumOfMessages)(Strategy.Executor(new scala.concurrent.forkjoin.ForkJoinPool()))
+  }
+
+  "actor with executor strategy backed by Java fork-join pool" should {
+    actorTests(NumOfMessages)(Strategy.Executor(new ForkJoinPool()))
+  }
+
+  "actor with executor strategy backed by fixed thread pool" should {
+    actorTests(NumOfMessages)(Strategy.Executor(Executors.newFixedThreadPool(NumOfThreads, Strategy.DefaultDaemonThreadFactory)))
+  }
+
+  "actor with naive strategy" should {
+    actorTests(NumOfMessages / 1000)(Strategy.Naive)
+  }
+
+  "actor with Swing worker strategy" should {
+    actorTests(NumOfMessages)(Strategy.SwingWorker)
+  }
+
+  "actor with Swing invoke later strategy" should {
+    actorTests(NumOfMessages)(Strategy.SwingInvokeLater)
+  }
+
+  "actor with actor strategy backed by Scala fork-join pool" should {
+    actorTests(NumOfMessages)(Actor.strategy(new scala.concurrent.forkjoin.ForkJoinPool()))
+  }
+
+  "actor with actor strategy backed by Java fork-join pool" should {
+    actorTests(NumOfMessages)(Actor.strategy(new ForkJoinPool()))
+  }
+
+  "actor with actor strategy backed by fixed thread pool" should {
+    actorTests(NumOfMessages)(Actor.strategy(Executors.newFixedThreadPool(NumOfThreads, Strategy.DefaultDaemonThreadFactory)))
+  }
+
+  def actorTests(n: Int)(implicit s: Strategy) = {
     "execute code async" in {
       val latch = new CountDownLatch(1)
       val actor = Actor[Int]((i: Int) => latch.countDown())
@@ -22,13 +62,13 @@ object ActorTest extends SpecLite {
 
     "catch code errors that can be handled" in {
       val latch = new CountDownLatch(1)
-      val actor = Actor[Int]((i: Int) => 100 / i, (ex: Throwable) => latch.countDown())
-      actor ! 0
+      val actor = Actor[Int]((i: Int) => 1 / 0, (ex: Throwable) => latch.countDown())
+      actor ! 1
       assertCountDown(latch, "Should catch an exception")
     }
 
     "exchange messages with another actor without loss" in {
-      val latch = new CountDownLatch(NumOfMessages)
+      val latch = new CountDownLatch(n)
       var actor1: Actor[Int] = null
       val actor2 = Actor[Int]((i: Int) => actor1 ! i - 1)
       actor1 = Actor[Int] {
@@ -39,80 +79,52 @@ object ActorTest extends SpecLite {
             latch.countDown()
           }
       }
-      actor1 ! NumOfMessages
-      assertCountDown(latch, "Should exchange " + NumOfMessages + " messages")
+      actor1 ! n
+      assertCountDown(latch, "Should exchange " + n + " messages")
+    }
+
+    "send messages to itself and process them" in {
+      val latch = new CountDownLatch(1)
+      var actor: Actor[Int] = null
+      actor = Actor[Int] {
+        (i: Int) =>
+          if (i > 0) actor ! i - 1
+          else latch.countDown()
+      }
+      actor ! n
+      assertCountDown(latch, "Should send & process " + n + " messages")
     }
 
     "handle messages in order of sending by each thread" in {
-      val latch = new CountDownLatch(NumOfMessages)
+      val latch = new CountDownLatch(n)
       val actor = countingDownActor(latch)
       for (j <- 1 to NumOfThreads) fork {
-        for (i <- 1 to NumOfMessagesPerThread) {
+        for (i <- 1 to n / NumOfThreads) {
           actor !(j, i)
         }
       }
-      assertCountDown(latch, "Should process " + NumOfMessages + " messages")
-    }
-  }
-
-  "actor strategy" should {
-    "execute code async for different pools" in {
-      val l = new CountDownLatch(2/*3*/)
-      val f = (_: Int) => l.countDown()
-      Actor(f) {
-        import scala.concurrent.forkjoin._
-        Actor.strategy(new ForkJoinPool(NumOfThreads))
-      } ! 1
-// TODO uncomment if Java 6 support will be discarded or add dependency on JSR166 classes compiled for Java 6
-/*
-      Actor(f) {
-        Actor.strategy(new ForkJoinPool(NumOfThreads))
-      } ! 1
-*/
-      Actor(f) {
-        Actor.strategy(Executors.newFixedThreadPool(NumOfThreads))
-      } ! 1
-      assertCountDown(l, "Should execute on all pools")
+      assertCountDown(latch, "Should process " + n + " messages")
     }
 
-    "redirect unhandled errors to thread's uncaught exception handler of different pools" in {
-      val l = new CountDownLatch(2/*3*/)
-      val f = (_: Int) => throw new RuntimeException()
-      val h = new java.lang.Thread.UncaughtExceptionHandler() {
-        override def uncaughtException(t: Thread, e: Throwable): Unit = l.countDown()
-      }
-      Actor(f) {
-        import scala.concurrent.forkjoin._
-        Actor.strategy(new ForkJoinPool(NumOfThreads, new ForkJoinPool.ForkJoinWorkerThreadFactory() {
-          override def newThread(pool: ForkJoinPool): ForkJoinWorkerThread = new ForkJoinWorkerThread(pool) {
-            setUncaughtExceptionHandler(h)
-          }
-        }, null, true))
-      } ! 1
-// TODO uncomment if Java 6 support will be discarded or add dependency on JSR166 classes compiled for Java 6
-/*
-      Actor(f) {
-        Actor.strategy(new ForkJoinPool(NumOfThreads, new ForkJoinPool.ForkJoinWorkerThreadFactory() {
-          override def newThread(pool: ForkJoinPool): ForkJoinWorkerThread = new ForkJoinWorkerThread(pool) {
-            setUncaughtExceptionHandler(h)
-          }
-        }, null, true))
-      } ! 1
-*/
-      Actor(f) {
-        Actor.strategy(new ThreadPoolExecutor(NumOfThreads, NumOfThreads, 0L, TimeUnit.MILLISECONDS,
-          new LinkedBlockingQueue[Runnable], new ThreadFactory {
-            override def newThread(r: Runnable): Thread = new Thread(r) {
-              setUncaughtExceptionHandler(h)
-            }
-          }))
-      } ! 1
-      assertCountDown(l, "Should handle all uncaught exceptions")
+    "redirect unhandled errors to uncaught exception handler of thread" in {
+      val l = new CountDownLatch(1)
+      val err = System.err
+      try {
+        System.setErr(new java.io.PrintStream(new java.io.OutputStream {
+          override def write(b: Int): Unit = l.countDown()
+        }))
+        Actor((_: Int) => 1 / 0) ! 1
+        assertCountDown(l, "Should print to System.err uncaught exception")
+      } catch {
+        case e: ArithmeticException if e.getMessage == "/ by zero" =>
+          l.countDown() // for a sequential strategy
+          assertCountDown(l, "Should print to System.err uncaught exception")
+      } finally System.setErr(err)
     }
   }
 
   def countingDownActor(latch: CountDownLatch): Actor[(Int, Int)] = Actor[(Int, Int)] {
-    val ms = mutable.Map[Int, Int]()
+    val ms = collection.mutable.Map[Int, Int]()
 
     (m: (Int, Int)) =>
       val (j, i) = m

--- a/tests/src/test/scala/scalaz/concurrent/ConcurrentTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/ConcurrentTest.scala
@@ -3,51 +3,47 @@ package concurrent
 
 import java.util.concurrent._
 import org.scalacheck.Prop
-import org.scalacheck.Prop.forAll
 
 object ConcurrentTest extends SpecLite{
 
   "Current test tools" should {
     "succeed on exhaused CountDownLatch" in {
       val latch = new CountDownLatch(1)
-      latch.countDown
+      latch.countDown()
       assertCountDown(latch, "Should always be processed immediately")
     }
 
     "run forked code" in {
       val latch = new CountDownLatch(1)
       fork {
-        latch.countDown
+        latch.countDown()
       }
       assertCountDown(latch, "Should be processed asynchronously")
     }
 
     "run test with timeout" in {
-      (withTimeout(2000) {
+      withTimeout(2000) {
         true
-      })
+      }
     }
 
     "fail when timeout occurs" in {
-      (withTimeout(100) {
+      withTimeout(100) {
         Thread.sleep(2000)
-        ()
-      }).mustThrowA[RuntimeException]
+      }.mustThrowA[RuntimeException]
     }
   }
 
-  def assertCountDown(latch: CountDownLatch, hint: String, timeout: Long = 1000) : Prop = {
+  def assertCountDown(latch: CountDownLatch, hint: String, timeout: Long = 1000) : Prop =
     if (latch.await(timeout, TimeUnit.MILLISECONDS)) ()
     else sys.error("Failed to count down within " + timeout + " millis: " + hint)
-  }
 
-  def fork(f: => Unit) {
+  def fork(f: => Unit): Unit =
     new Thread {
       override def run() {
         f
       }
     }.start()
-  }
 
   final class WithTimeout(timeout: Long) {
     def apply[A](test: => A): A = {
@@ -55,7 +51,7 @@ object ConcurrentTest extends SpecLite{
       @volatile var result: A = null.asInstanceOf[A]
       fork {
         result = test
-        latch.countDown
+        latch.countDown()
       }
       if (latch.await(timeout, TimeUnit.MILLISECONDS)) result
       else sys.error("Timeout occured, possible deadlock.")

--- a/tests/src/test/scala/scalaz/concurrent/StrategyTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/StrategyTest.scala
@@ -36,7 +36,7 @@ object StrategyTest extends SpecLite {
   }
 
   "the naive strategy" should {
-    recursiveStrategyTests(NumOfIterations, Strategy.Naive)
+    recursiveStrategyTests(NumOfIterations / 100, Strategy.Naive)
   }
 
   "the Swing worker strategy" should {

--- a/tests/src/test/scala/scalaz/concurrent/StrategyTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/StrategyTest.scala
@@ -1,0 +1,91 @@
+package scalaz
+package concurrent
+
+import java.util.concurrent._
+
+object StrategyTest extends SpecLite {
+  val NumOfIterations = 10000
+  val NumOfThreads = 4
+
+  "the sequential strategy" should {
+    strategyTests(Strategy.Sequential)
+  }
+
+  "the default strategy" should {
+    strategyTests(Strategy.DefaultStrategy)
+  }
+
+  "an executor strategy backed by Scala fork-join pool" should {
+    recursiveStrategyTests(NumOfIterations, Strategy.Executor(new scala.concurrent.forkjoin.ForkJoinPool()))
+  }
+
+  "an executor strategy backed by Java fork-join pool with FIFO mode" should {
+    recursiveStrategyTests(NumOfIterations, Strategy.Executor(Strategy.DefaultFIFOForkJoinPool))
+  }
+
+  "an executor strategy backed by Java fork-join pool with LIFO mode" should {
+    recursiveStrategyTests(NumOfIterations, Strategy.Executor(Strategy.DefaultLIFOForkJoinPool))
+  }
+
+  "an executor strategy backed by fixed thread pool" should {
+    strategyTests(Strategy.Executor(Executors.newFixedThreadPool(NumOfThreads, Strategy.DefaultDaemonThreadFactory)))
+  }
+
+  "the id strategy" should {
+    recursiveStrategyTests(NumOfIterations, Strategy.Id)
+  }
+
+  "the naive strategy" should {
+    recursiveStrategyTests(NumOfIterations, Strategy.Naive)
+  }
+
+  "the Swing worker strategy" should {
+    strategyTests(Strategy.SwingWorker)
+  }
+
+  "the Swing invoke later strategy" should {
+    strategyTests(Strategy.SwingInvokeLater)
+  }
+
+  def strategyTests(s: Strategy) = {
+    "evaluate result async" in {
+      val f = s(1 + 1)
+      f() must_== 2
+    }
+
+    "catch code errors that can be handled" in {
+      try {
+        val f = s(1 / 0)
+        if (s eq Strategy.Id) f().mustThrowA[ArithmeticException]
+        else f().mustThrowA[ExecutionException]
+      } catch {
+        case _: ArithmeticException => s must_== Strategy.Sequential
+      }
+    }
+  }
+
+  def recursiveStrategyTests(n: Int, s: Strategy) = {
+    strategyTests(s)
+
+    "be called recursively for parallel algorithms" in {
+      def factorial(n: Int): BigInt = {
+        def rangeProduct(n1: Int, n2: Int): BigInt = {
+          val d = n2 - n1
+          d match {
+            case 0 => BigInt(n1)
+            case 1 => BigInt(n1.toLong * n2)
+            case 2 => BigInt(n1.toLong * (n1 + 1)) * n2
+            case 3 => BigInt(n1.toLong * (n1 + 1)) * BigInt(n2.toLong * (n2 - 1))
+            case _ =>
+              val f = s(rangeProduct(n1, n1 + (d >> 1)))
+              rangeProduct(n1 + (d >> 1) + 1, n2) * f()
+          }
+        }
+
+        rangeProduct(1, n)
+      }
+
+      factorial(n) must_== (BigInt(1) to BigInt(n)).product
+    }
+  }
+}


### PR DESCRIPTION
Proposed changes and additions:
1. Reduce 40 bytes per actor instance by replacing `val` by `def` in `toEffect` definition.
2. Improve an executor strategies that baked by FJ pools to be more efficient in submitting tasks for execution.
3. Add `def apply(a: => Unit): Unit` to strategies to be yet more efficient with actors (or other message-passing systems).
4. Improvements of default error handiling in actors: fix `InterruptedException` to be rethown properly, add sending of uncatched errors to `UncaughtExceptionHandler` of thread that by default prints stack trace. 
5. Add creation on demand for default strategy, thread factory and executor services to minimize usage of resources.
6. Use default thread factory that creates deamon threads for the naive strategy.
7. Add `DefaultLIFOForkJoinPool` and `DefaultFIFOForkJoinPool` as more suitable thread pool (for async calculations & actors accordingy) than `DefaultExecutorService` backed by `ThreadPoolExecutor`.
8. Add `Executor(execService: ExecutorService, batchSize: Long): Strategy` to allow fine tuning of trade off between fairness and throughput of actors.
9. Reduce default batch size of actors from 1024 to 10 that allows to improve fairness of predefined strategies.
10. Fix the sequential strategy to run actors without stack overflow.
11. Improve the naive strategy to minimize forking of new threads in message handing loop of actors.
12. Improve tests for actors and strategies. 