### PR TITLE
Fix IMap/ISet to support lazy folding, and optimise intermediary operations

### DIFF
--- a/core/src/main/scala/scalaz/EphemeralStream.scala
+++ b/core/src/main/scala/scalaz/EphemeralStream.scala
@@ -2,6 +2,8 @@ package scalaz
 
 import java.lang.ref.WeakReference
 
+import scala.annotation.tailrec
+
 /** Like [[scala.collection.immutable.Stream]], but doesn't save
   * computed values.  As such, it can be used to represent similar
   * things, but without the space leak problem frequently encountered
@@ -102,6 +104,14 @@ sealed abstract class EphemeralStream[A] {
       emptyEphemeralStream
     else
       cons((head(), b.head()), tail() zip b.tail())
+
+  def zipLongest[B](b: => EphemeralStream[B]): EphemeralStream[A \&/ B] =
+    if (isEmpty)
+      b.map(\&/.That(_))
+    else if (b.isEmpty)
+      map(\&/.This(_))
+    else
+      cons(\&/.Both(head(), b.head()), tail() zipLongest b.tail())
 
   def unzip[X, Y](implicit ev: A <:< (X, Y)): (EphemeralStream[X], EphemeralStream[Y]) =
     foldRight((emptyEphemeralStream[X], emptyEphemeralStream[Y]))(q => r =>
@@ -239,9 +249,44 @@ sealed abstract class EphemeralStreamInstances {
     }
   }
 
-  import std.list._
+  implicit def ephemeralStreamEqual[A: Equal]: Equal[EphemeralStream[A]] = Equal.equal { (a, b) =>
+    val E = Equal[A]
+    (a zipLongest b).foldLeft(true) {
+      case false => _ => false   // short circuit.
+      case true  => {
+        case \&/.Both(x, y) => E.equal(x, y)
+        case _              => false
+      }
+    }
+  }
 
-  implicit def ephemeralStreamEqual[A: Equal]: Equal[EphemeralStream[A]] = Equal[List[A]] contramap {(_: EphemeralStream[A]).toList}
+  implicit def ephemeralStreamOrder[A: Order]: Order[EphemeralStream[A]] = Order.order { (a, b) =>
+    val O = Order[A]
+    import scalaz.Ordering._
+    (a zipLongest b).foldLeft(EQ: Ordering) {
+      case EQ    => {
+        case \&/.Both(x, y) => O.order(x, y)
+        case \&/.This(x)    => GT
+        case \&/.That(x)    => LT
+      }
+      case other => _ => other   // short circuit.
+    }
+  }
+
+  implicit def ephemeralStreamShow[A: Show]: Show[EphemeralStream[A]] = Show.show { stm =>
+    val A = Show[A]
+
+    @tailrec
+    def commaSep(rest: EphemeralStream[A], acc: Cord): Cord =
+      rest.headOption match {
+        case None    => acc
+        case Some(x) => commaSep(rest.tail(), (acc :+ ",") ++ A.show(x))
+      }
+    "[" +: (stm.headOption match {
+      case None    => Cord()
+      case Some(x) => commaSep(stm.tail(), A.show(x))
+    }) :+ "]"
+  }
 }
 
 trait EphemeralStreamFunctions {

--- a/core/src/main/scala/scalaz/EphemeralStream.scala
+++ b/core/src/main/scala/scalaz/EphemeralStream.scala
@@ -214,7 +214,7 @@ sealed abstract class EphemeralStreamInstances {
     override def foldRight[A, B](fa: EphemeralStream[A], z: => B)(f: (A, => B) => B): B =
       if(fa.isEmpty) z else f(fa.head(), foldRight(fa.tail(), z)(f))
     override def foldMap[A, B](fa: EphemeralStream[A])(f: A => B)(implicit M: Monoid[B]) =
-      this.foldRight(fa, M.zero)((a, b) => M.append(f(a), b))
+      this.foldLeft(fa, M.zero)((b, a) => M.append(b, f(a)))
     override def foldLeft[A, B](fa: EphemeralStream[A], z: B)(f: (B, A) => B) =
       fa.foldLeft(z)(b => a => f(b, a))
     override def zipWithL[A, B, C](fa: EphemeralStream[A], fb: EphemeralStream[B])(f: (A, Option[B]) => C) = {

--- a/core/src/main/scala/scalaz/ISet.scala
+++ b/core/src/main/scala/scalaz/ISet.scala
@@ -622,7 +622,7 @@ sealed abstract class ISetInstances {
       }
 
     def foldRight[A, B](fa: ISet[A], z: => B)(f: (A, => B) => B): B =
-      fa.foldRight(z)((a, b) => f(a, b))
+      fa.foldRightLazy(z)(f)
 
     override def foldLeft[A, B](fa: ISet[A], z: B)(f: (B, A) => B) =
       fa.foldLeft(z)(f)

--- a/core/src/main/scala/scalaz/ISet.scala
+++ b/core/src/main/scala/scalaz/ISet.scala
@@ -350,20 +350,24 @@ sealed abstract class ISet[A] {
     fromList(toList.map(f))
 
   // -- * Folds
-  final def foldRight[B](z: B)(f: (A, B) => B): B =
+  final def foldRight[B](z: B)(f: (A, B) => B): B = foldRightLazy(z)((a, b) => f(a, b))
+
+  final def foldRightLazy[B](z: => B)(f: (A, => B) => B): B =
     this match {
       case Tip() => z
-      case Bin(x, l ,r) => l.foldRight(f(x, r.foldRight(z)(f)))(f)
+      case Bin(x, l ,r) => l.foldRightLazy(f(x, r.foldRightLazy(z)(f)))(f)
     }
 
   final def foldr[B](z: B)(f: (A, B) => B): B =
     foldRight(z)(f)
 
-  final def foldLeft[B](z: B)(f: (B, A) => B): B =
+  final def foldLeft[B](z: B)(f: (B, A) => B): B =  foldLeftLazy(z)((b, a) => f(b, a))
+
+  final def foldLeftLazy[B](z: => B)(f: (=> B, A) => B): B =
     this match {
       case Tip() => z
       case Bin(x, l, r) =>
-        r.foldLeft(f(l.foldLeft(z)(f), x))(f)
+        r.foldLeftLazy(f(l.foldLeftLazy(z)(f), x))(f)
     }
 
   final def foldl[B](z: B)(f: (B, A) => B): B =

--- a/core/src/main/scala/scalaz/ISet.scala
+++ b/core/src/main/scala/scalaz/ISet.scala
@@ -347,7 +347,7 @@ sealed abstract class ISet[A] {
     }}}
     */
   def map[B: Order](f: A => B) =
