### PR TITLE
Fix a typo in AdjunctUsage example.

### DIFF
--- a/example/src/main/scala/scalaz/example/AdjunctUsage.scala
+++ b/example/src/main/scala/scalaz/example/AdjunctUsage.scala
@@ -20,7 +20,7 @@ object AdjunctUsage extends App {
     } yield (last === some(next))  // emit a boolean if this is the same as last
   }
  
-  // traverse the list with our stateful computation, pruducing a list
+  // traverse the list with our stateful computation, producing a list
   // of booleans for "was this a repeat of the previous"
   val res1: List[Boolean] = Traverse[List].traverseS(nonRepeating)(checkForRepeats).eval(None)
   val res2: List[Boolean] = Traverse[List].traverseS(repeating)(checkForRepeats).eval(None)


### PR DESCRIPTION
Tiny typo, not sure if such commits are welcome, but aspiring to contribute.