### PR TITLE
A balanced, streaming approach to IList traversal.

### DIFF
--- a/core/src/main/scala/scalaz/IList.scala
+++ b/core/src/main/scala/scalaz/IList.scala
@@ -560,6 +560,8 @@ sealed abstract class IListInstances extends IListInstance0 {
 
       def traverseImpl[F[_], A, B](fa: IList[A])(f: A => F[B])(implicit F: Applicative[F]): F[IList[B]] = {
         type StackEnt = F[IList[B] => IList[B]]
+        // For a brief explanation of 'roll':
+        // https://github.com/scalaz/scalaz/pull/1022#issuecomment-148694245
         @tailrec
         def roll(count: Int, stack: IList[StackEnt]): IList[StackEnt] =
           if ((count & 1) == 0) {

--- a/core/src/main/scala/scalaz/IList.scala
+++ b/core/src/main/scala/scalaz/IList.scala
@@ -570,9 +570,7 @@ sealed abstract class IListInstances extends IListInstance0 {
           case ((count, stack), a) =>
             (count + 1,
              roll(count + 1, F.map(f(a))(a => (a :: (_:IList[B]))) :: stack))
-        }._2.foldLeft(F.point(IList[B]())){(acc, se) =>
-          F.apply2(se, acc)(_(_))
-        }
+        }._2.foldLeft(F.point(IList[B]()))(F.ap(_)(_))
       }
 
       def unzip[A, B](a: IList[(A, B)]): (IList[A], IList[B]) =


### PR DESCRIPTION
I've always thought the "trampoline every applicative" answer was no solution; it's tedious, and we can do better in traversal, because we can build balanced applicative trees instead of applicative linked lists, which is what happens for a basic fold, be it left or right.

I emphasize that I'm not concerned with stack-overflow while traversing (though I also manage to keep that solved while still traversing the list only once), my interest is in _also_ solving the problem of stack consumption when interpreting the resulting applicative.  For example, the basic function applicative.

``` scala
import scalaz._, syntax.applicative._,
       syntax.traverse._, std.function._

object Test {
  trait Connection
  object AConnection extends Connection

  type DB[+A] = Connection => A

  def throwAt1000(n: Int): DB[IList[Unit]] =
    ((IList.fill(n - 1)(().point[DB])) ++
       (((_:Connection) => sys error s"thrown at $n")
          :: IList.fill(1000 - n - 1)(().point[DB]))).sequence[DB, Unit]
}
```

That mostly gives a bunch of repeated frames from the `bind` implementation for `Function1`; this represents the stack consumption while interpreting `Function1` (i.e. calling the resulting action).  So compare old b88002d1c4c1be6ee8437ba487fe861f77aa3b51 to new 2dd1bc12e50da914dd9dc90e4bfab8c52804d08f, with a few arguments to `throwAt1000`.
- 0: old 3, new 31
- 200: old 401, new 26
- 500: old 1001, new 24
- 999: old >1021, new 18

I emphasize again that the stack consumption that is improved is that when the resulting `DB` is called.  The consumption in the traversal phase remains constant.

There are a few approaches to balanced traversal, but this one is interesting because of the minimum amount of intermediate state it requires at any time.  It doesn't create another copy of the list outside the applicative.  In fact, for extra efficiency, the `state` could be a mutable stack without breaking anything, because it isn't used persistently; as the maximum stack height is logarithmic in list length, there would be considerable consing avoidance.

I will post a diagram later that may help explain why `roll` works.  I am also making a PR for `Vector`, showing off one simpler balanced traversal that I think is well-suited to `Vector` but not as good as this one for `IList` or `List`.

If we like this, I'll port it to `List`; it should just be name substitution to implement.
