### PR TITLE
fix license url for pomExtra

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -130,7 +130,7 @@ object build extends Build {
         <licenses>
           <license>
             <name>BSD-style</name>
-            <url>http://www.opensource.org/licenses/bsd-license.php</url>
+            <url>http://opensource.org/licenses/BSD-3-Clause</url>
             <distribution>repo</distribution>
           </license>
         </licenses>


### PR DESCRIPTION
Current URL link (http://opensource.org/licenses/bsd-license.php) move "The BSD 2-Clause License" page.