### PR TITLE
add [A:Order]distinct and [A:Equal]distinctE to Foldable/Foldable1

### DIFF
--- a/core/src/main/scala/scalaz/Foldable.scala
+++ b/core/src/main/scala/scalaz/Foldable.scala
@@ -255,6 +255,24 @@ trait Foldable[F[_]]  { self =>
       }
     })._1
 
+  /** ``O(n log n)`` complexity */
+  def distinct[A](fa: F[A])(implicit A: Order[A]): IList[A] =
+    foldLeft(fa, (ISet.empty[A],IList.empty[A])) {
+      case ((seen, acc), a) =>
+        if (seen.notMember(a))
+          (seen.insert(a), a :: acc)
+        else (seen, acc)
+    }._2.reverse
+
+  /** ``O(n^2^)`` complexity */
+  def distinctE[A](fa: F[A])(implicit A: Equal[A]): IList[A] =
+    foldLeft(fa, IList.empty[A]) {
+      case (seen, a) =>
+        if (!IList.instances.element(seen,a))
+          a :: seen
+        else seen
+    }.reverse
+
   def collapse[X[_], A](x: F[A])(implicit A: ApplicativePlus[X]): X[A] =
     foldRight(x, A.empty[A])((a, b) => A.plus(A.point(a), b))
 

--- a/core/src/main/scala/scalaz/Foldable1.scala
+++ b/core/src/main/scala/scalaz/Foldable1.scala
@@ -103,6 +103,24 @@ trait Foldable1[F[_]] extends Foldable[F] { self =>
   override def minimumOf[A, B: Order](fa: F[A])(f: A => B): Option[B] = Some(minimumOf1(fa)(f))
   override def minimumBy[A, B: Order](fa: F[A])(f: A => B): Option[A] = Some(minimumBy1(fa)(f))
 
+  /** ``O(n log n)`` complexity */
+  def distinct1[A](fa: F[A])(implicit A: Order[A]): NonEmptyList[A] =
+    foldMapLeft1[A,(ISet[A],NonEmptyList[A])](fa)(a => (ISet.singleton(a), NonEmptyList(a))) {
+      case ((seen, acc), a) =>
+        if (seen.notMember(a))
+          (seen.insert(a), a <:: acc)
+        else (seen, acc)
+    }._2.reverse
+
+  /** ``O(n^2^)`` complexity */
+  def distinctE1[A](fa: F[A])(implicit A: Equal[A]): NonEmptyList[A] =
+    foldMapLeft1[A,NonEmptyList[A]](fa)(a => NonEmptyList(a)) {
+      case (seen, a) =>
+        if (!NonEmptyList.nonEmptyList.element(seen,a))
+          a <:: seen
+        else seen
+    }.reverse
+  
   /** Insert an `A` between every A, yielding the sum. */
   def intercalate1[A](fa: F[A], a: A)(implicit A: Semigroup[A]): A =
     foldLeft1(fa)((x, y) => A.append(x, A.append(a, y)))

--- a/core/src/main/scala/scalaz/syntax/Foldable1Syntax.scala
+++ b/core/src/main/scala/scalaz/syntax/Foldable1Syntax.scala
@@ -21,6 +21,8 @@ final class Foldable1Ops[F[_],A] private[syntax](val self: F[A])(implicit val F:
   final def minimum1(implicit A: Order[A]): A = F.minimum1(self)
   final def minimumOf1[B: Order](f: A => B): B = F.minimumOf1(self)(f)
   final def minimumBy1[B: Order](f: A => B): A = F.minimumBy1(self)(f)
+  final def distinct1(implicit A: Order[A]): NonEmptyList[A] = F.distinct1(self)
+  final def distinctE1(implicit A: Equal[A]): NonEmptyList[A] = F.distinctE1(self)
   final def intercalate1(a: A)(implicit A: Semigroup[A]): A = F.intercalate1(self, a)
   final def msuml1[G[_], B](implicit ev: A === G[B], G: Plus[G]): G[B] = F.foldLeft1[G[B]](ev.subst[F](self))(G.plus[B](_, _))
   ////

--- a/core/src/main/scala/scalaz/syntax/FoldableSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/FoldableSyntax.scala
@@ -55,6 +55,8 @@ final class FoldableOps[F[_],A] private[syntax](val self: F[A])(implicit val F: 
   final def minimum(implicit A: Order[A]): Option[A] = F.minimum(self)
   final def minimumOf[B: Order](f: A => B): Option[B] = F.minimumOf(self)(f)
   final def minimumBy[B: Order](f: A => B): Option[A] = F.minimumBy(self)(f)
+  final def distinct(implicit A: Order[A]): IList[A] = F.distinct(self)
+  final def distinctE(implicit A: Equal[A]): IList[A] = F.distinctE(self)
   final def longDigits(implicit d: A <:< Digit): Long = F.longDigits(self)
   final def empty: Boolean = F.empty(self)
   final def element(a: A)(implicit A: Equal[A]): Boolean = F.element(self, a)

--- a/tests/src/test/scala/scalaz/Foldable1Test.scala
+++ b/tests/src/test/scala/scalaz/Foldable1Test.scala
@@ -35,6 +35,18 @@ object Foldable1Test extends SpecLite {
       (xs minimumBy1 f) must_===((xs.list zip (xs.list map f)).minBy(_._2)._1)
   }
 
+  "distinct1" ! forAll {
+    (xs: NonEmptyList[Int]) =>
+      xs.distinct1.toList must_== xs.toList.distinct
+      xs.distinct1(Order.order((_,_) => Ordering.EQ)).length must_== 1
+  }
+
+  "distinctE1" ! forAll {
+    (xs: NonEmptyList[Int]) =>
+      xs.distinctE1.toList must_== xs.toList.distinct
+      xs.distinctE1(Equal.equal((_,_) => true)).length must_== 1
+  }
+
   private val L = Foldable1[NonEmptyList]
 
   "product foldRight1 equivalence" ! forAll {

--- a/tests/src/test/scala/scalaz/FoldableTest.scala
+++ b/tests/src/test/scala/scalaz/FoldableTest.scala
@@ -59,6 +59,19 @@ object FoldableTest extends SpecLite {
         (xs minimumBy f) must_== Some((xs zip (xs map f)).minBy(_._2)._1)
   }
 
+  "distinct" ! forAll {
+    (xs: List[Int]) =>
+      val F = implicitly[Foldable[List]]
+      F.distinct(xs).toList must_== xs.distinct
+      if (xs.length > 0) F.distinct(xs)(Order.order((_,_) => Ordering.EQ)).length must_== 1
+  }
+
+  "distinctE" ! forAll {
+    (xs: List[Int]) =>
+      xs.distinctE.toList must_== xs.distinct
+      if (xs.length > 0) xs.distinctE(Equal.equal((_,_) => true)).length must_== 1
+  }
+
   "sumr1Opt" ! forAll {
     (xs: List[String]) => xs match {
       case Nil => xs.sumr1Opt must_== None


### PR DESCRIPTION
`IList[A].distinct` and `NonEmptyList[A].distinct` currently require `Order[A]`, even though they could complete with just `Equal[A]`, although the latter would need *O(n^2)* runtime instead of *O(n log n)*.

This patch adds both methods to `Foldable` and `Foldable1`, returning `IList[A]` and `NonEmptyList[A]` respectively.

What do folks think?