### PR TITLE
Make tree construction and pattern matching more consistent.

### DIFF
--- a/core/src/main/scala/scalaz/Tree.scala
+++ b/core/src/main/scala/scalaz/Tree.scala
@@ -116,7 +116,12 @@ object Tree extends TreeInstances with TreeFunctions {
    */
   object Node {
     def apply[A](root: => A, forest: => Stream[Tree[A]]): Tree[A] = {
-      node[A](root, forest)
+      new Tree[A] {
+        lazy val rootLabel = root
+        lazy val subForest = forest
+
+        override def toString = "<tree>"
+      }
     }
 
     def unapply[A](t: Tree[A]): Option[(A, Stream[Tree[A]])] = Some((t.rootLabel, t.subForest))
@@ -129,7 +134,7 @@ object Tree extends TreeInstances with TreeFunctions {
    */
   object Leaf {
     def apply[A](root: => A): Tree[A] = {
-      leaf(root)
+      Node(root, Stream.empty)
     }
 
     def unapply[A](t: Tree[A]): Option[A] = {
@@ -178,16 +183,11 @@ sealed abstract class TreeInstances {
 trait TreeFunctions {
   /** Construct a new Tree node. */
   @deprecated("Use Node.apply instead.")
-  def node[A](root: => A, forest: => Stream[Tree[A]]): Tree[A] = new Tree[A] {
-    lazy val rootLabel = root
-    lazy val subForest = forest
-
-    override def toString = "<tree>"
-  }
+  def node[A](root: => A, forest: => Stream[Tree[A]]): Tree[A] = Tree.Node(root, forest)
 
   /** Construct a tree node with no children. */
   @deprecated("Use Leaf.apply instead.")
-  def leaf[A](root: => A): Tree[A] = node(root, Stream.empty)
+  def leaf[A](root: => A): Tree[A] = Tree.Leaf(root)
 
   def unfoldForest[A, B](s: Stream[A])(f: A => (B, () => Stream[A])): Stream[Tree[B]] =
     s.map(unfoldTree(_)(f))

--- a/core/src/main/scala/scalaz/Tree.scala
+++ b/core/src/main/scala/scalaz/Tree.scala
@@ -108,10 +108,38 @@ object Tree extends TreeInstances with TreeFunctions {
   /** Construct a tree node with no children. */
   def apply[A](root: => A): Tree[A] = leaf(root)
 
+  /**
+   * Node represents a tree node that may have children.
+   *
+   * You can use Node for tree construction or pattern matching.
+   */
   object Node {
+    def apply[A](root: => A, forest: => Stream[Tree[A]]): Tree[A] = {
+      node[A](root, forest)
+    }
+
     def unapply[A](t: Tree[A]): Option[(A, Stream[Tree[A]])] = Some((t.rootLabel, t.subForest))
   }
 
+  /**
+   *  Leaf represents a a tree node with no children.
+   *
+   *  You can use Leaf for tree construction or pattern matching.
+   */
+  object Leaf {
+    def apply[A](root: => A): Tree[A] = {
+      leaf(root)
+    }
+
+    def unapply[A](t: Tree[A]): Option[A] = {
+      t match {
+        case Node(root, Stream.Empty) =>
+          Some(root)
+        case _ =>
+          None
+      }
+    }
+  }
 
 }
 

--- a/core/src/main/scala/scalaz/Tree.scala
+++ b/core/src/main/scala/scalaz/Tree.scala
@@ -177,6 +177,7 @@ sealed abstract class TreeInstances {
 
 trait TreeFunctions {
   /** Construct a new Tree node. */
+  @deprecated("Use Node.apply instead.")
   def node[A](root: => A, forest: => Stream[Tree[A]]): Tree[A] = new Tree[A] {
     lazy val rootLabel = root
     lazy val subForest = forest
@@ -185,6 +186,7 @@ trait TreeFunctions {
   }
 
   /** Construct a tree node with no children. */
+  @deprecated("Use Leaf.apply instead.")
   def leaf[A](root: => A): Tree[A] = node(root, Stream.empty)
 
   def unfoldForest[A, B](s: Stream[A])(f: A => (B, () => Stream[A])): Stream[Tree[B]] =

--- a/core/src/main/scala/scalaz/Tree.scala
+++ b/core/src/main/scala/scalaz/Tree.scala
@@ -106,6 +106,7 @@ sealed abstract class Tree[A] {
 
 object Tree extends TreeInstances with TreeFunctions {
   /** Construct a tree node with no children. */
+  @deprecated("Use Leaf.apply or Node.apply instead.")
   def apply[A](root: => A): Tree[A] = leaf(root)
 
   /**


### PR DESCRIPTION
Right now, you create trees with "def node", "def leaf", or the apply method of Tree. However, you pattern match, but do not create trees with Tree.Node. This is very inconsistent with how Scala construction and pattern matching usually work. Normally you have a capital letter object that you can use for both construction and pattern matching.

Changing Node to fit what I would normally expect from a Scala object is pretty easy; just add apply. Then as an analog of the leaf method, add a Leaf object with apply and unapply, so that pattern matching and construction is more like a normal Scala case class.

Tree.apply is completely weird. It actually is for creating a leaf, not a tree, and there's no corresponding unapply. I think that method should be deprecated or changed to create a node instead of a leaf, but that's another ticket.

Jeff