### PR TITLE
Switch to new Travis CI build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
+# Use Docker-based container (instead of OpenVZ)
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.sbt
+    - $HOME/.ivy2
+
 language: scala
 scala:
   - 2.11.2
@@ -5,4 +13,8 @@ scala:
 jdk:
   - openjdk7
 
-script: sbt ++$TRAVIS_SCALA_VERSION check-gen-type-classes test
+script:
+  - sbt ++$TRAVIS_SCALA_VERSION check-gen-type-classes test
+
+  # Trick to avoid unnecessary cache updates
+  - find $HOME/.sbt -name "*.lock" | xargs rm


### PR DESCRIPTION
- faster VM boot time (running in a docker container)
- better performances (linux kernel 3.x instead of 2.x, 4G of RAM
  instead of 3G, better CPU power/parallelism, faster download, etc.)
- Ability to cache files in S3 storage

After file cache being filled, the total build time is reduced from ~6-7 minutes per job to [~5 minutes per job](https://travis-ci.org/gildegoma/scalaz/builds/45020812).

See also http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/.
