### PR TITLE
Fix for #997 (Use Task's gatherUnordered instead of derived method)

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Task.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Task.scala
@@ -325,7 +325,10 @@ object Task {
    * @since 7.0.3
    */
   def gatherUnordered[A](tasks: Seq[Task[A]], exceptionCancels: Boolean = false): Task[List[A]] =
-    reduceUnordered[A, List[A]](tasks, exceptionCancels)
+    if (!exceptionCancels)
+      Nondeterminism[Task].gatherUnordered(tasks)
+    else
+      reduceUnordered[A, List[A]](tasks, exceptionCancels)
 
   def reduceUnordered[A, M](tasks: Seq[Task[A]], exceptionCancels: Boolean = false)(implicit R: Reducer[A, M]): Task[M] =
     if (!exceptionCancels) taskInstance.reduceUnordered(tasks)


### PR DESCRIPTION
When calling Task.gatherUnordered without exceptionCancels set, Task was then calling Nondeterminism[Task].reduceUnordered, which is the derived method from the parent instance.  This is non optimized for Task, and ended up being much slower than when calling Nondeterminism[Task].gatherUnordered. 

I've changed it to call the same method when you aren't trying to cancel running Tasks, as the behavior is the same but now calling either Task.gatherUnordered has the same performance as Nondeterminism[Task].gatherUnordered. 