### PR TITLE
Add a Band type-class

### DIFF
--- a/core/src/main/scala/scalaz/Band.scala
+++ b/core/src/main/scala/scalaz/Band.scala
@@ -1,0 +1,42 @@
+package scalaz
+
+////
+/**
+ * [[scalaz.Semigroup]] which is also idempotent, i.e. appending a value with
+ * itself results in the same value.
+ *
+ * @see [[scalaz.Band.BandLaw]]
+ */
+////
+trait Band[F] extends Semigroup[F] { self =>
+  ////
+
+  // derived functions
+
+  /**
+    * The default definition exploits idempotency to optimise to `O(1)`
+    */
+  override def multiply1(value: F, n: Int): F =
+    value
+
+  /**
+    * Band instances must satisfy [[scalaz.Semigroup.SemigroupLaw]] and 1 additional law:
+    *
+    *  - '''idempotency''': `forall a. append(a, a) == a`
+    */
+  trait BandLaw extends SemigroupLaw {
+    def idempotency(a: F)(implicit F: Equal[F]) = F.equal(a, append(a, a))
+  }
+  def bandLaw = new BandLaw {}
+
+  ////
+  val bandSyntax = new scalaz.syntax.BandSyntax[F] { def F = Band.this }
+}
+
+object Band {
+  @inline def apply[F](implicit F: Band[F]): Band[F] = F
+
+  ////
+
+  ////
+}

--- a/core/src/main/scala/scalaz/syntax/BandSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/BandSyntax.scala
@@ -1,0 +1,27 @@
+package scalaz
+package syntax
+
+/** Wraps a value `self` and provides methods related to `Band` */
+final class BandOps[F] private[syntax](val self: F)(implicit val F: Band[F]) extends Ops[F] {
+  ////
+
+  ////
+}
+
+trait ToBandOps extends ToSemigroupOps {
+  implicit def ToBandOps[F](v: F)(implicit F0: Band[F]) =
+    new BandOps[F](v)
+
+  ////
+
+  ////
+}
+
+trait BandSyntax[F] extends SemigroupSyntax[F] {
+  implicit def ToBandOps(v: F): BandOps[F] = new BandOps[F](v)(BandSyntax.this.F)
+  
+  def F: Band[F]
+  ////
+
+  ////
+}

--- a/project/GenTypeClass.scala
+++ b/project/GenTypeClass.scala
@@ -17,6 +17,7 @@ object TypeClass {
 
   lazy val semigroup = TypeClass("Semigroup", *)
   lazy val monoid = TypeClass("Monoid", *, extendsList = Seq(semigroup))
+  lazy val band = TypeClass("Band", *, extendsList = Seq(semigroup))
   lazy val equal = TypeClass("Equal", *)
   lazy val show = TypeClass("Show", *)
   lazy val order = TypeClass("Order", *, extendsList = Seq(equal))
@@ -82,6 +83,7 @@ object TypeClass {
 
   def core: List[TypeClass] = List(semigroup,
     monoid,
+    band,
     equal,
     show,
     order,


### PR DESCRIPTION
Gives an optimised `multiply1` method.

---

TODO:
- [ ] Instances for tags (e.g. First and Last)
- [ ] Instances for Sets
- [ ] value-coinductive instances for Maps