### PR TITLE
Added a findMapM method for Foldables

### DIFF
--- a/core/src/main/scala/scalaz/EphemeralStream.scala
+++ b/core/src/main/scala/scalaz/EphemeralStream.scala
@@ -87,6 +87,15 @@ sealed abstract class EphemeralStream[A] {
       Monad[M].bind(p(hh))(if (_) Monad[M].point(Some(hh)) else tail() findM p)
     }
 
+  def findMapM[M[_]: Monad, B](f: A => M[Option[B]]): M[Option[B]] = {
+    if(isEmpty)
+      Monad[M].point(None)
+    else{
+      val hh = head()
+      Monad[M].bind(f(hh)) { case Some(b) => Monad[M].point(Some(b)); case None => tail() findMapM f }
+    }
+  }
+
   def reverse: EphemeralStream[A] = {
     def lcons(xs: => List[A])(x: => A) = x :: xs
     apply(foldLeft(Nil: List[A])(lcons _) : _*)

--- a/core/src/main/scala/scalaz/Foldable.scala
+++ b/core/src/main/scala/scalaz/Foldable.scala
@@ -121,6 +121,10 @@ trait Foldable[F[_]]  { self =>
   final def foldlM[G[_], A, B](fa: F[A], z: => B)(f: B => A => G[B])(implicit M: Monad[G]): G[B] =
     foldLeftM(fa, z)((b, a) => f(b)(a))
 
+  /** map elements in a Foldable with a monadic function and return the first element that is mapped successfully */
+  final def findMapM[M[_]: Monad, A, B](fa: F[A])(f: A => M[Option[B]]): M[Option[B]] =
+    toEphemeralStream(fa) findMapM f
+
   /** Alias for `length`. */
   final def count[A](fa: F[A]): Int = length(fa)
 

--- a/core/src/main/scala/scalaz/syntax/FoldableSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/FoldableSyntax.scala
@@ -19,6 +19,7 @@ final class FoldableOps[F[_],A] private[syntax](val self: F[A])(implicit val F: 
   final def foldRightM[G[_], B](z: => B)(f: (A, => B) => G[B])(implicit M: Monad[G]): G[B] = F.foldRightM(self, z)(f)
   final def foldLeftM[G[_], B](z: B)(f: (B, A) => G[B])(implicit M: Monad[G]): G[B] = F.foldLeftM(self, z)(f)
   final def foldMapM[G[_] : Monad, B : Monoid](f: A => G[B]): G[B] = F.foldMapM(self)(f)
+  final def findMapM[G[_] : Monad, B](f: A => G[Option[B]]): G[Option[B]] = F.findMapM(self)(f)
   final def fold(implicit A: Monoid[A]): A = F.fold(self)(A)
   final def foldr[B](z: => B)(f: A => (=> B) => B): B = F.foldr(self, z)(f)
   final def foldr1Opt(f: A => (=> A) => A): Option[A] = F.foldr1Opt(self)(f)

--- a/tests/src/test/scala/scalaz/FoldableTest.scala
+++ b/tests/src/test/scala/scalaz/FoldableTest.scala
@@ -112,6 +112,28 @@ object FoldableTest extends SpecLite {
       (xs: List[String]) => xs.foldMapM(x => Some(x): Option[String]) must_== Some(xs.mkString)
     }
 
+    type StateInt[A] = State[Int, A]
+
+    def found(z: Int): State[Int, Option[Int]] =
+      State(n => (n + 1, Some(z * 2)))
+
+    def notfound: State[Int, Option[Int]] =
+      State(n => (n + 1, None))
+
+    "findMapM: finding the first element performs transform and only runs only necessary effects" ! forAll {
+      (x: Int, xs: List[Int]) => (x :: xs).findMapM[StateInt, Int](found).run(0) must_== (1 -> Some(x * 2))
+    }
+
+    "findMapM: finding the last element performs transform and runs all effects (once only)" ! forAll {
+      (x: Int, xs: List[Int]) => !xs.contains(x) ==> {
+        (xs ++ List(x)).findMapM[StateInt, Int](z => if (z == x) found(z) else notfound).run(0) must_==
+          ((xs.length + 1) -> Some(x * 2))
+      }
+    }
+
+    "findMapM: runs all effects but doesn't return a value for not found" ! forAll {
+      (xs: List[Int]) => xs.findMapM[StateInt, Int](_ => notfound).run(0) must_== (xs.length -> None)
+    }
   }
 
   private val L = Foldable[List]


### PR DESCRIPTION
We found that this method was useful in our code base when trying to find out an element matching a given criterion after being mapped to another value. We originally provided it on `List` but I thought that this could be useful for any `Foldable` given an interim transformation to an `EphemeralStream`.