### PR TITLE
Add liftEitherT to \/ instances.

### DIFF
--- a/core/src/main/scala/scalaz/syntax/EitherTOps.scala
+++ b/core/src/main/scala/scalaz/syntax/EitherTOps.scala
@@ -2,8 +2,8 @@ package scalaz
 package syntax
 
 final class EitherTOps[A, B](val self: A \/ B) extends AnyVal {
-  def liftEitherT[M[_]](implicit M0: Monad[M]): EitherT[M, A, B] =
-    EitherT(M0.point(self))
+  def liftEitherT[F[_]](implicit A0: Applicative[F]): EitherT[F, A, B] =
+    EitherT(A0.point(self))
 }
 
 trait ToEitherTOps {

--- a/core/src/main/scala/scalaz/syntax/EitherTOps.scala
+++ b/core/src/main/scala/scalaz/syntax/EitherTOps.scala
@@ -6,6 +6,6 @@ final class EitherTOps[A, B](val self: A \/ B) extends AnyVal {
     EitherT(A0.point(self))
 }
 
-trait ToEitherTOps {
-  implicit def ToEitherTOps[A, B](a: A \/ B) = new EitherTOps(a)
+trait EitherToEitherTOps {
+  implicit def EitherToEitherTOps[A, B](a: A \/ B) = new EitherTOps(a)
 }

--- a/core/src/main/scala/scalaz/syntax/EitherTOps.scala
+++ b/core/src/main/scala/scalaz/syntax/EitherTOps.scala
@@ -1,0 +1,11 @@
+package scalaz
+package syntax
+
+final class EitherTOps[A, B](val self: A \/ B) extends AnyVal {
+  def liftEitherT[M[_]](implicit M0: Monad[M]): EitherT[M, A, B] =
+    EitherT(M0.point(self))
+}
+
+trait ToEitherTOps {
+  implicit def ToEitherTOps[A, B](a: A \/ B) = new EitherTOps(a)
+}

--- a/core/src/main/scala/scalaz/syntax/Syntax.scala
+++ b/core/src/main/scala/scalaz/syntax/Syntax.scala
@@ -119,6 +119,8 @@ trait Syntaxes {
 
   object either extends ToEitherOps
 
+  object eitherT extends ToEitherTOps
+
   object nel extends ToNelOps
 
   object these extends ToTheseOps
@@ -144,6 +146,7 @@ trait ToDataOps
   with ToValidationOps
   with ToKleisliOps
   with ToEitherOps
+  with ToEitherTOps
   with ToNelOps
   with ToTheseOps
   with ToMaybeOps

--- a/core/src/main/scala/scalaz/syntax/Syntax.scala
+++ b/core/src/main/scala/scalaz/syntax/Syntax.scala
@@ -119,7 +119,7 @@ trait Syntaxes {
 
   object either extends ToEitherOps
 
-  object eitherT extends ToEitherTOps
+  object eitherT extends EitherToEitherTOps
 
   object nel extends ToNelOps
 
@@ -146,7 +146,7 @@ trait ToDataOps
   with ToValidationOps
   with ToKleisliOps
   with ToEitherOps
-  with ToEitherTOps
+  with EitherToEitherTOps
   with ToNelOps
   with ToTheseOps
   with ToMaybeOps

--- a/tests/src/test/scala/scalaz/EitherTTest.scala
+++ b/tests/src/test/scala/scalaz/EitherTTest.scala
@@ -93,8 +93,8 @@ object EitherTTest extends SpecLite {
 
     val r: String \/ Int = \/-(123)
     val l: String \/ Int = -\/("Fail")
-    val et1: EitherT[Option, String, Int] = r.liftEitherT[Option]
-    val et2: EitherT[Option, String, Int] = l.liftEitherT[Option]
+    r.liftEitherT[Option]: EitherT[Option, String, Int]
+    l.liftEitherT[Option]: EitherT[Option, String, Int]
   }
 
 }

--- a/tests/src/test/scala/scalaz/EitherTTest.scala
+++ b/tests/src/test/scala/scalaz/EitherTTest.scala
@@ -34,6 +34,11 @@ object EitherTTest extends SpecLite {
     a.flatMap(f andThen EitherT.apply) must_=== a.flatMapF(f)
   }
 
+  "liftEitherT must use the default minimal context of the lifted monad" ! forAll { (a: Int \/ Int) =>
+    import scalaz.syntax.eitherT._
+    a.liftEitherT[Option].run must_=== Some(a)
+  }
+
   object instances {
     def functor[F[_] : Functor, A] = Functor[({type λ[α] = EitherT[F, A, α]})#λ]
     def monad[F[_] : Monad, A] = Monad[({type λ[α] = EitherT[F, A, α]})#λ]
@@ -83,6 +88,13 @@ object EitherTTest extends SpecLite {
     for {
       (a,b) <- brokenMethod
     } yield "yay"
+
+    import scalaz.syntax.eitherT._
+
+    val r: String \/ Int = \/-(123)
+    val l: String \/ Int = -\/("Fail")
+    val et1: EitherT[Option, String, Int] = r.liftEitherT[Option]
+    val et2: EitherT[Option, String, Int] = l.liftEitherT[Option]
   }
 
 }


### PR DESCRIPTION
Implemented as a new EitherTOps class, rather than adding as a function to \/, because doing it there needed to specify all three types (lifted monad, left, right) due to covariant types in \/ and invariant types in EitherT.

Test and compilation check added.