### PR TITLE
MonadError that takes a unary-kinded F[_] (rather than F[_, _] 

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Task.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Task.scala
@@ -229,8 +229,8 @@ class Task[+A](val get: Future[Throwable \/ A]) {
 
 object Task {
 
-  implicit val taskInstance: Nondeterminism[Task] with Catchable[Task] with BindRec[Task] with MonadError[λ[(α,β) => Task[β]],Throwable] =
-    new Nondeterminism[Task] with Catchable[Task] with BindRec[Task] with MonadError[λ[(α, β) => Task[β]], Throwable] {
+  implicit val taskInstance: Nondeterminism[Task] with BindRec[Task] with Catchable[Task] with MonadError[Task,Throwable] =
+    new Nondeterminism[Task] with BindRec[Task] with Catchable[Task] with MonadError[Task, Throwable] {
       val F = Nondeterminism[Future]
       def point[A](a: => A) = Task.point(a)
       def bind[A,B](a: Task[A])(f: A => Task[B]): Task[B] =

--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -436,8 +436,8 @@ sealed abstract class DisjunctionInstances0 extends DisjunctionInstances1 {
 }
 
 sealed abstract class DisjunctionInstances1 extends DisjunctionInstances2 {
-  implicit def DisjunctionInstances1[L]: Traverse[L \/ ?] with Monad[L \/ ?] with BindRec[L \/ ?] with Cozip[L \/ ?] with Plus[L \/ ?] with Optional[L \/ ?] with MonadError[\/, L] =
-    new Traverse[L \/ ?] with Monad[L \/ ?] with BindRec[L \/ ?] with Cozip[L \/ ?] with Plus[L \/ ?] with Optional[L \/ ?] with MonadError[\/, L] {
+  implicit def DisjunctionInstances1[L]: Traverse[L \/ ?] with Monad[L \/ ?] with BindRec[L \/ ?] with Cozip[L \/ ?] with Plus[L \/ ?] with Optional[L \/ ?] with MonadError[L \/ ?, L] =
+    new Traverse[L \/ ?] with Monad[L \/ ?] with BindRec[L \/ ?] with Cozip[L \/ ?] with Plus[L \/ ?] with Optional[L \/ ?] with MonadError[L \/ ?, L] {
       override def map[A, B](fa: L \/ A)(f: A => B) =
         fa map f
 

--- a/core/src/main/scala/scalaz/EitherT.scala
+++ b/core/src/main/scala/scalaz/EitherT.scala
@@ -287,7 +287,7 @@ sealed abstract class EitherTInstances4 {
 }
 
 sealed abstract class EitherTInstances3 extends EitherTInstances4 {
-  implicit def eitherTMonadError[F[_], E](implicit F0: Monad[F]): MonadError[EitherT[F, ?, ?], E] =
+  implicit def eitherTMonadError[F[_], E](implicit F0: Monad[F]): MonadError[EitherT[F, E, ?], E] = 
     new EitherTMonadError[F, E] {
       implicit def F = F0
     }
@@ -477,7 +477,7 @@ private[scalaz] trait EitherTMonadListen[F[_, _], W, A] extends MonadListen[λ[(
   }
 }
 
-private trait EitherTMonadError[F[_], E] extends MonadError[EitherT[F, ?, ?], E] with EitherTMonad[F, E] {
+private trait EitherTMonadError[F[_], E] extends MonadError[EitherT[F, E, ?], E] with EitherTMonad[F, E] {
   implicit def F: Monad[F]
   def raiseError[A](e: E): EitherT[F, E, A] = EitherT(F.point(-\/(e)))
   def handleError[A](fa: EitherT[F, E, A])(f: E => EitherT[F, E, A]): EitherT[F, E, A] =

--- a/core/src/main/scala/scalaz/Kleisli.scala
+++ b/core/src/main/scala/scalaz/Kleisli.scala
@@ -158,7 +158,7 @@ sealed abstract class KleisliInstances6 extends KleisliInstances7 {
 }
 
 sealed abstract class KleisliInstances5 extends KleisliInstances6 {
-  implicit def kleisliMonadError[F[_, _], E, R](implicit F0: MonadError[F, E]): MonadError[Lambda[(E0, A) => Kleisli[F[E0, ?], R, A]], E] =
+  implicit def kleisliMonadError[F[_], E, R](implicit F0: MonadError[F, E]): MonadError[Kleisli[F, R, ?], E] =
     new KleisliMonadError[F, E, R] {
       implicit def F = F0
     }
@@ -353,14 +353,14 @@ private trait KleisliMonadPlus[F[_], R] extends MonadPlus[Kleisli[F, R, ?]] with
   implicit def F: MonadPlus[F]
 }
 
-private trait KleisliMonadError[F[_, _], E, R] extends MonadError[Lambda[(E0, A) => Kleisli[F[E0, ?], R, A]], E] with KleisliMonad[F[E, ?], R] {
+private trait KleisliMonadError[F[_], E, R] extends MonadError[Kleisli[F, R, ?], E] with KleisliMonad[F, R] {
   implicit def F: MonadError[F, E]
 
-  def handleError[A](fa: Kleisli[F[E, ?], R, A])(f: E => Kleisli[F[E, ?], R, A]): Kleisli[F[E, ?], R, A] =
-    Kleisli.kleisli[F[E, ?], R, A](r => F.handleError(fa.run(r))(e => f(e).run(r)))
+  def handleError[A](fa: Kleisli[F, R, A])(f: E => Kleisli[F, R, A]): Kleisli[F, R, A] =
+    Kleisli.kleisli[F, R, A](r => F.handleError(fa.run(r))(e => f(e).run(r)))
 
-  def raiseError[A](e: E): Kleisli[F[E, ?], R, A] =
-    Kleisli.kleisli[F[E, ?], R, A](_ => F.raiseError(e))
+  def raiseError[A](e: E): Kleisli[F, R, A] =
+    Kleisli.kleisli[F, R, A](_ => F.raiseError(e))
 }
 
 private trait KleisliContravariant[F[_], X] extends Contravariant[Kleisli[F, ?, X]] {

--- a/core/src/main/scala/scalaz/LazyEither.scala
+++ b/core/src/main/scala/scalaz/LazyEither.scala
@@ -160,8 +160,9 @@ object LazyEither extends LazyEitherInstances {
 
 // TODO more instances
 sealed abstract class LazyEitherInstances {
-  implicit def lazyEitherInstance[E]: Traverse[LazyEither[E, ?]] with Monad[LazyEither[E, ?]] with BindRec[LazyEither[E, ?]] with Cozip[LazyEither[E, ?]] with Optional[LazyEither[E, ?]] with MonadError[LazyEither, E] =
-    new Traverse[LazyEither[E, ?]] with Monad[LazyEither[E, ?]] with BindRec[LazyEither[E, ?]] with Cozip[LazyEither[E, ?]] with Optional[LazyEither[E, ?]] with MonadError[LazyEither, E] {
+  implicit def lazyEitherInstance[E]: Traverse[LazyEither[E, ?]] with Monad[LazyEither[E, ?]] with BindRec[LazyEither[E, ?]] with Cozip[LazyEither[E, ?]] with Optional[LazyEither[E, ?]] with MonadError[LazyEither[E, ?], E] =
+    new Traverse[LazyEither[E, ?]] with Monad[LazyEither[E, ?]] with BindRec[LazyEither[E, ?]] with Cozip[LazyEither[E, ?]] with Optional[LazyEither[E, ?]] with MonadError[LazyEither[E, ?], E] {
+
       def traverseImpl[G[_]: Applicative, A, B](fa: LazyEither[E, A])(f: A => G[B]): G[LazyEither[E, B]] =
         fa traverse f
 

--- a/core/src/main/scala/scalaz/LazyEitherT.scala
+++ b/core/src/main/scala/scalaz/LazyEitherT.scala
@@ -189,7 +189,7 @@ sealed abstract class LazyEitherTInstances1 {
       def iso = LazyEitherT.lazyEitherTLeftProjectionEIso2[F, L]
     }
 
-  implicit def lazyEitherTMonadError[F[_], L](implicit F0: Monad[F]): MonadError[LazyEitherT[F, ?, ?], L] =
+  implicit def lazyEitherTMonadError[F[_], L](implicit F0: Monad[F]): MonadError[LazyEitherT[F, L, ?], L] =
     new LazyEitherTMonadError[F, L] {
       implicit def F = F0
     }
@@ -376,8 +376,7 @@ private trait LazyEitherTBindRec[F[_], E] extends BindRec[LazyEitherT[F, E, ?]] 
     )
 }
 
-
-private trait LazyEitherTMonadError[F[_], E] extends MonadError[LazyEitherT[F, ?, ?], E] with LazyEitherTMonad[F, E] {
+private trait LazyEitherTMonadError[F[_], E] extends MonadError[LazyEitherT[F, E, ?], E] with LazyEitherTMonad[F, E] {
   def raiseError[A](e: E): LazyEitherT[F, E, A] = LazyEitherT.lazyLeftT(e)
   def handleError[A](fa: LazyEitherT[F, E, A])(f: E => LazyEitherT[F, E, A]): LazyEitherT[F, E, A] = fa.left.flatMap(e => f(e))
 }

--- a/core/src/main/scala/scalaz/MaybeT.scala
+++ b/core/src/main/scala/scalaz/MaybeT.scala
@@ -88,7 +88,7 @@ sealed abstract class MaybeTInstances3 {
 }
 
 sealed abstract class MaybeTInstances2 extends MaybeTInstances3 {
-  implicit def maybeTMonadError[F[_, _], E](implicit F0: MonadError[F, E]): MonadError[λ[(E0, A) => MaybeT[F[E0, ?], A]], E] =
+  implicit def maybeTMonadError[F[_], E](implicit F0: MonadError[F, E]): MonadError[MaybeT[F, ?], E] =
     new MaybeTMonadError[F, E] {
       def F = F0
     }
@@ -210,14 +210,14 @@ private trait MaybeTMonadPlus[F[_]] extends MonadPlus[MaybeT[F, ?]] with MaybeTM
   def plus[A](a: MaybeT[F, A], b: => MaybeT[F, A]): MaybeT[F, A] = a orElse b
 }
 
-private trait MaybeTMonadError[F[_, _], E] extends MonadError[λ[(E0, A) => MaybeT[F[E0, ?], A]], E] with MaybeTMonad[F[E, ?]] {
+private trait MaybeTMonadError[F[_], E] extends MonadError[MaybeT[F, ?], E] with MaybeTMonad[F] {
   override def F: MonadError[F, E]
 
   override def raiseError[A](e: E) =
-    MaybeT[F[E, ?], A](F.map(F.raiseError[A](e))(Maybe.just))
+    MaybeT[F, A](F.map(F.raiseError[A](e))(Maybe.just))
 
-  override def handleError[A](fa: MaybeT[F[E, ?], A])(f: E => MaybeT[F[E, ?], A]) =
-    MaybeT[F[E, ?], A](F.handleError(fa.run)(f(_).run))
+  override def handleError[A](fa: MaybeT[F, A])(f: E => MaybeT[F, A]) =
+    MaybeT[F, A](F.handleError(fa.run)(f(_).run))
 }
 
 private trait MaybeTMonadTell[F[_, _], W] extends MonadTell[λ[(α, β) => MaybeT[F[α, ?], β]], W] with MaybeTMonad[F[W, ?]] with MaybeTHoist {

--- a/core/src/main/scala/scalaz/Monad.scala
+++ b/core/src/main/scala/scalaz/Monad.scala
@@ -89,5 +89,8 @@ object Monad {
 
   ////
 
+  implicit def monadMTMAB[MT[_[_], _], MAB[_, _], A](implicit t: MonadTrans[MT], m: Monad[MAB[A, ?]]): Monad[MT[MAB[A, ?], ?]] = 
+    t.apply[MAB[A, ?]]
+  
   ////
 }

--- a/core/src/main/scala/scalaz/MonadError.scala
+++ b/core/src/main/scala/scalaz/MonadError.scala
@@ -5,28 +5,28 @@ package scalaz
  *
  */
 ////
-trait MonadError[F[_], E] extends Monad[F] { self =>
+trait MonadError[F[_], S] extends Monad[F] { self =>
   ////
 
-  def raiseError[A](e: E): F[A]
-  def handleError[A](fa: F[A])(f: E => F[A]): F[A]
+  def raiseError[A](e: S): F[A]
+  def handleError[A](fa: F[A])(f: S => F[A]): F[A]
 
   trait MonadErrorLaw {
-    def raisedErrorsHandled[A](e: E, f: E => F[A])(implicit FEA: Equal[F[A]]): Boolean =
+    def raisedErrorsHandled[A](e: S, f: S => F[A])(implicit FEA: Equal[F[A]]): Boolean =
       FEA.equal(handleError(raiseError(e))(f), f(e))
-    def errorsRaised[A](a: A, e: E)(implicit FEA: Equal[F[A]]): Boolean =
+    def errorsRaised[A](a: A, e: S)(implicit FEA: Equal[F[A]]): Boolean =
       FEA.equal(bind(point(a))(_ => raiseError(e)), raiseError(e))
-    def errorsStopComputation[A](e: E, a: A)(implicit FEA: Equal[F[A]]): Boolean =
+    def errorsStopComputation[A](e: S, a: A)(implicit FEA: Equal[F[A]]): Boolean =
       FEA.equal(bind(raiseError(e))(_ => point(a)), raiseError(e))
   }
   def monadErrorLaw = new MonadErrorLaw {}
 
   ////
-  val monadErrorSyntax = new scalaz.syntax.MonadErrorSyntax[F, E] { def F = MonadError.this }
+  val monadErrorSyntax = new scalaz.syntax.MonadErrorSyntax[F, S] { def F = MonadError.this }
 }
 
 object MonadError {
-  @inline def apply[F[_], E](implicit F: MonadError[F, E]): MonadError[F, E] = F
+  @inline def apply[F[_], S](implicit F: MonadError[F, S]): MonadError[F, S] = F
 
   ////
 

--- a/core/src/main/scala/scalaz/MonadError.scala
+++ b/core/src/main/scala/scalaz/MonadError.scala
@@ -5,28 +5,28 @@ package scalaz
  *
  */
 ////
-trait MonadError[F[_, _], S] extends Monad[F[S, ?]] { self =>
+trait MonadError[F[_], E] extends Monad[F] { self =>
   ////
 
-  def raiseError[A](e: S): F[S, A]
-  def handleError[A](fa: F[S, A])(f: S => F[S, A]): F[S, A]
+  def raiseError[A](e: E): F[A]
+  def handleError[A](fa: F[A])(f: E => F[A]): F[A]
 
   trait MonadErrorLaw {
-    def raisedErrorsHandled[A](e: S, f: S => F[S, A])(implicit FEA: Equal[F[S, A]]): Boolean =
+    def raisedErrorsHandled[A](e: E, f: E => F[A])(implicit FEA: Equal[F[A]]): Boolean =
       FEA.equal(handleError(raiseError(e))(f), f(e))
-    def errorsRaised[A](a: A, e: S)(implicit FEA: Equal[F[S, A]]): Boolean =
+    def errorsRaised[A](a: A, e: E)(implicit FEA: Equal[F[A]]): Boolean =
       FEA.equal(bind(point(a))(_ => raiseError(e)), raiseError(e))
-    def errorsStopComputation[A](e: S, a: A)(implicit FEA: Equal[F[S, A]]): Boolean =
+    def errorsStopComputation[A](e: E, a: A)(implicit FEA: Equal[F[A]]): Boolean =
       FEA.equal(bind(raiseError(e))(_ => point(a)), raiseError(e))
   }
   def monadErrorLaw = new MonadErrorLaw {}
 
   ////
-  val monadErrorSyntax = new scalaz.syntax.MonadErrorSyntax[F, S] { def F = MonadError.this }
+  val monadErrorSyntax = new scalaz.syntax.MonadErrorSyntax[F, E] { def F = MonadError.this }
 }
 
 object MonadError {
-  @inline def apply[F[_, _], S](implicit F: MonadError[F, S]): MonadError[F, S] = F
+  @inline def apply[F[_], E](implicit F: MonadError[F, E]): MonadError[F, E] = F
 
   ////
 

--- a/core/src/main/scala/scalaz/OptionT.scala
+++ b/core/src/main/scala/scalaz/OptionT.scala
@@ -124,7 +124,7 @@ sealed abstract class OptionTInstances1 extends OptionTInstances2 {
       implicit def F: Foldable[F] = F0
     }
 
-  implicit def optionTMonadError[F[_, _], E](implicit F0: MonadError[F, E]): MonadError[λ[(E0, A) => OptionT[F[E0, ?], A]], E] =
+  implicit def optionTMonadError[F[_], E](implicit F0: MonadError[F, E]): MonadError[OptionT[F, ?], E] =
     new OptionTMonadError[F, E] {
       def F = F0
     }
@@ -215,14 +215,14 @@ private trait OptionTMonad[F[_]] extends Monad[OptionT[F, ?]] with OptionTBind[F
   def point[A](a: => A): OptionT[F, A] = OptionT[F, A](F.point(some(a)))
 }
 
-private trait OptionTMonadError[F[_, _], E] extends MonadError[λ[(E0, A) => OptionT[F[E0, ?], A]], E] with OptionTMonad[F[E, ?]] {
+private trait OptionTMonadError[F[_], E] extends MonadError[OptionT[F, ?], E] with OptionTMonad[F] {
   override def F: MonadError[F, E]
 
   override def raiseError[A](e: E) =
-    OptionT[F[E, ?], A](F.map(F.raiseError[A](e))(Some(_)))
+    OptionT[F, A](F.map(F.raiseError[A](e))(Some(_)))
 
-  override def handleError[A](fa: OptionT[F[E, ?], A])(f: E => OptionT[F[E, ?], A]) =
-    OptionT[F[E, ?], A](F.handleError(fa.run)(f(_).run))
+  override def handleError[A](fa: OptionT[F, A])(f: E => OptionT[F, A]) =
+    OptionT[F, A](F.handleError(fa.run)(f(_).run))
 }
 
 private trait OptionTFoldable[F[_]] extends Foldable.FromFoldr[OptionT[F, ?]] {

--- a/core/src/main/scala/scalaz/Unapply.scala
+++ b/core/src/main/scala/scalaz/Unapply.scala
@@ -274,6 +274,17 @@ object Unapply extends Unapply_0 {
       def leibniz = refl
     }
 
+  /** Turns a MonadTrans-like instance that has two params and turns it into an M[A] */
+  implicit def unapplyMTMAB[TC[_[_]], MT[_[_], _], MAB[_, _], A0, A1](implicit TC0: TC[MT[MAB[A0,?], ?]]):
+    Unapply[TC, MT[MAB[A0, ?], A1]] {
+      type M[X] = MT[MAB[A0, ?], X]
+      type A = A1
+    } = new Unapply[TC, MT[MAB[A0, ?], A1]] {
+      type M[X] = MT[MAB[A0, ?], X]
+      type A = A1
+      def TC = TC0
+      def leibniz = Leibniz.refl
+    }  
   // TODO More!
 }
 

--- a/core/src/main/scala/scalaz/WriterT.scala
+++ b/core/src/main/scala/scalaz/WriterT.scala
@@ -204,8 +204,8 @@ sealed abstract class WriterTInstances4 extends WriterTInstance5 {
     }
   implicit def writerEqual[W, A](implicit E: Equal[(W, A)]): Equal[Writer[W, A]] = E.contramap((_: Writer[W, A]).run)
 
-  implicit def writerTMonadError[F[_, _], E, W](implicit F0: MonadError[F, E], W0: Monoid[W]): MonadError[Lambda[(E0, A) => WriterT[F[E0, ?], W, A]], E] =
-    new WriterTMonadError[F, E, W]{
+  implicit def writerTMonadError[F[_], E, W](implicit F0: MonadError[F, E], W0: Monoid[W]): MonadError[WriterT[F, W, ?], E] =
+    new WriterTMonadError[F, E, W] {
       override def F = F0
       override def W = W0
     }
@@ -366,14 +366,14 @@ private trait WriterTMonadPlus[F[_], W] extends MonadPlus[WriterT[F, W, ?]] with
   def F: MonadPlus[F]
 }
 
-private trait WriterTMonadError[F[_, _], E, W] extends MonadError[Lambda[(E0, A) => WriterT[F[E0, ?], W, A]], E] with WriterTMonad[F[E, ?], W] {
+private trait WriterTMonadError[F[_], E, W] extends MonadError[WriterT[F, W, ?], E] with WriterTMonad[F, W] {
   implicit def F: MonadError[F, E]
 
-  override def handleError[A](fa: WriterT[F[E, ?], W, A])(f: E => WriterT[F[E, ?], W, A]) =
-    WriterT[F[E, ?], W, A](F.handleError(fa.run)(f(_).run))
+  override def handleError[A](fa: WriterT[F, W, A])(f: E => WriterT[F, W, A]) =
+    WriterT[F, W, A](F.handleError(fa.run)(f(_).run))
 
   override def raiseError[A](e: E) =
-    WriterT[F[E, ?], W, A](F.raiseError[(W, A)](e))
+    WriterT[F, W, A](F.raiseError[(W, A)](e))
 }
 
 private trait WriterTFoldable[F[_], W] extends Foldable.FromFoldr[WriterT[F, W, ?]] {

--- a/core/src/main/scala/scalaz/std/Either.scala
+++ b/core/src/main/scala/scalaz/std/Either.scala
@@ -63,13 +63,13 @@ trait EitherInstances extends EitherInstances0 {
   }
 
   /** Right biased monad */
-  implicit def eitherMonad[L]: Traverse[Either[L, ?]] with MonadError[Either, L] with BindRec[Either[L, ?]] with Cozip[Either[L, ?]] =
-    new Traverse[Either[L, ?]] with MonadError[Either, L] with BindRec[Either[L, ?]] with Cozip[Either[L, ?]] {
+  implicit def eitherMonad[L]: Traverse[Either[L, ?]] with MonadError[Either[L, ?], L] with BindRec[Either[L, ?]] with Cozip[Either[L, ?]] = 
+    new Traverse[Either[L, ?]] with MonadError[Either[L, ?], L] with BindRec[Either[L, ?]] with Cozip[Either[L, ?]] {
       def bind[A, B](fa: Either[L, A])(f: A => Either[L, B]) = fa match {
         case Left(a)  => Left(a)
         case Right(b) => f(b)
       }
-  
+
       def handleError[A](fa: Either[L, A])(f: L => Either[L, A]) =
         fa match {
           case a @ Right(_) => a

--- a/core/src/main/scala/scalaz/std/Future.scala
+++ b/core/src/main/scala/scalaz/std/Future.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration.Duration
 import scala.util.{ Try, Success => TSuccess }
 
 trait FutureInstances1 {
-  implicit def futureInstance(implicit ec: ExecutionContext): Nondeterminism[Future] with Cobind[Future] with MonadError[λ[(α, β) => Future[β]], Throwable] with Catchable[Future] =
+  implicit def futureInstance(implicit ec: ExecutionContext): Nondeterminism[Future] with Cobind[Future] with MonadError[Future, Throwable] with Catchable[Future] =
     new FutureInstance
 
   implicit def futureSemigroup[A](implicit m: Semigroup[A], ec: ExecutionContext): Semigroup[Future[A]] =
@@ -27,7 +27,7 @@ trait FutureInstances extends FutureInstances1 {
     Monoid.liftMonoid[Future, A]
 }
 
-private class FutureInstance(implicit ec: ExecutionContext) extends Nondeterminism[Future] with Cobind[Future] with MonadError[λ[(α,β) => Future[β]], Throwable] with Catchable[Future] {
+private class FutureInstance(implicit ec: ExecutionContext) extends Nondeterminism[Future] with Cobind[Future] with MonadError[Future, Throwable] with Catchable[Future] {
   def point[A](a: => A): Future[A] = Future(a)
   def bind[A, B](fa: Future[A])(f: A => Future[B]): Future[B] = fa flatMap f
   override def map[A, B](fa: Future[A])(f: A => B): Future[B] = fa map f

--- a/core/src/main/scala/scalaz/syntax/MonadErrorIdOps.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadErrorIdOps.scala
@@ -2,6 +2,6 @@ package scalaz
 package syntax
 
 final class MonadErrorIdOps[E](val self: E) extends AnyVal {
-  def raiseError[F[_, _], A](implicit F: MonadError[F, E]): F[E, A] =
+  def raiseError[F[_], A](implicit F: MonadError[F, E]): F[A] =
     F.raiseError[A](self)
 }

--- a/core/src/main/scala/scalaz/syntax/MonadErrorIdOps.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadErrorIdOps.scala
@@ -1,7 +1,7 @@
 package scalaz
 package syntax
 
-final class MonadErrorIdOps[E](val self: E) extends AnyVal {
-  def raiseError[F[_], A](implicit F: MonadError[F, E]): F[A] =
+final class MonadErrorIdOps[S](val self: S) extends AnyVal {
+  def raiseError[F[_], A](implicit F: MonadError[F, S]): F[A] =
     F.raiseError[A](self)
 }

--- a/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
@@ -2,36 +2,31 @@ package scalaz
 package syntax
 
 /** Wraps a value `self` and provides methods related to `MonadError` */
-final class MonadErrorOps[F[_, _], S, A] private[syntax](self: F[S, A])(implicit val F: MonadError[F, S]) {
+final class MonadErrorOps[F[_], E, A] private[syntax](self: F[A])(implicit val F: MonadError[F, E]) {
   ////
-  final def handleError(f: S => F[S, A]): F[S, A] =
+  final def handleError(f: E => F[A]): F[A] =
     F.handleError(self)(f)
 
   ////
 }
 
-sealed trait ToMonadErrorOps0 {
-  implicit def ToMonadErrorOpsUnapply[FA](v: FA)(implicit F0: Unapply21[MonadError, FA]) =
-    new MonadErrorOps[F0.M, F0.A, F0.B](F0(v))(F0.TC)
-}
-
 trait ToMonadErrorOps extends ToMonadOps {
-  implicit def ToMonadErrorOps[F[_, _], S, A](v: F[S, A])(implicit F0: MonadError[F, S]) =
-    new MonadErrorOps[F, S, A](v)
+  implicit def ToMonadErrorOps[F[_], E, A](v: F[A])(implicit F0: MonadError[F, E]) =
+    new MonadErrorOps[F, E, A](v)
 
   ////
 
- implicit def ToMonadErrorIdOps[E](v: E) =
-   new MonadErrorIdOps[E](v)
+  implicit def ToMonadErrorIdOps[E](v: E) =
+    new MonadErrorIdOps[E](v)
 
   ////
 }
 
-trait MonadErrorSyntax[F[_, _], S] extends MonadSyntax[F[S, ?]] {
-  implicit def ToMonadErrorOps[A](v: F[S, A]): MonadErrorOps[F, S, A] =
-    new MonadErrorOps[F, S, A](v)(MonadErrorSyntax.this.F)
+trait MonadErrorSyntax[F[_], E] extends MonadSyntax[F] {
+  implicit def ToMonadErrorOps[A](v: F[A]): MonadErrorOps[F, E, A] =
+    new MonadErrorOps[F, E, A](v)(MonadErrorSyntax.this.F)
 
-  def F: MonadError[F, S]
+  def F: MonadError[F, E]
   ////
 
   ////

--- a/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
@@ -2,17 +2,17 @@ package scalaz
 package syntax
 
 /** Wraps a value `self` and provides methods related to `MonadError` */
-final class MonadErrorOps[F[_], E, A] private[syntax](self: F[A])(implicit val F: MonadError[F, E]) {
+final class MonadErrorOps[F[_], S, A] private[syntax](self: F[A])(implicit val F: MonadError[F, S]) {
   ////
-  final def handleError(f: E => F[A]): F[A] =
+  final def handleError(f: S => F[A]): F[A] =
     F.handleError(self)(f)
 
   ////
 }
 
 trait ToMonadErrorOps extends ToMonadOps {
-  implicit def ToMonadErrorOps[F[_], E, A](v: F[A])(implicit F0: MonadError[F, E]) =
-    new MonadErrorOps[F, E, A](v)
+  implicit def ToMonadErrorOps[F[_], S, A](v: F[A])(implicit F0: MonadError[F, S]) =
+    new MonadErrorOps[F, S, A](v)
 
   ////
 
@@ -22,11 +22,11 @@ trait ToMonadErrorOps extends ToMonadOps {
   ////
 }
 
-trait MonadErrorSyntax[F[_], E] extends MonadSyntax[F] {
-  implicit def ToMonadErrorOps[A](v: F[A]): MonadErrorOps[F, E, A] =
-    new MonadErrorOps[F, E, A](v)(MonadErrorSyntax.this.F)
+trait MonadErrorSyntax[F[_], S] extends MonadSyntax[F] {
+  implicit def ToMonadErrorOps[A](v: F[A]): MonadErrorOps[F, S, A] =
+    new MonadErrorOps[F, S, A](v)(MonadErrorSyntax.this.F)
 
-  def F: MonadError[F, E]
+  def F: MonadError[F, S]
   ////
 
   ////

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazProperties.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazProperties.scala
@@ -556,16 +556,16 @@ object ScalazProperties {
   }
 
   object monadError {
-    def raisedErrorsHandled[F[_, _], E, A](implicit me: MonadError[F, E], eq: Equal[F[E, A]], ae: Arbitrary[E], afea: Arbitrary[E => F[E,A]]) =
+    def raisedErrorsHandled[F[_], E, A](implicit me: MonadError[F, E], eq: Equal[F[A]], ae: Arbitrary[E], afea: Arbitrary[E => F[A]]) =
       forAll(me.monadErrorLaw.raisedErrorsHandled[A] _)
-    def errorsRaised[F[_, _], E, A](implicit me: MonadError[F, E], eq: Equal[F[E, A]], ae: Arbitrary[E], aa: Arbitrary[A]) =
+    def errorsRaised[F[_], E, A](implicit me: MonadError[F, E], eq: Equal[F[A]], ae: Arbitrary[E], aa: Arbitrary[A]) =
       forAll(me.monadErrorLaw.errorsRaised[A] _)
-    def errorsStopComputation[F[_, _], E, A](implicit me: MonadError[F, E], eq: Equal[F[E, A]], ae: Arbitrary[E], aa: Arbitrary[A]) =
+    def errorsStopComputation[F[_], E, A](implicit me: MonadError[F, E], eq: Equal[F[A]], ae: Arbitrary[E], aa: Arbitrary[A]) =
       forAll(me.monadErrorLaw.errorsStopComputation[A] _)
 
-    def laws[F[_, _], E](implicit me: MonadError[F, E], am: Arbitrary[F[E, Int]], afap: Arbitrary[F[E, Int => Int]], aeq: Equal[F[E, Int]], ae: Arbitrary[E]) =
+    def laws[F[_], E](implicit me: MonadError[F, E], am: Arbitrary[F[Int]], afap: Arbitrary[F[Int => Int]], aeq: Equal[F[Int]], ae: Arbitrary[E]) =
       new Properties("monad error") {
-        include(monad.laws[F[E, ?]])
+        include(monad.laws[F])
         property("raisedErrorsHandled") = raisedErrorsHandled[F, E, Int]
         property("errorsRaised") = errorsRaised[F, E, Int]
         property("errorsStopComputation") = errorsStopComputation[F, E, Int]

--- a/tests/src/test/scala/scalaz/DisjunctionTest.scala
+++ b/tests/src/test/scala/scalaz/DisjunctionTest.scala
@@ -11,11 +11,11 @@ object DisjunctionTest extends SpecLite {
   checkAll(monoid.laws[Int \/ Int])
   checkAll(bindRec.laws[Int \/ ?])
   checkAll(monad.laws[Int \/ ?])
+  checkAll(monadError.laws[Int \/ ?, Int])
   checkAll(plus.laws[Int \/ ?])
   checkAll(traverse.laws[Int \/ ?])
   checkAll(bitraverse.laws[\/])
   checkAll(associative.laws[\/])
-  checkAll(monadError.laws[\/, Int])
 
   "fromTryCatchThrowable" in {
     class Foo extends Throwable

--- a/tests/src/test/scala/scalaz/EitherTTest.scala
+++ b/tests/src/test/scala/scalaz/EitherTTest.scala
@@ -14,9 +14,9 @@ object EitherTTest extends SpecLite {
   checkAll(equal.laws[EitherTListInt[Int]])
   checkAll(bindRec.laws[EitherTListInt])
   checkAll(monadPlus.laws[EitherTListInt])
+  checkAll(monadError.laws[EitherTListInt, Int])
   checkAll(traverse.laws[EitherTListInt])
   checkAll(bitraverse.laws[EitherTList])
-  checkAll(monadError.laws[EitherTList, Int])
 
   "rightU" should {
     val a: String \/ Int = \/-(1)
@@ -67,7 +67,7 @@ object EitherTTest extends SpecLite {
     def foldable[F[_] : Traverse, A] = Foldable[EitherT[F, A, ?]]
     def bifunctor[F[_] : Traverse] = Bifunctor[EitherT[F, ?, ?]]
     def bifoldable[F[_] : Traverse] = Bifoldable[EitherT[F, ?, ?]]
-    def monadError[F[_] : Monad, A] = MonadError[EitherT[F, ?, ?], A]
+    def monadError[F[_] : Monad, A] = MonadError[EitherT[F, A, ?], A]
   }
 
   def compilationTests() = {

--- a/tests/src/test/scala/scalaz/LazyEitherTTest.scala
+++ b/tests/src/test/scala/scalaz/LazyEitherTTest.scala
@@ -19,7 +19,7 @@ object LazyEitherTTest extends SpecLite {
   checkAll(traverse.laws[LazyEitherTListInt])
   checkAll(bitraverse.laws[LazyEitherTList])
   checkAll(bindRec.laws[LazyEitherTListInt])
-  checkAll(monadError.laws[LazyEitherTList, Int])
+  checkAll(monadError.laws[LazyEitherTListInt, Int])
 
   "tail recursive tailrecM" in {
     import Scalaz.Id
@@ -58,10 +58,10 @@ object LazyEitherTTest extends SpecLite {
     def functor[F[_] : Monad, A: Monoid] = Functor[LazyEitherT[F, A, ?]]
     def bind[F[_] : Monad : BindRec, A] = Bind[LazyEitherT[F, A, ?]]
     def monad[F[_] : Monad, A: Monoid] = Monad[LazyEitherT[F, A, ?]]
+    def monadError[F[_] : Monad, A] = MonadError[LazyEitherT[F, A, ?], A]
     def foldable[F[_] : Traverse, A] = Foldable[LazyEitherT[F, A, ?]]
     def bifunctor[F[_] : Traverse] = Bifunctor[LazyEitherT[F, ?, ?]]
     def bifoldable[F[_] : Traverse] = Bifoldable[LazyEitherT[F, ?, ?]]
-    def monadError[F[_] : Monad, A] = MonadError[LazyEitherT[F, ?, ?], A]
   }
 
 }

--- a/tests/src/test/scala/scalaz/LazyEitherTest.scala
+++ b/tests/src/test/scala/scalaz/LazyEitherTest.scala
@@ -14,7 +14,7 @@ object LazyEitherTest extends SpecLite {
   
   checkAll(equal.laws[LazyEither[Int,Int]])
   checkAll(monad.laws[LazyEither[Int, ?]])
-  checkAll(monadError.laws[LazyEither, Int])
+  checkAll(monadError.laws[LazyEither[Int, ?], Int])
   checkAll(bindRec.laws[LazyEither[Int, ?]])
   checkAll(traverse.laws[LazyEither[Int, ?]])
   checkAll(associative.laws[LazyEither])

--- a/tests/src/test/scala/scalaz/MaybeTTest.scala
+++ b/tests/src/test/scala/scalaz/MaybeTTest.scala
@@ -8,34 +8,27 @@ import std.AllInstances._
 object MaybeTTest extends SpecLite {
 
   type MaybeTList[A] = MaybeT[List, A]
+  type IntOr[A] = Int \/ A
+  type MaybeTEither[A] = MaybeT[IntOr, A]
 
   checkAll(equal.laws[MaybeTList[Int]])
   checkAll(bindRec.laws[MaybeTList])
   checkAll(monadPlus.laws[MaybeTList])
   checkAll(traverse.laws[MaybeTList])
-
-  {
-    implicit def maybeTArb0[F[_, _], E, A](implicit F: Arbitrary[F[E, Maybe[A]]]): Arbitrary[MaybeT[F[E, ?], A]] =
-      maybeTArb[F[E, ?], A]
-
-    implicit def maybeTEqual0[F[_, _], E, A](implicit F: Equal[F[E, Maybe[A]]]): Equal[MaybeT[F[E, ?], A]] =
-      MaybeT.maybeTEqual[F[E, ?], A]
-
-    checkAll(monadError.laws[λ[(E0, A) => MaybeT[E0 \/ ?, A]], Int])
-  }
+  checkAll(monadError.laws[MaybeTEither, Int])
 
   object instances {
     def functor[F[_] : Functor] = Functor[MaybeT[F, ?]]
     def monad[F[_] : Monad] = MonadPlus[MaybeT[F, ?]]
     def bindRec[F[_] : Monad : BindRec] = BindRec[MaybeT[F, ?]]
-    def monadError[F[_, _], E](implicit F: MonadError[F, E]) = MonadError[λ[(E0, A) => MaybeT[F[E0, ?], A]], E]
+    def monadError[F[_], E](implicit F: MonadError[F, E]) = MonadError[MaybeT[F, ?], E]
     def foldable[F[_] : Foldable] = Foldable[MaybeT[F, ?]]
     def traverse[F[_] : Traverse] = Traverse[MaybeT[F, ?]]
 
     // checking absence of ambiguity
     def functor[F[_] : Monad] = Functor[MaybeT[F, ?]]
     def functor[F[_] : Monad : Traverse] = Functor[MaybeT[F, ?]]
-    def functor[F[_, _], E](implicit F1: MonadError[F, E], F2: Traverse[F[E, ?]]) = Functor[MaybeT[λ[A => F[E, A]], ?]]
+    def functor[F[_], E](implicit F1: MonadError[F, E], F2: Traverse[F]) = Functor[MaybeT[F, ?]]
     def apply[F[_] : Monad] = Apply[MaybeT[F, ?]]
     def foldable[F[_] : Traverse] = Foldable[MaybeT[F, ?]]
   }

--- a/tests/src/test/scala/scalaz/MaybeTTest.scala
+++ b/tests/src/test/scala/scalaz/MaybeTTest.scala
@@ -31,5 +31,6 @@ object MaybeTTest extends SpecLite {
     def functor[F[_], E](implicit F1: MonadError[F, E], F2: Traverse[F]) = Functor[MaybeT[F, ?]]
     def apply[F[_] : Monad] = Apply[MaybeT[F, ?]]
     def foldable[F[_] : Traverse] = Foldable[MaybeT[F, ?]]
+    def monadEither[E] = Monad[MaybeT[E \/ ?, ?]]
   }
 }

--- a/tests/src/test/scala/scalaz/OptionTTest.scala
+++ b/tests/src/test/scala/scalaz/OptionTTest.scala
@@ -10,21 +10,14 @@ object OptionTTest extends SpecLite {
 
   type OptionTList[A] = OptionT[List, A]
   type OptionTOption[A] = OptionT[Option, A]
+  type IntOr[A] = Int \/ A
+  type OptionTEither[A] = OptionT[IntOr, A]
 
   checkAll(equal.laws[OptionTList[Int]])
   checkAll(bindRec.laws[OptionTList])
   checkAll(monadPlus.laws[OptionTList])
   checkAll(traverse.laws[OptionTList])
-
-  {
-    implicit def optionTArb0[F[_, _], E, A](implicit F: Arbitrary[F[E, Option[A]]]): Arbitrary[OptionT[F[E, ?], A]] =
-      optionTArb[F[E, ?], A]
-
-    implicit def optionTEqual0[F[_, _], E, A](implicit F: Equal[F[E, Option[A]]]): Equal[OptionT[F[E, ?], A]] =
-      OptionT.optionTEqual[F[E, ?], A]
-
-    checkAll(monadError.laws[λ[(E0, A) => OptionT[E0 \/ ?, A]], Int])
-  }
+  checkAll(monadError.laws[OptionTEither, Int])
 
   "show" ! forAll { a: OptionTList[Int] =>
     Show[OptionTList[Int]].show(a) must_=== Show[List[Option[Int]]].show(a.run)
@@ -39,14 +32,14 @@ object OptionTTest extends SpecLite {
   object instances {
     def functor[F[_] : Functor] = Functor[OptionT[F, ?]]
     def monad[F[_] : Monad] = MonadPlus[OptionT[F, ?]]
-    def monadError[F[_, _], E](implicit F: MonadError[F, E]) = MonadError[λ[(E0, A) => OptionT[F[E0, ?], A]], E]
+    def monadError[F[_], E](implicit F: MonadError[F, E]) = MonadError[OptionT[F, ?], E]
     def foldable[F[_] : Foldable] = Foldable[OptionT[F, ?]]
     def traverse[F[_] : Traverse] = Traverse[OptionT[F, ?]]
 
     // checking absence of ambiguity
     def functor[F[_] : Monad] = Functor[OptionT[F, ?]]
     def functor[F[_] : Monad : Traverse] = Functor[OptionT[F, ?]]
-    def functor[F[_, _], E](implicit F1: MonadError[F, E], F2: Traverse[F[E, ?]]) = Functor[OptionT[λ[A => F[E, A]], ?]]
+    def functor[F[_], E](implicit F1: MonadError[F, E], F2: Traverse[F]) = Functor[OptionT[F, ?]]
     def apply[F[_] : Monad] = Apply[OptionT[F, ?]]
     def foldable[F[_] : Traverse] = Foldable[OptionT[F, ?]]
   }

--- a/tests/src/test/scala/scalaz/std/EitherTest.scala
+++ b/tests/src/test/scala/scalaz/std/EitherTest.scala
@@ -31,7 +31,7 @@ object EitherTest extends SpecLite {
   checkAll("Either.RightProjection @@ Last", monad.laws[λ[α => Either.RightProjection[Int, α] @@ Last]])
 
   checkAll("Either", bindRec.laws[Either[Int, ?]])
-  checkAll("Either", monadError.laws[Either, Int])
+  checkAll("Either", monadError.laws[Either[Int, ?], Int])
   checkAll("Either", bifunctor.laws[Either])
   checkAll("Either", traverse.laws[Either[Int, ?]])
   checkAll("Either", bitraverse.laws[Either])

--- a/tests/src/test/scala/scalaz/std/FutureTest.scala
+++ b/tests/src/test/scala/scalaz/std/FutureTest.scala
@@ -47,7 +47,7 @@ class FutureTest extends SpecLite {
   checkAll(monoid.laws[Future[Int @@ Multiplication]])
 
   // For some reason ArbitraryThrowable isn't being chosen by scalac, so we give it explicitly.
-  checkAll(monadError.laws[λ[(α, β) => Future[β]], Throwable](implicitly, implicitly, implicitly, implicitly, ArbitraryThrowable))
+  checkAll(monadError.laws[Future, Throwable](implicitly, implicitly, implicitly, implicitly, ArbitraryThrowable))
 
   // Scope these away from the rest as Comonad[Future] is a little evil.
   // Should fail to compile by default: implicitly[Comonad[Future]]


### PR DESCRIPTION
This is the first part of a series that will do the same for all MTL type-classes.