### PR TITLE
Add Foldable[StreamT] instance

### DIFF
--- a/tests/src/test/scala/scalaz/StreamTTest.scala
+++ b/tests/src/test/scala/scalaz/StreamTTest.scala
@@ -47,12 +47,18 @@ object StreamTTest extends SpecLite {
         Traverse[Stream].traverse(s)(i => l.map(_ + i)) ::: 
         Traverse[Stream].traverse(s0)(i => l.map(_ + i))
       )
+  }
 
+  "foldMap" ! forAll {
+    (s: Stream[Int]) =>
+      import scalaz.Scalaz._
+      StreamT.fromStream(s.some).foldMap(_.toString) must_==(s.foldMap(_.toString))
   }
 
   checkAll(equal.laws[StreamTOpt[Int]])
   checkAll(monoid.laws[StreamTOpt[Int]])
   checkAll(monadPlus.laws[StreamTOpt])
+  checkAll(foldable.laws[StreamTOpt])
   
   object instances {
     def semigroup[F[_]: Functor, A] = Semigroup[StreamT[F, A]]
@@ -62,6 +68,7 @@ object StreamTTest extends SpecLite {
     def plus[F[_]: Functor] = Plus[StreamT[F, ?]]
     def monad[F[_]: Applicative] = Monad[StreamT[F, ?]]
     def monadPlus[F[_]: Applicative] = MonadPlus[StreamT[F, ?]]
+    def foldable[F[_]: Foldable] = Foldable[StreamT[F, ?]]
 
     // checking absence of ambiguity
     def semigroup[F[_]: Applicative, A] = Semigroup[StreamT[F, A]]


### PR DESCRIPTION
This is just adding Foldable instance for StreamT.

I would like to remove `StreamT#foldLeft` and `StreamT#foldRight` for 2 reasons.
1. These method have lazy signatures, but works strict.
2. These should be done by `StreamT#toStream.map(_.foldLeft)` or `StreamT#toStream.map(_.foldRight)`.

I have not done anything with `foldLeft` or `foldRight` yet.
Could we do anything with these (like add `@deprecated`)?

Thanks.