### PR TITLE
More stack-safety for FreeT.

### DIFF
--- a/tests/src/test/scala/scalaz/FreeTTest.scala
+++ b/tests/src/test/scala/scalaz/FreeTTest.scala
@@ -6,6 +6,7 @@ import std.AllInstances._
 import FreeT._
 import scalaz.scalacheck.ScalazProperties._
 import scalaz.scalacheck.ScalaCheckBinding._
+import scalaz.syntax.monad._
 
 case class FreeTListOption[A](f: FreeT[List, Option, A])
 
@@ -28,6 +29,9 @@ object FreeTListOption {
 
     def traverseImpl[G[_]: Applicative, A, B](fa: FreeTListOption[A])(f: A => G[B]) =
       Functor[G].map(Traverse[FreeT[List, Option, ?]].traverseImpl(fa.f)(f))(FreeTListOption.apply)
+
+    override def map[A, B](fa: FreeTListOption[A])(f: A => B) =
+      FreeTListOption(Monad[FreeT[List, Option, ?]].map(fa.f)(f))
 
     override def foldMap[A, B: Monoid](fa: FreeTListOption[A])(f: A => B) =
       Foldable[FreeT[List, Option, ?]].foldMap(fa.f)(f)
@@ -66,6 +70,26 @@ object FreeTTest extends SpecLite {
       Equal[FreeTListOption[Unit]].equal(expected, result)
     }
 
+    "not stack overflow with 50k left-associated binds" in {
+      val expected = Applicative[FreeTListOption].point(())
+      val result =
+        (0 until 50000).foldLeft(Applicative[FreeTListOption].point(()))(
+          (fu, i) => fu.flatMap(u => Applicative[FreeTListOption].point(u))
+        )
+
+      Equal[FreeTListOption[Unit]].equal(expected, result)
+    }
+
+    "not stack overflow with bind followed by 50k maps" in {
+      val expected = Applicative[FreeTListOption].point(())
+      val result =
+        (0 until 50000).foldLeft(().point[FreeTListOption].flatMap(u => u.point[FreeTListOption]))(
+          (fu, i) => fu.map(u => u)
+        )
+
+      Equal[FreeTListOption[Unit]].equal(expected, result)
+    }
+
     "hoistM" ! forAll { a: FreeTListOption[Int] =>
       val b = FreeTListOption(a.f.hoistM(NaturalTransformation.refl))
       Equal[FreeTListOption[Int]].equal(a, b)
@@ -98,7 +122,7 @@ object FreeTTest extends SpecLite {
   }
 
   object instances {
-    def bind[S[_]: Functor, F[_]: Functor] = Bind[FreeT[S, F, ?]]
+    def bind[S[_]: Functor, F[_]: Applicative] = Bind[FreeT[S, F, ?]]
     def foldable[S[_]: Foldable: Functor, F[_]: Foldable: Applicative: BindRec] = Foldable[FreeT[S, F, ?]]
     def traverse[S[_]: Traverse, F[_]: Traverse: Applicative: BindRec] = Traverse[FreeT[S, F, ?]]
     def monad[S[_]: Functor, F[_]: Applicative] = Monad[FreeT[S, F, ?]]
@@ -111,10 +135,8 @@ object FreeTTest extends SpecLite {
     def monadTrans[S[_]: Functor] = MonadTrans[FreeT[S, ?[_], ?]]
 
     // checking absence of ambiguity
-    def functor[S[_]: Functor, F[_]: Functor] = Functor[FreeT[S, F, ?]]
     def functor[S[_]: Traverse, F[_]: Traverse: Applicative: BindRec] = Functor[FreeT[S, F, ?]]
     def foldable[S[_]: Traverse, F[_]: Traverse: Applicative: BindRec] = Foldable[FreeT[S, F, ?]]
-    def bind[S[_]: Functor, F[_]: Applicative] = Bind[FreeT[S, F, ?]]
     def monad[S[_]: Functor, F[_]: ApplicativePlus: BindRec] = Monad[FreeT[S, F, ?]]
     def plus[S[_]: Functor, F[_]: ApplicativePlus: BindRec] = Plus[FreeT[S, F, ?]]
   }


### PR DESCRIPTION
It is crucial that

    Gosub(a, f1) >>= f2

is not transformed _eagerly_ to

    Gosub(a, x => f1(x) >>= f2)

because then

    Gosub(a, f1) >>= f2 >>= f3 >>= f4 >>= ...

builds up `Gosub(a, g)` with `g` stack-unsafe.

On the other hand, if we keep it as

    Gosub(...Gosub(Gosub(Gosub(Gosub(a, f1), f2), f3), f4)...)

we then in `resume` compose functions from the right and each of the composed functions is stack safe (`f3`, `f4` are composed to `g3 = x => Gosub(f3(x), f4)`, then `f2`, `g3` to `g2 = x => Gosub(f2(x), g3)` and finally `f1`, `g2` to `g1 = x => Gosub(f1(x), g2)`. We see that stack-safety of each _g<sub>i</sub>_ depends only _f<sub>i</sub>_, not on _g<sub>i+1</sub>_, so the stack frames don't add up.)

As a consequence, for `FreeT[S, M, ?]` to be a `Functor`, `M` must be at least `Applicative`.

I checked that the two newly added test cases did not pass before.