### PR TITLE
Backport performance improvements to Free in series/7.1.x

### DIFF
--- a/core/src/main/scala/scalaz/Free.scala
+++ b/core/src/main/scala/scalaz/Free.scala
@@ -65,16 +65,30 @@ sealed abstract class Free[S[_], A] {
   final def fold[B](r: A => B, s: S[Free[S, A]] => B)(implicit S: Functor[S]): B =
     resume.fold(s, r)
 
-  /** Evaluates a single layer of the free monad. */
-  @tailrec final def resume(implicit S: Functor[S]): (S[Free[S, A]] \/ A) = this match {
-    case Return(a)  => \/-(a)
-    case Suspend(t) => -\/(t)
-    case x @ Gosub() => x.a() match {
-      case Return(a)   => x.f(a).resume
-      case Suspend(t)  => -\/(S.map(t)(_ flatMap x.f))
-      case y @ Gosub() => y.a().flatMap(z => y.f(z) flatMap x.f).resume
+  /* performs a bind type operation that does not cause expansion of Gosubs at the expense of not being tail recursive*/
+  private final def fastFlatMap[B](i: Int, f: A => Free[S,B])(implicit S: Functor[S]): Free[S,B] = 
+    this match {
+      case Return(a) => f(a)
+      case Suspend(t) => Suspend(S.map(t)(_ fastFlatMap(i+1, f)))
+      case a @ Gosub() => if (i < 500)
+                            a.a().fastFlatMap(i+1, aa => a.f(aa).fastFlatMap(i+1, f))
+                          else 
+                            gosub(a.a)(x => gosub(() => a.f(x))(f))
+      }
+  
+
+  /** Evaluates a single layer of the free monad **/
+  @tailrec final def resume(implicit S: Functor[S]): (S[Free[S,A]] \/ A) = 
+    this match {
+      case Return(a) => \/-(a)
+      case Suspend(t) => -\/(t)
+      case x @ Gosub() => x.a() match { 
+        case Return(a) => x.f(a).resume
+        case Suspend(t) => -\/(S.map(t)(_ fastFlatMap(0, x.f)))
+        case y @ Gosub() => 
+          y.a().fastFlatMap(0, (z => y.f(z).fastFlatMap(0, x.f) ) ).resume
+      }
     }
-  }
 
   /** Changes the suspension functor by the given natural transformation. */
   final def mapSuspension[T[_]](f: S ~> T)(implicit S: Functor[S], T: Functor[T]): Free[T, A] =


### PR DESCRIPTION
While investigating some performance regressions in one of our web services, I noticed that between scalaz 7.0.x and 7.1.x there was a performance degradation in `Free`. We use `IO` and `Free` heavily throughout our code so these had a noticeable impact.

While looking at the changes to `Free` in 7.2, I found this series of commits from @vmarquez. Hopeful, I back ported them to the series/7.1.x branch and did some testing. In my testing, I saw similar performance gains to what @vmarquez reported, yielding significant improvements in the response time and throughput of our service.

There were other significant changes to `Free` in 7.2 so that these changes ended up not being incorporated in that release. But those changes are not backwards compatible and these changes offer a quick performance win to anyone that cannot upgrade to 7.2 just yet.