-    fromList(toList.map(f))
+    fromEphemeralStream(toAscEphemeralStream.map(f))
 
   // -- * Folds
   final def foldRight[B](z: B)(f: (A, B) => B): B = foldRightLazy(z)((a, b) => f(a, b))
@@ -449,6 +449,13 @@ sealed abstract class ISet[A] {
 
   final def toDescList =
     foldLeft(List.empty[A])((a, b) => b :: a)
+
+  // -- ** EphemeralStream
+  def toAscEphemeralStream: EphemeralStream[A] =
+    foldRightLazy(EphemeralStream[A]())((x, xs) => x ##:: xs)
+
+  def toDescEphemeralStream: EphemeralStream[A] =
+    foldLeftLazy(EphemeralStream[A]())((xs, x) => x ##:: xs)
 
   private def glue[A](l: ISet[A], r: ISet[A]): ISet[A] =
     (l, r) match {
@@ -560,8 +567,10 @@ sealed abstract class ISet[A] {
         false
     }
 
-  override def hashCode: Int =
-    toAscList.hashCode
+  override def hashCode: Int = {
+    val stm = toAscEphemeralStream
+    scala.util.hashing.MurmurHash3.orderedHash(EphemeralStream.toIterable(stm).iterator)
+  }
 }
 
 object ISet extends ISetInstances with ISetFunctions {
@@ -589,13 +598,11 @@ sealed abstract class ISetInstances {
     def A = implicitly
 
     def order(x: ISet[A], y: ISet[A]) =
-      Order[List[A]].order(x.toAscList, y.toAscList)
+      Order[EphemeralStream[A]].order(x.toAscEphemeralStream, y.toAscEphemeralStream)
   }
 
-  implicit def setShow[A: Show]: Show[ISet[A]] = new Show[ISet[A]] {
-    override def shows(f: ISet[A]) =
-      f.toAscList.mkString("ISet(", ",", ")")
-  }
+  implicit def setShow[A: Show]: Show[ISet[A]] =
+    Contravariant[Show].contramap(Show[EphemeralStream[A]])(_.toAscEphemeralStream)
 
   implicit def setMonoid[A: Order]: Monoid[ISet[A]] = new Monoid[ISet[A]] {
     def zero: ISet[A] =
@@ -692,6 +699,9 @@ sealed trait ISetFunctions {
   final def fromFoldable[F[_], A](xs: F[A])(implicit F: Foldable[F], o: Order[A]): ISet[A] =
     F.foldLeft(xs, empty[A])((a, b) => a insert b)
 
+  final def fromEphemeralStream[A](xs: EphemeralStream[A])(implicit o: Order[A]): ISet[A] =
+    xs.foldLeft(empty[A])(a => b => a insert b)
+
   final def unions[A](xs: List[ISet[A]])(implicit o: Order[A]): ISet[A] =
     xs.foldLeft(ISet.empty[A])(_ union _)
 
@@ -768,5 +778,5 @@ private sealed trait ISetEqual[A] extends Equal[ISet[A]] {
   implicit def A: Equal[A]
 
   override final def equal(a1: ISet[A], a2: ISet[A]) =
-    (a1.size == a2.size) && Equal[List[A]].equal(a1.toAscList, a2.toAscList)
+    (a1.size == a2.size) && Equal[EphemeralStream[A]].equal(a1.toAscEphemeralStream, a2.toAscEphemeralStream)
 }

--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -1045,7 +1045,7 @@ sealed abstract class MapInstances extends MapInstances0 {
         }
 
       override def foldRight[A, B](fa: S ==>> A, z: => B)(f: (A, => B) => B) =
-        fa.foldrWithKey(z)((_, b, acc) => f(b, acc))
+        fa.foldrWithKeyLazy(z)((_, b, acc) => f(b, acc))
 
       override def foldLeft[A, B](fa: S ==>> A, z: B)(f: (B, A) => B) =
         fa.foldlWithKey(z)((acc, _, b) => f(acc, b))
@@ -1093,7 +1093,7 @@ sealed abstract class MapInstances extends MapInstances0 {
       }
 
     def bifoldRight[A,B,C](fa: A ==>> B, z: => C)(f: (A, => C) => C)(g: (B, => C) => C): C =
-      fa.foldrWithKey(z)((a, b, c) => f(a, g(b, c)))
+      fa.foldrWithKeyLazy(z)((a, b, c) => f(a, g(b, c)))
 
     override def bifoldLeft[A,B,C](fa: A ==>> B, z: C)(f: (C, A) => C)(g: (C, B) => C): C =
       fa.foldlWithKey(z)((c, a, b) => g(f(c, a), b))

--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -494,26 +494,30 @@ sealed abstract class ==>>[A, B] {
     foldlWithKey(empty[C, B])((xs, k, x) => xs.insert(f(k), x))
 
   def mapKeysWith[C](f: A => C, f2: (B, B) => B)(implicit o: Order[C]): C ==>> B =
-    fromListWith[C, B](toList.map(x => (f(x._1), x._2)))(f2)
+    fromEphemeralStreamWith[C, B](toAscEphemeralStream.map(x => (f(x._1), x._2)))(f2)
 
   /* Folds */
   def fold[C](z: C)(f: (A, B, C) => C): C =
     foldrWithKey(z)(f)
 
-  def foldlWithKey[C](z: C)(f:  (C, A, B) => C): C =
+  def foldlWithKey[C](z: C)(f:  (C, A, B) => C): C = foldlWithKeyLazy(z)((c, a, b) => f(c, a, b))
+
+  def foldlWithKeyLazy[C](z: => C)(f:  (=> C, A, B) => C): C =
     this match {
       case Tip() =>
         z
       case Bin(kx, x, l, r) =>
-        r.foldlWithKey(f(l.foldlWithKey(z)(f), kx, x))(f)
+        r.foldlWithKeyLazy(f(l.foldlWithKeyLazy(z)(f), kx, x))(f)
     }
 
-  def foldrWithKey[C](z: C)(f: (A, B, C) => C): C =
+  def foldrWithKey[C](z: C)(f: (A, B, C) => C): C = foldrWithKeyLazy(z)((a, b, c) => f(a, b, c))
+
+  def foldrWithKeyLazy[C](z: => C)(f: (A, B, => C) => C): C =
     this match {
       case Tip() =>
         z
       case Bin(kx, x, l, r) =>
-        l.foldrWithKey(f(kx, x, r.foldrWithKey(z)(f)))(f)
+        l.foldrWithKeyLazy(f(kx, x, r.foldrWithKeyLazy(z)(f)))(f)
     }
 
   /* Unions */

--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -232,6 +232,12 @@ sealed abstract class ==>>[A, B] {
   def toDescList: List[(A, B)] =
     foldlWithKey(List.empty[(A, B)])((xs, k, x) => (k, x) :: xs)
 
+  def toAscEphemeralStream: EphemeralStream[(A, B)] =
+    foldrWithKeyLazy(EphemeralStream[(A, B)]())((k, x, xs) => (k, x) ##:: xs)
+
+  def toDescEphemeralStream: EphemeralStream[(A, B)] =
+    foldlWithKeyLazy(EphemeralStream[(A, B)]())((xs, k, x) => (k, x) ##:: xs)
+
   def member(k: A)(implicit n: Order[A]) =
     lookup(k)(n).isDefined
 
@@ -869,8 +875,10 @@ sealed abstract class ==>>[A, B] {
         false
     }
 
-  override def hashCode: Int =
-    toAscList.hashCode
+  override def hashCode: Int = {
+    val stm = toAscEphemeralStream
+    scala.util.hashing.MurmurHash3.orderedHash(EphemeralStream.toIterable(stm).iterator)
+  }
 
   // filters on keys
   private def filterGt(f: A => Ordering)(implicit o: Order[A]): A ==>> B =
@@ -1002,7 +1010,7 @@ sealed abstract class MapInstances extends MapInstances0 {
   import std.tuple._
 
   implicit def mapShow[A: Show, B: Show]: Show[==>>[A, B]] =
-    Contravariant[Show].contramap(Show[List[(A, B)]])(_.toAscList)
+    Contravariant[Show].contramap(Show[EphemeralStream[(A, B)]])(_.toAscEphemeralStream)
 
   implicit def mapEqual[A: Equal, B: Equal]: Equal[A ==>> B] =
     new MapEqual[A, B] {def A = implicitly; def B = implicitly}
@@ -1012,7 +1020,7 @@ sealed abstract class MapInstances extends MapInstances0 {
       def A = implicitly
       def B = implicitly
       def order(o1: A ==>> B, o2: A ==>> B) =
-        Order[List[(A,B)]].order(o1.toAscList, o2.toAscList)
+        Order[EphemeralStream[(A,B)]].order(o1.toAscEphemeralStream, o2.toAscEphemeralStream)
     }
 
   implicit def mapUnion[A, B](implicit A: Order[A], B: Semigroup[B]): Monoid[A ==>> B] =
@@ -1099,7 +1107,7 @@ private[scalaz] sealed trait MapEqual[A, B] extends Equal[A ==>> B] {
   implicit def A: Equal[A]
   implicit def B: Equal[B]
   final override def equal(a1: A ==>> B, a2: A ==>> B) =
-    Equal[Int].equal(a1.size, a2.size) && Equal[List[(A, B)]].equal(a1.toAscList, a2.toAscList)
+    Equal[Int].equal(a1.size, a2.size) && Equal[EphemeralStream[(A, B)]].equal(a1.toAscEphemeralStream, a2.toAscEphemeralStream)
 }
 
 trait MapFunctions {
@@ -1133,6 +1141,16 @@ trait MapFunctions {
 
   final def fromFoldableWithKey[F[_]: Foldable, A: Order, B](fa: F[(A, B)])(f: (A, B, B) => B): A ==>> B =
     Foldable[F].foldLeft(fa, empty[A, B])((a, c) => a.insertWithKey(f, c._1, c._2))
+
+  /* EphemeralStream operations */
+  final def fromEphemeralStream[A: Order, B](s: EphemeralStream[(A, B)]): A ==>> B =
+    s.foldLeft(empty[A, B]) { t => x => t.insert(x._1, x._2) }
+
+  final def fromEphemeralStreamWith[A: Order, B](s: EphemeralStream[(A, B)])(f: (B, B) => B): A ==>> B =
+    fromEphemeralStreamWithKey(s)((_, x, y) => f(x, y))
+
+  final def fromEphemeralStreamWithKey[A: Order, B](s: EphemeralStream[(A, B)])(f: (A, B, B) => B): A ==>> B =
+    s.foldLeft(empty[A, B])(a => c => a.insertWithKey(f, c._1, c._2))
 
   final def unions[A: Order, B](xs: List[A ==>> B]): A ==>> B =
     xs.foldLeft(empty[A, B])((a, c) => a.union(c))

--- a/tests/src/test/scala/scalaz/EphemeralStreamTest.scala
+++ b/tests/src/test/scala/scalaz/EphemeralStreamTest.scala
@@ -9,6 +9,7 @@ import org.scalacheck.Prop.forAll
 object EphemeralStreamTest extends SpecLite {
 
   checkAll(equal.laws[EphemeralStream[Int]])
+  checkAll(order.laws[EphemeralStream[Int]])
   checkAll(monadPlus.strongLaws[EphemeralStream])
   checkAll(isEmpty.laws[EphemeralStream])
   checkAll(traverse.laws[EphemeralStream])
@@ -16,8 +17,12 @@ object EphemeralStreamTest extends SpecLite {
   checkAll(align.laws[EphemeralStream])
   checkAll(cobind.laws[EphemeralStream])
 
-  implicit def ephemeralStreamShow[A: Show]: Show[EphemeralStream[A]] =
+  def ephemeralStreamSlowShow[A: Show]: Show[EphemeralStream[A]] =
     Show[List[A]].contramap(_.toList)
+
+  "show" ! forAll{ e: EphemeralStream[Int] =>
+    implicitly[Show[EphemeralStream[Int]]].show(e) must_===(ephemeralStreamSlowShow[Int].show(e))
+  }
 
   "reverse" ! forAll{ e: EphemeralStream[Int] =>
     e.reverse.toList must_===(e.toList.reverse)
@@ -39,8 +44,17 @@ object EphemeralStreamTest extends SpecLite {
     (firsts zip seconds) must_===(xs)
   }
 
+  "unzip zipLongest" ! forAll { xs: EphemeralStream[(Int, Int)] =>
+    val (firsts, seconds) = xs.unzip
+    (firsts zipLongest seconds).map { case a \&/ b => (a, b) } must_===(xs)
+  }
+
   "zip has right length" ! forAll {(xs: EphemeralStream[Int], ys: EphemeralStream[Int]) =>
     (xs zip ys).length must_===(xs.length min ys.length)
+  }
+
+  "zipLongest has right length" ! forAll {(xs: EphemeralStream[Int], ys: EphemeralStream[Int]) =>
+    (xs zipLongest ys).length must_===(xs.length max ys.length)
   }
 
   "interleave has right length" ! forAll {(xs: EphemeralStream[Int], ys: EphemeralStream[Int]) =>

--- a/tests/src/test/scala/scalaz/ISetTest.scala
+++ b/tests/src/test/scala/scalaz/ISetTest.scala
@@ -40,6 +40,11 @@ object ISetTest extends SpecLite {
     b.sorted must_=== b
   }
 
+  "toAscEphemeralStream" ! forAll { a: ISet[Int] =>
+    val b = a.toAscEphemeralStream.toList
+    b.sorted must_=== b
+  }
+
   "equals/hashCode" ! forAll { a: ISet[Int] =>
     val b = ISet.fromList(Random.shuffle(a.toList))
     a must_== b

--- a/tests/src/test/scala/scalaz/MapTest.scala
+++ b/tests/src/test/scala/scalaz/MapTest.scala
@@ -644,6 +644,8 @@ object MapTest extends SpecLite {
       empty[Int, String].keySet must_===(Set.empty[Int])
     }
 
+    // From / to List
+
     "fromList" in {
       fromList(List.empty[(Int, String)]) must_===(empty[Int, String])
       fromList(List(5 -> "a", 3 -> "b", 5 -> "c")) must_===(fromList(List(5 -> "c", 3 -> "b")))
@@ -667,6 +669,33 @@ object MapTest extends SpecLite {
       fromList(List(5 -> "a", 3 -> "b")).toList must_===(List(3 -> "b", 5 -> "a"))
       empty[Int, String].toList must_===(List.empty[(Int, String)])
     }
+
+    // From / to EphemeralStream
+
+    "fromEphemeralStream" in {
+      fromEphemeralStream(EphemeralStream[(Int, String)]()) must_===(empty[Int, String])
+      fromEphemeralStream(EphemeralStream(5 -> "a", 3 -> "b", 5 -> "c")) must_===(fromEphemeralStream(EphemeralStream(5 -> "c", 3 -> "b")))
+      fromEphemeralStream(EphemeralStream(5 -> "c", 3 -> "b", 5 -> "a")) must_===(fromEphemeralStream(EphemeralStream(5 -> "a", 3 -> "b")))
+    }
+
+    "fromEphemeralStreamWith" in {
+      fromEphemeralStreamWith(EphemeralStream(5 -> "a", 5 -> "b", 3 -> "b", 3 -> "a", 5 -> "a"))(_ + _) must_===(fromEphemeralStream(EphemeralStream(3 -> "ab", 5 -> "aba")))
+      fromEphemeralStreamWith(EphemeralStream[(Int, String)]())(_ + _) must_===(empty[Int, String])
+    }
+
+    "fromEphemeralStreamWithKey" in {
+      val f = (k: Int, a1: String, a2: String) => k.toString + a1 + a2
+
+      fromEphemeralStreamWithKey(EphemeralStream(5 -> "a", 5 -> "b", 3 -> "b", 3 -> "a", 5 -> "a"))(f) must_===(fromEphemeralStream(EphemeralStream(3 -> "3ab", 5 -> "5a5ba")))
+      fromEphemeralStreamWithKey(EphemeralStream[(Int, String)]())(f) must_===(empty[Int, String])
+    }
+
+    "toAscEphemeralStream" in {
+      import std.tuple._
+      fromEphemeralStream(EphemeralStream(5 -> "a", 3 -> "b")).toAscEphemeralStream must_===(EphemeralStream(3 -> "b", 5 -> "a"))
+      empty[Int, String].toAscEphemeralStream must_===(EphemeralStream[(Int, String)]())
+    }
+
   }
 
   /*"==>> validity" should {


### PR DESCRIPTION
This addresses #1098.

By adding variants of the `foldLeft`/`foldRight` methods which are lazy, it's now possible to fold over these structures efficiently, without allocating an additional `O(n)`.

* A lot of intermediate operations, as well as typeclasses, were using `toList` and `fromList` behind the scenes, and such uses have been replaced with `toAscEphemeralStream` and `fromEphemeralStream`. 
* Similar to the above, for both `IMap` and `ISet`, hashCode now calls `MurmurHash3.orderedHash` on an iterator that traverses the stream, rather than `.toList.hashCode`.
* `Foldable` / `BiFoldable` instances now use the lazy variant of `foldRight` in each case, making all such operations efficient as well.

Necessary changes to `EphemeralStream`:
* Implement `Equal`, `Order` and `Show`, plus tests
* Add `zipLongest` method (plus tests), which is used in the implementation of `Equal` and `Order`.

_Bonus_: Fix `Foldable.foldMap` implementation for `EphemeralStream` to use `foldLeft` rather than `foldRight`, since the latter can easily blow the stack, for example if you do:
```scala
EphemeralStream.range(0, 1000000).foldMap(ISet.singleton)
```