### PR TITLE
Performance improvement for Free/Trampoline (~10%)

### DIFF
--- a/core/src/main/scala/scalaz/Free.scala
+++ b/core/src/main/scala/scalaz/Free.scala
@@ -66,7 +66,7 @@ sealed abstract class Free[S[_], A] {
     resume.fold(s, r)
 
   /* performs a bind type operation that does not cause expansion of Gosubs at the expense of not being tail recursive*/
-  final def fastFlatMap[B](i: Int, f: A => Free[S,B])(implicit S: Functor[S]): Free[S,B] = 
+  private final def fastFlatMap[B](i: Int, f: A => Free[S,B])(implicit S: Functor[S]): Free[S,B] = 
     this match {
       case Return(a) => f(a)
       case Suspend(t) => Suspend(S.map(t)(_ fastFlatMap(i+1, f)))


### PR DESCRIPTION
Part of what makes Free slow is the expansion of Gosubs in the resume method.  This change drastically reduces the number of necessary resume calls made(which happens when folding a Free structure or calling go on a trampoline) and results in about a 8-10% performance improvement when testing with both trampolines and generic free structures.

https://github.com/vmarquez/scalaz/blob/free_jmhtesting/bench/src/main/scala/scalaz/FreeBench.scala 

Is a branch with jmh testing if anyone wants to replicate/tune.  (thanks to @julien-truffaut for the jmh templates) I've also created additional tests with caliper and found (on average) identical results.  After testing various numbers, 500 appeared to be the drop off point for any measurable improvement, though even much smaller sizes did result in measurable improvements.   


