### PR TITLE
Refactor RWST to allow for trampolining

### DIFF
--- a/tests/src/test/scala/scalaz/ReaderWriterStateTTest.scala
+++ b/tests/src/test/scala/scalaz/ReaderWriterStateTTest.scala
@@ -27,12 +27,19 @@ object ReaderWriterStateTTest extends SpecLite {
 
   checkAll(bindRec.laws[RWSOptInt])
   checkAll(monadPlus.strongLaws[RWSOptInt])
-
+  
+  "ReaderWriterStateT can be trampolined without stack overflow" in {
+    import scalaz.Free._
+    val result = (0 to 10000).toList.map(ii => ReaderWriterStateT[Trampoline, Unit, String, Int, Int]((_, i: Int) => Trampoline.done(("", i, ii))))
+      .foldLeft(ReaderWriterStateT[Trampoline, Unit, String, Int, Int]((_, i: Int) => Trampoline.done(("", i, i))))( (a, b) => a.flatMap(_ => b))
+    10000 must_=== result.run((),0).run._3
+  }
+ 
   object instances {
     def functor[F[_]: Functor, R, W, S] = Functor[RWST[F, R, W, S, ?]]
     def plus[F[_]: Plus, R, W, S1, S2] = Plus[IRWST[F, R, W, S1, S2, ?]]
     def plusEmpty[F[_]: PlusEmpty, R, W, S1, S2] = PlusEmpty[IRWST[F, R, W, S1, S2, ?]]
-    def bindRec[F[_]: BindRec : Applicative, R, W: Semigroup, S] = BindRec[RWST[F, R, W, S, ?]]
+    def bindRec[F[_]: BindRec : Monad, R, W: Semigroup, S] = BindRec[RWST[F, R, W, S, ?]]
     def monad[F[_]: Monad, R, W: Monoid, S] = Monad[RWST[F, R, W, S, ?]]
     def monadPlus[F[_]: MonadPlus, R, W: Monoid, S] = MonadPlus[RWST[F, R, W, S, ?]]
     def bind[F[_]: Bind, R, W: Semigroup, S] = Bind[RWST[F, R, W, S, ?]]


### PR DESCRIPTION
This is the same change as 

https://github.com/scalaz/scalaz/pull/949

in that it allows for stack safety as long as any underlying F is trampolined or otherwise a free monad.  This touches a lot less than IndexedStateT and so hopefully a lot easier to review.  