### PR TITLE
supply a unary-kinded F[_] parameter to all the Monad* (MTL-like) classes

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Task.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Task.scala
@@ -229,8 +229,8 @@ class Task[+A](val get: Future[Throwable \/ A]) {
 
 object Task {
 
-  implicit val taskInstance: Nondeterminism[Task] with Catchable[Task] with BindRec[Task] with MonadError[λ[(α,β) => Task[β]],Throwable] =
-    new Nondeterminism[Task] with Catchable[Task] with BindRec[Task] with MonadError[λ[(α, β) => Task[β]], Throwable] {
+  implicit val taskInstance: Nondeterminism[Task] with BindRec[Task] with Catchable[Task] with MonadError[Task,Throwable] =
+    new Nondeterminism[Task] with BindRec[Task] with Catchable[Task] with MonadError[Task, Throwable] {
       val F = Nondeterminism[Future]
       def point[A](a: => A) = Task.point(a)
       def bind[A,B](a: Task[A])(f: A => Task[B]): Task[B] =

--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -436,8 +436,8 @@ sealed abstract class DisjunctionInstances0 extends DisjunctionInstances1 {
 }
 
 sealed abstract class DisjunctionInstances1 extends DisjunctionInstances2 {
-  implicit def DisjunctionInstances1[L]: Traverse[L \/ ?] with Monad[L \/ ?] with BindRec[L \/ ?] with Cozip[L \/ ?] with Plus[L \/ ?] with Optional[L \/ ?] with MonadError[\/, L] =
-    new Traverse[L \/ ?] with Monad[L \/ ?] with BindRec[L \/ ?] with Cozip[L \/ ?] with Plus[L \/ ?] with Optional[L \/ ?] with MonadError[\/, L] {
+  implicit def DisjunctionInstances1[L]: Traverse[L \/ ?] with Monad[L \/ ?] with BindRec[L \/ ?] with Cozip[L \/ ?] with Plus[L \/ ?] with Optional[L \/ ?] with MonadError[L \/ ?, L] =
+    new Traverse[L \/ ?] with Monad[L \/ ?] with BindRec[L \/ ?] with Cozip[L \/ ?] with Plus[L \/ ?] with Optional[L \/ ?] with MonadError[L \/ ?, L] {
       override def map[A, B](fa: L \/ A)(f: A => B) =
         fa map f
 

--- a/core/src/main/scala/scalaz/LazyEither.scala
+++ b/core/src/main/scala/scalaz/LazyEither.scala
@@ -160,8 +160,9 @@ object LazyEither extends LazyEitherInstances {
 
 // TODO more instances
 sealed abstract class LazyEitherInstances {
-  implicit def lazyEitherInstance[E]: Traverse[LazyEither[E, ?]] with Monad[LazyEither[E, ?]] with BindRec[LazyEither[E, ?]] with Cozip[LazyEither[E, ?]] with Optional[LazyEither[E, ?]] with MonadError[LazyEither, E] =
-    new Traverse[LazyEither[E, ?]] with Monad[LazyEither[E, ?]] with BindRec[LazyEither[E, ?]] with Cozip[LazyEither[E, ?]] with Optional[LazyEither[E, ?]] with MonadError[LazyEither, E] {
+  implicit def lazyEitherInstance[E]: Traverse[LazyEither[E, ?]] with Monad[LazyEither[E, ?]] with BindRec[LazyEither[E, ?]] with Cozip[LazyEither[E, ?]] with Optional[LazyEither[E, ?]] with MonadError[LazyEither[E, ?], E] =
+    new Traverse[LazyEither[E, ?]] with Monad[LazyEither[E, ?]] with BindRec[LazyEither[E, ?]] with Cozip[LazyEither[E, ?]] with Optional[LazyEither[E, ?]] with MonadError[LazyEither[E, ?], E] {
+
       def traverseImpl[G[_]: Applicative, A, B](fa: LazyEither[E, A])(f: A => G[B]): G[LazyEither[E, B]] =
         fa traverse f
 

--- a/core/src/main/scala/scalaz/LazyEitherT.scala
+++ b/core/src/main/scala/scalaz/LazyEitherT.scala
@@ -189,7 +189,7 @@ sealed abstract class LazyEitherTInstances1 {
       def iso = LazyEitherT.lazyEitherTLeftProjectionEIso2[F, L]
     }
 
-  implicit def lazyEitherTMonadError[F[_], L](implicit F0: Monad[F]): MonadError[LazyEitherT[F, ?, ?], L] =
+  implicit def lazyEitherTMonadError[F[_], L](implicit F0: Monad[F]): MonadError[LazyEitherT[F, L, ?], L] =
     new LazyEitherTMonadError[F, L] {
       implicit def F = F0
     }
@@ -376,8 +376,7 @@ private trait LazyEitherTBindRec[F[_], E] extends BindRec[LazyEitherT[F, E, ?]] 
     )
 }
 
-
-private trait LazyEitherTMonadError[F[_], E] extends MonadError[LazyEitherT[F, ?, ?], E] with LazyEitherTMonad[F, E] {
+private trait LazyEitherTMonadError[F[_], E] extends MonadError[LazyEitherT[F, E, ?], E] with LazyEitherTMonad[F, E] {
   def raiseError[A](e: E): LazyEitherT[F, E, A] = LazyEitherT.lazyLeftT(e)
   def handleError[A](fa: LazyEitherT[F, E, A])(f: E => LazyEitherT[F, E, A]): LazyEitherT[F, E, A] = fa.left.flatMap(e => f(e))
 }

--- a/core/src/main/scala/scalaz/Monad.scala
+++ b/core/src/main/scala/scalaz/Monad.scala
@@ -89,5 +89,8 @@ object Monad {
 
   ////
 
+  implicit def monadMTMAB[MT[_[_], _], MAB[_, _], A](implicit t: MonadTrans[MT], m: Monad[MAB[A, ?]]): Monad[MT[MAB[A, ?], ?]] = 
+    t.apply[MAB[A, ?]]
+  
   ////
 }

--- a/core/src/main/scala/scalaz/MonadError.scala
+++ b/core/src/main/scala/scalaz/MonadError.scala
@@ -5,18 +5,18 @@ package scalaz
  *
  */
 ////
-trait MonadError[F[_, _], S] extends Monad[F[S, ?]] { self =>
+trait MonadError[F[_], S] extends Monad[F] { self =>
   ////
 
-  def raiseError[A](e: S): F[S, A]
-  def handleError[A](fa: F[S, A])(f: S => F[S, A]): F[S, A]
+  def raiseError[A](e: S): F[A]
+  def handleError[A](fa: F[A])(f: S => F[A]): F[A]
 
   trait MonadErrorLaw {
-    def raisedErrorsHandled[A](e: S, f: S => F[S, A])(implicit FEA: Equal[F[S, A]]): Boolean =
+    def raisedErrorsHandled[A](e: S, f: S => F[A])(implicit FEA: Equal[F[A]]): Boolean =
       FEA.equal(handleError(raiseError(e))(f), f(e))
-    def errorsRaised[A](a: A, e: S)(implicit FEA: Equal[F[S, A]]): Boolean =
+    def errorsRaised[A](a: A, e: S)(implicit FEA: Equal[F[A]]): Boolean =
       FEA.equal(bind(point(a))(_ => raiseError(e)), raiseError(e))
-    def errorsStopComputation[A](e: S, a: A)(implicit FEA: Equal[F[S, A]]): Boolean =
+    def errorsStopComputation[A](e: S, a: A)(implicit FEA: Equal[F[A]]): Boolean =
       FEA.equal(bind(raiseError(e))(_ => point(a)), raiseError(e))
   }
   def monadErrorLaw = new MonadErrorLaw {}
@@ -26,7 +26,7 @@ trait MonadError[F[_, _], S] extends Monad[F[S, ?]] { self =>
 }
 
 object MonadError {
-  @inline def apply[F[_, _], S](implicit F: MonadError[F, S]): MonadError[F, S] = F
+  @inline def apply[F[_], S](implicit F: MonadError[F, S]): MonadError[F, S] = F
 
   ////
 

--- a/core/src/main/scala/scalaz/MonadListen.scala
+++ b/core/src/main/scala/scalaz/MonadListen.scala
@@ -1,14 +1,14 @@
 package scalaz
 
-trait MonadListen[F[_, _], W] extends MonadTell[F, W] {
-  def listen[A](ma: F[W, A]): F[W, (A, W)]
+trait MonadListen[F[_], W] extends MonadTell[F, W] {
+  def listen[A](ma: F[A]): F[(A, W)]
 
-  def pass[A](ma: F[W, (A, W => W)]): F[W, A] =
+  def pass[A](ma: F[(A, W => W)]): F[A] =
     bind(listen(ma)){ case ((a, f), w) => writer(f(w), a) }
 
   val monadListenSyntax = new scalaz.syntax.MonadListenSyntax[F, W]{def F = MonadListen.this}
 }
 
 object MonadListen {
-  def apply[F[_, _], W](implicit ML: MonadListen[F, W]) = ML
+  def apply[F[_], W](implicit ML: MonadListen[F, W]) = ML
 }

--- a/core/src/main/scala/scalaz/MonadReader.scala
+++ b/core/src/main/scala/scalaz/MonadReader.scala
@@ -5,20 +5,20 @@ package scalaz
  *
  */
 ////
-trait MonadReader[F[_, _], S] extends Monad[F[S, ?]] { self =>
+trait MonadReader[F[_], S] extends Monad[F] { self =>
   ////
 
-  def ask: F[S,S]
-  def local[A](f: S => S)(fa: F[S,A]): F[S,A]
-  def scope[A](k: S)(fa: F[S,A]): F[S,A] = local(_ => k)(fa)
-  def asks[A](f: S => A): F[S,A] = map(ask)(f)
+  def ask: F[S]
+  def local[A](f: S => S)(fa: F[A]): F[A]
+  def scope[A](k: S)(fa: F[A]): F[A] = local(_ => k)(fa)
+  def asks[A](f: S => A): F[A] = map(ask)(f)
 
   ////
   
 }
 
 object MonadReader {
-  @inline def apply[F[_, _], S](implicit F: MonadReader[F, S]): MonadReader[F, S] = F
+  @inline def apply[F[_], S](implicit F: MonadReader[F, S]): MonadReader[F, S] = F
 
   ////
 

--- a/core/src/main/scala/scalaz/MonadState.scala
+++ b/core/src/main/scala/scalaz/MonadState.scala
@@ -6,23 +6,23 @@ package scalaz
  *
  */
 ////
-trait MonadState[F[_, _], S] extends Monad[F[S, ?]] { self =>
+trait MonadState[F[_], S] extends Monad[F] { self =>
   ////
 
-  def state[A](a: A): F[S, A] = bind(init)(s => point(a))
-  def constantState[A](a: A, s: => S): F[S, A] = bind(put(s))(_ => point(a))
-  def init: F[S, S]
-  def get: F[S, S]
-  def gets[A](f: S => A): F[S, A] = bind(init)(s => point(f(s)))
-  def put(s: S): F[S, Unit]
-  def modify(f: S => S): F[S, Unit] = bind(init)(s => put(f(s)))
+  def state[A](a: A): F[A] = bind(init)(s => point(a))
+  def constantState[A](a: A, s: => S): F[A] = bind(put(s))(_ => point(a))
+  def init: F[S]
+  def get: F[S]
+  def gets[A](f: S => A): F[A] = bind(init)(s => point(f(s)))
+  def put(s: S): F[Unit]
+  def modify(f: S => S): F[Unit] = bind(init)(s => put(f(s)))
 
   ////
   
 }
 
 object MonadState {
-  @inline def apply[F[_, _], S](implicit F: MonadState[F, S]): MonadState[F, S] = F
+  @inline def apply[F[_], S](implicit F: MonadState[F, S]): MonadState[F, S] = F
 
   ////
 

--- a/core/src/main/scala/scalaz/MonadTell.scala
+++ b/core/src/main/scala/scalaz/MonadTell.scala
@@ -5,18 +5,18 @@ package scalaz
  *
  */
 ////
-trait MonadTell[F[_, _], S] extends Monad[F[S, ?]] { self =>
+trait MonadTell[F[_], S] extends Monad[F] { self =>
   ////
-  def writer[A](w: S, v: A): F[S, A]
+  def writer[A](w: S, v: A): F[A]
 
-  def tell(w: S): F[S, Unit] = writer(w, ())
+  def tell(w: S): F[Unit] = writer(w, ())
 
   ////
   val monadTellSyntax = new scalaz.syntax.MonadTellSyntax[F, S] { def F = MonadTell.this }
 }
 
 object MonadTell {
-  @inline def apply[F[_, _], S](implicit F: MonadTell[F, S]): MonadTell[F, S] = F
+  @inline def apply[F[_], S](implicit F: MonadTell[F, S]): MonadTell[F, S] = F
 
   ////
 

--- a/core/src/main/scala/scalaz/ReaderWriterStateT.scala
+++ b/core/src/main/scala/scalaz/ReaderWriterStateT.scala
@@ -98,9 +98,9 @@ sealed abstract class ReaderWriterStateTInstances0 extends IndexedReaderWriterSt
     }
 
   implicit def rwstMonad[F[_], R, W, S](implicit W0: Monoid[W], F0: Monad[F]):
-  MonadReader[ReaderWriterStateT[F, ?, W, S, ?], R] with
-  MonadState[ReaderWriterStateT[F, R, W, ?, ?], S] with
-  MonadListen[ReaderWriterStateT[F, R, ?, S, ?], W] =
+  MonadReader[ReaderWriterStateT[F, R, W, S, ?], R] with
+  MonadState[ReaderWriterStateT[F, R, W, S, ?], S] with
+  MonadListen[ReaderWriterStateT[F, R, W, S, ?], W] =
     new ReaderWriterStateTMonad[F, R, W, S] {
       implicit def F = F0
       implicit def W = W0
@@ -177,9 +177,9 @@ private abstract class ReaderWriterStateTMonadPlus[F[_], R, W, S]
 }
 
 private trait ReaderWriterStateTMonad[F[_], R, W, S]
-  extends MonadReader[ReaderWriterStateT[F, ?, W, S, ?], R]
-  with MonadState[ReaderWriterStateT[F, R, W, ?, ?], S]
-  with MonadListen[ReaderWriterStateT[F, R, ?, S, ?], W]
+  extends MonadReader[ReaderWriterStateT[F, R, W, S, ?], R]
+  with MonadState[ReaderWriterStateT[F, R, W, S, ?], S]
+  with MonadListen[ReaderWriterStateT[F, R, W, S, ?], W]
   with ReaderWriterStateTBind[F, R, W, S] {
   implicit def F: Monad[F]
   implicit def W: Monoid[W]

--- a/core/src/main/scala/scalaz/StateT.scala
+++ b/core/src/main/scala/scalaz/StateT.scala
@@ -152,7 +152,7 @@ sealed abstract class StateTInstances3 extends IndexedStateTInstances {
 }
 
 sealed abstract class StateTInstances2 extends StateTInstances3 {
-  implicit def stateTMonadState[S, F[_]](implicit F0: Monad[F]): MonadState[StateT[F, ?, ?], S] = 
+  implicit def stateTMonadState[S, F[_]](implicit F0: Monad[F]): MonadState[StateT[F, S, ?], S] = 
     new StateTMonadState[S, F] {
       implicit def F: Monad[F] = F0
     }
@@ -171,7 +171,7 @@ sealed abstract class StateTInstances0 extends StateTInstances1 {
 }
 
 abstract class StateTInstances extends StateTInstances0 {
-  implicit def stateMonad[S]: MonadState[State[?, ?], S] =
+  implicit def stateMonad[S]: MonadState[State[S, ?], S] =
       StateT.stateTMonadState[S, Id](Id.id)
 }
 
@@ -240,7 +240,7 @@ private trait StateTBindRec[S, F[_]] extends StateTBind[S, F] with BindRec[State
   }
 }
 
-private trait StateTMonadState[S, F[_]] extends MonadState[StateT[F, ?, ?], S] with StateTBind[S, F] {
+private trait StateTMonadState[S, F[_]] extends MonadState[StateT[F, S, ?], S] with StateTBind[S, F] {
   implicit def F: Monad[F]
 
   def point[A](a: => A): StateT[F, S, A] = {

--- a/core/src/main/scala/scalaz/Unapply.scala
+++ b/core/src/main/scala/scalaz/Unapply.scala
@@ -274,6 +274,17 @@ object Unapply extends Unapply_0 {
       def leibniz = refl
     }
 
+  /** Turns a MonadTrans-like instance that has two params and turns it into an M[A] */
+  implicit def unapplyMTMAB[TC[_[_]], MT[_[_], _], MAB[_, _], A0, A1](implicit TC0: TC[MT[MAB[A0,?], ?]]):
+    Unapply[TC, MT[MAB[A0, ?], A1]] {
+      type M[X] = MT[MAB[A0, ?], X]
+      type A = A1
+    } = new Unapply[TC, MT[MAB[A0, ?], A1]] {
+      type M[X] = MT[MAB[A0, ?], X]
+      type A = A1
+      def TC = TC0
+      def leibniz = Leibniz.refl
+    }  
   // TODO More!
 }
 

--- a/core/src/main/scala/scalaz/WriterT.scala
+++ b/core/src/main/scala/scalaz/WriterT.scala
@@ -204,8 +204,8 @@ sealed abstract class WriterTInstances4 extends WriterTInstance5 {
     }
   implicit def writerEqual[W, A](implicit E: Equal[(W, A)]): Equal[Writer[W, A]] = E.contramap((_: Writer[W, A]).run)
 
-  implicit def writerTMonadError[F[_, _], E, W](implicit F0: MonadError[F, E], W0: Monoid[W]): MonadError[Lambda[(E0, A) => WriterT[F[E0, ?], W, A]], E] =
-    new WriterTMonadError[F, E, W]{
+  implicit def writerTMonadError[F[_], E, W](implicit F0: MonadError[F, E], W0: Monoid[W]): MonadError[WriterT[F, W, ?], E] =
+    new WriterTMonadError[F, E, W] {
       override def F = F0
       override def W = W0
     }
@@ -259,7 +259,7 @@ sealed abstract class WriterTInstances0 extends WriterTInstances1 {
 }
 
 sealed abstract class WriterTInstances extends WriterTInstances0 {
-  implicit def writerTMonadListen[F[_], W](implicit F0: Monad[F], W0: Monoid[W]): MonadListen[WriterT[F, ?, ?], W] =
+  implicit def writerTMonadListen[F[_], W](implicit F0: Monad[F], W0: Monoid[W]): MonadListen[WriterT[F, W, ?], W] =
     new WriterTMonadListen[F, W] {
       implicit def F = F0
       implicit def W = W0
@@ -366,14 +366,14 @@ private trait WriterTMonadPlus[F[_], W] extends MonadPlus[WriterT[F, W, ?]] with
   def F: MonadPlus[F]
 }
 
-private trait WriterTMonadError[F[_, _], E, W] extends MonadError[Lambda[(E0, A) => WriterT[F[E0, ?], W, A]], E] with WriterTMonad[F[E, ?], W] {
+private trait WriterTMonadError[F[_], E, W] extends MonadError[WriterT[F, W, ?], E] with WriterTMonad[F, W] {
   implicit def F: MonadError[F, E]
 
-  override def handleError[A](fa: WriterT[F[E, ?], W, A])(f: E => WriterT[F[E, ?], W, A]) =
-    WriterT[F[E, ?], W, A](F.handleError(fa.run)(f(_).run))
+  override def handleError[A](fa: WriterT[F, W, A])(f: E => WriterT[F, W, A]) =
+    WriterT[F, W, A](F.handleError(fa.run)(f(_).run))
 
   override def raiseError[A](e: E) =
-    WriterT[F[E, ?], W, A](F.raiseError[(W, A)](e))
+    WriterT[F, W, A](F.raiseError[(W, A)](e))
 }
 
 private trait WriterTFoldable[F[_], W] extends Foldable.FromFoldr[WriterT[F, W, ?]] {
@@ -426,7 +426,7 @@ private trait WriterTHoist[W] extends Hoist[λ[(α[_], β) => WriterT[α, W, β]
     }
 }
 
-private trait WriterTMonadListen[F[_], W] extends MonadListen[WriterT[F, ?, ?], W] with WriterTMonad[F, W] {
+private trait WriterTMonadListen[F[_], W] extends MonadListen[WriterT[F, W, ?], W] with WriterTMonad[F, W] {
   implicit def F: Monad[F]
   implicit def W: Monoid[W]
 

--- a/core/src/main/scala/scalaz/std/Either.scala
+++ b/core/src/main/scala/scalaz/std/Either.scala
@@ -63,13 +63,13 @@ trait EitherInstances extends EitherInstances0 {
   }
 
   /** Right biased monad */
-  implicit def eitherMonad[L]: Traverse[Either[L, ?]] with MonadError[Either, L] with BindRec[Either[L, ?]] with Cozip[Either[L, ?]] =
-    new Traverse[Either[L, ?]] with MonadError[Either, L] with BindRec[Either[L, ?]] with Cozip[Either[L, ?]] {
+  implicit def eitherMonad[L]: Traverse[Either[L, ?]] with MonadError[Either[L, ?], L] with BindRec[Either[L, ?]] with Cozip[Either[L, ?]] = 
+    new Traverse[Either[L, ?]] with MonadError[Either[L, ?], L] with BindRec[Either[L, ?]] with Cozip[Either[L, ?]] {
       def bind[A, B](fa: Either[L, A])(f: A => Either[L, B]) = fa match {
         case Left(a)  => Left(a)
         case Right(b) => f(b)
       }
-  
+
       def handleError[A](fa: Either[L, A])(f: L => Either[L, A]) =
         fa match {
           case a @ Right(_) => a

--- a/core/src/main/scala/scalaz/std/Future.scala
+++ b/core/src/main/scala/scalaz/std/Future.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration.Duration
 import scala.util.{ Try, Success => TSuccess }
 
 trait FutureInstances1 {
-  implicit def futureInstance(implicit ec: ExecutionContext): Nondeterminism[Future] with Cobind[Future] with MonadError[λ[(α, β) => Future[β]], Throwable] with Catchable[Future] =
+  implicit def futureInstance(implicit ec: ExecutionContext): Nondeterminism[Future] with Cobind[Future] with MonadError[Future, Throwable] with Catchable[Future] =
     new FutureInstance
 
   implicit def futureSemigroup[A](implicit m: Semigroup[A], ec: ExecutionContext): Semigroup[Future[A]] =
@@ -27,7 +27,7 @@ trait FutureInstances extends FutureInstances1 {
     Monoid.liftMonoid[Future, A]
 }
 
-private class FutureInstance(implicit ec: ExecutionContext) extends Nondeterminism[Future] with Cobind[Future] with MonadError[λ[(α,β) => Future[β]], Throwable] with Catchable[Future] {
+private class FutureInstance(implicit ec: ExecutionContext) extends Nondeterminism[Future] with Cobind[Future] with MonadError[Future, Throwable] with Catchable[Future] {
   def point[A](a: => A): Future[A] = Future(a)
   def bind[A, B](fa: Future[A])(f: A => Future[B]): Future[B] = fa flatMap f
   override def map[A, B](fa: Future[A])(f: A => B): Future[B] = fa map f

--- a/core/src/main/scala/scalaz/syntax/MonadErrorIdOps.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadErrorIdOps.scala
@@ -1,7 +1,7 @@
 package scalaz
 package syntax
 
-final class MonadErrorIdOps[E](val self: E) extends AnyVal {
-  def raiseError[F[_, _], A](implicit F: MonadError[F, E]): F[E, A] =
+final class MonadErrorIdOps[S](val self: S) extends AnyVal {
+  def raiseError[F[_], A](implicit F: MonadError[F, S]): F[A] =
     F.raiseError[A](self)
 }

--- a/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
@@ -2,33 +2,28 @@ package scalaz
 package syntax
 
 /** Wraps a value `self` and provides methods related to `MonadError` */
-final class MonadErrorOps[F[_, _], S, A] private[syntax](self: F[S, A])(implicit val F: MonadError[F, S]) {
+final class MonadErrorOps[F[_], S, A] private[syntax](self: F[A])(implicit val F: MonadError[F, S]) {
   ////
-  final def handleError(f: S => F[S, A]): F[S, A] =
+  final def handleError(f: S => F[A]): F[A] =
     F.handleError(self)(f)
 
   ////
 }
 
-sealed trait ToMonadErrorOps0 {
-  implicit def ToMonadErrorOpsUnapply[FA](v: FA)(implicit F0: Unapply21[MonadError, FA]) =
-    new MonadErrorOps[F0.M, F0.A, F0.B](F0(v))(F0.TC)
-}
-
 trait ToMonadErrorOps extends ToMonadOps {
-  implicit def ToMonadErrorOps[F[_, _], S, A](v: F[S, A])(implicit F0: MonadError[F, S]) =
+  implicit def ToMonadErrorOps[F[_], S, A](v: F[A])(implicit F0: MonadError[F, S]) =
     new MonadErrorOps[F, S, A](v)
 
   ////
 
- implicit def ToMonadErrorIdOps[E](v: E) =
-   new MonadErrorIdOps[E](v)
+  implicit def ToMonadErrorIdOps[E](v: E) =
+    new MonadErrorIdOps[E](v)
 
   ////
 }
 
-trait MonadErrorSyntax[F[_, _], S] extends MonadSyntax[F[S, ?]] {
-  implicit def ToMonadErrorOps[A](v: F[S, A]): MonadErrorOps[F, S, A] =
+trait MonadErrorSyntax[F[_], S] extends MonadSyntax[F] {
+  implicit def ToMonadErrorOps[A](v: F[A]): MonadErrorOps[F, S, A] =
     new MonadErrorOps[F, S, A](v)(MonadErrorSyntax.this.F)
 
   def F: MonadError[F, S]

--- a/core/src/main/scala/scalaz/syntax/MonadListenSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadListenSyntax.scala
@@ -1,24 +1,21 @@
 package scalaz
 package syntax
 
-final class MonadListenOps[F[_, _], W, A] private[syntax](self: F[W, A])(implicit ML: MonadListen[F, W]) {
+final class MonadListenOps[F[_], W, A] private[syntax](self: F[A])(implicit ML: MonadListen[F, W]) {
 
-  final def written: F[W, W] = ML.map(ML.listen(self)){ case (_, w) => w }
+  final def written: F[W] = 
+    ML.map(ML.listen(self)){ case (_, w) => w }
 
-  final def listen: F[W, (A, W)] = ML.listen[A](self)
+  final def listen: F[(A, W)] = 
+    ML.listen[A](self)
 }
 
-sealed trait ToMonadListenOps0 {
-  implicit def ToMonadListenOpsUnapply[FA](v: FA)(implicit F0: Unapply21[MonadListen, FA]) =
-    new MonadListenOps[F0.M, F0.A, F0.B](F0(v))(F0.TC)
-}
-
-trait ToMonadListenOps extends ToMonadListenOps0 with ToMonadTellOps {
-  implicit def ToMonadListenOps[F[_, _], A, W](v: F[W, A])(implicit F0: MonadListen[F, W]) = 
+trait ToMonadListenOps extends ToMonadTellOps {
+  implicit def ToMonadListenOps[F[_], A, W](v: F[A])(implicit F0: MonadListen[F, W]) = 
     new MonadListenOps[F, W, A](v)(F0)
 }
 
-trait MonadListenSyntax[F[_, _], W] extends MonadTellSyntax[F, W] {
-  implicit def ToMonadListenOps[A](v: F[W, A])(implicit F0: MonadListen[F, W]) =
+trait MonadListenSyntax[F[_], W] extends MonadTellSyntax[F, W] {
+  implicit def ToMonadListenOps[A](v: F[A])(implicit F0: MonadListen[F, W]) =
     new MonadListenOps[F, W, A](v)(F0)
 }

--- a/core/src/main/scala/scalaz/syntax/MonadTellSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadTellSyntax.scala
@@ -2,24 +2,19 @@ package scalaz
 package syntax
 
 /** Wraps a value `self` and provides methods related to `MonadTell` */
-final class MonadTellOps[F[_, _], S, A] private[syntax](self: F[S, A])(implicit val F: MonadTell[F, S]) {
+final class MonadTellOps[F[_], S, A] private[syntax](self: F[A])(implicit val F: MonadTell[F, S]) {
   ////
 
-  final def :++>(w: => S): F[S, A] = F.bind(self)(a => F.map(F.tell(w))(_ => a))
+  final def :++>(w: => S): F[A] = F.bind(self)(a => F.map(F.tell(w))(_ => a))
 
-  final def :++>>(f: A => S): F[S, A] =
+  final def :++>>(f: A => S): F[A] =
     F.bind(self)(a => F.map(F.tell(f(a)))(_ => a))
 
   ////
 }
 
-sealed trait ToMonadTellOps0 {
-  implicit def ToMonadTellOpsUnapply[FA](v: FA)(implicit F0: Unapply21[MonadTell, FA]) =
-    new MonadTellOps[F0.M, F0.A, F0.B](F0(v))(F0.TC)
-}
-
 trait ToMonadTellOps extends ToMonadOps {
-  implicit def ToMonadTellOps[F[_, _], S, A](v: F[S, A])(implicit F0: MonadTell[F, S]) =
+  implicit def ToMonadTellOps[F[_], S, A](v: F[A])(implicit F0: MonadTell[F, S]) =
     new MonadTellOps[F, S, A](v)
 
   ////
@@ -27,8 +22,8 @@ trait ToMonadTellOps extends ToMonadOps {
   ////
 }
 
-trait MonadTellSyntax[F[_, _], S] extends MonadSyntax[F[S, ?]] {
-  implicit def ToMonadTellOps[A](v: F[S, A]): MonadTellOps[F, S, A] =
+trait MonadTellSyntax[F[_], S] extends MonadSyntax[F] {
+  implicit def ToMonadTellOps[A](v: F[A]): MonadTellOps[F, S, A] =
     new MonadTellOps[F, S, A](v)(MonadTellSyntax.this.F)
 
   def F: MonadTell[F, S]

--- a/example/src/main/scala/scalaz/example/StateTUsage.scala
+++ b/example/src/main/scala/scalaz/example/StateTUsage.scala
@@ -6,13 +6,13 @@ object StateTUsage extends App {
   import StateT._
 
   def f[M[_]: Functor] {
-    Functor[({type l[a] = StateT[M, Int, a]})#l]
+    Functor[StateT[M, Int, ?]]
   }
 
   def m[M[_]: Monad] {
-    Applicative[({type l[a] = StateT[M, Int, a]})#l]
-    Monad[({type l[a] = StateT[M, Int, a]})#l]
-    MonadState[({type f[s, a] = StateT[M, s, a]})#f, Int]
+    Applicative[StateT[M, Int, ?]]
+    Monad[StateT[M, Int, ?]]
+    MonadState[StateT[M, Int, ?], Int]
   }
 
   def state() {

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazProperties.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazProperties.scala
@@ -556,16 +556,16 @@ object ScalazProperties {
   }
 
   object monadError {
-    def raisedErrorsHandled[F[_, _], E, A](implicit me: MonadError[F, E], eq: Equal[F[E, A]], ae: Arbitrary[E], afea: Arbitrary[E => F[E,A]]) =
+    def raisedErrorsHandled[F[_], E, A](implicit me: MonadError[F, E], eq: Equal[F[A]], ae: Arbitrary[E], afea: Arbitrary[E => F[A]]) =
       forAll(me.monadErrorLaw.raisedErrorsHandled[A] _)
-    def errorsRaised[F[_, _], E, A](implicit me: MonadError[F, E], eq: Equal[F[E, A]], ae: Arbitrary[E], aa: Arbitrary[A]) =
+    def errorsRaised[F[_], E, A](implicit me: MonadError[F, E], eq: Equal[F[A]], ae: Arbitrary[E], aa: Arbitrary[A]) =
       forAll(me.monadErrorLaw.errorsRaised[A] _)
-    def errorsStopComputation[F[_, _], E, A](implicit me: MonadError[F, E], eq: Equal[F[E, A]], ae: Arbitrary[E], aa: Arbitrary[A]) =
+    def errorsStopComputation[F[_], E, A](implicit me: MonadError[F, E], eq: Equal[F[A]], ae: Arbitrary[E], aa: Arbitrary[A]) =
       forAll(me.monadErrorLaw.errorsStopComputation[A] _)
 
-    def laws[F[_, _], E](implicit me: MonadError[F, E], am: Arbitrary[F[E, Int]], afap: Arbitrary[F[E, Int => Int]], aeq: Equal[F[E, Int]], ae: Arbitrary[E]) =
+    def laws[F[_], E](implicit me: MonadError[F, E], am: Arbitrary[F[Int]], afap: Arbitrary[F[Int => Int]], aeq: Equal[F[Int]], ae: Arbitrary[E]) =
       new Properties("monad error") {
-        include(monad.laws[F[E, ?]])
+        include(monad.laws[F])
         property("raisedErrorsHandled") = raisedErrorsHandled[F, E, Int]
         property("errorsRaised") = errorsRaised[F, E, Int]
         property("errorsStopComputation") = errorsStopComputation[F, E, Int]

--- a/tests/src/test/scala/scalaz/DisjunctionTest.scala
+++ b/tests/src/test/scala/scalaz/DisjunctionTest.scala
@@ -11,11 +11,11 @@ object DisjunctionTest extends SpecLite {
   checkAll(monoid.laws[Int \/ Int])
   checkAll(bindRec.laws[Int \/ ?])
   checkAll(monad.laws[Int \/ ?])
+  checkAll(monadError.laws[Int \/ ?, Int])
   checkAll(plus.laws[Int \/ ?])
   checkAll(traverse.laws[Int \/ ?])
   checkAll(bitraverse.laws[\/])
   checkAll(associative.laws[\/])
-  checkAll(monadError.laws[\/, Int])
 
   "fromTryCatchThrowable" in {
     class Foo extends Throwable

--- a/tests/src/test/scala/scalaz/EitherTTest.scala
+++ b/tests/src/test/scala/scalaz/EitherTTest.scala
@@ -14,9 +14,9 @@ object EitherTTest extends SpecLite {
   checkAll(equal.laws[EitherTListInt[Int]])
   checkAll(bindRec.laws[EitherTListInt])
   checkAll(monadPlus.laws[EitherTListInt])
+  checkAll(monadError.laws[EitherTListInt, Int])
   checkAll(traverse.laws[EitherTListInt])
   checkAll(bitraverse.laws[EitherTList])
-  checkAll(monadError.laws[EitherTList, Int])
 
   "rightU" should {
     val a: String \/ Int = \/-(1)
@@ -67,7 +67,7 @@ object EitherTTest extends SpecLite {
     def foldable[F[_] : Traverse, A] = Foldable[EitherT[F, A, ?]]
     def bifunctor[F[_] : Traverse] = Bifunctor[EitherT[F, ?, ?]]
     def bifoldable[F[_] : Traverse] = Bifoldable[EitherT[F, ?, ?]]
-    def monadError[F[_] : Monad, A] = MonadError[EitherT[F, ?, ?], A]
+    def monadError[F[_] : Monad, A] = MonadError[EitherT[F, A, ?], A]
   }
 
   def compilationTests() = {

--- a/tests/src/test/scala/scalaz/LazyEitherTTest.scala
+++ b/tests/src/test/scala/scalaz/LazyEitherTTest.scala
@@ -19,7 +19,7 @@ object LazyEitherTTest extends SpecLite {
   checkAll(traverse.laws[LazyEitherTListInt])
   checkAll(bitraverse.laws[LazyEitherTList])
   checkAll(bindRec.laws[LazyEitherTListInt])
-  checkAll(monadError.laws[LazyEitherTList, Int])
+  checkAll(monadError.laws[LazyEitherTListInt, Int])
 
   "tail recursive tailrecM" in {
     import Scalaz.Id
@@ -58,10 +58,10 @@ object LazyEitherTTest extends SpecLite {
     def functor[F[_] : Monad, A: Monoid] = Functor[LazyEitherT[F, A, ?]]
     def bind[F[_] : Monad : BindRec, A] = Bind[LazyEitherT[F, A, ?]]
     def monad[F[_] : Monad, A: Monoid] = Monad[LazyEitherT[F, A, ?]]
+    def monadError[F[_] : Monad, A] = MonadError[LazyEitherT[F, A, ?], A]
     def foldable[F[_] : Traverse, A] = Foldable[LazyEitherT[F, A, ?]]
     def bifunctor[F[_] : Traverse] = Bifunctor[LazyEitherT[F, ?, ?]]
     def bifoldable[F[_] : Traverse] = Bifoldable[LazyEitherT[F, ?, ?]]
-    def monadError[F[_] : Monad, A] = MonadError[LazyEitherT[F, ?, ?], A]
   }
 
 }

--- a/tests/src/test/scala/scalaz/LazyEitherTest.scala
+++ b/tests/src/test/scala/scalaz/LazyEitherTest.scala
@@ -14,7 +14,7 @@ object LazyEitherTest extends SpecLite {
   
   checkAll(equal.laws[LazyEither[Int,Int]])
   checkAll(monad.laws[LazyEither[Int, ?]])
-  checkAll(monadError.laws[LazyEither, Int])
+  checkAll(monadError.laws[LazyEither[Int, ?], Int])
   checkAll(bindRec.laws[LazyEither[Int, ?]])
   checkAll(traverse.laws[LazyEither[Int, ?]])
   checkAll(associative.laws[LazyEither])

--- a/tests/src/test/scala/scalaz/MaybeTTest.scala
+++ b/tests/src/test/scala/scalaz/MaybeTTest.scala
@@ -8,35 +8,29 @@ import std.AllInstances._
 object MaybeTTest extends SpecLite {
 
   type MaybeTList[A] = MaybeT[List, A]
+  type IntOr[A] = Int \/ A
+  type MaybeTEither[A] = MaybeT[IntOr, A]
 
   checkAll(equal.laws[MaybeTList[Int]])
   checkAll(bindRec.laws[MaybeTList])
   checkAll(monadPlus.laws[MaybeTList])
   checkAll(traverse.laws[MaybeTList])
-
-  {
-    implicit def maybeTArb0[F[_, _], E, A](implicit F: Arbitrary[F[E, Maybe[A]]]): Arbitrary[MaybeT[F[E, ?], A]] =
-      maybeTArb[F[E, ?], A]
-
-    implicit def maybeTEqual0[F[_, _], E, A](implicit F: Equal[F[E, Maybe[A]]]): Equal[MaybeT[F[E, ?], A]] =
-      MaybeT.maybeTEqual[F[E, ?], A]
-
-    checkAll(monadError.laws[λ[(E0, A) => MaybeT[E0 \/ ?, A]], Int])
-  }
+  checkAll(monadError.laws[MaybeTEither, Int])
 
   object instances {
     def functor[F[_] : Functor] = Functor[MaybeT[F, ?]]
     def monad[F[_] : Monad] = MonadPlus[MaybeT[F, ?]]
     def bindRec[F[_] : Monad : BindRec] = BindRec[MaybeT[F, ?]]
-    def monadError[F[_, _], E](implicit F: MonadError[F, E]) = MonadError[λ[(E0, A) => MaybeT[F[E0, ?], A]], E]
+    def monadError[F[_], E](implicit F: MonadError[F, E]) = MonadError[MaybeT[F, ?], E]
     def foldable[F[_] : Foldable] = Foldable[MaybeT[F, ?]]
     def traverse[F[_] : Traverse] = Traverse[MaybeT[F, ?]]
 
     // checking absence of ambiguity
     def functor[F[_] : Monad] = Functor[MaybeT[F, ?]]
     def functor[F[_] : Monad : Traverse] = Functor[MaybeT[F, ?]]
-    def functor[F[_, _], E](implicit F1: MonadError[F, E], F2: Traverse[F[E, ?]]) = Functor[MaybeT[λ[A => F[E, A]], ?]]
+    def functor[F[_], E](implicit F1: MonadError[F, E], F2: Traverse[F]) = Functor[MaybeT[F, ?]]
     def apply[F[_] : Monad] = Apply[MaybeT[F, ?]]
     def foldable[F[_] : Traverse] = Foldable[MaybeT[F, ?]]
+    def monadEither[E] = Monad[MaybeT[E \/ ?, ?]]
   }
 }

--- a/tests/src/test/scala/scalaz/OptionTTest.scala
+++ b/tests/src/test/scala/scalaz/OptionTTest.scala
@@ -10,21 +10,14 @@ object OptionTTest extends SpecLite {
 
   type OptionTList[A] = OptionT[List, A]
   type OptionTOption[A] = OptionT[Option, A]
+  type IntOr[A] = Int \/ A
+  type OptionTEither[A] = OptionT[IntOr, A]
 
   checkAll(equal.laws[OptionTList[Int]])
   checkAll(bindRec.laws[OptionTList])
   checkAll(monadPlus.laws[OptionTList])
   checkAll(traverse.laws[OptionTList])
-
-  {
-    implicit def optionTArb0[F[_, _], E, A](implicit F: Arbitrary[F[E, Option[A]]]): Arbitrary[OptionT[F[E, ?], A]] =
-      optionTArb[F[E, ?], A]
-
-    implicit def optionTEqual0[F[_, _], E, A](implicit F: Equal[F[E, Option[A]]]): Equal[OptionT[F[E, ?], A]] =
-      OptionT.optionTEqual[F[E, ?], A]
-
-    checkAll(monadError.laws[λ[(E0, A) => OptionT[E0 \/ ?, A]], Int])
-  }
+  checkAll(monadError.laws[OptionTEither, Int])
 
   "show" ! forAll { a: OptionTList[Int] =>
     Show[OptionTList[Int]].show(a) must_=== Show[List[Option[Int]]].show(a.run)
@@ -39,14 +32,14 @@ object OptionTTest extends SpecLite {
   object instances {
     def functor[F[_] : Functor] = Functor[OptionT[F, ?]]
     def monad[F[_] : Monad] = MonadPlus[OptionT[F, ?]]
-    def monadError[F[_, _], E](implicit F: MonadError[F, E]) = MonadError[λ[(E0, A) => OptionT[F[E0, ?], A]], E]
+    def monadError[F[_], E](implicit F: MonadError[F, E]) = MonadError[OptionT[F, ?], E]
     def foldable[F[_] : Foldable] = Foldable[OptionT[F, ?]]
     def traverse[F[_] : Traverse] = Traverse[OptionT[F, ?]]
 
     // checking absence of ambiguity
     def functor[F[_] : Monad] = Functor[OptionT[F, ?]]
     def functor[F[_] : Monad : Traverse] = Functor[OptionT[F, ?]]
-    def functor[F[_, _], E](implicit F1: MonadError[F, E], F2: Traverse[F[E, ?]]) = Functor[OptionT[λ[A => F[E, A]], ?]]
+    def functor[F[_], E](implicit F1: MonadError[F, E], F2: Traverse[F]) = Functor[OptionT[F, ?]]
     def apply[F[_] : Monad] = Apply[OptionT[F, ?]]
     def foldable[F[_] : Traverse] = Foldable[OptionT[F, ?]]
   }

--- a/tests/src/test/scala/scalaz/ReaderWriterStateTTest.scala
+++ b/tests/src/test/scala/scalaz/ReaderWriterStateTTest.scala
@@ -36,8 +36,8 @@ object ReaderWriterStateTTest extends SpecLite {
     def monad[F[_]: Monad, R, W: Monoid, S] = Monad[RWST[F, R, W, S, ?]]
     def monadPlus[F[_]: MonadPlus, R, W: Monoid, S] = MonadPlus[RWST[F, R, W, S, ?]]
     def bind[F[_]: Bind, R, W: Semigroup, S] = Bind[RWST[F, R, W, S, ?]]
-    def monadReader[F[_]: Monad, R, W: Monoid, S] = MonadReader[RWST[F, ?, W, S, ?], R]
-    def monadState[F[_]: Monad, R, W: Monoid, S] = MonadState[RWST[F, R, W, ?, ?], S]
+    def monadReader[F[_]: Monad, R, W: Monoid, S] = MonadReader[RWST[F, R, W, S, ?], R]
+    def monadState[F[_]: Monad, R, W: Monoid, S] = MonadState[RWST[F, R, W, S, ?], S]
     def monadTrans[R, W: Monoid, S] = MonadTrans[λ[(f[_], α) => RWST[f, R, W, S, α]]]
     // checking absence of ambiguity
     def functor[F[_]: Monad, R, W: Monoid, S] = Functor[RWST[F, R, W, S, ?]]

--- a/tests/src/test/scala/scalaz/StateTTest.scala
+++ b/tests/src/test/scala/scalaz/StateTTest.scala
@@ -22,12 +22,12 @@ object StateTTest extends SpecLite {
     def functor[S, F[_] : Functor] = Functor[StateT[F, S, ?]]
     def plus[F[_]: Monad: Plus, S1, S2] = Plus[IndexedStateT[F, S1, S2, ?]]
     def bindRec[S, F[_] : Monad : BindRec] = BindRec[StateT[F, S, ?]]
-    def monadState[S, F[_] : Monad] = MonadState[StateT[F, ?, ?], S]
+    def monadState[S, F[_] : Monad] = MonadState[StateT[F, S, ?], S]
     def monadPlus[S, F[_]: MonadPlus] = MonadPlus[StateT[F, S, ?]]
 
     // F = Id
     def functor[S] = Functor[State[S, ?]]
-    def monadState[S] = MonadState[State[?, ?], S]
+    def monadState[S] = MonadState[State[S, ?], S]
 
     // checking absence of ambiguity
     def functor[S, F[_] : Monad] = Functor[StateT[F, S, ?]]

--- a/tests/src/test/scala/scalaz/std/EitherTest.scala
+++ b/tests/src/test/scala/scalaz/std/EitherTest.scala
@@ -31,7 +31,7 @@ object EitherTest extends SpecLite {
   checkAll("Either.RightProjection @@ Last", monad.laws[λ[α => Either.RightProjection[Int, α] @@ Last]])
 
   checkAll("Either", bindRec.laws[Either[Int, ?]])
-  checkAll("Either", monadError.laws[Either, Int])
+  checkAll("Either", monadError.laws[Either[Int, ?], Int])
   checkAll("Either", bifunctor.laws[Either])
   checkAll("Either", traverse.laws[Either[Int, ?]])
   checkAll("Either", bitraverse.laws[Either])

--- a/tests/src/test/scala/scalaz/std/FutureTest.scala
+++ b/tests/src/test/scala/scalaz/std/FutureTest.scala
@@ -47,7 +47,7 @@ class FutureTest extends SpecLite {
   checkAll(monoid.laws[Future[Int @@ Multiplication]])
 
   // For some reason ArbitraryThrowable isn't being chosen by scalac, so we give it explicitly.
-  checkAll(monadError.laws[λ[(α, β) => Future[β]], Throwable](implicitly, implicitly, implicitly, implicitly, ArbitraryThrowable))
+  checkAll(monadError.laws[Future, Throwable](implicitly, implicitly, implicitly, implicitly, ArbitraryThrowable))
 
   // Scope these away from the rest as Comonad[Future] is a little evil.
   // Should fail to compile by default: implicitly[Comonad[Future]]


### PR DESCRIPTION
Supply a unary-kinded `F[_]` parameter to all the Monad* (MTL-like) classes (rather than a binary-kinded `F[_, _]`). Makes them much simpler and easier to work with.