### PR TITLE
Fixed a minor race between the two actors in the message loss test

### DIFF
--- a/tests/src/test/scala/scalaz/concurrent/ActorTest.scala
+++ b/tests/src/test/scala/scalaz/concurrent/ActorTest.scala
@@ -33,9 +33,9 @@ object ActorTest extends SpecLite {
     actor1 = Actor[Int] {
       (i: Int) =>
         if (i == latch.getCount) {
+          latch.countDown()
+          latch.countDown()
           if (i != 0) actor2 ! i - 1
-          latch.countDown()
-          latch.countDown()
         }
     }
     actor1 ! NumOfMessages


### PR DESCRIPTION
I believe there is a race condition between actor2 and actor1 when the ping pong happens. The countdown should happen before you ping a message to the actor otherwise, you can potentially encounter a hang.

PS: This is my first 1) contribution to an OSS project ever, 2) first pull request ever. so please ignore my mistakes if any.