### PR TITLE
Make Applicative instance for Future sequential

### DIFF
--- a/core/src/main/scala/scalaz/std/Future.scala
+++ b/core/src/main/scala/scalaz/std/Future.scala
@@ -65,10 +65,6 @@ private class FutureInstance(implicit ec: ExecutionContext) extends Nondetermini
   override def gather[A](fs: Seq[Future[A]]): Future[List[A]] =
     Future.sequence(fs.toList)
 
-  // override for actual parallel execution
-  override def ap[A, B](fa: => Future[A])(fab: => Future[A => B]) =
-    fab zip fa map { case (fa, a) => fa(a) }
-
   def attempt[A](f: Future[A]): Future[Throwable \/ A] =
     f.map(\/.right).recover { case e => -\/(e) }
 


### PR DESCRIPTION
DISCLAIMER: I was unsure if I should do this pr at all, because I profit from the parallel applicative instance of Future currently, but I think it should at least be mentioned ;)

The issue is that in the definition of `ap` for the standard `scala.concurrent.Future` it uses the `Future.zip` method which runs in parallel (introduced here 4fc139114f38cb408e56e9cdb00d0307e2b089d4).  This clashes with the rule that the `ap` definition should be equivalent to the definition which uses `flatMap` if there also is a `Monad` instance. 

Maybe you are all aware of this fact and decided that it is nevertheless a beneficial evil, so take it or leave it ;)

-- 24pullrequests
[![](http://24pullrequests.com/assets/logo-8a77737f86fec8def19a1c9a605c9841dbd44e59f243ed3bf64bbdf3214d6fa1.png)](http://24pullrequests.com/)