### PR TITLE
Add failureNel, successNel to Option

### DIFF
--- a/core/src/main/scala/scalaz/std/Option.scala
+++ b/core/src/main/scala/scalaz/std/Option.scala
@@ -183,6 +183,16 @@ trait OptionFunctions {
     case None    => Success(b)
   }
 
+  final def toSuccessNel[A,E](oa: Option[A])(e: => E) : ValidationNel[E,A] = oa match {
+    case Some(a) => Success(a)
+    case None    => Failure(NonEmptyList(e))
+  }
+
+  final def toFailureNel[A,B](oa: Option[A])(b: => B) : ValidationNel[A,B] = oa match {
+    case Some(a) => Failure(NonEmptyList(a))
+    case None    => Success(b)
+  }
+
   final def toRight[A, E](oa: Option[A])(e: => E): E \/ A = oa match {
     case Some(a) => \/-(a)
     case None    => -\/(e)

--- a/core/src/main/scala/scalaz/syntax/std/OptionOps.scala
+++ b/core/src/main/scala/scalaz/syntax/std/OptionOps.scala
@@ -74,6 +74,10 @@ final class OptionOps[A](self: Option[A]) {
 
   final def toFailure[B](b: => B): Validation[A, B] = o.toFailure(self)(b)
 
+  final def toSuccessNel[E](e: => E): ValidationNel[E, A] = o.toSuccessNel(self)(e)
+
+  final def toFailureNel[B](b: => B): ValidationNel[A, B] = o.toFailureNel(self)(b)
+
   final def toRightDisjunction[E](e: => E): E \/ A = o.toRight(self)(e)
 
   final def toLeftDisjunction[B](b: => B): A \/ B = o.toLeft(self)(b)

--- a/tests/src/test/scala/scalaz/OptionalTest.scala
+++ b/tests/src/test/scala/scalaz/OptionalTest.scala
@@ -64,8 +64,18 @@ object OptionalTest extends SpecLite {
     def success(a: Int): VString[Int] = Validation.success(a)
     def failure(s: String): VString[Int] = Validation.failure(s)
 
-    definedTests(success(1), 1, 0, success(0))
-    undefinedTests(failure("oO"), 0, success(0))
+    definedTests[VString, Int](success(1), 1, 0, success(0))
+    undefinedTests[VString, Int](failure("oO"), 0, success(0))
+  }
+
+  """ValidationNel instance tests""" in {
+    type VStringNel[A] = ValidationNel[String, A]
+
+    def successNel(a: Int): VStringNel[Int] = Validation.success(a)
+    def failureNel(s: String): VStringNel[Int] = Validation.failureNel(s)
+
+    definedTests[VStringNel, Int](successNel(1), 1, 0, successNel(0))
+    undefinedTests[VStringNel, Int](failureNel("oO"), 0, successNel(0))
   }
 
   "Id instance tests" in {


### PR DESCRIPTION
Convenience functions to transform an Option[A] to a ValidationNel[E,A]
or an Option[A] to a ValidationNel[A,B]