### PR TITLE
new combinator in BindSyntax. bind with ignored result of function

### DIFF
--- a/core/src/main/scala/scalaz/syntax/BindSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/BindSyntax.scala
@@ -18,6 +18,8 @@ final class BindOps[F[_],A] private[syntax](val self: F[A])(implicit val F: Bind
 
   def >>[B](b: => F[B]): F[B] = F.bind(self)(_ => b)
 
+  def >>![B](f: A => F[B]): F[A] = F.bind(self)(a => F.map(f(a))(_ => a))
+
   def ifM[B](ifTrue: => F[B], ifFalse: => F[B])(implicit ev: A === Boolean): F[B] = {
     val value: F[Boolean] = ev.subst(self)
     F.ifM(value, ifTrue, ifFalse)


### PR DESCRIPTION
I often use this to do something in monad context without sensible output value. e.g. with State or IO.