### PR TITLE
Fix a cast exception

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Future.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Future.scala
@@ -282,7 +282,7 @@ object Future {
                 Trampoline.done(()) // noop; another thread will have already invoked `cb` w/ our residual
               }
             val notifyListener =
-              if (listener.compareAndSet(null, finishedCallback.asInstanceOf[A => Trampoline[Unit]]))
+              if (listener.compareAndSet(null, finishedCallback))
                 // noop; no listeners yet, any added after this will use result stored in `ref`
                 Trampoline.done(())
               else // there is a registered listener, invoke it with the result
@@ -293,8 +293,8 @@ object Future {
       }
     }
 
-    private val finishedCallback: String => Trampoline[Unit] =
-      s => sys.error("impossible, since there can only be one runner of chooseAny")
+    private val finishedCallback: Any => Trampoline[Unit] =
+      _ => sys.error("impossible, since there can only be one runner of chooseAny")
 
     // implementation runs all threads, dumping to a shared queue
     // last thread to finish invokes the callback with the results


### PR DESCRIPTION
A generic param A was being forced into a String => Trampoline[Unit].

This shouldn't be encountered under normal use, and I found it when using ```Task.async``` incorrectly. Nevertheless, it is always nice to remove a cast.