### PR TITLE
Fixed foldLeftM stack overflows on Set #866

### DIFF
--- a/core/src/main/scala/scalaz/std/Set.scala
+++ b/core/src/main/scala/scalaz/std/Set.scala
@@ -16,7 +16,9 @@ trait SetInstances {
       fa.foreach(a => s += a)
       var r = z
       while (!s.isEmpty) {
-        r = f(s.pop, r)
+        // Fixes stack overflow issue (#866)
+        val w = r
+        r = f(s.pop, w)
       }
       r
     }

--- a/tests/src/test/scala/scalaz/std/SetTest.scala
+++ b/tests/src/test/scala/scalaz/std/SetTest.scala
@@ -1,13 +1,30 @@
 package scalaz
 package std
 
+import syntax.foldable._
 import std.AllInstances._
 import scalaz.scalacheck.ScalazProperties._
 import org.scalacheck.Prop.forAll
 
 object SetTest extends SpecLite {
+
   checkAll(order.laws[Set[Int]])
   checkAll(monoid.laws[Set[Int]])
   checkAll(isEmpty.laws[Set])
   checkAll(foldable.laws[Set])
+
+  "foldLeftM" should {
+
+    // as reported in <https://github.com/scalaz/scalaz/issues/866>
+    // fixed in b0b80be
+    "not stack overflow" in {
+
+      def sum = Set(1,2,3).foldLeftM[Option,Int](0) { case (x,y) => Some(x+y) }
+
+      sum must_== Some(6)
+
+    }
+
+  }
+
 }


### PR DESCRIPTION
Open up <code>scalaz/std/Set.scala</code>. Change the definition of <code>foldRight</code> in <code>SetInstances</code> to:

```scala
def foldRight[A, B](fa: Set[A], z: => B)(f: (A, => B) => B) = {
  import scala.collection.mutable.ArrayStack
  val s = new ArrayStack[A]
  fa.foreach(a => s += a)
  var r = z
  while (!s.isEmpty) {
    val w = r // <-- add this
    r = f(s.pop, w)
  }
  r
}
```

```scala
scala> Set(0).foldLeftM[Option, Int](0) { case (x, y) => Some(x+y) } 
res0: Option[Int] = Some(0)
```

Signed-off-by: Mark <m4farrel@uwaterloo.ca>