### PR TITLE
Add method NonEmptyList#inits.

### DIFF
--- a/core/src/main/scala/scalaz/NonEmptyList.scala
+++ b/core/src/main/scala/scalaz/NonEmptyList.scala
@@ -63,6 +63,9 @@ final class NonEmptyList[A] private[scalaz](val head: A, val tail: IList[A]) {
   /** @since 7.0.2 */
   def init: IList[A] = tail.initOption.fold[IList[A]](INil())(il => head :: il)
 
+  def inits: NonEmptyList[NonEmptyList[A]] =
+    reverse.tails.map(_.reverse)
+
   /** @since 7.0.2 */
   def last: A = tail.lastOption.getOrElse(head)
 


### PR DESCRIPTION
`IList` has both `tails` and `inits`, so I think `NonEmptyList` should, too.

The implementation is in terms of `tails` and `reverse`, which is analogous to the implementation of `IList#inits`.