### PR TITLE
Change after function to use scheduler instead of Timer

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Future.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Future.scala
@@ -276,11 +276,11 @@ sealed abstract class Future[+A] {
   /**
    * Returns a `Future` that delays the execution of this `Future` by the duration `t`.
    */
-  def after(t: Duration): Future[A] =
-    after(t.toMillis)
+  def after(t: Duration)(implicit scheduler:ScheduledExecutorService = Strategy.DefaultTimeoutScheduler): Future[A] =
+    schedule((), t)(scheduler).flatMap(_ => this)
 
-  def after(t: Long): Future[A] =
-    Timer.default.valueWait((), t).flatMap(_ => this)
+  def afterMillis(delay: Long)(implicit scheduler:ScheduledExecutorService = Strategy.DefaultTimeoutScheduler): Future[A] =
+    after(FiniteDuration(delay, TimeUnit.MILLISECONDS))(scheduler)
 }
 
 object Future {


### PR DESCRIPTION
I was trying out the Task#retry functionality in Task and I found that it uses a scalaz.concurrent.Timer to implement its logic, and it appears scalaz.concurrent.Timer uses Thread.sleep.

Following the example of Future#timed, which uses the ScheduledExecutorService, we can avoid the use of Thread.sleep in the implementation of Task#retry