### PR TITLE
Add mapF in analogy to flatMapF to Monad Transformers

### DIFF
--- a/core/src/main/scala/scalaz/EitherT.scala
+++ b/core/src/main/scala/scalaz/EitherT.scala
@@ -71,6 +71,12 @@ final case class EitherT[F[_], A, B](run: F[A \/ B]) {
   def map[C](f: B => C)(implicit F: Functor[F]): EitherT[F, A, C] =
     EitherT(F.map(run)(_.map(f)))
 
+  /** Map on the right of this disjunction. */
+  def mapF[C](f: B => F[C])(implicit M: Monad[F]): EitherT[F, A, C] =
+    flatMapF {
+      f andThen (mb => M.map(mb)(b => \/-(b)))
+    }
+
   /** Traverse on the right of this disjunction. */
   def traverse[G[_], C](f: B => G[C])(implicit F: Traverse[F], G: Applicative[G]): G[EitherT[F, A, C]] =
     G.map(F.traverse(run)(o => Traverse[A \/ ?].traverse(o)(f)))(EitherT(_))

--- a/core/src/main/scala/scalaz/MaybeT.scala
+++ b/core/src/main/scala/scalaz/MaybeT.scala
@@ -1,5 +1,6 @@
 package scalaz
 
+
 /**
   * monad transformer for Maybe
   */
@@ -9,12 +10,22 @@ final case class MaybeT[F[_], A](run: F[Maybe[A]]) {
 
   def map[B](f: A => B)(implicit F: Functor[F]): MaybeT[F, B] = new MaybeT[F, B](mapO(_ map f))
 
+  def mapF[B](f: A => F[B])(implicit F: Monad[F]): MaybeT[F, B] = new MaybeT[F, B](
+    F.bind(self.run) {
+      case Empty() => F.point(empty[B])
+      case Just(z) => F.map(f(z))(b => just(b))
+    }
+  )
+
   def flatMap[B](f: A => MaybeT[F, B])(implicit F: Monad[F]): MaybeT[F, B] = new MaybeT[F, B](
     F.bind(self.run)(_.cata(f(_).run, F.point(empty)))
   )
 
-  def flatMapF[B](f: A => F[B])(implicit F: Monad[F]): MaybeT[F, B] = new MaybeT[F, B](
-    F.bind(self.run)(_.cata((a => F.map(f(a))(just)), F.point(empty)))
+  def flatMapF[B](f: A => F[Maybe[B]])(implicit F: Monad[F]): MaybeT[F, B] = new MaybeT[F, B](
+    F.bind(self.run) {
+      case Empty() => F.point(empty[B])
+      case Just(z) => f(z)
+    }
   )
 
   def foldRight[Z](z: => Z)(f: (A, => Z) => Z)(implicit F: Foldable[F]): Z = {
@@ -124,6 +135,9 @@ sealed abstract class MaybeTInstances extends MaybeTInstances0 {
 
   implicit def maybeTEqual[F[_], A](implicit F0: Equal[F[Maybe[A]]]): Equal[MaybeT[F, A]] =
     F0.contramap((_: MaybeT[F, A]).run)
+
+  implicit def maybeTShow[F[_], A](implicit F0: Show[F[Maybe[A]]]): Show[MaybeT[F, A]] =
+    Contravariant[Show].contramap(F0)(_.run)
 }
 
 object MaybeT extends MaybeTInstances {

--- a/core/src/main/scala/scalaz/OptionT.scala
+++ b/core/src/main/scala/scalaz/OptionT.scala
@@ -17,10 +17,17 @@ final case class OptionT[F[_], A](run: F[Option[A]]) {
     }
   )
 
-  def flatMapF[B](f: A => F[B])(implicit F: Monad[F]): OptionT[F, B] = new OptionT[F, B](
+  def mapF[B](f: A => F[B])(implicit F: Monad[F]): OptionT[F, B] = new OptionT[F, B](
     F.bind(self.run) {
       case None    => F.point(none[B])
       case Some(z) => F.map(f(z))(b => some(b))
+    }
+  )
+
+  def flatMapF[B](f: A => F[Option[B]])(implicit F: Monad[F]): OptionT[F, B] = new OptionT[F, B](
+    F.bind(self.run) {
+      case None    => F.point(none[B])
+      case Some(z) => f(z)
     }
   )
 

--- a/core/src/main/scala/scalaz/WriterT.scala
+++ b/core/src/main/scala/scalaz/WriterT.scala
@@ -45,6 +45,10 @@ final case class WriterT[F[_], W, A](run: F[(W, A)]) { self =>
   def map[B](f: A => B)(implicit F: Functor[F]): WriterT[F, W, B] =
     writerT(F.map(run)(wa => (wa._1, f(wa._2))))
 
+  def mapF[B](f: A => F[B])(implicit F: Bind[F], s: Semigroup[W]): WriterT[F, W, B] = writerT {
+    F.bind(run)(wa => F.map(f(wa._2))(a => (wa._1, a)))
+  }
+
   def ap[B](f: => WriterT[F, W, A => B])(implicit F: Apply[F], W: Semigroup[W]): WriterT[F, W, B] = writerT {
     F.apply2(f.run, run) {
       case ((w1, fab), (w2, a)) => (W.append(w1, w2), fab(a))

--- a/tests/src/test/scala/scalaz/EitherTTest.scala
+++ b/tests/src/test/scala/scalaz/EitherTTest.scala
@@ -48,6 +48,11 @@ object EitherTTest extends SpecLite {
     a.flatMap(f andThen EitherT.apply) must_=== a.flatMapF(f)
   }
 
+  "mapF consistent with map" ! forAll { (a: EitherTList[Int, Int], f: Int => String) =>
+    a.map(f) must_=== a.mapF(f andThen (s => Applicative[List].point(s)))
+  }
+
+
   "orElse only executes the left hand monad once" should {
     val counter = new AtomicInteger(0)
     val inc: EitherTComputation[Int] = EitherT.right(() => counter.incrementAndGet())

--- a/tests/src/test/scala/scalaz/ListTTest.scala
+++ b/tests/src/test/scala/scalaz/ListTTest.scala
@@ -45,10 +45,18 @@ object ListTTest extends SpecLite {
       ListT.fromList(ass).map(_ * 2).toList must_===(ass.map(_.map(_ * 2)))
   }
 
+  "mapF consistent with map" ! forAll { (fa: ListTOpt[Int], f: Int => Int) =>
+    fa.map(f) must_=== fa.mapF(f andThen (i => Applicative[Option].point(i)))
+  }
+
   "flatMap" ! forAll {
     (ass: List[List[Int]]) =>
       (ListT.fromList(ass).flatMap(number => ListT.fromList(List(List(number.toFloat)))).toList
       must_===(ass.map(_.flatMap(number => List(number.toFloat)))))
+  }
+
+  "flatMapF consistent with flatMap" ! forAll { (fa: ListTOpt[Int], f: Int => Option[List[String]]) =>
+    fa.flatMap(f andThen ListT.apply) must_=== fa.flatMapF(f)
   }
 
   // Exists to ensure that fromList and map don't stack overflow.

--- a/tests/src/test/scala/scalaz/MaybeTTest.scala
+++ b/tests/src/test/scala/scalaz/MaybeTTest.scala
@@ -1,5 +1,7 @@
 package scalaz
 
+import org.scalacheck.Prop._
+
 import scalaz.scalacheck.ScalazProperties._
 import scalaz.scalacheck.ScalazArbitrary._
 import std.AllInstances._
@@ -15,6 +17,18 @@ object MaybeTTest extends SpecLite {
   checkAll(monadPlus.laws[MaybeTList])
   checkAll(traverse.laws[MaybeTList])
   checkAll(monadError.laws[MaybeTEither, Int])
+
+  "show" ! forAll { a: MaybeTList[Int] =>
+    Show[MaybeTList[Int]].show(a) must_=== Show[List[Maybe[Int]]].show(a.run)
+  }
+
+  "flatMapF consistent with flatMap" ! forAll { (fa: MaybeTList[Int], f: Int => List[Maybe[Int]]) =>
+    fa.flatMap(f andThen MaybeT.apply) must_=== fa.flatMapF(f)
+  }
+
+  "mapF consistent with map" ! forAll { (fa: MaybeTList[Int], f: Int => Int) =>
+    fa.map(f) must_=== fa.mapF(f andThen (i => Applicative[List].point(i)))
+  }
 
   object instances {
     def functor[F[_] : Functor] = Functor[MaybeT[F, ?]]

--- a/tests/src/test/scala/scalaz/OptionTTest.scala
+++ b/tests/src/test/scala/scalaz/OptionTTest.scala
@@ -28,6 +28,14 @@ object OptionTTest extends SpecLite {
 
   "listT" ! forAll { a: OptionTList[Int] => a.toListT.run must_=== a.run.map(_.toList)}
 
+  "flatMapF consistent with flatMap" ! forAll { (fa: OptionTList[Int], f: Int => List[Option[Int]]) =>
+    fa.flatMap(f andThen OptionT.apply) must_=== fa.flatMapF(f)
+  }
+
+  "mapF consistent with map" ! forAll { (fa: OptionTList[Int], f: Int => Int) =>
+    fa.map(f) must_=== fa.mapF(f andThen (i => Applicative[List].point(i)))
+  }
+
   object instances {
     def functor[F[_] : Functor] = Functor[OptionT[F, ?]]
     def bindRec[F[_] : Monad: BindRec] = BindRec[OptionT[F, ?]]

--- a/tests/src/test/scala/scalaz/WriterTTest.scala
+++ b/tests/src/test/scala/scalaz/WriterTTest.scala
@@ -35,6 +35,11 @@ object WriterTTest extends SpecLite {
       fa.flatMapF(f) must_=== fa.flatMap(f andThen WriterT.writerT)
   }
 
+  "mapF consistent with map" ! forAll {
+    (fa: WriterTOptInt[Int], f: Int => String) =>
+      fa.mapF(f andThen (s => Applicative[Option].point(s))) must_=== fa.map(f)
+  }
+
   private def writerTUcompilationTest: Unit = {
     import syntax.either._
     val a: String \/ (Int, Boolean) = (1, true).right[String]


### PR DESCRIPTION
Given map(A => B) and flatMapF(A => G[F[B]) we should have mapF(A => G[B])
I also fixed an anomaly in the flatMapF signature of OptionT compared to the other transformers.
I also added a show instance for MaybeT.
This would break existing code, please review carefully.
