### PR TITLE
Foldable.splitBy and splitByRelation

### DIFF
--- a/core/src/main/scala/scalaz/Foldable.scala
+++ b/core/src/main/scala/scalaz/Foldable.scala
@@ -263,6 +263,17 @@ trait Foldable[F[_]]  { self =>
       }, Some(pa))
     })._1
 
+  /**
+    * Splits the elements into groups that produce the same result by a function f.
+    */
+  def splitBy[A, B: Equal](fa: F[A])(f: A => B): IList[(B, NonEmptyList[A])] =
+    foldRight(fa, IList[(B, NonEmptyList[A])]())((a, bas) => {
+      val fa = f(a)
+      bas match {
+        case INil() => IList.single((fa, NonEmptyList(a)))
+        case ICons((b, as), tail) => if (Equal[B].equal(fa, b)) ICons((b, a <:: as), tail) else ICons((fa, NonEmptyList(a)), bas)
+      }
+    })
 
   /**
    * Selects groups of elements that satisfy p and discards others.

--- a/core/src/main/scala/scalaz/Foldable.scala
+++ b/core/src/main/scala/scalaz/Foldable.scala
@@ -270,8 +270,19 @@ trait Foldable[F[_]]  { self =>
     foldRight(fa, IList[(B, NonEmptyList[A])]())((a, bas) => {
       val fa = f(a)
       bas match {
-        case INil() => IList.single((fa, NonEmptyList(a)))
-        case ICons((b, as), tail) => if (Equal[B].equal(fa, b)) ICons((b, a <:: as), tail) else ICons((fa, NonEmptyList(a)), bas)
+        case INil() => IList.single((fa, NonEmptyList.nel(a, INil())))
+        case ICons((b, as), tail) => if (Equal[B].equal(fa, b)) ICons((b, a <:: as), tail) else ICons((fa, NonEmptyList.nel(a, INil())), bas)
+      }
+    })
+
+  /**
+    * Splits into groups of elements that are transitively dependant by a relation r.
+    */
+  def splitByRelation[A](fa: F[A])(r: (A, A) => Boolean): IList[NonEmptyList[A]] =
+    foldRight(fa, IList[NonEmptyList[A]]())((a, neas) => {
+      neas match {
+        case INil() => IList.single(NonEmptyList.nel(a, INil()))
+        case ICons(nea, tail) => if (r(a, nea.head)) ICons(a <:: nea, tail) else ICons(NonEmptyList.nel(a, INil()), neas)
       }
     })
 

--- a/core/src/main/scala/scalaz/syntax/FoldableSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/FoldableSyntax.scala
@@ -63,6 +63,7 @@ final class FoldableOps[F[_],A] private[syntax](val self: F[A])(implicit val F: 
   final def empty: Boolean = F.empty(self)
   final def element(a: A)(implicit A: Equal[A]): Boolean = F.element(self, a)
   final def splitWith(p: A => Boolean): List[NonEmptyList[A]] = F.splitWith(self)(p)
+  final def splitBy[B: Equal](f: A => B): IList[(B, NonEmptyList[A])] = F.splitBy(self)(f)
   final def selectSplit(p: A => Boolean): List[NonEmptyList[A]] = F.selectSplit(self)(p)
   final def collapse[X[_]](implicit A: ApplicativePlus[X]): X[A] = F.collapse(self)
   final def concatenate(implicit A: Monoid[A]): A = F.fold(self)

--- a/core/src/main/scala/scalaz/syntax/FoldableSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/FoldableSyntax.scala
@@ -64,6 +64,7 @@ final class FoldableOps[F[_],A] private[syntax](val self: F[A])(implicit val F: 
   final def element(a: A)(implicit A: Equal[A]): Boolean = F.element(self, a)
   final def splitWith(p: A => Boolean): List[NonEmptyList[A]] = F.splitWith(self)(p)
   final def splitBy[B: Equal](f: A => B): IList[(B, NonEmptyList[A])] = F.splitBy(self)(f)
+  final def splitByRelation(r: (A, A) => Boolean): IList[NonEmptyList[A]] = F.splitByRelation(self)(r)
   final def selectSplit(p: A => Boolean): List[NonEmptyList[A]] = F.selectSplit(self)(p)
   final def collapse[X[_]](implicit A: ApplicativePlus[X]): X[A] = F.collapse(self)
   final def concatenate(implicit A: Monoid[A]): A = F.fold(self)


### PR DESCRIPTION
```splitBy``` splits the elements into groups that produce the same result  by a function f:
```scala
scala> List("A","B","C", "AA","AB", "A", "ABC", "EFG") splitBy (_.length)
res1: scalaz.IList[(Int, scalaz.NonEmptyList[String])] =
   [(1,NonEmpty[A,B,C]),(2,NonEmpty[AA,AB]),(1,NonEmpty[A]),(3,NonEmpty[ABC,EFG])]
```
following @ritschwumm comment, also added ```splitByRelation``` that splits into groups of elements that are transitively dependant by a relation r:
```scala
scala> List("A","BA","BC", "AA","BC", "AC") splitByRelation ((s1, s2) => !s2.intersect(s1).isEmpty)
res6: scalaz.IList[scalaz.NonEmptyList[String]] = [NonEmpty[A,BA,BC],NonEmpty[AA],NonEmpty[BC,AC]]
```