### PR TITLE
MonadPlus[NonEmptyList]

### DIFF
--- a/core/src/main/scala/scalaz/NonEmptyList.scala
+++ b/core/src/main/scala/scalaz/NonEmptyList.scala
@@ -131,7 +131,7 @@ sealed abstract class NonEmptyListInstances0 {
 
 sealed abstract class NonEmptyListInstances extends NonEmptyListInstances0 {
   implicit val nonEmptyList =
-    new Traverse1[NonEmptyList] with Monad[NonEmptyList] with Plus[NonEmptyList] with Comonad[NonEmptyList] with Zip[NonEmptyList] with Unzip[NonEmptyList] with Align[NonEmptyList] {
+    new Traverse1[NonEmptyList] with MonadPlus[NonEmptyList] with Comonad[NonEmptyList] with Zip[NonEmptyList] with Unzip[NonEmptyList] with Align[NonEmptyList] {
       def traverse1Impl[G[_] : Apply, A, B](fa: NonEmptyList[A])(f: A => G[B]): G[NonEmptyList[B]] =
         fa traverse1 f
 


### PR DESCRIPTION
Because
```
scala> implicitly[MonadPlus[NonEmptyList]]
<console>:11: error: could not find implicit value for parameter e: scalaz.MonadPlus[scalaz.NonEmptyList]
              implicitly[MonadPlus[NonEmptyList]]
                        ^
```