### PR TITLE
Capture typeclass

### DIFF
--- a/effect/src/main/scala/scalaz/effect/Capture.scala
+++ b/effect/src/main/scala/scalaz/effect/Capture.scala
@@ -1,0 +1,21 @@
+package scalaz
+package effect
+
+/** 
+ * A typeclass for capturing effects. This provides a mechanism for abstracting over effectful 
+ * monads such as [[scalaz.concurrent.Task]] and [[scalaz.effect.IO]].
+ */
+trait Capture[F[_]] {
+
+  /** Capture an effect. This operation is referentially transparent for all A. */
+  def capture[A](a: => A): F[A]
+
+  /** Extract the value from the given `F[A]`, performing any captured effect. */
+  def unsafeRun[A](fa: F[A]): A
+
+}
+
+object Capture {
+  @inline def apply[F[_]](implicit F: Capture[F]): Capture[F] = F
+}
+

--- a/effect/src/main/scala/scalaz/effect/IO.scala
+++ b/effect/src/main/scala/scalaz/effect/IO.scala
@@ -161,6 +161,12 @@ sealed abstract class IOInstances extends IOInstances0 {
       def fail[A](err: Throwable): IO[A] = IO(throw err)
     }
 
+  implicit val ioCapture: Capture[IO] = 
+    new Capture[IO] {
+      def capture[A](a: => A) = IO(a)
+      def unsafeRun[A](fa: IO[A]) = fa.unsafePerformIO
+    }
+
 }
 
 private trait IOMonad extends Monad[IO] {

--- a/effect/src/main/scala/scalaz/syntax/effect/CaptureSyntax.scala
+++ b/effect/src/main/scala/scalaz/syntax/effect/CaptureSyntax.scala
@@ -1,0 +1,37 @@
+package scalaz
+package syntax
+package effect
+
+import scalaz.effect.Capture
+import scalaz.effect.Resource
+
+/** Wraps a value `self` and provides methods related to [[[scalaz.effect.Capture]]]. */
+sealed abstract class CaptureOps[F[_],A] extends Ops[F[A]] {
+  implicit def F: Capture[F]
+  ////
+  def unsafeRun: A = F.unsafeRun(self)
+  ////
+}
+
+sealed trait ToCaptureOps0 {
+  implicit def ToCaptureOpsUnapply[FA](v: FA)(implicit F0: Unapply[Capture, FA]) =
+    new CaptureOps[F0.M,F0.A] { def self = F0(v); implicit def F: Capture[F0.M] = F0.TC }
+
+}
+
+trait ToCaptureOps extends ToCaptureOps0 {
+  implicit def ToCaptureOps[F[_],A](v: F[A])(implicit F0: Capture[F]) =
+    new CaptureOps[F,A] { def self = v; implicit def F: Capture[F] = F0 }
+
+  ////
+
+  ////
+}
+
+trait CaptureSyntax[F[_]] {
+  implicit def ToCaptureOps[A](v: F[A])(implicit F0: Capture[F]): CaptureOps[F, A] = new CaptureOps[F,A] { def self = v; implicit def F: Capture[F] = F0 }
+
+  ////
+
+  ////
+}

--- a/effect/src/main/scala/scalaz/syntax/effect/EffectSyntax.scala
+++ b/effect/src/main/scala/scalaz/syntax/effect/EffectSyntax.scala
@@ -8,12 +8,14 @@ trait EffectSyntaxes {
 
   object monadCatchIO extends ToMonadCatchIOOps
   
+  object capture extends ToCaptureOps
+
   object all extends ToAllEffectTypeClassOps
 
 }
 
 trait ToAllEffectTypeClassOps
-    extends ToIdOps with ToResourceOps with ToMonadCatchIOOps
+    extends ToIdOps with ToResourceOps with ToMonadCatchIOOps with ToCaptureOps
 
 /**The members of this object are also offered in the package object [[scalaz.syntax.effect]] */
 object EffectSyntax extends EffectSyntaxes


### PR DESCRIPTION
This is mostly to start a discusssion.

So, we have a variety of IO-like types in the wild (including non-scalaz types like `remotely.Response` and @aloiscochard's [matterhorn](https://github.com/aloiscochard/matterhorn)) that provide an effect-capturing unit as well as an unsafe extract. Because there is currently no way to abstract over these operations we end up with overspecialized code, such as this example from `scalaz.stream.io`:

```scala
  def fillBuffer[A](buf: collection.mutable.Buffer[A]): Sink[Task,A] =
    channel((a: A) => Task.delay { buf += a })
```

Using `Capture` we can abstract over the context:

```scala
  def fillBuffer[F[_], A](buf: collection.mutable.Buffer[A])(implicit F: Capture[F]): Sink[F,A] =
    channel((a: A) => F.capture { buf += a })
```
 
I have used a similar abstraction in my own work with good results.

Question: What is the law of `Capture`? It would need to be stated in terms of when a side-effect happens, which is kind of outside the language we usually use to state laws. (See also the "law" of `Catchable`.)