### PR TITLE
Heap is now stack safe (and doesn't rely on stream)

### DIFF
--- a/core/src/main/scala/scalaz/Heap.scala
+++ b/core/src/main/scala/scalaz/Heap.scala
@@ -1,7 +1,7 @@
 package scalaz
 
 import std.tuple._
-
+import scala.annotation.tailrec
 
 /**An efficient, asymptotically optimal, implementation of priority queues
  * extended with support for efficient size.
@@ -17,9 +17,11 @@ sealed abstract class Heap[A] {
 
   import Heap._
   import Heap.impl._
-  import Tree._
+  import Cofree._
 
-  def fold[B](empty: => B, nonempty: (Int, (A, A) => Boolean, Tree[Ranked[A]]) => B): B
+  type CTree[A] = Cofree[IList, A]
+
+  def fold[B](empty: => B, nonempty: (Int, (A, A) => Boolean, CTree[Ranked[A]]) => B): B
 
   /**Is the heap empty? O(1)*/
   def isEmpty = fold(true, (_, _, _) => false)
@@ -46,54 +48,54 @@ sealed abstract class Heap[A] {
   def union(as: Heap[A]) = (this, as) match {
     case (Empty(), q)                         => q
     case (q, Empty())                         => q
-    case (Heap(s1, leq, t1@Node(Ranked(r1, x1), f1)),
-    Heap(s2, _, t2@Node(Ranked(r2, x2), f2))) =>
-      if (leq(x1, x2))
-        Heap(s1 + s2, leq, node(Ranked(0, x1), skewInsert(leq, t2, f1)))
-      else
-        Heap(s1 + s2, leq, node(Ranked(0, x2), skewInsert(leq, t1, f2)))
+    case (Heap(s1, leq, t1 @ Cofree(Ranked(r1, x1), f1)),
+    Heap(s2, _, t2 @ Cofree(Ranked(r2, x2), f2))) =>
+      if (leq(x1, x2)) {
+        Heap(s1 + s2, leq, Cofree(Ranked(0, x1), skewInsert(leq, t2, f1)))
+      } else {
+        Heap(s1 + s2, leq, Cofree(Ranked(0, x2), skewInsert(leq, t1, f2)))
+      }
   }
 
   /**Split the heap into the minimum element and the remainder. O(log n)*/
   def uncons: Option[(A, Heap[A])] =
-    fold(None, (_, _, t) => Some((t.rootLabel.value, deleteMin)))
+    fold(None, (_, _, t) => Some((t.head.value, deleteMin)))
 
   /**Get the minimum key on the (nonempty) heap. O(1) */
-  def minimum: A = fold(sys.error("Heap.minimum: empty heap"), (_, _, t) => t.rootLabel.value)
+  def minimum: A = fold(sys.error("Heap.minimum: empty heap"), (_, _, t) => t.head.value)
 
   /**Get the minimum key on the (nonempty) heap. O(1) */
-  def minimumO: Option[A] = fold(None, (_, _, t) => Some(t.rootLabel.value))
+  def minimumO: Option[A] = fold(None, (_, _, t) => Some(t.head.value))
 
   /**Delete the minimum key from the heap and return the resulting heap. O(log n) */
   def deleteMin: Heap[A] = {
     fold(Empty[A], (s, leq, t) => t match {
-      case Node(_, Stream()) => Empty[A]
-      case Node(_, f0)       => {
-        val (Node(Ranked(r, x), cf), ts2) = getMin(leq, f0)
-        val (zs, ts1, f1) = splitForest(r, Stream(), Stream(), cf)
+      case Cofree(_, INil()) => Empty[A]
+      case Cofree(_, f0)       => {
+        val (Cofree(Ranked(r, x), cf), ts2) = getMin(leq, f0)
+        val (zs, ts1, f1) = splitForest(r, empty[A](), empty[A](), cf)
         val f2 = skewMeld(leq, skewMeld(leq, ts1, ts2), f1)
         val f3 = zs.foldRight(f2)(skewInsert(leq, _, _))
-        Heap(s - 1, leq, node(Ranked(0, x), f3))
+        Heap(s - 1, leq, Cofree(Ranked(0, x), f3))
       }
     })
   }
 
   def adjustMin(f: A => A): Heap[A] = this match {
-    case Heap(s, leq, Node(Ranked(r, x), xs)) =>
-      Heap(s, leq, heapify(leq)(node(Ranked(r, f(x)), xs)))
+    case Heap(s, leq, Cofree(Ranked(r, x), xs)) =>
+      Heap(s, leq, heapify(leq)( Cofree(Ranked(r, f(x)), xs)))
   }
 
-  def toUnsortedStream: Stream[A] = fold(Stream(), (_, _, t) => t.flatten.map(_.value))
+  def toUnsortedStream: Stream[A] = toUnsortedList.toStream 
 
-  def toUnsortedList: List[A] = toUnsortedStream.toList
+  def toUnsortedList: IList[A] = fold(INil[A](), (_, _, t) => Foldable[CTree].foldRight(t, (INil(): IList[A]))((a,b) => a.value :: b) ) 
 
-  def toStream: Stream[A] =
-    std.stream.unfold(this)(_.uncons)
-
-  def toList: List[A] = toStream.toList
+  def toList: IList[A] = toListHeap(this, INil())
+  
+  def toStream: Stream[A] = toList.toStream 
 
   /**Map a function over the heap, returning a new heap ordered appropriately. O(n)*/
-  def map[B: Order](f: A => B) = fold(Empty[B], (_, _, t) => t.foldMap(x => singleton(f(x.value))))
+  def map[B: Order](f: A => B): Heap[B] = fold(Empty[B], (_, _, t) => Foldable[CTree].foldMap(t)(x => singleton(f(x.value))))
 
   def forall(f: A => Boolean) = toStream.forall(f)
 
@@ -102,13 +104,13 @@ sealed abstract class Heap[A] {
   def foreach(f: A => Unit) = toStream.foreach(f)
 
   /**Filter the heap, retaining only values that satisfy the predicate. O(n)*/
-  def filter(p: A => Boolean): Heap[A] =
-    fold(Empty[A], (_, leq, t) => t foldMap (x => if (p(x.value)) singletonWith(leq, x.value) else Empty[A]))
+  def filter(p: A => Boolean): Heap[A] = 
+    fold(Empty[A], (_, leq, t) => Foldable[CTree].foldMap(t)(x => if (p(x.value)) singletonWith(leq, x.value) else Empty[A]))
 
   /**Partition the heap according to a predicate. The first heap contains all elements that
    * satisfy the predicate. The second contains all elements that fail the predicate. O(n)*/
   def partition(p: A => Boolean): (Heap[A], Heap[A]) =
-    fold((Empty[A], Empty[A]), (_, leq, t) => t.foldMap(x =>
+    fold((Empty[A], Empty[A]), (_, leq, t) => Foldable[CTree].foldMap(t)(x =>
       if (p(x.value)) (singletonWith(leq, x.value), Empty[A])
       else
         (Empty[A], singletonWith(leq, x.value))))
@@ -121,7 +123,7 @@ sealed abstract class Heap[A] {
         (singletonWith(leq, x), Empty[A], Empty[A])
       else
         (Empty[A], Empty[A], singletonWith(leq, x))
-      t foldMap (x => f(x.value))
+      Foldable[CTree].foldMap(t)(x => f(x.value))
     })
   }
 
@@ -157,9 +159,9 @@ sealed abstract class Heap[A] {
   def dropWhile(p: A => Boolean) =
     withList(_.dropWhile(p))
 
-  /**Remove duplicate entries from the heap. O(n log n)*/
+/**Remove duplicate entries from the heap. O(n log n)*/
   def nub: Heap[A] = fold(Empty[A], (_, leq, t) => {
-    val x = t.rootLabel.value
+    val x = t.head.value
     val xs = deleteMin
     val zs = xs.dropWhile(leq(_, x))
     zs.nub.insertWith(leq, x)
@@ -167,40 +169,40 @@ sealed abstract class Heap[A] {
 
   /**Construct heaps from each element in this heap and union them together into a new heap. O(n)*/
   def flatMap[B: Order](f: A => Heap[B]): Heap[B] =
-    fold(Empty[B], (_, _, t) => t foldMap (x => f(x.value)))
+    fold(Empty[B], (_, _, t) => Foldable[CTree].foldMap(t)(x => f(x.value)))
 
   /**Traverse the elements of the heap in sorted order and produce a new heap with applicative effects.
    * O(n log n)*/
   def traverse[F[_] : Applicative, B: Order](f: A => F[B]): F[Heap[B]] = {
     val F = Applicative[F]
     import std.stream._
-    F.map(F.traverse(toStream)(f))(fromCodata[Stream, B])
+    F.map(F.traverse(toList)(f))(fromCodata[IList, B])
   }
 
-  def foldRight[B](z: B)(f: (A, => B) => B): B = {
-    import std.stream._
-    Foldable[Stream].foldRight(toStream, z)(f)
-  }
+  def foldRight[B](z: B)(f: (A, => B) => B): B = Foldable[IList].foldRight(toList, z)(f)
 
-  private def withList(f: List[A] => List[A]) = {
+  private def withList(f: IList[A] => IList[A]) = {
     import std.list._
     fold(Empty[A], (_, leq, _) => fromDataWith(leq, f(toList)))
   }
 
   private[scalaz] def insertWith(f: (A, A) => Boolean, x: A) =
     fold(singletonWith(f, x), (s, _, t) => {
-      val y = t.rootLabel.value
-      if (f(x, y)) Heap(s + 1, f, node(Ranked(0, x), Stream(t)))
-      else
-        Heap(s + 1, f, node(Ranked(0, y),
-          skewInsert(f, node(Ranked(0, x), Stream()), t.subForest)))
+      val y = t.head.value
+      if (f(x, y)) {
+        Heap(s + 1, f, Cofree(Ranked(0, x), IList(t)))
+      } else {
+        val skewed = skewInsert(f, Cofree(Ranked(0, x), IList[CTree[Ranked[A]]]()), t.tail) 
+        Heap(s + 1, f, Cofree(Ranked(0, y),
+          skewed))
+      }
     })
 
-  private def splitWithList(f: List[A] => (List[A], List[A])) = {
+  private def splitWithList(f: IList[A] => (IList[A], IList[A])) = {
     import std.list._
 
     fold((Empty[A], Empty[A]), (_, leq, _) => {
-      val g = (x: List[A]) => fromDataWith(leq, x)
+      val g = (x: IList[A]) => fromDataWith(leq, x)
       val x = f(toList)
       (g(x._1), g(x._2))
     })
@@ -212,43 +214,56 @@ sealed abstract class Heap[A] {
 case class Ranked[A](rank: Int, value: A)
 
 object Heap extends HeapInstances with HeapFunctions {
-  def apply[A](sz: Int, leq: (A, A) => Boolean, t: Tree[Ranked[A]]): Heap[A] = new Heap[A] {
-    def fold[B](empty: => B, nonempty: (Int, (A, A) => Boolean, Tree[Ranked[A]]) => B) =
+  import Cofree._
+  type CTree[A] = Cofree[IList, A]
+
+
+  @tailrec private def toListHeap[A](h: Heap[A], l: IList[A]): IList[A] = h.uncons match {
+    case Some((a, h)) => 
+      toListHeap(h, a :: l)
+    case None => l.reverse
+  }
+      
+  def hnode[A](root: => A, forest: => IList[CTree[A]]): CTree[A] = Cofree(root, forest)
+  
+  def apply[A](sz: Int, leq: (A, A) => Boolean, t: CTree[Ranked[A]]): Heap[A] = new Heap[A] {
+    def fold[B](empty: => B, nonempty: (Int, (A, A) => Boolean, CTree[Ranked[A]]) => B) =
       nonempty(sz, leq, t)
   }
 
-  def unapply[A](h: Heap[A]): Option[(Int, (A, A) => Boolean, Tree[Ranked[A]])] =
+  def unapply[A](h: Heap[A]): Option[(Int, (A, A) => Boolean, CTree[Ranked[A]])] =
     h.fold(None, (sz, leq, t) => Some((sz, leq, t)))
 
   private[scalaz] object impl {
     import Tree._
 
     def rightZ[A]: ForestZipper[A] => ForestZipper[A] = {
-      case (path, x #:: xs) => (x #:: path, xs)
+      case (path, a @ ICons(x, xs)) => (x :: path, xs)
+      case t @ _ => (t._1, t._2) //stream checks were not exhaustive due to stream not being sealed, so we need to handle this case now
     }
 
-    def adjustZ[A](f: Tree[Ranked[A]] => Tree[Ranked[A]]):
+    def adjustZ[A](f: CTree[Ranked[A]] => CTree[Ranked[A]]):
     ForestZipper[A] => ForestZipper[A] = {
-      case (path, x #:: xs) => (path, f(x) #:: xs)
+      case (path, ICons(x, xs)) => (path, f(x) :: xs)
       case z                => z
     }
 
     def rezip[A]: ForestZipper[A] => Forest[A] = {
-      case (Stream(), xs)   => xs
-      case (x #:: path, xs) => rezip((path, x #:: xs))
+      case (INil(), xs)   => xs
+      case (ICons(x, path), xs) => rezip((path, x :: xs))
     }
 
     def rootZ[A]: ForestZipper[A] => A = {
-      case (_, x #:: _) => x.rootLabel.value
+      case (_, ICons(x, _)) => x.head.value
       case _            => sys.error("Heap.rootZ: empty zipper")
     }
 
-    def zipper[A](xs: Forest[A]): ForestZipper[A] = (Stream(), xs)
+    def zipper[A](xs: Forest[A]): ForestZipper[A] = (INil(), xs)
 
-    def emptyZ[A]: ForestZipper[A] = (Stream(), Stream())
+    def emptyZ[A]: ForestZipper[A] = (INil(), INil())
 
     def minZ[A](f: (A, A) => Boolean): Forest[A] => ForestZipper[A] = {
-      case Stream() => emptyZ
+      case INil() => emptyZ
       case xs       => {
         val z = zipper(xs)
         minZp(f)(z, z)
@@ -257,111 +272,141 @@ object Heap extends HeapInstances with HeapFunctions {
 
     def minZp[A](leq: (A, A) => Boolean):
     (ForestZipper[A], ForestZipper[A]) => ForestZipper[A] = {
-      case (lo, (_, Stream())) => lo
+      case (lo, (_, INil())) => lo
       case (lo, z)             => minZp(leq)(if (leq(rootZ(lo), rootZ(z))) lo else z, rightZ(z))
     }
-
-    def heapify[A](leq: (A, A) => Boolean): Tree[Ranked[A]] => Tree[Ranked[A]] = {
-      case n@Node(_, Stream())      => n
-      case n@Node(Ranked(r, a), as) => {
-        val (left, Node(Ranked(rp, ap), asp) #:: right) = minZ(leq)(as)
-        if (leq(a, ap)) n
-        else
-          node(Ranked(r, ap), rezip((left, heapify(leq)(node(Ranked(rp, a), asp)) #:: right)))
+    
+    def heapify[A](leq: (A, A) => Boolean): CTree[Ranked[A]] => CTree[Ranked[A]] = {
+      case n @ Cofree(_, INil())      => n
+      case n@ Cofree(Ranked(r, a), as) => {
+        val (left, ICons(Cofree(Ranked(rp, ap), asp), right)) = minZ(leq)(as) 
+        if (leq(a, ap)) {
+          n
+        } else {
+          Cofree(Ranked(r, ap), rezip(left, heapify(leq)(Cofree(Ranked(rp, a), asp)) :: right))
+        }
       }
     }
 
     def singletonWith[A](f: (A, A) => Boolean, a: A) =
-      Heap(1, f, node(Ranked(0, a), Stream()))
+      Heap(1, f, Cofree(Ranked(0, a), IList[CTree[Ranked[A]]]()))
 
 
-    def rank[A](t: Tree[Ranked[A]]) = t.rootLabel.rank
+    def rank[A](t: CTree[Ranked[A]]) = t.head.rank
 
     def skewLink[A](f: (A, A) => Boolean,
-                    t0: Tree[Ranked[A]],
-                    t1: Tree[Ranked[A]],
-                    t2: Tree[Ranked[A]]): Tree[Ranked[A]] = (t0, t1, t2) match {
-      case (Node(Ranked(r0, x0), cf0), Node(Ranked(r1, x1), cf1), Node(Ranked(r2, x2), cf2)) =>
-        if (f(x1, x0) && f(x1, x2)) node(Ranked(r1 + 1, x1), t0 #:: t2 #:: cf1)
+                    t0: CTree[Ranked[A]],
+                    t1: CTree[Ranked[A]],
+                    t2: CTree[Ranked[A]]): CTree[Ranked[A]] = (t0, t1, t2) match {
+      case (Cofree(Ranked(r0, x0), cf0), Cofree(Ranked(r1, x1), cf1), Cofree(Ranked(r2, x2), cf2)) =>
+        if (f(x1, x0) && f(x1, x2)) Cofree(Ranked(r1 + 1, x1), t0 :: t2 :: cf1)
         else
-        if (f(x2, x0) && f(x2, x1)) node(Ranked(r2 + 1, x2), t0 #:: t1 #:: cf2)
+        if (f(x2, x0) && f(x2, x1)) Cofree(Ranked(r2 + 1, x2), t0 :: t1 :: cf2)
         else
-          node(Ranked(r1 + 1, x0), t1 #:: t2 #:: cf0)
+          Cofree(Ranked(r1 + 1, x0), t1 :: t2 :: cf0)
     }
 
     def link[A](f: (A, A) => Boolean):
-    (Tree[Ranked[A]], Tree[Ranked[A]]) => Tree[Ranked[A]] = {
-      case (t1@Node(Ranked(r1, x1), cf1), t2@Node(Ranked(r2, x2), cf2)) =>
-        if (f(x1, x2)) node(Ranked(r1 + 1, x1), t2 #:: cf1)
+    (CTree[Ranked[A]],CTree[Ranked[A]]) => CTree[Ranked[A]] = {
+      case (t1 @ Cofree(Ranked(r1, x1), cf1), t2 @ Cofree(Ranked(r2, x2), cf2)) =>
+        if (f(x1, x2)) Cofree(Ranked(r1 + 1, x1), t2 :: cf1)
         else
-          node(Ranked(r2 + 1, x2), t1 #:: cf2)
+          Cofree(Ranked(r2 + 1, x2), t1 :: cf2)
     }
-
-    def skewInsert[A](f: (A, A) => Boolean, t: Tree[Ranked[A]], ts: Forest[A]): Forest[A] =
+    
+    def skewInsert[A](f: (A, A) => Boolean, t: CTree[Ranked[A]], ts: Forest[A]): Forest[A] = 
       ts match {
-        case t1 #:: t2 #:: rest =>
-          if (rank(t1) == rank(t2))
-            skewLink(f, t, t1, t2) #:: rest
-          else (t #:: ts)
-        case _                  => t #:: ts
+        case ICons(t1, ICons(t2, rest)) =>
+          if (rank(t1) == rank(t2)) {
+            skewLink(f, t, t1, t2) :: rest
+          } else (t :: ts)
+        case _                  => 
+          t :: ts
       }
 
-    def getMin[A](f: (A, A) => Boolean, trees: Forest[A]): (Tree[Ranked[A]], Forest[A]) =
+    def getMin[A](f: (A, A) => Boolean, trees: Forest[A]): (CTree[Ranked[A]], Forest[A]) =
       trees match {
-        case Stream(t) => (t, Stream())
-        case t #:: ts  => {
+       case ICons(Cofree(h, t),INil()) => 
+        (Cofree(h, t), INil()) 
+        case ICons(t, ts)  => {
           val (tp, tsp) = getMin(f, ts)
-          if (f(t.rootLabel.value, tp.rootLabel.value)) (t, ts) else (tp, t #:: tsp)
+          if (f(t.head.value, tp.head.value)) (t, ts) else (tp, t :: tsp)
         }
       }
 
     def splitForest[A]:
     (Int, Forest[A], Forest[A], Forest[A]) => (Forest[A], Forest[A], Forest[A]) = {
       case (0, zs, ts, f)                  => (zs, ts, f)
-      case (1, zs, ts, Stream(t))          => (zs, t #:: ts, Stream())
-      case (1, zs, ts, t1 #:: t2 #:: f)    =>
-        if (rank(t2) == 0) (t1 #:: zs, t2 #:: ts, f)
+      case (1, zs, ts, ICons(tt, INil()))          => 
+        (zs, tt :: ts, INil())
+      case (1, zs, ts, ICons(t1, ICons(t2, f))) =>
+        if (rank(t2) == 0) 
+          (t1 :: zs, t2 :: ts, f)
         else
-          (zs, t1 #:: ts, t2 #:: f)
-      case (r, zs, ts, (t1 #:: t2 #:: cf)) =>
-        if (rank(t1) == rank(t2)) (zs, t1 #:: t2 #:: ts, cf)
+          (zs, t1 :: ts, t2 :: f)
+      case (r, zs, ts, ICons(t1, ICons(t2, cf))) =>
+        if (rank(t1) == rank(t2))
+          (zs, t1 :: t2 :: ts, cf)
         else
-        if (rank(t1) == 0) splitForest(r - 1, t1 #:: zs, t2 #:: ts, cf)
-        else
-          splitForest(r - 1, zs, t1 #:: ts, t2 #:: cf)
-      case (_, _, _, _)                    => sys.error("Heap.splitForest: invalid arguments")
+          if (rank(t1) == 0) 
+            splitForest(r - 1, t1 :: zs, t2 :: ts, cf)
+          else
+            splitForest(r - 1, zs, t1 :: ts, t2 :: cf)
+        case (_, _, _, _)                    => sys.error("Heap.splitForest: invalid arguments")
     }
 
     def skewMeld[A](f: (A, A) => Boolean, ts: Forest[A], tsp: Forest[A]) =
       unionUniq(f)(uniqify(f)(ts), uniqify(f)(tsp))
 
-    def ins[A](f: (A, A) => Boolean, t: Tree[Ranked[A]]): Forest[A] => Forest[A] = {
-      case Stream()    => Stream(t)
-      case (tp #:: ts) => if (rank(t) < rank(tp)) t #:: tp #:: ts
+    def ins[A](f: (A, A) => Boolean, t: CTree[Ranked[A]]): Forest[A] => Forest[A] = {
+      case INil()    => IList(t)
+      case ICons(tp, ts) => if (rank(t) < rank(tp)) t :: tp :: ts
       else
         ins(f, link(f)(t, tp))(ts)
     }
 
     def uniqify[A](f: (A, A) => Boolean): Forest[A] => Forest[A] = {
-      case Stream()   => Stream()
-      case (t #:: ts) => ins(f, t)(ts)
+      case INil()   => INil()
+      case ICons(t,ts) => ins(f, t)(ts)
     }
 
     def unionUniq[A](f: (A, A) => Boolean): (Forest[A], Forest[A]) => Forest[A] = {
-      case (Stream(), ts)                         => ts
-      case (ts, Stream())                         => ts
-      case (tts1@(t1 #:: ts1), tts2@(t2 #:: ts2)) =>
+      case (INil(), ts)                         => ts
+      case (ts, INil())                         => ts
+      case (tts1@ ICons(t1, ts1), tts2 @ ICons(t2, ts2)) =>
         import std.anyVal._
         Order[Int].order(rank(t1), rank(t2)) match {
-          case Ordering.LT => t1 #:: unionUniq(f)(ts1, tts2)
+          case Ordering.LT => t1 :: unionUniq(f)(ts1, tts2)
           case Ordering.EQ => ins(f, link(f)(t1, t2))(unionUniq(f)(ts1, ts2))
-          case Ordering.GT => t2 #:: unionUniq(f)(tts1, ts2)
+          case Ordering.GT => t2 :: unionUniq(f)(tts1, ts2)
         }
     }
   }
+  
 }
 
+
 sealed abstract class HeapInstances {
+  
+  import Heap._
+
+  implicit val ctreeInstance = new Foldable[CTree] {
+    
+    def foldMap[A,B](ct: CTree[A])(f: A => B)(implicit M: Monoid[B]): B = {
+      val root = f(ct.head)
+      val tail: B = Foldable[IList].foldMap(ct.tail)(cf => {
+        foldMap(cf)(f)(M)
+      })
+      M.append(root, tail)
+    } 
+    
+    def foldRight[A, B](ct: CTree[A], z: => B)(f: (A, =>B) => B): B = {
+      Foldable[IList].foldRight(Cofree[IList, A](ct.head, INil()) :: ct.tail, z)( (a,b) => {
+          Foldable[CTree].foldRight(a, b)(f) 
+      }) 
+    }
+  }
+  
   implicit val heapInstance = new Foldable[Heap] with Foldable.FromFoldr[Heap] {
     def foldRight[A, B](fa: Heap[A], z: => B)(f: (A, => B) => B) = fa.foldRight(z)(f)
   }
@@ -371,19 +416,27 @@ sealed abstract class HeapInstances {
     def zero = Heap.Empty.apply
   }
 
+
   import std.stream._
 
-  implicit def heapEqual[A: Equal]: Equal[Heap[A]] = Equal.equalBy((_: Heap[A]).toStream)
+  implicit def heapEqual[A: Equal]: Equal[Heap[A]] = Equal.equalBy((_: Heap[A]).toList)
 }
 
+
 trait HeapFunctions {
-  type Forest[A] = Stream[Tree[Ranked[A]]]
+  
+  import Heap._
+  
+  type Forest[A] = IList[Cofree[IList, Ranked[A]]]
+  
   type ForestZipper[A] = (Forest[A], Forest[A])
+
+  def empty[A](): Forest[A] = INil[CTree[Ranked[A]]]()
 
   /**The empty heap */
   object Empty {
     def apply[A]: Heap[A] = new Heap[A] {
-      def fold[B](empty: => B, nonempty: (Int, (A, A) => Boolean, Tree[Ranked[A]]) => B): B = empty
+      def fold[B](empty: => B, nonempty: (Int, (A, A) => Boolean, CTree[Ranked[A]]) => B): B = empty
     }
 
     def unapply[A](h: Heap[A]): Boolean = h.fold(true, (_, _, _) => false)
@@ -401,10 +454,10 @@ trait HeapFunctions {
     Foldable[F].foldLeft(as, Empty[A])((x, y) => x.insertWith(f, y))
 
   /**Heap sort */
-  def sort[F[_] : Foldable, A: Order](xs: F[A]): List[A] = fromData(xs).toList
+  def sort[F[_] : Foldable, A: Order](xs: F[A]): IList[A] = fromData(xs).toList
 
   /**Heap sort */
-  def sortWith[F[_] : Foldable, A](f: (A, A) => Boolean, xs: F[A]): List[A] = fromDataWith(f, xs).toList
+  def sortWith[F[_] : Foldable, A](f: (A, A) => Boolean, xs: F[A]): IList[A] = fromDataWith(f, xs).toList
 
   /**A heap with one element. */
   def singleton[A: Order](a: A): Heap[A] = singletonWith[A](Order[A].lessThanOrEqual, a)

--- a/tests/src/test/scala/scalaz/HeapTest.scala
+++ b/tests/src/test/scala/scalaz/HeapTest.scala
@@ -19,11 +19,11 @@ object HeapTest extends SpecLite {
   "toList / toStream" ! forAll {
     (a: Heap[Int]) => a.toStream must_===(a.toList.toStream)
   }
-
+  
   "filter" ! forAll {
     (a: Heap[Int]) => a.filter(pred).toStream must_===(a.toStream.filter(pred))
   }
-
+  
   "partition" ! forAll {
     (a: Heap[Int]) =>
       val (ts, fs) = a.partition(pred)
@@ -37,5 +37,9 @@ object HeapTest extends SpecLite {
       lt.forall(_ < x) must_===(true)
       eq.forall(_ == x) must_===(true)
       gt.forall(_ > x) must_===(true)
+  }
+  "no stack overflow for toList" in {
+    val li = (0 to 3000).toList
+    IList.fromList(li) must_===(Heap.fromData(li).toList)
   }
 }


### PR DESCRIPTION
https://github.com/scalaz/scalaz/issues/911

https://github.com/scalaz/scalaz/issues/240

Both show problems with Heap.  One part of the problem is Tree itself is unsafe for many operations.  By moving to Cofree[IList,A] in place of Tree we're able to prevent SOs, because of it being trampolined.  