### PR TITLE
Mark all *Syntax values as transient lazy val to allow serializable instances.

### DIFF
--- a/core/src/main/scala/scalaz/Align.scala
+++ b/core/src/main/scala/scalaz/Align.scala
@@ -59,7 +59,7 @@ trait Align[F[_]] extends Functor[F] { self =>
   def alignLaw = new AlignLaw {}
 
   ////
-  val alignSyntax = new scalaz.syntax.AlignSyntax[F] { def F = Align.this }
+  @transient lazy val alignSyntax = new scalaz.syntax.AlignSyntax[F] { def F = Align.this }
 }
 
 object Align {

--- a/core/src/main/scala/scalaz/Applicative.scala
+++ b/core/src/main/scala/scalaz/Applicative.scala
@@ -110,7 +110,7 @@ trait Applicative[F[_]] extends Apply[F] { self =>
   def applicativeLaw = new ApplicativeLaw {}
 
   ////
-  val applicativeSyntax = new scalaz.syntax.ApplicativeSyntax[F] { def F = Applicative.this }
+  @transient lazy val applicativeSyntax = new scalaz.syntax.ApplicativeSyntax[F] { def F = Applicative.this }
 }
 
 object Applicative {

--- a/core/src/main/scala/scalaz/ApplicativePlus.scala
+++ b/core/src/main/scala/scalaz/ApplicativePlus.scala
@@ -39,7 +39,7 @@ trait ApplicativePlus[F[_]] extends Applicative[F] with PlusEmpty[F] { self =>
   }
 
   ////
-  val applicativePlusSyntax = new scalaz.syntax.ApplicativePlusSyntax[F] { def F = ApplicativePlus.this }
+  @transient lazy val applicativePlusSyntax = new scalaz.syntax.ApplicativePlusSyntax[F] { def F = ApplicativePlus.this }
 }
 
 object ApplicativePlus {

--- a/core/src/main/scala/scalaz/Apply.scala
+++ b/core/src/main/scala/scalaz/Apply.scala
@@ -135,7 +135,7 @@ trait Apply[F[_]] extends Functor[F] { self =>
   def applyLaw = new ApplyLaw {}
 
   ////
-  val applySyntax = new scalaz.syntax.ApplySyntax[F] { def F = Apply.this }
+  @transient lazy val applySyntax = new scalaz.syntax.ApplySyntax[F] { def F = Apply.this }
 }
 
 object Apply {

--- a/core/src/main/scala/scalaz/Arrow.scala
+++ b/core/src/main/scala/scalaz/Arrow.scala
@@ -63,7 +63,7 @@ trait Arrow[=>:[_, _]] extends Split[=>:] with Strong[=>:] with Category[=>:] { 
     <<<[A, B, C](arr(f), fab)
 
   ////
-  val arrowSyntax = new scalaz.syntax.ArrowSyntax[=>:] { def F = Arrow.this }
+  @transient lazy val arrowSyntax = new scalaz.syntax.ArrowSyntax[=>:] { def F = Arrow.this }
 }
 
 object Arrow {

--- a/core/src/main/scala/scalaz/Associative.scala
+++ b/core/src/main/scala/scalaz/Associative.scala
@@ -31,7 +31,7 @@ trait Associative[=>:[_, _]]  { self =>
 
   def associativeLaw = new AssociativeLaw {}
   ////
-  val associativeSyntax = new scalaz.syntax.AssociativeSyntax[=>:] { def F = Associative.this }
+  @transient lazy val associativeSyntax = new scalaz.syntax.AssociativeSyntax[=>:] { def F = Associative.this }
 }
 
 object Associative {

--- a/core/src/main/scala/scalaz/Bifoldable.scala
+++ b/core/src/main/scala/scalaz/Bifoldable.scala
@@ -94,7 +94,7 @@ trait Bifoldable[F[_, _]]  { self =>
 
   def bifoldableLaw = new BifoldableLaw {}
   ////
-  val bifoldableSyntax = new scalaz.syntax.BifoldableSyntax[F] { def F = Bifoldable.this }
+  @transient lazy val bifoldableSyntax = new scalaz.syntax.BifoldableSyntax[F] { def F = Bifoldable.this }
 }
 
 object Bifoldable {

--- a/core/src/main/scala/scalaz/Bifunctor.scala
+++ b/core/src/main/scala/scalaz/Bifunctor.scala
@@ -63,7 +63,7 @@ trait Bifunctor[F[_, _]]  { self =>
     embed[Id.Id,H]
 
   ////
-  val bifunctorSyntax = new scalaz.syntax.BifunctorSyntax[F] { def F = Bifunctor.this }
+  @transient lazy val bifunctorSyntax = new scalaz.syntax.BifunctorSyntax[F] { def F = Bifunctor.this }
 }
 
 object Bifunctor {

--- a/core/src/main/scala/scalaz/Bind.scala
+++ b/core/src/main/scala/scalaz/Bind.scala
@@ -62,7 +62,7 @@ trait Bind[F[_]] extends Apply[F] { self =>
   def bindLaw = new BindLaw {}
 
   ////
-  val bindSyntax = new scalaz.syntax.BindSyntax[F] { def F = Bind.this }
+  @transient lazy val bindSyntax = new scalaz.syntax.BindSyntax[F] { def F = Bind.this }
 }
 
 object Bind {

--- a/core/src/main/scala/scalaz/Bitraverse.scala
+++ b/core/src/main/scala/scalaz/Bitraverse.scala
@@ -124,7 +124,7 @@ trait Bitraverse[F[_, _]] extends Bifunctor[F] with Bifoldable[F] { self =>
     embed[Id.Id,H]
 
   ////
-  val bitraverseSyntax = new scalaz.syntax.BitraverseSyntax[F] { def F = Bitraverse.this }
+  @transient lazy val bitraverseSyntax = new scalaz.syntax.BitraverseSyntax[F] { def F = Bitraverse.this }
 }
 
 object Bitraverse {

--- a/core/src/main/scala/scalaz/Catchable.scala
+++ b/core/src/main/scala/scalaz/Catchable.scala
@@ -24,7 +24,7 @@ trait Catchable[F[_]]  { self =>
   // derived functions
 
   ////
-  val catchableSyntax = new scalaz.syntax.CatchableSyntax[F] { def F = Catchable.this }
+  @transient lazy val catchableSyntax = new scalaz.syntax.CatchableSyntax[F] { def F = Catchable.this }
 }
 
 object Catchable {

--- a/core/src/main/scala/scalaz/Category.scala
+++ b/core/src/main/scala/scalaz/Category.scala
@@ -44,7 +44,7 @@ trait Category[=>:[_, _]] extends Compose[=>:] { self =>
   def categoryLaw = new CategoryLaw {}
 
   ////
-  val categorySyntax = new scalaz.syntax.CategorySyntax[=>:] { def F = Category.this }
+  @transient lazy val categorySyntax = new scalaz.syntax.CategorySyntax[=>:] { def F = Category.this }
 }
 
 object Category {

--- a/core/src/main/scala/scalaz/Choice.scala
+++ b/core/src/main/scala/scalaz/Choice.scala
@@ -15,7 +15,7 @@ trait Choice[=>:[_, _]] extends Category[=>:] { self =>
   def codiagonal[A]: (A \/ A) =>: A = choice(id, id)
 
   ////
-  val choiceSyntax = new scalaz.syntax.ChoiceSyntax[=>:] { def F = Choice.this }
+  @transient lazy val choiceSyntax = new scalaz.syntax.ChoiceSyntax[=>:] { def F = Choice.this }
 }
 
 object Choice {

--- a/core/src/main/scala/scalaz/Cobind.scala
+++ b/core/src/main/scala/scalaz/Cobind.scala
@@ -30,7 +30,7 @@ trait Cobind[F[_]] extends Functor[F] { self =>
   def cobindLaw = new CobindLaws {}
 
   ////
-  val cobindSyntax = new scalaz.syntax.CobindSyntax[F] { def F = Cobind.this }
+  @transient lazy val cobindSyntax = new scalaz.syntax.CobindSyntax[F] { def F = Cobind.this }
 }
 
 object Cobind {

--- a/core/src/main/scala/scalaz/Comonad.scala
+++ b/core/src/main/scala/scalaz/Comonad.scala
@@ -25,7 +25,7 @@ trait Comonad[F[_]] extends Cobind[F] { self =>
   def comonadLaw = new ComonadLaws {}
 
   ////
-  val comonadSyntax = new scalaz.syntax.ComonadSyntax[F] { def F = Comonad.this }
+  @transient lazy val comonadSyntax = new scalaz.syntax.ComonadSyntax[F] { def F = Comonad.this }
 }
 
 object Comonad {

--- a/core/src/main/scala/scalaz/Compose.scala
+++ b/core/src/main/scala/scalaz/Compose.scala
@@ -36,7 +36,7 @@ trait Compose[=>:[_, _]]  { self =>
   def composeLaw = new ComposeLaw {}
 
   ////
-  val composeSyntax = new scalaz.syntax.ComposeSyntax[=>:] { def F = Compose.this }
+  @transient lazy val composeSyntax = new scalaz.syntax.ComposeSyntax[=>:] { def F = Compose.this }
 }
 
 object Compose {

--- a/core/src/main/scala/scalaz/Contravariant.scala
+++ b/core/src/main/scala/scalaz/Contravariant.scala
@@ -69,7 +69,7 @@ trait Contravariant[F[_]] extends InvariantFunctor[F] { self =>
   def contravariantLaw = new ContravariantLaw {}
 
   ////
-  val contravariantSyntax = new scalaz.syntax.ContravariantSyntax[F] { def F = Contravariant.this }
+  @transient lazy val contravariantSyntax = new scalaz.syntax.ContravariantSyntax[F] { def F = Contravariant.this }
 }
 
 object Contravariant {

--- a/core/src/main/scala/scalaz/Cozip.scala
+++ b/core/src/main/scala/scalaz/Cozip.scala
@@ -26,7 +26,7 @@ trait Cozip[F[_]]  { self =>
     cozip(x).map(cozip(_) map (cozip(_) map (cozip(_) map (cozip(_) map(cozip(_))))))
 
   ////
-  val cozipSyntax = new scalaz.syntax.CozipSyntax[F] { def F = Cozip.this }
+  @transient lazy val cozipSyntax = new scalaz.syntax.CozipSyntax[F] { def F = Cozip.this }
 }
 
 object Cozip {

--- a/core/src/main/scala/scalaz/Enum.scala
+++ b/core/src/main/scala/scalaz/Enum.scala
@@ -215,7 +215,7 @@ trait Enum[F] extends Order[F] { self =>
   def enumLaw = new EnumLaw {}
 
   ////
-  val enumSyntax = new scalaz.syntax.EnumSyntax[F] { def F = Enum.this }
+  @transient lazy val enumSyntax = new scalaz.syntax.EnumSyntax[F] { def F = Enum.this }
 }
 
 object Enum {

--- a/core/src/main/scala/scalaz/Equal.scala
+++ b/core/src/main/scala/scalaz/Equal.scala
@@ -33,7 +33,7 @@ trait Equal[F]  { self =>
   }
   def equalLaw = new EqualLaw {}
   ////
-  val equalSyntax = new scalaz.syntax.EqualSyntax[F] { def F = Equal.this }
+  @transient lazy val equalSyntax = new scalaz.syntax.EqualSyntax[F] { def F = Equal.this }
 }
 
 object Equal {

--- a/core/src/main/scala/scalaz/Foldable.scala
+++ b/core/src/main/scala/scalaz/Foldable.scala
@@ -284,7 +284,7 @@ trait Foldable[F[_]]  { self =>
   def foldableLaw = new FoldableLaw {}
 
   ////
-  val foldableSyntax = new scalaz.syntax.FoldableSyntax[F] { def F = Foldable.this }
+  @transient lazy val foldableSyntax = new scalaz.syntax.FoldableSyntax[F] { def F = Foldable.this }
 }
 
 object Foldable {

--- a/core/src/main/scala/scalaz/Foldable1.scala
+++ b/core/src/main/scala/scalaz/Foldable1.scala
@@ -154,7 +154,7 @@ trait Foldable1[F[_]] extends Foldable[F] { self =>
   def foldable1Law = new Foldable1Law {}
 
   ////
-  val foldable1Syntax = new scalaz.syntax.Foldable1Syntax[F] { def F = Foldable1.this }
+  @transient lazy val foldable1Syntax = new scalaz.syntax.Foldable1Syntax[F] { def F = Foldable1.this }
 }
 
 object Foldable1 {

--- a/core/src/main/scala/scalaz/Functor.scala
+++ b/core/src/main/scala/scalaz/Functor.scala
@@ -107,7 +107,7 @@ trait Functor[F[_]] extends InvariantFunctor[F] { self =>
   }
   def functorLaw = new FunctorLaw {}
   ////
-  val functorSyntax = new scalaz.syntax.FunctorSyntax[F] { def F = Functor.this }
+  @transient lazy val functorSyntax = new scalaz.syntax.FunctorSyntax[F] { def F = Functor.this }
 }
 
 object Functor {

--- a/core/src/main/scala/scalaz/InvariantFunctor.scala
+++ b/core/src/main/scala/scalaz/InvariantFunctor.scala
@@ -43,7 +43,7 @@ trait InvariantFunctor[F[_]]  { self =>
 
   def invariantFunctorLaw = new InvariantFunctorLaw {}
   ////
-  val invariantFunctorSyntax = new scalaz.syntax.InvariantFunctorSyntax[F] { def F = InvariantFunctor.this }
+  @transient lazy val invariantFunctorSyntax = new scalaz.syntax.InvariantFunctorSyntax[F] { def F = InvariantFunctor.this }
 }
 
 object InvariantFunctor {

--- a/core/src/main/scala/scalaz/IsEmpty.scala
+++ b/core/src/main/scala/scalaz/IsEmpty.scala
@@ -22,7 +22,7 @@ trait IsEmpty[F[_]] extends PlusEmpty[F] { self =>
   def isEmptyLaw = new IsEmptyLaw {}
 
   ////
-  val isEmptySyntax = new scalaz.syntax.IsEmptySyntax[F] { def F = IsEmpty.this }
+  @transient lazy val isEmptySyntax = new scalaz.syntax.IsEmptySyntax[F] { def F = IsEmpty.this }
 }
 
 object IsEmpty {

--- a/core/src/main/scala/scalaz/Monad.scala
+++ b/core/src/main/scala/scalaz/Monad.scala
@@ -74,7 +74,7 @@ trait Monad[F[_]] extends Applicative[F] with Bind[F] { self =>
   }
   def monadLaw = new MonadLaw {}
   ////
-  val monadSyntax = new scalaz.syntax.MonadSyntax[F] { def F = Monad.this }
+  @transient lazy val monadSyntax = new scalaz.syntax.MonadSyntax[F] { def F = Monad.this }
 }
 
 object Monad {

--- a/core/src/main/scala/scalaz/MonadError.scala
+++ b/core/src/main/scala/scalaz/MonadError.scala
@@ -22,7 +22,7 @@ trait MonadError[F[_, _], S] extends Monad[F[S, ?]] { self =>
   def monadErrorLaw = new MonadErrorLaw {}
 
   ////
-  val monadErrorSyntax = new scalaz.syntax.MonadErrorSyntax[F, S] { def F = MonadError.this }
+  @transient lazy val monadErrorSyntax = new scalaz.syntax.MonadErrorSyntax[F, S] { def F = MonadError.this }
 }
 
 object MonadError {

--- a/core/src/main/scala/scalaz/MonadListen.scala
+++ b/core/src/main/scala/scalaz/MonadListen.scala
@@ -6,7 +6,7 @@ trait MonadListen[F[_, _], W] extends MonadTell[F, W] {
   def pass[A](ma: F[W, (A, W => W)]): F[W, A] =
     bind(listen(ma)){ case ((a, f), w) => writer(f(w), a) }
 
-  val monadListenSyntax = new scalaz.syntax.MonadListenSyntax[F, W]{def F = MonadListen.this}
+  @transient lazy val monadListenSyntax = new scalaz.syntax.MonadListenSyntax[F, W]{def F = MonadListen.this}
 }
 
 object MonadListen {

--- a/core/src/main/scala/scalaz/MonadPlus.scala
+++ b/core/src/main/scala/scalaz/MonadPlus.scala
@@ -50,7 +50,7 @@ trait MonadPlus[F[_]] extends Monad[F] with ApplicativePlus[F] { self =>
   def monadPlusLaw = new MonadPlusLaw {}
   def strongMonadPlusLaw = new StrongMonadPlusLaw {}
   ////
-  val monadPlusSyntax = new scalaz.syntax.MonadPlusSyntax[F] { def F = MonadPlus.this }
+  @transient lazy val monadPlusSyntax = new scalaz.syntax.MonadPlusSyntax[F] { def F = MonadPlus.this }
 }
 
 object MonadPlus {

--- a/core/src/main/scala/scalaz/MonadTell.scala
+++ b/core/src/main/scala/scalaz/MonadTell.scala
@@ -12,7 +12,7 @@ trait MonadTell[F[_, _], S] extends Monad[F[S, ?]] { self =>
   def tell(w: S): F[S, Unit] = writer(w, ())
 
   ////
-  val monadTellSyntax = new scalaz.syntax.MonadTellSyntax[F, S] { def F = MonadTell.this }
+  @transient lazy val monadTellSyntax = new scalaz.syntax.MonadTellSyntax[F, S] { def F = MonadTell.this }
 }
 
 object MonadTell {

--- a/core/src/main/scala/scalaz/Monoid.scala
+++ b/core/src/main/scala/scalaz/Monoid.scala
@@ -79,7 +79,7 @@ trait Monoid[F] extends Semigroup[F] { self =>
   def monoidLaw = new MonoidLaw {}
 
   ////
-  val monoidSyntax = new scalaz.syntax.MonoidSyntax[F] { def F = Monoid.this }
+  @transient lazy val monoidSyntax = new scalaz.syntax.MonoidSyntax[F] { def F = Monoid.this }
 }
 
 object Monoid {

--- a/core/src/main/scala/scalaz/Nondeterminism.scala
+++ b/core/src/main/scala/scalaz/Nondeterminism.scala
@@ -159,7 +159,7 @@ trait Nondeterminism[F[_]] extends Monad[F] { self =>
     map(gatherUnordered(fs))(_.foldLeft(implicitly[Monoid[A]].zero)((a,b) => implicitly[Monoid[A]].append(a,b)))
 
   ////
-  val nondeterminismSyntax = new scalaz.syntax.NondeterminismSyntax[F] { def F = Nondeterminism.this }
+  @transient lazy val nondeterminismSyntax = new scalaz.syntax.NondeterminismSyntax[F] { def F = Nondeterminism.this }
 }
 
 object Nondeterminism {

--- a/core/src/main/scala/scalaz/Optional.scala
+++ b/core/src/main/scala/scalaz/Optional.scala
@@ -47,7 +47,7 @@ trait Optional[F[_]]  { self =>
   def toMaybe[A](fa: F[A]): Maybe[A] = pextract(fa).toMaybe
 
   ////
-  val optionalSyntax = new scalaz.syntax.OptionalSyntax[F] { def F = Optional.this }
+  @transient lazy val optionalSyntax = new scalaz.syntax.OptionalSyntax[F] { def F = Optional.this }
 }
 
 object Optional {

--- a/core/src/main/scala/scalaz/Order.scala
+++ b/core/src/main/scala/scalaz/Order.scala
@@ -66,7 +66,7 @@ trait Order[F] extends Equal[F] { self =>
   def orderLaw = new OrderLaw {}
 
   ////
-  val orderSyntax = new scalaz.syntax.OrderSyntax[F] { def F = Order.this }
+  @transient lazy val orderSyntax = new scalaz.syntax.OrderSyntax[F] { def F = Order.this }
 }
 
 object Order {

--- a/core/src/main/scala/scalaz/Plus.scala
+++ b/core/src/main/scala/scalaz/Plus.scala
@@ -35,7 +35,7 @@ trait Plus[F[_]]  { self =>
   def plusLaw = 
     new PlusLaw {}
   ////
-  val plusSyntax = new scalaz.syntax.PlusSyntax[F] { def F = Plus.this }
+  @transient lazy val plusSyntax = new scalaz.syntax.PlusSyntax[F] { def F = Plus.this }
 }
 
 object Plus {

--- a/core/src/main/scala/scalaz/PlusEmpty.scala
+++ b/core/src/main/scala/scalaz/PlusEmpty.scala
@@ -43,7 +43,7 @@ trait PlusEmpty[F[_]] extends Plus[F] { self =>
     new EmptyLaw {}
 
   ////
-  val plusEmptySyntax = new scalaz.syntax.PlusEmptySyntax[F] { def F = PlusEmpty.this }
+  @transient lazy val plusEmptySyntax = new scalaz.syntax.PlusEmptySyntax[F] { def F = PlusEmpty.this }
 }
 
 object PlusEmpty {

--- a/core/src/main/scala/scalaz/ProChoice.scala
+++ b/core/src/main/scala/scalaz/ProChoice.scala
@@ -12,7 +12,7 @@ trait ProChoice[=>:[_, _]] extends Profunctor[=>:] { self =>
   def right[A, B, C](fa: A =>: B): (C \/ A) =>: (C \/ B)
 
   ////
-  val proChoiceSyntax = new scalaz.syntax.ProChoiceSyntax[=>:] { def F = ProChoice.this }
+  @transient lazy val proChoiceSyntax = new scalaz.syntax.ProChoiceSyntax[=>:] { def F = ProChoice.this }
 }
 
 object ProChoice {

--- a/core/src/main/scala/scalaz/Profunctor.scala
+++ b/core/src/main/scala/scalaz/Profunctor.scala
@@ -37,7 +37,7 @@ trait Profunctor[=>:[_, _]]  { self =>
     }
 
   ////
-  val profunctorSyntax = new scalaz.syntax.ProfunctorSyntax[=>:] { def F = Profunctor.this }
+  @transient lazy val profunctorSyntax = new scalaz.syntax.ProfunctorSyntax[=>:] { def F = Profunctor.this }
 }
 
 object Profunctor {

--- a/core/src/main/scala/scalaz/Semigroup.scala
+++ b/core/src/main/scala/scalaz/Semigroup.scala
@@ -62,7 +62,7 @@ trait Semigroup[F]  { self =>
 
 
   ////
-  val semigroupSyntax = new scalaz.syntax.SemigroupSyntax[F] { def F = Semigroup.this }
+  @transient lazy val semigroupSyntax = new scalaz.syntax.SemigroupSyntax[F] { def F = Semigroup.this }
 }
 
 object Semigroup {

--- a/core/src/main/scala/scalaz/Show.scala
+++ b/core/src/main/scala/scalaz/Show.scala
@@ -13,7 +13,7 @@ trait Show[F]  { self =>
 
   // derived functions
   ////
-  val showSyntax = new scalaz.syntax.ShowSyntax[F] { def F = Show.this }
+  @transient lazy val showSyntax = new scalaz.syntax.ShowSyntax[F] { def F = Show.this }
 }
 
 object Show {

--- a/core/src/main/scala/scalaz/Split.scala
+++ b/core/src/main/scala/scalaz/Split.scala
@@ -12,7 +12,7 @@ trait Split[=>:[_, _]] extends Compose[=>:] { self =>
   // derived functions
 
   ////
-  val splitSyntax = new scalaz.syntax.SplitSyntax[=>:] { def F = Split.this }
+  @transient lazy val splitSyntax = new scalaz.syntax.SplitSyntax[=>:] { def F = Split.this }
 }
 
 object Split {

--- a/core/src/main/scala/scalaz/Strong.scala
+++ b/core/src/main/scala/scalaz/Strong.scala
@@ -12,7 +12,7 @@ trait Strong[=>:[_, _]] extends Profunctor[=>:] { self =>
   def second[A, B, C](fa: A =>: B): (C, A) =>: (C, B)
 
   ////
-  val strongSyntax = new scalaz.syntax.StrongSyntax[=>:] { def F = Strong.this }
+  @transient lazy val strongSyntax = new scalaz.syntax.StrongSyntax[=>:] { def F = Strong.this }
 }
 
 object Strong {

--- a/core/src/main/scala/scalaz/Traverse.scala
+++ b/core/src/main/scala/scalaz/Traverse.scala
@@ -195,7 +195,7 @@ trait Traverse[F[_]] extends Functor[F] with Foldable[F] { self =>
   def traverseLaw = new TraverseLaw {}
 
   ////
-  val traverseSyntax = new scalaz.syntax.TraverseSyntax[F] { def F = Traverse.this }
+  @transient lazy val traverseSyntax = new scalaz.syntax.TraverseSyntax[F] { def F = Traverse.this }
 }
 
 object Traverse {

--- a/core/src/main/scala/scalaz/Traverse1.scala
+++ b/core/src/main/scala/scalaz/Traverse1.scala
@@ -90,7 +90,7 @@ trait Traverse1[F[_]] extends Traverse[F] with Foldable1[F] { self =>
   def traverse1Law = new Traverse1Law {}
 
   ////
-  val traverse1Syntax = new scalaz.syntax.Traverse1Syntax[F] { def F = Traverse1.this }
+  @transient lazy val traverse1Syntax = new scalaz.syntax.Traverse1Syntax[F] { def F = Traverse1.this }
 }
 
 object Traverse1 {

--- a/core/src/main/scala/scalaz/Unzip.scala
+++ b/core/src/main/scala/scalaz/Unzip.scala
@@ -60,7 +60,7 @@ trait Unzip[F[_]]  { self =>
   }
 
   ////
-  val unzipSyntax = new scalaz.syntax.UnzipSyntax[F] { def F = Unzip.this }
+  @transient lazy val unzipSyntax = new scalaz.syntax.UnzipSyntax[F] { def F = Unzip.this }
 }
 
 object Unzip {

--- a/core/src/main/scala/scalaz/Zip.scala
+++ b/core/src/main/scala/scalaz/Zip.scala
@@ -62,7 +62,7 @@ trait Zip[F[_]]  { self =>
   def zipLaw = new ZipLaw {}
 
   ////
-  val zipSyntax = new scalaz.syntax.ZipSyntax[F] { def F = Zip.this }
+  @transient lazy val zipSyntax = new scalaz.syntax.ZipSyntax[F] { def F = Zip.this }
 }
 
 object Zip {

--- a/effect/src/main/scala/scalaz/effect/LiftControlIO.scala
+++ b/effect/src/main/scala/scalaz/effect/LiftControlIO.scala
@@ -15,7 +15,7 @@ trait LiftControlIO[F[_]]  { self =>
   // derived functions
 
   ////
-  val liftControlIOSyntax = new scalaz.syntax.effect.LiftControlIOSyntax[F] { def F = LiftControlIO.this }
+  @transient lazy val liftControlIOSyntax = new scalaz.syntax.effect.LiftControlIOSyntax[F] { def F = LiftControlIO.this }
 }
 
 object LiftControlIO {

--- a/effect/src/main/scala/scalaz/effect/LiftIO.scala
+++ b/effect/src/main/scala/scalaz/effect/LiftIO.scala
@@ -14,7 +14,7 @@ trait LiftIO[F[_]]  { self =>
   // derived functions
 
   ////
-  val liftIOSyntax = new scalaz.syntax.effect.LiftIOSyntax[F] { def F = LiftIO.this }
+  @transient lazy val liftIOSyntax = new scalaz.syntax.effect.LiftIOSyntax[F] { def F = LiftIO.this }
 }
 
 object LiftIO {

--- a/effect/src/main/scala/scalaz/effect/MonadControlIO.scala
+++ b/effect/src/main/scala/scalaz/effect/MonadControlIO.scala
@@ -12,7 +12,7 @@ trait MonadControlIO[F[_]] extends LiftControlIO[F] with Monad[F] { self =>
   // derived functions
 
   ////
-  val monadControlIOSyntax = new scalaz.syntax.effect.MonadControlIOSyntax[F] { def F = MonadControlIO.this }
+  @transient lazy val monadControlIOSyntax = new scalaz.syntax.effect.MonadControlIOSyntax[F] { def F = MonadControlIO.this }
 }
 
 object MonadControlIO {

--- a/effect/src/main/scala/scalaz/effect/MonadIO.scala
+++ b/effect/src/main/scala/scalaz/effect/MonadIO.scala
@@ -12,7 +12,7 @@ trait MonadIO[F[_]] extends LiftIO[F] with Monad[F] { self =>
   // derived functions
 
   ////
-  val monadIOSyntax = new scalaz.syntax.effect.MonadIOSyntax[F] { def F = MonadIO.this }
+  @transient lazy val monadIOSyntax = new scalaz.syntax.effect.MonadIOSyntax[F] { def F = MonadIO.this }
 }
 
 object MonadIO {

--- a/effect/src/main/scala/scalaz/effect/Resource.scala
+++ b/effect/src/main/scala/scalaz/effect/Resource.scala
@@ -19,7 +19,7 @@ trait Resource[F]  { self =>
   }
 
   ////
-  val resourceSyntax = new scalaz.syntax.effect.ResourceSyntax[F] { def F = Resource.this }
+  @transient lazy val resourceSyntax = new scalaz.syntax.effect.ResourceSyntax[F] { def F = Resource.this }
 }
 
 object Resource {

--- a/project/GenTypeClass.scala
+++ b/project/GenTypeClass.scala
@@ -244,9 +244,9 @@ object GenTypeClass {
     val syntaxPackString1 = tc.syntaxPack.mkString(".")
     val syntaxMember = if(tc.createSyntax) {
       if (kind == Kind.*^*->*->*) {
-        s"val ${Util.initLower(typeClassName)}Syntax = new $syntaxPackString1.${typeClassName}Syntax[$classifiedTypeIdent, S] { def F = $typeClassName.this }"
+        s"@transient lazy val ${Util.initLower(typeClassName)}Syntax = new $syntaxPackString1.${typeClassName}Syntax[$classifiedTypeIdent, S] { def F = $typeClassName.this }"
       } else {
-        s"val ${Util.initLower(typeClassName)}Syntax = new $syntaxPackString1.${typeClassName}Syntax[$classifiedTypeIdent] { def F = $typeClassName.this }"
+        s"@transient lazy val ${Util.initLower(typeClassName)}Syntax = new $syntaxPackString1.${typeClassName}Syntax[$classifiedTypeIdent] { def F = $typeClassName.this }"
       }
     } else ""
 


### PR DESCRIPTION
I need to be able to serialize my instances when using scalaz together with Apache Spark. However even when I mixin Serializable, e.g. "new Functor[T] with Serializable" the serialization fails because the field functorSyntax is not serializable. This patch marks all such fields as "@transient lazy val" to exclude them from serialization (they will be automatically reinitialized after deserialization).