### PR TITLE
Include all modules for getting scalaz

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,15 @@ a large number of data structures.
 
 The current stable version is 7.1.1, which is cross-built against Scala 2.9.3, 2.10.x and 2.11.x.
 
-If you're using SBT, add the following line to your build file:
+If you're using SBT, add the following lines to your build file to get all Scalaz [modules](#modularity):
 
 ```scala
-libraryDependencies += "org.scalaz" %% "scalaz-core" % "7.1.1"
+libraryDependencies ++= Seq(
+  "org.scalaz" %% "scalaz-core" % "7.1.1",
+  "org.scalaz" %% "scalaz-effect" % "7.1.1",
+  "org.scalaz" %% "scalaz-concurrent" % "7.1.1",
+  "org.scalaz" %% "scalaz-iteratee" % "7.1.1"
+)
 ```
 
 For Maven and other build tools, you can visit [search.maven.org](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.scalaz%22%20AND%20v%3A%227.1.1%22).


### PR DESCRIPTION
Paper cut I encountered when getting started: "why doesn't import scalaz.concurrent._ work?"