### PR TITLE
adding liftF syntactic sugar to help lift to the Free monad over the Ind...

### DIFF
--- a/core/src/main/scala/scalaz/ReaderWriterStateT.scala
+++ b/core/src/main/scala/scalaz/ReaderWriterStateT.scala
@@ -50,6 +50,8 @@ sealed abstract class IndexedReaderWriterStateT[F[_], -R, W, -S1, S2, A] {
         }
       }
     }
+  
+  def liftF[SS <: S1, RR <: R](implicit F: Functor[F]) = Free.liftF[IndexedReaderWriterStateT[F, RR, W, SS, S2, ?],A](this)
 }
 
 object IndexedReaderWriterStateT extends ReaderWriterStateTInstances with ReaderWriterStateTFunctions {


### PR DESCRIPTION
adding liftF syntactic sugar to help lift to the Free monad over the IndexedReaderWriterStateT functor.  This is useful for stack safety, similar PR was accepted here:

https://github.com/scalaz/scalaz/pull/777