### PR TITLE
delete cofreeEqual and cofreeZipEqual

### DIFF
--- a/core/src/main/scala/scalaz/Cofree.scala
+++ b/core/src/main/scala/scalaz/Cofree.scala
@@ -171,15 +171,6 @@ sealed abstract class CofreeInstances0 extends CofreeInstances1 {
       def F = implicitly
       def G = implicitly
     }
-
-  implicit def cofreeEqual[A, F[_]](implicit A: Equal[A], F: Equal ~> λ[α => Equal[F[α]]]): Equal[Cofree[F, A]] =
-    Equal.equal{ (a, b) =>
-      A.equal(a.head, b.head) && F(cofreeEqual[A, F]).equal(a.tail, b.tail)
-    }
-
-
-  implicit def cofreeZipEqual[A, F[_]](implicit A: Equal[A], F: Equal ~> λ[α => Equal[F[α]]]): Equal[CofreeZip[F, A]] =
-    Tag.subst(cofreeEqual[A, F])
 }
 
 sealed abstract class CofreeInstances extends CofreeInstances0 {

--- a/tests/src/test/scala/scalaz/CofreeTest.scala
+++ b/tests/src/test/scala/scalaz/CofreeTest.scala
@@ -19,13 +19,13 @@ object CofreeTest extends SpecLite {
   type OneAndList[A] = OneAnd[List, A]
   type CofreeOption[A] = Cofree[Option, A]
 
-  implicit val lazyOptionEqualNat = new (Equal ~> λ[α => Equal[LazyOption[α]]]) {
-    def apply[A](a: Equal[A]) = LazyOption.lazyOptionEqual(a)
-  }
+  implicit def cofreeEqual[F[_], A](implicit F: Eq1[F], A: Equal[A]): Equal[Cofree[F, A]] =
+    Equal.equal{ (a, b) =>
+      A.equal(a.head, b.head) && F.eq1(cofreeEqual[F, A]).equal(a.tail, b.tail)
+    }
 
-  implicit val streamEqualNat = new (Equal ~> λ[α => Equal[Stream[α]]]) {
-    def apply[A](a: Equal[A]) = std.stream.streamEqual(a)
-  }
+  implicit def cofreeZipEqual[F[_]: Eq1, A: Equal]: Equal[CofreeZip[F, A]] =
+    Tag.subst(cofreeEqual[F, A])
 
   //needed to prevent SOE for testing wiht equality
   implicit def cofreeOptEquals[A](implicit e: Equal[A]): Equal[CofreeOption[A]] = new Equal[CofreeOption[A]] {

--- a/tests/src/test/scala/scalaz/Eq1.scala
+++ b/tests/src/test/scala/scalaz/Eq1.scala
@@ -1,0 +1,23 @@
+package scalaz
+
+import std.stream._
+
+trait Eq1[F[_]] {
+  def eq1[A: Equal]: Equal[F[A]]
+}
+
+object Eq1 {
+
+  def apply[F[_]](implicit F: Eq1[F]): Eq1[F] = F
+
+  implicit val lazyOption: Eq1[LazyOption] =
+    new Eq1[LazyOption] {
+      def eq1[A: Equal] = Equal[LazyOption[A]]
+    }
+
+  implicit val stream: Eq1[Stream] =
+    new Eq1[Stream] {
+      def eq1[A: Equal] = Equal[Stream[A]]
+    }
+
+}


### PR DESCRIPTION
I was wrong.
`scalaz.NaturalTransformation` is not typeclass.

- https://github.com/scalaz/scalaz/commit/a05ab2c0053d54b37474e48fcc1056
- https://github.com/scalaz/scalaz/commit/286c3398adebf0a6759cf498f167f7