### PR TITLE
Fixed drawTree stack overflow and memory usage problems

### DIFF
--- a/core/src/main/scala/scalaz/Tree.scala
+++ b/core/src/main/scala/scalaz/Tree.scala
@@ -28,9 +28,10 @@ sealed abstract class Tree[A] {
   def drawTree(implicit sh: Show[A]): String = {
     val reversedLines = draw.run
     val first = new StringBuilder(reversedLines.head.toString.reverse)
-    first.append("\n").append(reversedLines.tail.reduceLeft { (acc, elem) => 
-      acc.append("\n").append(elem.toString.reverse)
-    }.append("\n").toString).toString
+    val rest = reversedLines.tail
+    rest.foldLeft(first) { (acc, elem) => 
+      acc.append("\n").append(elem.toString.reverse) 
+    }.append("\n").toString
   }
 
   /** A histomorphic transform. Each element in the resulting tree


### PR DESCRIPTION
Fixes issue 673, `Tree.drawTree` stack overflow for wide trees. After trampolining `drawTree`, it started to throw `OutOfMemoryError` on large trees. I rewrote it to use `Vector[StringBuilder]` to represent the lines of the tree representation instead of `Stream[String]`, and had to represent the lines backwards for efficient prepending. Now, it works for trees up to 6000 members before it runs out of memory on my laptop. I have a local test, but it's a bit slow.