### PR TITLE
Improve new Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jdk:
   - openjdk7
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION check-gen-type-classes test
+  - sbt ++$TRAVIS_SCALA_VERSION -J-Xmx3784m check-gen-type-classes test
 
   # Tricks to avoid unnecessary cache updates
   - find $HOME/.sbt -name "*.lock" | xargs rm


### PR DESCRIPTION
@xuwei-k in continuation of #867, it does not make sense to cache the complete `~/.sbt`, which contains dependencies of scala versions unused in this project.

The comments in `.travis.yml` are quite verbose, please tell me if you prefer that I move them into git commit details. I feel that it is handy to have them as a reminder, but I understand if you prefer something shorter.

Please pay attention that during my little tests, I encountered [once](https://travis-ci.org/gildegoma/scalaz/jobs/45080095#L3867) a [false negative build](https://travis-ci.org/gildegoma/scalaz/builds/45080094). Is it some known problem? Or could it be related to the new build environment context (Docker, LXC, ...)?

PS: I don't know if d1c4d53 makes sense or not (to improve performance or stability). Please tell me if you prefer to drop it.
