### PR TITLE
enable pattern matching on `TagOf` instances

### DIFF
--- a/core/src/main/scala/scalaz/Tag.scala
+++ b/core/src/main/scala/scalaz/Tag.scala
@@ -52,6 +52,9 @@ object Tag {
 
     /** Like `Tag.unsubst`, but specify only the `T`. */
     def unsubst[F[_], A](fa: F[A @@ T]): F[A] = Tag.unsubst(fa)
+
+    /** Pattern match on a tagged value */
+    def unapply[A](a: A @@ T): Option[A] = Some(unwrap(a))
   }
 
   /** Variants of `apply`, `subst`, and `unsubst` that require

--- a/example/src/main/scala/scalaz/example/TagUsage.scala
+++ b/example/src/main/scala/scalaz/example/TagUsage.scala
@@ -98,4 +98,9 @@ object TagUsage extends App {
 
   implicit val ord = implicitly[Order[Option[Int]]].toScalaOrdering
   assert(minOption(sortList(List(3,2,1,5,3))) === Some(1))
+
+  // we can also use pattern matching:
+  def minOption_v2[A]: List[A] @@ Sorted ⇒ Option[A] = {
+    case Sorted(list) ⇒ list.headOption
+  }
 }

--- a/tests/src/test/scala/scalaz/TagTest.scala
+++ b/tests/src/test/scala/scalaz/TagTest.scala
@@ -41,4 +41,13 @@ object TagTest extends SpecLite {
       true
     }
   }
+
+  "of.unapply" should {
+    "support unwrapping in pattern match" in {
+      Monoid[Int @@ Mult].append(Mult(3), Mult(3)) match {
+        case Mult(9) ⇒ true
+        case Mult(_) ⇒ false
+      }
+    }
+  }
 }


### PR DESCRIPTION
This would help me scrap some boilerplate.  Any objections?