### PR TITLE
Rework StateT to allow for trampolining

### DIFF
--- a/core/src/main/scala/scalaz/Bitraverse.scala
+++ b/core/src/main/scala/scalaz/Bitraverse.scala
@@ -74,13 +74,11 @@ trait Bitraverse[F[_, _]] extends Bifunctor[F] with Bifoldable[F] { self =>
     import Free._
     implicit val A = StateT.stateTMonadState[S, Trampoline].compose(Applicative[G])
 
-    new State[S, G[F[C, D]]] {
-      def apply(initial: S) = {
-        val st = bitraverse[λ[α => StateT[Trampoline, S, G[α]]], A, B, C, D](fa)(f(_: A).lift[Trampoline])(g(_: B).lift[Trampoline])
-        st(initial).run
-      }
-    }
-  }
+    State[S, G[F[C, D]]](initial => {
+      val st = bitraverse[λ[α => StateT[Trampoline, S, G[α]]], A, B, C, D](fa)(f(_: A).lift[Trampoline])(g(_: B).lift[Trampoline])
+      st(initial).run
+    })
+   }
 
   /** Bitraverse `fa` with a `Kleisli[G, S, C]` and `Kleisli[G, S, D]`, internally using a `Trampoline` to avoid stack overflow. */
   def bitraverseKTrampoline[S, G[_] : Applicative, A, B, C, D](fa: F[A, B])(f: A => Kleisli[G, S, C])(g: B => Kleisli[G, S, D]): Kleisli[G, S, F[C, D]] = {

--- a/core/src/main/scala/scalaz/Kleisli.scala
+++ b/core/src/main/scala/scalaz/Kleisli.scala
@@ -69,7 +69,7 @@ final case class Kleisli[M[_], A, B](run: A => M[B]) { self =>
       }
     )
 
-  def state(implicit M: Functor[M]): StateT[M, A, B] =
+  def state(implicit M: Monad[M]): StateT[M, A, B] =
     StateT(a => M.map(run(a))((a, _)))
 
   def liftMK[T[_[_], _]](implicit T: MonadTrans[T], M: Monad[M]): Kleisli[T[M, ?], A, B] =

