### PR TITLE
Fix TreeLoc.fromForest

### DIFF
--- a/core/src/main/scala/scalaz/TreeLoc.scala
+++ b/core/src/main/scala/scalaz/TreeLoc.scala
@@ -439,8 +439,9 @@ object TreeLoc extends TreeLocInstances {
   def loc[A](t: Tree[A], l: TreeForest[A], r: TreeForest[A], p: Parents[A]): TreeLoc[A] =
     TreeLoc(t, l, r, p)
 
-  def fromForest[A](ts: TreeForest[A]) = ts match {
+  def fromForest[A](ts: TreeForest[A]): Option[TreeLoc[A]] = ts match {
     case (Stream.cons(t, ts)) => Some(loc(t, Stream.Empty, ts, Stream.Empty))
+    case _ => None
   }
 }
 

--- a/tests/src/test/scala/scalaz/TreeLocTest.scala
+++ b/tests/src/test/scala/scalaz/TreeLocTest.scala
@@ -1,10 +1,11 @@
 package scalaz
 
-import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalazArbitrary._
 import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll
+
+import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.scalacheck.ScalazProperties._
+import scalaz.std.AllInstances._
 
 object TreeLocTest extends SpecLite {
 
@@ -12,15 +13,18 @@ object TreeLocTest extends SpecLite {
   checkAll("TreeLoc", traverse1.laws[TreeLoc])
   checkAll(FoldableTests.anyAndAllLazy[TreeLoc])
 
-  "ScalazArbitrary.treeLocGenSized" ! forAll(Gen.choose(1, 200)){ size =>
+  "ScalazArbitrary.treeLocGenSized" ! forAll(Gen.choose(1, 200)) { size =>
     val gen = treeLocGenSized[Unit](size)
     Stream.continually(gen.sample).flatten.take(10).map(Foldable[TreeLoc].length(_)).forall(_ == size)
   }
 
   {
     def treeEqual[A: Equal]: Equal[Tree[A]] = new Equal[Tree[A]] {
+
       import std.stream.streamEqual
+
       def streamEqualApprox = streamEqual[Tree[A]].contramap((_: Stream[Tree[A]]).take(1000))
+
       def equal(a1: Tree[A], a2: Tree[A]) =
         Equal[A].equal(a1.rootLabel, a2.rootLabel) && streamEqualApprox.equal(a1.subForest, a2.subForest)
     }
@@ -29,11 +33,20 @@ object TreeLocTest extends SpecLite {
     checkAll("TreeLoc", comonad.laws[TreeLoc])
   }
 
+  "TreeLoc from empty forest does not throw an exception" ! {
+    import scalaz.std.option._
+    val result: Option[TreeLoc[Int]] = TreeLoc.fromForest(Stream.empty[Tree[Int]])
+    result must_==(none[TreeLoc[Int]])
+  }
+
+
   object instances {
     def equal[A: Equal] = Equal[TreeLoc[A]]
+
     def order[A: Order] = Order[TreeLoc[A]]
 
     // checking absence of ambiguity
     def equal[A: Order] = Equal[TreeLoc[A]]
   }
+
 }


### PR DESCRIPTION
fromForest did not handle empty streams and returned Some[TreeLoc[A]] instead of Option[TreeLoc[A]]