### PR TITLE
Add method IList#foreach.

### DIFF
--- a/core/src/main/scala/scalaz/IList.scala
+++ b/core/src/main/scala/scalaz/IList.scala
@@ -240,6 +240,9 @@ sealed abstract class IList[A] extends Product with Serializable {
   def map[B](f: A => B): IList[B] =
     foldRight(IList.empty[B])(f(_) :: _)
 
+  def foreach(f: A => Unit): Unit =
+    toList.foreach(f)
+
   // private helper for mapAccumLeft/Right below
   private[this] def mapAccum[B, C](as: IList[A])(c: C, f: (C, A) => (C, B)): (C, IList[B]) =
     as.foldLeft((c, IList.empty[B])) { case ((c, bs), a) => BFT.rightMap(f(c, a))(_ :: bs) }

--- a/core/src/main/scala/scalaz/NonEmptyList.scala
+++ b/core/src/main/scala/scalaz/NonEmptyList.scala
@@ -22,10 +22,8 @@ final class NonEmptyList[A] private[scalaz](val head: A, val tail: IList[A]) {
   def map[B](f: A => B): NonEmptyList[B] = nel(f(head), tail.map(f))
 
   /** @since 7.0.3 */
-  def foreach(f: A => Unit): Unit = {
-    f(head)
-    tail.toList.foreach(f)
-  }
+  def foreach(f: A => Unit): Unit =
+    list.foreach(f)
 
   def flatMap[B](f: A => NonEmptyList[B]): NonEmptyList[B] = {
     val rev = reverse


### PR DESCRIPTION
Since `NonEmptyList` already has a `foreach` method, I thought `IList` should, too.