### PR TITLE
Added multiply1 on Semigroup with efficient default implementation

### DIFF
--- a/core/src/main/scala/scalaz/Monoid.scala
+++ b/core/src/main/scala/scalaz/Monoid.scala
@@ -29,7 +29,7 @@ trait Monoid[F] extends Semigroup[F] { self =>
    * For `n = 2`, `append(append(zero, value), value)`
    */
   def multiply(value: F, n: Int): F =
-    Stream.fill(n)(value).foldLeft(zero)((a,b) => append(a,b))
+    if (n <= 0) zero else multiply1(value, n - 1)
 
   /** Whether `a` == `zero`. */
   def isMZero(a: F)(implicit eq: Equal[F]): Boolean =

--- a/core/src/main/scala/scalaz/Semigroup.scala
+++ b/core/src/main/scala/scalaz/Semigroup.scala
@@ -22,6 +22,26 @@ trait Semigroup[F]  { self =>
   def append(f1: F, f2: => F): F
 
   // derived functions
+
+  /**
+   * For `n = 0`, `value`
+   * For `n = 1`, `append(value, value)`
+   * For `n = 2`, `append(append(value, value), value)`
+   *
+   * The default definition uses peasant multiplication, exploiting associativity to only
+   * require `O(log n)` uses of [[append]]
+   */
+  def multiply1(value: F, n: Int): F = {
+    @scala.annotation.tailrec
+    def go(x: F, y: Int, z: F): F = y match {
+      case y if (y & 1) == 0 => go(append(x, x), y >>> 1, z)
+      case y if (y == 1)     => append(x, z)
+      case _                 => go(append(x, x), (y - 1) >>>  1, append(x, z))
+    }
+    if (n <= 0) value else go(value, n, value)
+  }
+
+
   protected[this] trait SemigroupCompose extends Compose[λ[(α, β) => F]] {
     def compose[A, B, C](f: F, g: F) = append(f, g)
   }


### PR DESCRIPTION
and used it in default implementation of Monoid[F].multiply.

Straight port of times1p from the haskell semigroups package.