--- a/core/src/main/scala/scalaz/ReaderWriterStateT.scala
+++ b/core/src/main/scala/scalaz/ReaderWriterStateT.scala
@@ -6,7 +6,7 @@ sealed abstract class IndexedReaderWriterStateT[F[_], -R, W, -S1, S2, A] {
   def run(r: R, s: S1): F[(W, A, S2)]
 
   /** Discards the writer component. */
-  def state(r: R)(implicit F: Functor[F]): IndexedStateT[F, S1, S2, A] =
+  def state(r: R)(implicit F: Monad[F]): IndexedStateT[F, S1, S2, A] =
     IndexedStateT((s: S1) => F.map(run(r, s)) {
       case (w, a, s1) => (s1, a)
     })

--- a/core/src/main/scala/scalaz/package.scala
+++ b/core/src/main/scala/scalaz/package.scala
@@ -139,21 +139,15 @@ package object scalaz {
   type State[S, A] = StateT[Id, S, A]
 
   object StateT extends StateTInstances with StateTFunctions {
-    def apply[F[_], S, A](f: S => F[(S, A)]): StateT[F, S, A] = new StateT[F, S, A] {
-      def apply(s: S) = f(s)
-    }
+    def apply[F[_], S, A](f: S => F[(S, A)])(implicit F: Monad[F]): StateT[F, S, A] = IndexedStateT[F, S, S, A](s => f(s))
   }
   object IndexedState extends StateFunctions {
-    def apply[S1, S2, A](f: S1 => (S2, A)): IndexedState[S1, S2, A] = new IndexedState[S1, S2, A] {
-      def apply(s: S1) = f(s)
-    }
+    def apply[S1, S2, A](f: S1 => (S2, A)): IndexedState[S1, S2, A] = IndexedStateT[Id, S1, S2, A](s => f(s)) 
   }
   object State extends StateFunctions {
-    def apply[S, A](f: S => (S, A)): State[S, A] = new StateT[Id, S, A] {
-      def apply(s: S) = f(s)
-    }
+    def apply[S, A](f: S => (S, A)): State[S, A] = StateT[Id, S, A](s => f(s))
   }
-
+  
   type StoreT[F[_], A, B] = IndexedStoreT[F, A, A, B]
   type IndexedStore[I, A, B] = IndexedStoreT[Id, I, A, B]
   type Store[A, B] = StoreT[Id, A, B]

--- a/core/src/main/scala/scalaz/syntax/StateOps.scala
+++ b/core/src/main/scala/scalaz/syntax/StateOps.scala
@@ -3,7 +3,7 @@ package syntax
 
 final class StateOps[A](val self: A) extends AnyVal {
   def state[S]: State[S, A] = State.state[S, A](self)
-  def stateT[F[_]:Applicative, S]: StateT[F, S, A] = StateT.stateT[F, S, A](self)
+  def stateT[F[_]:Monad, S]: StateT[F, S, A] = StateT.stateT[F, S, A](self)
 }
 
 trait ToStateOps {

--- a/effect/src/main/scala/scalaz/effect/LiftIO.scala
+++ b/effect/src/main/scala/scalaz/effect/LiftIO.scala
@@ -56,7 +56,7 @@ object LiftIO {
       def liftIO[A](ioa: IO[A]) = WriterT(LiftIO[F].liftIO(ioa.map((Monoid[W].zero, _))))
     }
 
-  implicit def stateTLiftIO[F[_]: LiftIO, S] =
+  implicit def stateTLiftIO[F[_]: LiftIO, S](implicit F: Monad[F]) =
     new LiftIO[StateT[F, S, ?]] {
       def liftIO[A](ioa: IO[A]) = StateT(s => LiftIO[F].liftIO(ioa.map((s, _))))
     }

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
@@ -303,10 +303,10 @@ object ScalazArbitrary {
     Functor[Arbitrary].map(A)(LazyEitherT[F, A, B](_))
 
   // backwards compatibility
-  def stateTArb[F[+_], S, A](implicit A: Arbitrary[S => F[(S, A)]]): Arbitrary[StateT[F, S, A]] =
-    indexedStateTArb[F, S, S, A](A)
+  def stateTArb[F[+_], S, A](implicit A: Arbitrary[S => F[(S, A)]], F: Monad[F]): Arbitrary[StateT[F, S, A]] =
+    indexedStateTArb[F, S, S, A](A, F)
 
-  implicit def indexedStateTArb[F[_], S1, S2, A](implicit A: Arbitrary[S1 => F[(S2, A)]]): Arbitrary[IndexedStateT[F, S1, S2, A]] =
+  implicit def indexedStateTArb[F[_], S1, S2, A](implicit A: Arbitrary[S1 => F[(S2, A)]], F: Monad[F]): Arbitrary[IndexedStateT[F, S1, S2, A]] =
     Functor[Arbitrary].map(A)(IndexedStateT[F, S1, S2, A](_))
 
   implicit def eitherTArb[F[_], A, B](implicit A: Arbitrary[F[A \/ B]]): Arbitrary[EitherT[F, A, B]] =

--- a/tests/src/test/scala/scalaz/StateTTest.scala
+++ b/tests/src/test/scala/scalaz/StateTTest.scala
@@ -63,4 +63,11 @@ object StateTTest extends SpecLite {
     val b = StateT[List, Int, Boolean](s => List((s, true)))
     instances.monadPlus[Int, List].plus(a, b).run(0) must_===(List((0, false), (0, true)))
   }
+  
+  "StateT can be trampolined without stack overflow" in {
+    import scalaz.Free._    
+    val result = (0 to 4000).toList.map(i => StateT[Trampoline, Int, Int]((ii:Int) => Trampoline.done((i,i))))
+      .foldLeft(StateT((s:Int) => Trampoline.done((s,s))))( (a,b) => a.flatMap(_ => b))
+    4000 must_=== result(0).run._1 
+  }
 }


### PR DESCRIPTION
A few folks have discovered that while it intuitively seems like creation of a StateT[Trampoline, A, B] would result in stack safety, it actually can still SOE on recursive flatMap calls. 
John De Goes pointed out that this could be avoided by refactoring StateT’s application function to be F[A => F[(A,B)]] rather than just A => F[(A,B)].  I implemented a toy version of this for my Lambda-Conf talk on stack safety in Scala and showed the way John imagined State does allow for stack safety.  It’s more or less: 

```scala
   case class StateT[F[_], S, A](sf: F[S => F[(S,A)]]) {
    def flatMap[B](f: A => StateT[F, S, B])(implicit M: Monad[F]): StateT[F, S, B] = 
      StateT[F, S, B](((s1: S) => { 
        sf.flatMap(sfa => {          //the key, important line here that f application happens inside the F[_]s bind and not before hand
            sfa(s1).flatMap(t =>  
                f(t._2).sf.flatMap(z => z(s1)) 
          )
        }) 
      }).point[F])
  }
```

Though ‘applying’ it gets to be a bit weird, hence why I now have a monad instance in the StateT trait. 

Another negative to this is it requires a lot more monads…everywhere.  Permeates through Hoist most obviously, and also some other method calls

We could make the argument that if we want to get fancy with state
then you can just use the free monad fold trick I’ve proposed, but the current StateT[Trampoline,A,B] *does* fail against the test case I provided (though it may need to be a bigger list).  Kleisli and RWST also
suffer from the same problem.  If this is a change we’re OK with I’d be happy to fix it on those classes too.   Feedback/review from @runarorama @tpolecat  @S11001001 and any others would be greatly appreciated.  