### PR TITLE
Make Inject[F, G] extend (F ~> G).

### DIFF
--- a/core/src/main/scala/scalaz/Inject.scala
+++ b/core/src/main/scala/scalaz/Inject.scala
@@ -7,7 +7,8 @@ import std.option.{none, some}
  *
  * @see [[http://www.staff.science.uu.nl/~swier004/Publications/DataTypesALaCarte.pdf]]
  */
-sealed abstract class Inject[F[_], G[_]] {
+sealed abstract class Inject[F[_], G[_]] extends (F ~> G) {
+  def apply[A](fa: F[A]): G[A] = inj(fa)
   def inj[A](fa: F[A]): G[A]
   def prj[A](ga: G[A]): Option[F[A]]
 }


### PR DESCRIPTION
This makes Inject[F, G] directly usable as an argument to Free[F, A]#mapSuspension().

```scala
val fa: Free[F, A] = ???
val ga: Free[G, A] = fa.mapSuspension(implicitly[Inject[F, G]])
```