### PR TITLE
Generalize forever to Apply

### DIFF
--- a/core/src/main/scala/scalaz/Bind.scala
+++ b/core/src/main/scala/scalaz/Bind.scala
@@ -37,11 +37,6 @@ trait Bind[F[_]] extends Apply[F] { self =>
     bind(value)(if(_) t else f)
   }
 
-  /**
-   * Repeats a monadic action infinitely
-   */
-  def forever[A, B](fa: F[A]): F[B] = bind(fa)(_ => forever(fa))
-
   /** Pair `A` with the result of function application. */
   def mproduct[A, B](fa: F[A])(f: A => F[B]): F[(A, B)] =
     bind(fa)(a => map(f(a))((a, _)))

--- a/core/src/main/scala/scalaz/syntax/ApplySyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/ApplySyntax.scala
@@ -8,11 +8,11 @@ final class ApplyOps[F[_],A] private[syntax](val self: F[A])(implicit val F: App
   final def <*>[B](f: F[A => B]): F[B] = F.ap(self)(f)
   final def tuple[B](f: F[B]): F[(A,B)] = F.tuple2(self,f)
 
-  /** Combine `self` and `fb` according to `Apply[F]` with a function that discards the `A`s */
-  final def *>[B](fb: F[B]): F[B] = F.apply2(self,fb)((_,b) => b)
+  /** Combine `self` and `fb` according to `Apply[F]` and discard the `A`(s) */
+  final def *>[B](fb: F[B]): F[B] = F.discardLeft(self,fb)
 
-  /** Combine `self` and `fb` according to `Apply[F]` with a function that discards the `B`s */
-  final def <*[B](fb: F[B]): F[A] = F.apply2(self,fb)((a,_) => a)
+  /** Combine `self` and `fb` according to `Apply[F]` and discard the `B`(s) */
+  final def <*[B](fb: F[B]): F[A] = F.discardRight(self,fb)
 
   /**
    * DSL for constructing Applicative expressions.
@@ -31,6 +31,12 @@ final class ApplyOps[F[_],A] private[syntax](val self: F[A])(implicit val F: App
   /** Alias for `|@|` */
   final def ⊛[B](fb: F[B]) = |@|(fb)
 
+  /**
+   * Repeats this applicative action infinitely.
+   */
+  final def forever[B]: F[B] = F.forever(self)
+
+  // Do not remove this comment; used as delimiter by `genTypeClasses` sbt task.
   ////
 }
 


### PR DESCRIPTION
* Added `*>` and `<*` to the instance, instead of just in the syntax.
* Added forever to syntax also.

Example usage:
```scala
import scalaz._, Scalaz._, effect._, IO._

val a: IO[Unit] = putStrLn("Hello, world!")
val b: IO[Unit] = a.forever
b.unsafePerformIO // prints "Hello, world!" forever
```