### PR TITLE
Add EitherT factory method that infers the outer type constructor

### DIFF
--- a/core/src/main/scala/scalaz/EitherT.scala
+++ b/core/src/main/scala/scalaz/EitherT.scala
@@ -304,6 +304,10 @@ sealed abstract class EitherTInstances extends EitherTInstances0 {
 trait EitherTFunctions {
   def eitherT[F[_], A, B](a: F[A \/ B]): EitherT[F, A, B] = EitherT[F, A, B](a)
 
+  def eitherTU[FAB, AB, A0, B0](fab: FAB)(
+    implicit u1: Unapply[Functor, FAB]{type A = AB}, u2: Unapply2[Bifunctor, AB]{type A = A0; type B = B0}, l: Leibniz.===[AB, A0 \/ B0])
+      : EitherT[u1.M, A0, B0] = eitherT(l.subst[u1.M](u1(fab)))
+
   def monadTell[F[_, _], W, A](implicit MT0: MonadTell[F, W]): EitherTMonadTell[F, W, A] = new EitherTMonadTell[F, W, A]{
     def MT = MT0
   }

--- a/tests/src/test/scala/scalaz/EitherTTest.scala
+++ b/tests/src/test/scala/scalaz/EitherTTest.scala
@@ -84,4 +84,12 @@ object EitherTTest extends SpecLite {
       (a,b) <- brokenMethod
     } yield "yay"
   }
+
+  //compilation test for eitherTU
+  {
+    val se: State[Vector[String], Int \/ Float] = null
+    EitherT.eitherTU(se)
+    val ee: String \/ (Int \/ Float) = null
+    EitherT.eitherTU(ee)
+  }
 }

--- a/tests/src/test/scala/scalaz/EitherTTest.scala
+++ b/tests/src/test/scala/scalaz/EitherTTest.scala
@@ -56,40 +56,42 @@ object EitherTTest extends SpecLite {
     def monadError[F[_] : Monad, A] = MonadError[EitherT[F, ?, ?], A]
   }
 
-  // compilation test
-  // https://gist.github.com/vmarquez/5106252/
-  {
-    import scalaz.syntax.either._
+  def compilationTests() = {
+    // compilation test
+    // https://gist.github.com/vmarquez/5106252/
+    {
+      import scalaz.syntax.either._
 
-    case class ABC(s:String)
+      case class ABC(s:String)
 
-    implicit val m = new Monoid[(ABC, Int)] {
-      def zero: (ABC, Int) = (null, -1)
-      def append(f1: (ABC, Int), f2: => (ABC, Int)): (ABC, Int) = f1
-    }
-
-    def brokenMethod: EitherT[Option, (ABC, Int), (ABC, String)] =
-      EitherT(Some((ABC("abcData"),"Success").right))
-
-    def filterComp =
-      brokenMethod
-      .filter {
-        case (abc,"Success") => true
-        case _ => false
-      }.map {
-        case (abc, "Success") => "yay"
+      implicit val m = new Monoid[(ABC, Int)] {
+        def zero: (ABC, Int) = (null, -1)
+        def append(f1: (ABC, Int), f2: => (ABC, Int)): (ABC, Int) = f1
       }
 
-    for {
-      (a,b) <- brokenMethod
-    } yield "yay"
-  }
+      def brokenMethod: EitherT[Option, (ABC, Int), (ABC, String)] =
+        EitherT(Some((ABC("abcData"),"Success").right))
 
-  //compilation test for eitherTU
-  {
-    val se: State[Vector[String], Int \/ Float] = null
-    EitherT.eitherTU(se)
-    val ee: String \/ (Int \/ Float) = null
-    EitherT.eitherTU(ee)
+      def filterComp =
+        brokenMethod
+        .filter {
+          case (abc,"Success") => true
+          case _ => false
+        }.map {
+          case (abc, "Success") => "yay"
+        }
+
+      for {
+        (a,b) <- brokenMethod
+      } yield "yay"
+    }
+
+    //compilation test for eitherTU
+    {
+      val se: State[Vector[String], Int \/ Float] = null
+      EitherT.eitherTU(se)
+      val ee: String \/ (Int \/ Float) = null
+      EitherT.eitherTU(ee)
+    }
   }
 }


### PR DESCRIPTION
First PR, hope I've followed the correct conventions. Apologies if this is duplicating existing functionality; if so I wasn't able to find it.

Add an `EitherT` factory method that infers the outer type constructor. This makes it easier to use `EitherT` with monad types that have multiple parameters e.g. `State` - currently one has to use explicit type parameters (including a type lambda) when calling `EitherT.eitherT` (or `new EitherT`) with a `State`.

The use of `Functor` in the first `Unapply` is somewhat arbitrary/pragmatic, with the rationale that it's a very weak type and an `EitherT` for an `F[_]` that doesn't even have a `Functor` instance is somewhat useless. Very open to any better alternative here, or a way to avoid needing to specify a typeclass at all.

The `Unapply2` is unused but necessary to guide type inference. Again very open to a better way of doing this.

Thanks,
Michael