### PR TITLE
Relax more FreeT constraints

### DIFF
--- a/core/src/main/scala/scalaz/Free.scala
+++ b/core/src/main/scala/scalaz/Free.scala
@@ -325,7 +325,7 @@ sealed abstract class Free[S[_], A] {
   /** Extraction from `Free` as a comonad in the endofunctor category. */
   def extractF(implicit S: Monad[S]): S[A] = foldMap(NaturalTransformation.refl[S])
 
-  def toFreeT(implicit S: Functor[S]): FreeT[S, Id, A] =
+  def toFreeT: FreeT[S, Id, A] =
     this match {
       case Return(a) =>
         FreeT.point(a)

--- a/tests/src/test/scala/scalaz/FreeTTest.scala
+++ b/tests/src/test/scala/scalaz/FreeTTest.scala
@@ -6,6 +6,7 @@ import std.AllInstances._
 import FreeT._
 import scalaz.scalacheck.ScalazProperties._
 import scalaz.scalacheck.ScalaCheckBinding._
+import scalaz.syntax.monad._
 
 case class FreeTListOption[A](f: FreeT[List, Option, A])
 
@@ -28,6 +29,9 @@ object FreeTListOption {
 
     def traverseImpl[G[_]: Applicative, A, B](fa: FreeTListOption[A])(f: A => G[B]) =
       Functor[G].map(Traverse[FreeT[List, Option, ?]].traverseImpl(fa.f)(f))(FreeTListOption.apply)
+
+    override def map[A, B](fa: FreeTListOption[A])(f: A => B) =
+      FreeTListOption(Monad[FreeT[List, Option, ?]].map(fa.f)(f))
 
     override def foldMap[A, B: Monoid](fa: FreeTListOption[A])(f: A => B) =
       Foldable[FreeT[List, Option, ?]].foldMap(fa.f)(f)
@@ -66,6 +70,26 @@ object FreeTTest extends SpecLite {
       Equal[FreeTListOption[Unit]].equal(expected, result)
     }
 
+    "not stack overflow with 50k left-associated binds" in {
+      val expected = Applicative[FreeTListOption].point(())
+      val result =
+        (0 until 50000).foldLeft(Applicative[FreeTListOption].point(()))(
+          (fu, i) => fu.flatMap(u => Applicative[FreeTListOption].point(u))
+        )
+
+      Equal[FreeTListOption[Unit]].equal(expected, result)
+    }
+
+    "not stack overflow with bind followed by 50k maps" in {
+      val expected = Applicative[FreeTListOption].point(())
+      val result =
+        (0 until 50000).foldLeft(().point[FreeTListOption].flatMap(u => u.point[FreeTListOption]))(
+          (fu, i) => fu.map(u => u)
+        )
+
+      Equal[FreeTListOption[Unit]].equal(expected, result)
+    }
+
     "hoistM" ! forAll { a: FreeTListOption[Int] =>
       val b = FreeTListOption(a.f.hoistM(NaturalTransformation.refl))
       Equal[FreeTListOption[Int]].equal(a, b)
@@ -98,7 +122,7 @@ object FreeTTest extends SpecLite {
   }
 
   object instances {
-    def bind[S[_]: Functor, F[_]: Functor] = Bind[FreeT[S, F, ?]]
+    def bind[S[_]: Functor, F[_]: Applicative] = Bind[FreeT[S, F, ?]]
     def foldable[S[_]: Foldable: Functor, F[_]: Foldable: Applicative: BindRec] = Foldable[FreeT[S, F, ?]]
     def traverse[S[_]: Traverse, F[_]: Traverse: Applicative: BindRec] = Traverse[FreeT[S, F, ?]]
     def monad[S[_]: Functor, F[_]: Applicative] = Monad[FreeT[S, F, ?]]
@@ -111,10 +135,8 @@ object FreeTTest extends SpecLite {
     def monadTrans[S[_]: Functor] = MonadTrans[FreeT[S, ?[_], ?]]
 
     // checking absence of ambiguity
-    def functor[S[_]: Functor, F[_]: Functor] = Functor[FreeT[S, F, ?]]
     def functor[S[_]: Traverse, F[_]: Traverse: Applicative: BindRec] = Functor[FreeT[S, F, ?]]
     def foldable[S[_]: Traverse, F[_]: Traverse: Applicative: BindRec] = Foldable[FreeT[S, F, ?]]
-    def bind[S[_]: Functor, F[_]: Applicative] = Bind[FreeT[S, F, ?]]
     def monad[S[_]: Functor, F[_]: ApplicativePlus: BindRec] = Monad[FreeT[S, F, ?]]
     def plus[S[_]: Functor, F[_]: ApplicativePlus: BindRec] = Plus[FreeT[S, F, ?]]
   }

--- a/tests/src/test/scala/scalaz/FreeTTest.scala
+++ b/tests/src/test/scala/scalaz/FreeTTest.scala
@@ -90,23 +90,13 @@ object FreeTTest extends SpecLite {
       Equal[FreeTListOption[Unit]].equal(expected, result)
     }
 
-    "hoistM" ! forAll { a: FreeTListOption[Int] =>
-      val b = FreeTListOption(a.f.hoistM(NaturalTransformation.refl))
+    "hoist" ! forAll { a: FreeTListOption[Int] =>
+      val b = FreeTListOption(a.f.hoist(NaturalTransformation.refl))
       Equal[FreeTListOption[Int]].equal(a, b)
     }
 
-    "hoistN" ! forAll { a: FreeTListOption[Int] =>
-      val b = FreeTListOption(a.f.hoistN(NaturalTransformation.refl))
-      Equal[FreeTListOption[Int]].equal(a, b)
-    }
-
-    "interpretS" ! forAll { a: FreeTListOption[Int] =>
-      val b = FreeTListOption(a.f.interpretS(NaturalTransformation.refl))
-      Equal[FreeTListOption[Int]].equal(a, b)
-    }
-
-    "interpretT" ! forAll { a: FreeTListOption[Int] =>
-      val b = FreeTListOption(a.f.interpretT(NaturalTransformation.refl))
+    "interpret" ! forAll { a: FreeTListOption[Int] =>
+      val b = FreeTListOption(a.f.interpret(NaturalTransformation.refl))
       Equal[FreeTListOption[Int]].equal(a, b)
     }
   }


### PR DESCRIPTION
This is a follow up to #1113 and #1115.

Changing `FreeT[S, M, A]` encoding slightly and embracing that `M` will eventually need to be a monad anyway, so it is OK to require `Applicative[M]` anywhere, we are able to lift more `S[_]: Functor` constraints on `FreeT` operations.

The encoding and constraints on `S` are now more analogous to `Free`.