### PR TITLE
Use kind projector for type lambdas with type bounds

### DIFF
--- a/core/src/main/scala/scalaz/Leibniz.scala
+++ b/core/src/main/scala/scalaz/Leibniz.scala
@@ -87,13 +87,13 @@ object Leibniz extends LeibnizInstances {
     f: Leibniz[L, H, B, C],
     g: Leibniz[L, H, A, B]
   ): Leibniz[L, H, A, C] =
-    f.subst[({type λ[X >: L <: H] = Leibniz[L, H, A, X]})#λ](g) // note kind-projector 0.5.2 cannot do super/subtype bounds
+    f.subst[λ[`X >: L <: H` => Leibniz[L, H, A, X]]](g) // note kind-projector 0.5.2 cannot do super/subtype bounds
 
   /** Equality is symmetric */
   def symm[L, H >: L, A >: L <: H, B >: L <: H](
     f: Leibniz[L, H, A, B]
   )  : Leibniz[L, H, B, A] =
-    f.subst[({type λ[X>:L<:H]=Leibniz[L, H, X, A]})#λ](refl) // note kind-projector 0.5.2 cannot do super/subtype bounds
+    f.subst[λ[`X>:L<:H` => Leibniz[L, H, X, A]]](refl)
 
   /** We can lift equality into any type constructor */
   def lift[
@@ -104,7 +104,7 @@ object Leibniz extends LeibnizInstances {
   ](
     a: Leibniz[LA, HA, A, A2]
   ): Leibniz[LT, HT, T[A], T[A2]] =
-    a.subst[({type λ[X >: LA <: HA] = Leibniz[LT, HT, T[A], T[X]]})#λ](refl) // note kind-projector 0.5.2 cannot do super/subtype bounds
+    a.subst[λ[`X >: LA <: HA` => Leibniz[LT, HT, T[A], T[X]]]](refl)
 
   /** We can lift equality into any type constructor */
   def lift2[
@@ -117,8 +117,8 @@ object Leibniz extends LeibnizInstances {
     a: Leibniz[LA, HA, A, A2],
     b: Leibniz[LB, HB, B, B2]
   ) : Leibniz[LT, HT, T[A, B], T[A2, B2]] =
-    b.subst[({type λ[X >: LB <: HB] = Leibniz[LT, HT, T[A, B], T[A2, X]]})#λ]( // note kind-projector 0.5.2 cannot do super/subtype bounds
-      a.subst[({type λ[X >: LA <: HA] = Leibniz[LT, HT, T[A, B], T[X, B]]})#λ]( // note kind-projector 0.5.2 cannot do super/subtype bounds
+    b.subst[λ[`X >: LB <: HB` => Leibniz[LT, HT, T[A, B], T[A2, X]]]](
+      a.subst[λ[`X >: LA <: HA` => Leibniz[LT, HT, T[A, B], T[X, B]]]](
         refl))
 
   /** We can lift equality into any type constructor */
@@ -134,9 +134,9 @@ object Leibniz extends LeibnizInstances {
     b: Leibniz[LB, HB, B, B2],
     c: Leibniz[LC, HC, C, C2]
   ): Leibniz[LT, HT, T[A, B, C], T[A2, B2, C2]] =
-    c.subst[({type λ[X >: LC <: HC] = Leibniz[LT, HT, T[A, B, C], T[A2, B2, X]]})#λ]( // note kind-projector 0.5.2 cannot do super/subtype bounds
-      b.subst[({type λ[X >: LB <: HB] = Leibniz[LT, HT, T[A, B, C], T[A2, X, C]]})#λ]( // note kind-projector 0.5.2 cannot do super/subtype bounds
-        a.subst[({type λ[X >: LA <: HA] = Leibniz[LT, HT, T[A, B, C], T[X, B, C]]})#λ]( // note kind-projector 0.5.2 cannot do super/subtype bounds
+    c.subst[λ[`X >: LC <: HC` => Leibniz[LT, HT, T[A, B, C], T[A2, B2, X]]]](
+      b.subst[λ[`X >: LB <: HB` => Leibniz[LT, HT, T[A, B, C], T[A2, X, C]]]](
+        a.subst[λ[`X >: LA <: HA` => Leibniz[LT, HT, T[A, B, C], T[X, B, C]]]](
           refl)))
 
   /**

--- a/project/build.scala
+++ b/project/build.scala
@@ -167,8 +167,8 @@ object build extends Build {
         </developers>
       ),
     // kind-projector plugin
-    resolvers += "bintray/non" at "http://dl.bintray.com/non/maven",
-    addCompilerPlugin("org.spire-math" % "kind-projector" % "0.6.1" cross CrossVersion.binary)
+    resolvers += Resolver.sonatypeRepo("releases"),
+    addCompilerPlugin("org.spire-math" % "kind-projector" % "0.6.3" cross CrossVersion.binary)
   ) ++ osgiSettings ++ Seq[Sett](
     OsgiKeys.additionalHeaders := Map("-removeheaders" -> "Include-Resource,Private-Package")
   )


### PR DESCRIPTION
Kind Projector version > 0.6.0 supports simple type bounds.

I used Intellij IDEA 15 inspection to find cases where kind projector can be used instead of regular type projections for type lambdas. 