### PR TITLE
Fix documentation of ==>>.insertWith{,Key}

### DIFF
--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -48,7 +48,7 @@ sealed abstract class ==>>[A, B] {
   /** inserts a new key/value pair, resolving the conflict if the key already exists - O(log n)
    *
    * @param f function to resolve conflict with existing key:
-   *   (existingValue, insertedValue) => resolvedValue
+   *   (insertedValue, existingValue) => resolvedValue
    * @param kx key
    * @param x value to insert if the key is not already present */
   def insertWith(f: (B, B) => B, kx: A, x: B)(implicit o: Order[A]): A ==>> B =
@@ -57,7 +57,7 @@ sealed abstract class ==>>[A, B] {
   /** inserts a new key/value pair, resolving the conflict if the key already exists - O(log n)
    *
    * @param f function to resolve conflict with existing key:
-   *   (key, existingValue, insertedValue) => resolvedValue
+   *   (key, insertedValue, existingValue) => resolvedValue
    * @param kx key
    * @param x value to insert if the key is not already present */
   def insertWithKey(f: (A, B, B) => B, kx: A, x: B)(implicit o: Order[A]): A ==>> B =


### PR DESCRIPTION
The documentation of the `f` parameter in `==>>.insertWith` and `==>>.insertWithKey` has mixed up the `existingValue` and `insertedValue` parameters:
```scala
scala> ==>>.singleton(0, 10).insertWith((existing, inserted) => inserted + 1, 0, 20)
res8: scalaz.==>>[Int,Int] = Bin(0,11,Tip,Tip)

scala> ==>>.singleton(0, 10).insertWith((existing, inserted) => existing + 1, 0, 20)
res9: scalaz.==>>[Int,Int] = Bin(0,21,Tip,Tip)
```
The first is actually the `insertedValue` and the second is actually the `existingValue`. This PR swaps the parameter names in the docstring.