### PR TITLE
Add gather function for Task

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Task.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Task.scala
@@ -1,13 +1,12 @@
 package scalaz.concurrent
 
-import java.util.concurrent.{ScheduledExecutorService, ConcurrentLinkedQueue, ExecutorService, Executors}
+import java.util.concurrent.{ScheduledExecutorService, ConcurrentLinkedQueue, ExecutorService}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 
-import scalaz.{Catchable, Maybe, MonadError, Nondeterminism, Reducer, Traverse, \/, -\/, \/-}
+import scalaz.{Catchable, Maybe, MonadError, Nondeterminism, Reducer, Trampoline, Traverse, \/, -\/, \/-}
 import scalaz.syntax.monad._
 import scalaz.std.list._
 import scalaz.Free.Trampoline
-import scalaz.Trampoline
 import scalaz.\/._
 
 import collection.JavaConversions._
@@ -307,6 +306,9 @@ object Task {
    */
   def async[A](register: ((Throwable \/ A) => Unit) => Unit): Task[A] =
     new Task(Future.async(register))
+
+  def schedule[A](a: => A, delay: Duration)(implicit pool: ScheduledExecutorService =
+    Strategy.DefaultTimeoutScheduler): Task[A] = new Task(Future.schedule(Try(a), delay))
 
   /**
    * Like `Nondeterminism[Task].gatherUnordered`, but if `exceptionCancels` is true,

--- a/tests/src/test/scala/scalaz/concurrent/TaskTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/TaskTest.scala
@@ -196,7 +196,7 @@ object TaskTest extends SpecLite {
     implicit val anyArb = Arbitrary[Any](Gen.oneOf(arbitrary[Number], arbitrary[Int], arbitrary[Boolean]))
 
     "early terminate once any of the tasks failed (ordered)" ! forAll { (xs: List[Task[Any]], ex: Throwable, time: Byte, index: Int) =>
-      val fail = Task.schedule(throw ex, time.milliseconds)
+      val fail = Task.schedule(throw ex, time.toInt.milliseconds)
       val toSeq =
         if (xs.isEmpty) List(fail)
         else {

--- a/tests/src/test/scala/scalaz/concurrent/TaskTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/TaskTest.scala
@@ -1,6 +1,11 @@
 package scalaz
 package concurrent
 
+import org.scalacheck.{Gen, Arbitrary}
+import Arbitrary.arbitrary
+
+
+import scala.concurrent.duration._
 import scalaz.std.AllInstances._
 import scalaz.scalacheck.ScalazArbitrary._
 import org.scalacheck.Prop._
@@ -185,6 +190,25 @@ object TaskTest extends SpecLite {
 
       t1v.get must_== 0
       t3v.get must_== 0
+    }
+
+    implicit val arb3: Arbitrary[Byte] = Arbitrary(Gen.choose(0, Byte.MaxValue))
+    implicit val anyArb = Arbitrary[Any](Gen.oneOf(arbitrary[Number], arbitrary[Int], arbitrary[Boolean]))
+
+    "early terminate once any of the tasks failed (ordered)" ! forAll { (xs: List[Task[Any]], ex: Throwable, time: Byte, index: Int) =>
+      val fail = Task.schedule(throw ex, time.milliseconds)
+      val toSeq =
+        if (xs.isEmpty) List(fail)
+        else {
+          val (begin, end) = xs.splitAt(index % xs.length)
+          begin ::: fail :: end
+        }
+
+      val sequenced = Task.gather(toSeq)
+      val result = sequenced.attemptRunFor((time + 20).milliseconds)
+      result match {
+        case -\/(failure) => failure == ex
+      }
     }
 
     "early terminate once any of the tasks failed, and cancels execution" in {


### PR DESCRIPTION
Because it is useful and maintains consistency; NonDeterminism also has both a gatherUnordered and a gather. Task should be the same.