### PR TITLE
Improve EphemeralStream's weakMemo to be optimistic using CAS

### DIFF
--- a/core/src/main/scala/scalaz/EphemeralStream.scala
+++ b/core/src/main/scala/scalaz/EphemeralStream.scala
@@ -280,8 +280,8 @@ object EphemeralStream extends EphemeralStreamInstances {
   def weakMemo[V](f: => V): () => V = {
     val ref: AtomicReference[WeakReference[V]] = new AtomicReference()
     () => {
-      def genNew(old: WeakReference[V]) = {
-        val x = f
+      @inline
+      def genNew(x: V, old: WeakReference[V]) = {
         ref.compareAndSet(old, new WeakReference(x))
         x
       }
@@ -289,9 +289,9 @@ object EphemeralStream extends EphemeralStreamInstances {
       if (v != null) {
         val crt = v.get()
         if (crt == null) {
-          genNew(v)
+          genNew(f, v)
         } else crt
-      } else genNew(v)
+      } else genNew(f, v)
     }
   }
 

--- a/tests/src/test/scala/scalaz/EphemeralStreamTest.scala
+++ b/tests/src/test/scala/scalaz/EphemeralStreamTest.scala
@@ -132,4 +132,15 @@ object EphemeralStreamTest extends SpecLite {
       EphemeralStream.fromStream(Stream.iterate(0)(_ + 1).zipWithIndex.take(n))
     )
   }
+
+  "reading from a stream in parallel should be safe" in {
+    import scalaz.concurrent._
+    val limit = 10000000
+    val stm = EphemeralStream.range(1, limit + 1)
+    val nthreads = 4
+    // Ensure that we get back the right numbers, in the right order.
+    val tsks = Task.gatherUnordered( List.fill(nthreads)(Task(stm.foldLeft(0)(prev => n => { (prev + 1) must_=== n; n }))) )
+    // And that the result contains the last number for each of the threads.
+    tsks.unsafePerformSync must_=== List.fill(nthreads)(limit)
+  }
 }


### PR DESCRIPTION
- Implement the change outlined in #1103.
- Add a test which reads the same stream from 4 threads concurrently, and ensures that the values being read are correct and in the right order. This should check that contention over the memoized head/tail values does not break safety.
