### PR TITLE
Add working UnapplyProduct

### DIFF
--- a/core/src/main/scala/scalaz/syntax/BitraverseSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/BitraverseSyntax.scala
@@ -7,8 +7,6 @@ final class BitraverseOps[F[_, _],A, B] private[syntax](val self: F[A, B])(impli
   final def bitraverse[G[_], C, D](f: A => G[C], g: B => G[D])(implicit ap: Applicative[G]): G[F[C, D]] =
       F.bitraverseImpl(self)(f, g)
 
-  // Would be nice, but I'm not sure we can conjure UnapplyProduct implicitly, at least without multiple implicit
-  // parameter lists.
   final def bitraverseU[GC, GD](f: A => GC, g: B => GD)(implicit G1: UnapplyProduct[Applicative, GC, GD]): G1.M[F[G1.A, G1.B]] =
       F.bitraverseImpl(self)(a => G1._1(f(a)), b => G1._2(g(b)))(G1.TC)
 

--- a/tests/src/test/scala/scalaz/UnapplyTest.scala
+++ b/tests/src/test/scala/scalaz/UnapplyTest.scala
@@ -24,4 +24,14 @@ object UnapplyTest extends SpecLite {
     // needs only transient stable type
     Unapply2[Arrow, Kleisli[NonEmptyList, Int, String]].TC: Arrow[Kleisli[NonEmptyList, ?, ?]]
   }
+
+  object unapplyProduct {
+    val ue = UnapplyProduct[Applicative, Writer[IList[String], Int], Writer[IList[String], Char]]
+    def mequiv[A] = implicitly[ue.M[A] === Writer[IList[String], A]]
+    implicitly[ue.A === Int]
+    implicitly[ue.B === Char]
+
+    // needs only transient stable type
+    UnapplyProduct[Applicative, Writer[IList[String], Int], Writer[IList[String], Char]].TC: Applicative[Writer[IList[String], ?]]
+  }
 }


### PR DESCRIPTION
This uses a trick for approximating the effect of multiple parameter lists (a trick I learned [from Miles](https://gist.github.com/milessabin/cadd73b7756fe4097ca0), of course) to provide `UnapplyProduct` instances. This means that the following finally works:

```scala
import scalaz._, Scalaz._

(1, 'a).bitraverseU(_.set("saw int" :: Nil), _.set("saw sym" :: Nil))
```

I've added a compilation test on the model of the other `Unapply` types, but no tests for syntax.