### PR TITLE
Make NonEmptyList#tails stack safe.

### DIFF
--- a/core/src/main/scala/scalaz/NonEmptyList.scala
+++ b/core/src/main/scala/scalaz/NonEmptyList.scala
@@ -66,10 +66,15 @@ final class NonEmptyList[A] private[scalaz](val head: A, val tail: IList[A]) {
   /** @since 7.0.2 */
   def last: A = tail.lastOption.getOrElse(head)
 
-  def tails: NonEmptyList[NonEmptyList[A]] = nel(this, tail match {
-    case INil()    => INil()
-    case ICons(h, t) => nel(h, t).tails.list
-  })
+  def tails: NonEmptyList[NonEmptyList[A]] = {
+    @annotation.tailrec
+    def tails0(as: NonEmptyList[A], accum: IList[NonEmptyList[A]]): NonEmptyList[NonEmptyList[A]] =
+      as.tail match {
+        case INil() => nel(as, accum).reverse
+        case ICons(h, t) => tails0(nel(h, t), as :: accum)
+      }
+    tails0(this, IList.empty)
+  }
 
   def reverse: NonEmptyList[A] = (list.reverse: @unchecked) match {
     case ICons(x, xs) => nel(x, xs)

--- a/tests/src/test/scala/scalaz/NonEmptyListTest.scala
+++ b/tests/src/test/scala/scalaz/NonEmptyListTest.scala
@@ -85,6 +85,17 @@ object NonEmptyListTest extends SpecLite {
     val largeNel = NonEmptyList.nel(0, IList.fromList((1 to 100000).toList))
     (largeNel map Option.apply).sequence must_===(Option(largeNel))
   }
+  "correctness of tails" ! forAll { xs: NonEmptyList[Int] =>
+    import NonEmptyList._
+    xs.tails must_=== nel(xs, xs.tail match {
+      case INil() => INil()
+      case ICons(h, t) => nel(h, t).tails.list
+    })
+  }
+  "stack-safety of tails" in {
+    val largeNel = NonEmptyList.nel(0, IList.fill(1000000)(0))
+    largeNel.tails.size must_== 1000001
+  }
   "toNel is self" ! forAll { xs: NonEmptyList[Int] =>
     Foldable1[NonEmptyList].toNel(xs) must_=== xs
   }


### PR DESCRIPTION
The original implementation was converted to a test of correctness.