### PR TITLE
[WIP. Don't merge] scalacheck 1.13.0

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -56,7 +56,7 @@ object build extends Build {
     crossScalaVersions := Seq("2.10.6", "2.11.7", "2.12.0-M3"),
     resolvers ++= (if (scalaVersion.value.endsWith("-SNAPSHOT")) List(Opts.resolver.sonatypeSnapshots) else Nil),
     fullResolvers ~= {_.filterNot(_.name == "jcenter")}, // https://github.com/sbt/sbt/issues/2217
-    scalaCheckVersion := "1.12.5",
+    scalaCheckVersion := "1.13.0",
     scalacOptions ++= Seq(
       // contains -language:postfixOps (because 1+ as a parameter to a higher-order function is treated as a postfix op)
       "-deprecation",

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalaCheckBinding.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalaCheckBinding.scala
@@ -5,7 +5,7 @@ package scalacheck
  * Type class instances for types from [[https://github.com/rickynils/scalacheck Scalacheck]]
  */
 object ScalaCheckBinding {
-  import org.scalacheck.{Gen, Arbitrary, Shrink}
+  import org.scalacheck.{Cogen, Gen, Arbitrary, Shrink}
   import Gen.{sized, const}
 
   implicit val ArbitraryMonad: Monad[Arbitrary] = new Monad[Arbitrary] {
@@ -18,6 +18,18 @@ object ScalaCheckBinding {
     def point[A](a: => A) = sized(_ => const(a))
     def bind[A, B](fa: Gen[A])(f: A => Gen[B]) = fa flatMap f
     override def map[A, B](fa: Gen[A])(f: A => B) = fa map f
+  }
+
+  implicit val CogenInstance: Divisible[Cogen] = new Divisible[Cogen] {
+    def contramap[A, B](a: Cogen[A])(f: B => A) =
+      a contramap f
+    override def conquer[A] =
+      Cogen((seed, _) => seed)
+    override def divide[A, B, C](fa: Cogen[A], fb: Cogen[B])(f: C => (A, B)) =
+      Cogen{ (seed, c) =>
+        val (a, b) = f(c)
+        fb.perturb(fa.perturb(seed, a), b)
+      }
   }
 
   implicit val ShrinkFunctor: InvariantFunctor[Shrink] =

--- a/tests/src/test/scala/scalaz/CoKleisliTest.scala
+++ b/tests/src/test/scala/scalaz/CoKleisliTest.scala
@@ -5,6 +5,7 @@ import org.scalacheck.{Arbitrary, Gen}
 
 object CokleisliTest extends SpecLite {
 
+  // TODO https://github.com/rickynils/scalacheck/issues/190
   implicit val cokleisliArb1: Arbitrary[Cokleisli[Option, Int, Int]] = {
     def arb(f: (Option[Int], Int, Int) => Int): Gen[Cokleisli[Option, Int, Int]] =
       for{
@@ -20,6 +21,7 @@ object CokleisliTest extends SpecLite {
     ))
   }
 
+  // TODO https://github.com/rickynils/scalacheck/issues/190
   implicit val cokleisliArb2: Arbitrary[Cokleisli[Option, Int, Int => Int]] = {
     def arb(f: (Option[Int], Int) => (Int => Int)): Gen[Cokleisli[Option, Int, Int => Int]] =
       implicitly[Arbitrary[Int]].arbitrary.map(a => Cokleisli[Option, Int, Int => Int](f(_, a)))

--- a/tests/src/test/scala/scalaz/CofreeTest.scala
+++ b/tests/src/test/scala/scalaz/CofreeTest.scala
@@ -5,7 +5,7 @@ import scalaz.scalacheck.ScalazProperties._
 import scalaz.scalacheck.ScalazArbitrary._
 import scalaz.scalacheck.ScalaCheckBinding._
 import std.AllInstances._
-import org.scalacheck.Arbitrary
+import org.scalacheck.{Arbitrary, Cogen}
 import org.scalacheck.Prop.forAll
 import Cofree._
 import Cofree.CofreeZip
@@ -40,14 +40,21 @@ object CofreeTest extends SpecLite {
     }
   }
  
-  val oneAndListNat: OneAndList ~> CofreeOption =
-    new (OneAndList ~> CofreeOption) {
-      def apply[A](fa: OneAndList[A]): CofreeOption[A] =
+  val oneAndListCofreeOptionIso: OneAndList <~> CofreeOption =
+    new IsoFunctorTemplate[OneAndList, CofreeOption] {
+      def to[A](fa: OneAndList[A]) =
         Cofree.unfold(fa) {
           case OneAnd(a, h :: t) => 
             (a, Some(OneAnd(h, t)))
           case OneAnd(a, _) => (a, None)
         }
+      def from[A](ga: CofreeOption[A]) =
+        OneAnd(
+          ga.head,
+          ga.tail.map(s =>
+            Foldable[CofreeOption].foldRight(s, List.empty[A])(_ :: _)
+          ).getOrElse(Nil)
+        )
     }
 
   val oneAndStreamCofreeLazyOptionIso: OneAndStream <~> CofreeLazyOption =
@@ -80,14 +87,22 @@ object CofreeTest extends SpecLite {
   implicit def CofreeStreamArb[A: Arbitrary]: Arbitrary[CofreeStream[A]] =
     Functor[Arbitrary].map(implicitly[Arbitrary[Tree[A]]])(treeCofreeStreamIso.to)
 
+  implicit def CofreeLazyOptionCogen[A: Cogen]: Cogen[CofreeLazyOption[A]] =
+    implicitly[Cogen[OneAndStream[A]]].contramap(oneAndStreamCofreeLazyOptionIso.from)
+
+  implicit def CofreeStreamCogen[A: Cogen]: Cogen[CofreeStream[A]] =
+    implicitly[Cogen[Tree[A]]].contramap(treeCofreeStreamIso.from)
+
+  implicit def CofreeOptionCogen[A: Cogen]: Cogen[CofreeOption[A]] =
+    implicitly[Cogen[OneAndList[A]]].contramap(oneAndListCofreeOptionIso.from)
 
   implicit def CofreeOptionArb[A: Arbitrary]: Arbitrary[CofreeOption[A]] = {
     import org.scalacheck.Arbitrary._
     import org.scalacheck.Gen
     val arb = Arbitrary { Gen.listOfN(5000, implicitly[Arbitrary[A]].arbitrary ) }   
     Functor[Arbitrary].map(arb){ 
-      case h :: Nil => oneAndListNat( OneAnd(h, Nil))
-      case h :: t => oneAndListNat( OneAnd(h, t) )
+      case h :: Nil => oneAndListCofreeOptionIso.to( OneAnd(h, Nil))
+      case h :: t => oneAndListCofreeOptionIso.to( OneAnd(h, t) )
     }    
   }
 

--- a/tests/src/test/scala/scalaz/SpecLite.scala
+++ b/tests/src/test/scala/scalaz/SpecLite.scala
@@ -42,8 +42,8 @@ abstract class SpecLite extends Properties("") {
       context = s; try a finally context = saved
     }
     def ![A](a: => A)(implicit ev: (A) => Prop): Unit = in(a)
-    def in[A](a: => A)(implicit ev: (A) => Prop): Unit = property(context + ":" + s) = new Prop {
-      def apply(prms: Parameters): Result = ev(a).apply(prms) // TODO sort out the laziness / implicit conversions properly
+    def in[A](a: => A)(implicit ev: (A) => Prop): Unit = property(context + ":" + s) = Prop { prms =>
+      ev(a).apply(prms) // TODO sort out the laziness / implicit conversions properly
     }
   }
 

--- a/tests/src/test/scala/scalaz/StoreTTest.scala
+++ b/tests/src/test/scala/scalaz/StoreTTest.scala
@@ -1,10 +1,16 @@
 package scalaz
 
-import std.AllInstances._
-import scalaz.scalacheck.ScalazProperties._
+import org.scalacheck.Cogen
+
 import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.scalacheck.ScalazProperties._
+import scalaz.std.AllInstances._
 
 object StoreTTest extends SpecLite {
+
+  // https://github.com/rickynils/scalacheck/issues/190
+  private[this] implicit def storeTCogen[F[_], A, B, I: Cogen]: Cogen[IndexedStoreT[F, I, A, B]] =
+    Cogen[I].contramap(_.run._2)
 
   implicit def storeTuple1IntEqual = new Equal[StoreT[Tuple1, Int, Int]] {
     def equal(a1: StoreT[Tuple1, Int, Int], a2: StoreT[Tuple1, Int, Int]) = (a1.run, a2.run) match {

--- a/tests/src/test/scala/scalaz/UnwriterTTest.scala
+++ b/tests/src/test/scala/scalaz/UnwriterTTest.scala
@@ -4,7 +4,7 @@ import scalaz.scalacheck.ScalazProperties._
 import scalaz.scalacheck.ScalazArbitrary._
 import scalaz.scalacheck.ScalaCheckBinding._
 import std.AllInstances._
-import org.scalacheck.Arbitrary
+import org.scalacheck.{Cogen, Arbitrary}
 
 object UnwriterTTest extends SpecLite {
 
@@ -18,6 +18,9 @@ object UnwriterTTest extends SpecLite {
 
   implicit def UnwriterArb[F[_], W, A](implicit W: Arbitrary[W], A: Arbitrary[A]): Arbitrary[Unwriter[W, A]] =
     Applicative[Arbitrary].apply2(W, A)(Unwriter(_, _))
+
+  private[this] implicit def unwriterCogen[W: Cogen, A: Cogen]: Cogen[Unwriter[W, A]] =
+    Cogen[(W, A)].contramap(_.run)
 
   checkAll(comonad.laws[Unwriter[Int, ?]])
 

--- a/tests/src/test/scala/scalaz/WriterTTest.scala
+++ b/tests/src/test/scala/scalaz/WriterTTest.scala
@@ -4,7 +4,7 @@ import scalaz.scalacheck.ScalazProperties._
 import scalaz.scalacheck.ScalazArbitrary._
 import scalaz.scalacheck.ScalaCheckBinding._
 import std.AllInstances._
-import org.scalacheck.Arbitrary
+import org.scalacheck.{Cogen, Arbitrary}
 import Id._
 import org.scalacheck.Prop.forAll
 
@@ -27,6 +27,9 @@ object WriterTTest extends SpecLite {
 
   implicit def writerArb[W, A](implicit W: Arbitrary[W], A: Arbitrary[A]): Arbitrary[Writer[W, A]] =
     Applicative[Arbitrary].apply2(W, A)((w, a) => Writer[W, A](w, a))
+
+  private[this] implicit def writerCogen[W: Cogen, A: Cogen]: Cogen[Writer[W, A]] =
+    Cogen[(W, A)].contramap(_.run)
 
   checkAll(comonad.laws[Writer[Int, ?]])
 

--- a/tests/src/test/scala/scalaz/std/FunctionTest.scala
+++ b/tests/src/test/scala/scalaz/std/FunctionTest.scala
@@ -1,6 +1,8 @@
 package scalaz
 package std
 
+import org.scalacheck.Cogen
+
 import std.AllInstances._
 import std.AllFunctions.fix
 import scalaz.scalacheck.ScalazProperties._
@@ -28,6 +30,10 @@ object FunctionTest extends SpecLite {
   implicit def EqualFunction3 = Equal.equalBy[(Int, Int, Int) => Int, Int](_.apply(0, 0, 0))
   implicit def EqualFunction4 = Equal.equalBy[(Int, Int, Int, Int) => Int, Int](_.apply(0, 0, 0, 0))
   implicit def EqualFunction5 = Equal.equalBy[(Int, Int, Int, Int, Int) => Int, Int](_.apply(0, 0, 0, 0, 0))
+
+  // https://github.com/rickynils/scalacheck/issues/190
+  private[this] implicit def function1Cogen[A, B]: Cogen[A => B] =
+    Cogen(_ => 0)
 
   checkAll("Function1", monoid.laws[Int => Int])
 

--- a/tests/src/test/scala/scalaz/std/FutureTest.scala
+++ b/tests/src/test/scala/scalaz/std/FutureTest.scala
@@ -3,7 +3,7 @@ package std
 
 import _root_.java.util.concurrent.Executors
 
-import org.scalacheck.Arbitrary
+import org.scalacheck.{Cogen, Arbitrary}
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Prop.forAll
 
@@ -18,6 +18,9 @@ import scala.concurrent.duration._
 class FutureTest extends SpecLite {
 
   val duration: Duration = 1.seconds
+
+  private[this] implicit def cogenFuture[A: Cogen]: Cogen[Future[A]] =
+    Cogen[A].contramap(scala.concurrent.Await.result(_, duration))
 
   implicit val throwableEqual: Equal[Throwable] = Equal.equalA[Throwable]
 
@@ -41,11 +44,14 @@ class FutureTest extends SpecLite {
 
   implicit val ArbitraryThrowable: Arbitrary[Throwable] = Arbitrary(arbitrary[Int].map(SomeFailure))
 
+  implicit val cogenThrowable: Cogen[Throwable] =
+    Cogen[Int].contramap(_.asInstanceOf[SomeFailure].n)
+
   checkAll(monoid.laws[Future[Int]])
   checkAll(monoid.laws[Future[Int @@ Multiplication]])
 
   // For some reason ArbitraryThrowable isn't being chosen by scalac, so we give it explicitly.
-  checkAll(monadError.laws[Future, Throwable](implicitly, implicitly, implicitly, implicitly, ArbitraryThrowable))
+  checkAll(monadError.laws[Future, Throwable](implicitly, implicitly, implicitly, implicitly, ArbitraryThrowable, implicitly))
 
   // Scope these away from the rest as Comonad[Future] is a little evil.
   // Should fail to compile by default: implicitly[Comonad[Future]]

--- a/tests/src/test/scala/scalaz/std/MapTest.scala
+++ b/tests/src/test/scala/scalaz/std/MapTest.scala
@@ -24,7 +24,7 @@ abstract class XMapTest[Map[K, V] <: SMap[K, V] with MapLike[K, V, Map[K, V]], B
   checkAll(order.laws[Map[Int,String]])
   checkAll(equal.laws[Map[Int,String]])
 
-  "satisfy equals laws when not natural" ! equal.laws[Map[NotNatural, String]]
+  checkAll("satisfy equals laws when not natural", equal.laws[Map[NotNatural, String]])
 
   implicit def mapArb[A: Arbitrary: BKC, B: Arbitrary]: Arbitrary[Map[A, B]] =
     Arbitrary(arbitrary[SMap[A, B]] map (m => fromSeq(m.toSeq:_*)))

--- a/tests/src/test/scala/scalaz/std/StreamTest.scala
+++ b/tests/src/test/scala/scalaz/std/StreamTest.scala
@@ -2,6 +2,7 @@ package scalaz
 package std
 
 import std.AllInstances._
+import scalaz.scalacheck.ScalazArbitrary._
 import scalaz.scalacheck.ScalazProperties._
 import org.scalacheck.Prop.forAll
 


### PR DESCRIPTION

https://travis-ci.org/xuwei-k/scalaz/jobs/107306187#L4398

```
[info] ! scalaz.CofreeTest.CofreeStream:monad.left identity: Exception raised on property evaluation.
[info] > ARG_0: -1
[info] > ARG_1: <function1>
[info] > Exception: java.util.NoSuchElementException: None.get
```

I think scalacheck is broken... :(