### PR TITLE
Top-down divide-and-conquer-style traverse for Vector.

### DIFF
--- a/core/src/main/scala/scalaz/std/Vector.scala
+++ b/core/src/main/scala/scalaz/std/Vector.scala
@@ -2,7 +2,7 @@ package scalaz
 package std
 
 import vector._
-import annotation.tailrec
+import annotation.{switch, tailrec}
 
 sealed trait VectorInstances0 {
   implicit def vectorEqual[A](implicit A0: Equal[A]): Equal[Vector[A]] = new VectorEqual[A] {
@@ -30,9 +30,18 @@ trait VectorInstances extends VectorInstances0 {
     def unzip[A, B](a: Vector[(A, B)]) = a.unzip
 
     def traverseImpl[F[_], A, B](v: Vector[A])(f: A => F[B])(implicit F: Applicative[F]) = {
-      v.foldLeft(F.point(empty[B])) { (fvb, a) =>
-        F.apply2(fvb, f(a))(_ :+ _)
+      // invariant: 0 <= s <= e <= v.size
+      def rec(s: Int, e: Int): F[Vector[B]] = (e - s: @switch) match {
+        case 0 => F.point(Vector())
+        case 1 => F.map(f(v(s)))(Vector(_))
+        // cases >1 but the inductive case are just optimizations; the
+        // returns diminish pretty rapidly, so only '2' is here
+        case 2 => F.apply2(f(v(s)), f(v(s + 1)))(Vector(_, _))
+        case n =>
+          val pivot = s + n / 2
+          F.apply2(rec(s, pivot), rec(pivot, e))(_ ++ _)
       }
+      rec(0, v.size)
     }
 
     override def traverseS[S,A,B](v: Vector[A])(f: A => State[S,B]): State[S,Vector[B]] =


### PR DESCRIPTION
(Goals as explained in #1022.)

For `Vector`, random access means we can treat the whole structure as a tree by just pivoting at the middle.  Stack consumption while traversing is logarithmic in vector length, but the implementation uses even less intermediate state, the trees are more balanced, and some obvious microoptimizations (see comment in code) can yield quick constant-factor improvements.

The pivot could be chosen a little more intelligently, e.g. a 4-6 split is more efficient than a 5-5 split when a `case 2` exists, but I have not done this, for simplicity.

I also believe a `DVector`-style approach, with `compose` in the inductive case, as with #1022's rolling, might pay off versus simply appending the vectors.  Again, simplicity has stayed my hand.
