### PR TITLE
Add a `filterLength` function

### DIFF
--- a/core/src/main/scala/scalaz/Foldable.scala
+++ b/core/src/main/scala/scalaz/Foldable.scala
@@ -177,6 +177,9 @@ trait Foldable[F[_]]  { self =>
   def anyM[G[_], A](fa: F[A])(p: A => G[Boolean])(implicit G: Monad[G]): G[Boolean] =
     foldRight(fa, G.point(false))((a, b) => G.bind(p(a))(q => if(q) G.point(true) else b))
 
+  def filterLength[A](fa: F[A])(f: A => Boolean): Int =
+    foldLeft(fa, 0)((b, a) => (if (f(a)) 1 else 0) + b)
+
   import Ordering.{GT, LT}
   import std.option.{some, none}
 

--- a/core/src/main/scala/scalaz/syntax/FoldableSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/FoldableSyntax.scala
@@ -49,6 +49,7 @@ final class FoldableOps[F[_],A] private[syntax](val self: F[A])(implicit val F: 
   final def anyM[G[_]: Monad](p: A => G[Boolean]): G[Boolean] = F.anyM(self)(p)
   final def any(p: A => Boolean): Boolean = F.any(self)(p)
   final def ∃(p: A => Boolean): Boolean = F.any(self)(p)
+  final def filterLength(p: A => Boolean): Int = F.filterLength(self)(p)
   final def count: Int = F.count(self)
   final def maximum(implicit A: Order[A]): Option[A] = F.maximum(self)
   final def maximumOf[B: Order](f: A => B): Option[B] = F.maximumOf(self)(f)


### PR DESCRIPTION
Counts how many matches of a predicate occur in a Foldable.

The same as:

    filterLength f = length . filter f

But this version is manually fused, for better efficiency in Scala.