### PR TITLE
Add Bifunctor widen

### DIFF
--- a/core/src/main/scala/scalaz/Bifunctor.scala
+++ b/core/src/main/scala/scalaz/Bifunctor.scala
@@ -62,6 +62,10 @@ trait Bifunctor[F[_, _]]  { self =>
   def embedRight[H[_]](implicit H0: Functor[H]): Bifunctor[λ[(α, β) => F[α,H[β]]]] = 
     embed[Id.Id,H]
 
+  /** Bifunctors are covariant by nature */
+  def widen[A, B, C >: A, D >: B](fab: F[A, B]): F[C, D] =
+    bimap(fab)(identity[C], identity[D])
+
   ////
   val bifunctorSyntax = new scalaz.syntax.BifunctorSyntax[F] { def F = Bifunctor.this }
 }

--- a/core/src/main/scala/scalaz/syntax/BifunctorSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/BifunctorSyntax.scala
@@ -15,6 +15,7 @@ final class BifunctorOps[F[_, _],A, B] private[syntax](val self: F[A, B])(implic
   final def leftMap[C](f: A => C): F[C, B] = F.bimap(self)(f, b => b)
   final def rightAs[C](c: => C): F[A, C] = F.bimap(self)(a => a, _ => c)
   final def leftAs[C](c: => C): F[C, B] = F.bimap(self)(_ => c, b => b)
+  final def widen[C >: A, D >: B]: F[C, D] = F.widen(self)
   ////
 }
 

--- a/example/src/main/scala/scalaz/example/BifunctorUsage.scala
+++ b/example/src/main/scala/scalaz/example/BifunctorUsage.scala
@@ -46,6 +46,9 @@ object BifunctorUsage extends App {
   // There is syntax for bimap:
   assert(("asdf",1).bimap(_.length, _+1) === (4,2))
 
+  // Bifunctors are covariant in both their type parameters, which is expressed by widen
+  assert(("asdf", 1).widen[Any, Any].isInstanceOf[(Any, Any)])
+
   //
   // leftMap / rightMap
   //


### PR DESCRIPTION
Adds a function `widen` to take advantage of the natural covariance of `Bifunctor`. I was initially going to implement this for `EitherT` because that was my use-case, but this is probably more useful.