### PR TITLE
Move InvariantFunctor[F] instances to F companion object

### DIFF
--- a/core/src/main/scala/scalaz/InvariantFunctor.scala
+++ b/core/src/main/scala/scalaz/InvariantFunctor.scala
@@ -50,20 +50,5 @@ object InvariantFunctor {
   @inline def apply[F[_]](implicit F: InvariantFunctor[F]): InvariantFunctor[F] = F
 
   ////
-
-  /** Semigroup is an invariant functor. */
-  implicit val semigroupInvariantFunctor: InvariantFunctor[Semigroup] = new InvariantFunctor[Semigroup] {
-    def xmap[A, B](ma: Semigroup[A], f: A => B, g: B => A): Semigroup[B] = new Semigroup[B] {
-      def append(x: B, y: => B): B = f(ma.append(g(x), g(y)))
-    }
-  }
-
-  /** Monoid is an invariant functor. */
-  implicit val monoidInvariantFunctor: InvariantFunctor[Monoid] = new InvariantFunctor[Monoid] {
-    def xmap[A, B](ma: Monoid[A], f: A => B, g: B => A): Monoid[B] = new Monoid[B] {
-      def zero: B = f(ma.zero)
-      def append(x: B, y: => B): B = f(ma.append(g(x), g(y)))
-    }
-  }
   ////
 }

--- a/core/src/main/scala/scalaz/Monoid.scala
+++ b/core/src/main/scala/scalaz/Monoid.scala
@@ -109,5 +109,13 @@ object Monoid {
     def plus[A](f1: A0[A], f2: => A0[A]): A0[A] = M0.append(f1, f2)
   }
 
+  /** Monoid is an invariant functor. */
+  implicit val monoidInvariantFunctor: InvariantFunctor[Monoid] = new InvariantFunctor[Monoid] {
+    def xmap[A, B](ma: Monoid[A], f: A => B, g: B => A): Monoid[B] = new Monoid[B] {
+      def zero: B = f(ma.zero)
+      def append(x: B, y: => B): B = f(ma.append(g(x), g(y)))
+    }
+  }
+
   ////
 }

--- a/core/src/main/scala/scalaz/Semigroup.scala
+++ b/core/src/main/scala/scalaz/Semigroup.scala
@@ -118,5 +118,12 @@ object Semigroup {
   def iterate[F[_], A](a: A)(f: A => A)(implicit F: Applicative[F], m: Semigroup[F[A]]): F[A] =
     m.append(F.point(a), iterate[F, A](f(a))(f))
 
+  /** Semigroup is an invariant functor. */
+  implicit val semigroupInvariantFunctor: InvariantFunctor[Semigroup] = new InvariantFunctor[Semigroup] {
+    def xmap[A, B](ma: Semigroup[A], f: A => B, g: B => A): Semigroup[B] = new Semigroup[B] {
+      def append(x: B, y: => B): B = f(ma.append(g(x), g(y)))
+    }
+  }
+
   ////
 }

--- a/tests/src/test/scala/scalaz/InvariantFunctorTest.scala
+++ b/tests/src/test/scala/scalaz/InvariantFunctorTest.scala
@@ -30,15 +30,4 @@ object InvariantFunctorTest extends SpecLite {
   case class Num(x: Int)
   implicit val showNum = Show.showA[Num]
   implicit val eqNum = Equal.equalA[Num]
-
-  "semigroup" in {
-    val sg: Semigroup[Num] = Semigroup[Int].xmap[Num](Num.apply _, _.x)
-    sg.append(Num(1), Num(2)) must_===(Num(3))
-  }
-
-  "monoid" in {
-    val sg: Monoid[Num] = Monoid[Int].xmap[Num](Num.apply _, _.x)
-    sg.append(Num(1), Num(2)) must_===(Num(3))
-    sg.zero must_===(Num(0))
-  }
 }

--- a/tests/src/test/scala/scalaz/MonoidTest.scala
+++ b/tests/src/test/scala/scalaz/MonoidTest.scala
@@ -41,4 +41,13 @@ object MonoidTest extends SpecLite {
     ((Foldable[List] compose Foldable[Vector]).intercalate(xs, Cord("!!")).toString
      must_===(Cord("this!!has!!elements!!beneath").toString))
   }
+
+  "invariant functor" in {
+    import InvariantFunctorTest._
+    import syntax.invariantFunctor._
+
+    val sg: Monoid[Num] = Monoid[Int].xmap[Num](Num.apply _, _.x)
+    sg.append(Num(1), Num(2)) must_===(Num(3))
+    sg.zero must_===(Num(0))
+  }
 }

--- a/tests/src/test/scala/scalaz/SemigroupTest.scala
+++ b/tests/src/test/scala/scalaz/SemigroupTest.scala
@@ -1,0 +1,16 @@
+package scalaz
+
+import std.AllInstances._
+import scalaz.scalacheck.ScalazProperties._
+import scalaz.scalacheck.ScalazArbitrary._
+import org.scalacheck.Arbitrary
+
+object SemigroupTest extends SpecLite {
+  "invariant functor" in {
+    import InvariantFunctorTest._
+    import syntax.invariantFunctor._
+
+    val sg: Semigroup[Num] = Semigroup[Int].xmap[Num](Num.apply _, _.x)
+    sg.append(Num(1), Num(2)) must_===(Num(3))
+  }
+}


### PR DESCRIPTION
This makes the instance locations consistent with instances for other
type classes. For example, the Contravariant[Equal] instance is in the
Equal companion object, and the Contravariant[Order] instance is on the
Order companion object.
