### PR TITLE
Add Semigroup[A] => BindRec[Tuple2[A, ?]]

### DIFF
--- a/tests/src/test/scala/scalaz/std/TupleTest.scala
+++ b/tests/src/test/scala/scalaz/std/TupleTest.scala
@@ -96,7 +96,7 @@ object TupleTest extends SpecLite {
       def associative = Associative[Tuple2]
       def bitraverse = Bitraverse[Tuple2]
       def functor = Functor[(B, ?)]
-      def bindRec[A: Monoid] = BindRec[(A, ?)]
+      def bindRec[A: Semigroup] = BindRec[(A, ?)]
       def monad[A: Monoid] = Monad[(A, ?)]
       def cozip = Cozip[(A, ?)]
 


### PR DESCRIPTION
Due to the hierarchy, given Semigroup[A], this also gives rise to:

1. Apply[Tuple2[A, ?]]
2. Bind[Tuple2[A, ?]]