### PR TITLE
Some consistency changes in FreeAp

### DIFF
--- a/core/src/main/scala/scalaz/FreeAp.scala
+++ b/core/src/main/scala/scalaz/FreeAp.scala
@@ -64,7 +64,7 @@ sealed abstract class FreeAp[F[_],A] {
    * Embeds this program in the free monad on `F`.
    */
   def monadic(implicit F: Functor[F]): Free[F,A] =
-    foldMap[({type λ[α] = Free[F,α]})#λ](new (F ~> ({type λ[α] = Free[F,α]})#λ) {
+    foldMap[Free[F,?]](new (F ~> Free[F,?]) {
       def apply[B](fb: F[B]) = Free.liftF(fb)
     })
 


### PR DESCRIPTION
Noticed some style inconsistencies:

- use `ap(x.v(),x.k())` instead of  `ap(x.v() -> x.k())` (tuple syntax instead of `->`)
- in `monadic` replace the two type lambdas with the nicer kind-projector version