### PR TITLE
Added print trace feature to ShowOps

### DIFF
--- a/core/src/main/scala/scalaz/syntax/ShowSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/ShowSyntax.scala
@@ -8,6 +8,79 @@ final class ShowOps[F] private[syntax](val self: F)(implicit val F: Show[F]) ext
   final def shows: String = F.shows(self)
   final def print: Unit = Console.print(shows)
   final def println: Unit = Console.println(shows)
+
+  /**
+    * 1 internal call, 1 thread call, and ShowOps.traceInternal are the three levels of stack trace offset.
+    */
+  private val stackOffset = 3
+
+  /**
+    * Prints this (self) and returns this
+    * @return this (self)
+    */
+  final def trace0: F = traceInternal(0)
+  /**
+    * Prints this (self) with a 1 line stack trace for easy locate-ability and returns this
+    * @return this (self)
+    */
+  final def trace1: F = traceInternal(1)
+  /**
+    * Prints this (self) with a 1 line stack trace for easy locate-ability and returns this (self). Short for "trace1"
+    * @return this (self)
+    */
+  final def trace: F = traceInternal(1)
+  /**
+    * Prints this (self) with a 2 line stack trace for easy locate-ability and returns this
+    * @return this (self)
+    */
+  final def trace2: F = traceInternal(2)
+  /**
+    * Prints this (self) with a 3 line stack trace for easy locate-ability and returns this
+    * @return this (self)
+    */
+  final def trace3: F = traceInternal(3)
+  /**
+    * Prints this (self) with a 4 line stack trace for easy locate-ability and returns this
+    * @return this (self)
+    */
+  final def trace4: F = traceInternal(4)
+  /**
+    * Prints this (self) with a 5 line stack trace for easy locate-ability and returns this
+    * @return this (self)
+    */
+  final def trace5: F = traceInternal(5)
+  /**
+    * Prints this (self) with an n line stack trace for easy locate-ability and returns this
+    * @param numStackLines The number of lines of stack trace. No stack trace lines if numStackLines is less than or equal to zero.
+    * @return this (self)
+    */
+  final def traceN(numStackLines: Int): F = traceInternal(numStackLines)
+
+  /**
+    * Used internally by other trace statements. Prints this (self) with trace.
+    * @param numStackLinesIntended The number of lines of stack trace. No stack trace lines if this is less than or equal to zero.
+    * @return this (self)
+    */
+  private final def traceInternal(numStackLinesIntended: Int): F  = {
+    val numStackLines = if (numStackLinesIntended > 0) {
+      numStackLinesIntended
+    } else {
+      0
+    }
+    // adds thread name for easy locatability
+    val threadName = Thread.currentThread().getName
+    val stackTrace = Thread.currentThread().getStackTrace 
+    // format the trace like an exception so the IDE can link with the relevant lines in the source code
+    var toPrint = "\"" + shows + "\"" + " in thread " + threadName + ":"
+    for (row <- 0 to Math.min(numStackLines - 1, stackTrace.length - 1 - stackOffset)) {
+      val lineNumber = stackOffset + row;
+      val stackLine = stackTrace(lineNumber);
+      toPrint += "\n" + "  at " + stackLine
+    }
+    toPrint += "\n"
+    Console.println(toPrint)
+    self
+  }
   ////
 }
 


### PR DESCRIPTION
Print trace feature includes a stack trace in the print so that the user can trace the print.

_______________________________________________________________________________

**Example 1:**

`if( reallyImportantThing.trace ) `

**Output:**

```
"true" in thread eventThread:
  at path.to.file.MyClassName(MyClassName.scala:49)
```

^ The IDE will create a link to the location. User can click on the console instead of navigating.

_______________________________________________________________________________

**Example 2:**

`if( reallyImportantThing.trace2 ) `

**Output:**

```
"true" in thread eventThread:
  at path.to.file.MyClassName(MyClassName.scala:49)
  at path.to.file.ParentClass(ParentClass.scala:32)
```

_______________________________________________________________________________

**Example 3:**

`if( reallyImportantThing.trace0 ) `

**Output:**

`"true" in thread eventThread:`

_______________________________________________________________________________

**Example 4:**

`if( reallyImportantThing.traceN(6) ) `

**Output:**

```
"true" in thread eventThread:
  at path.to.file.MyClassName(MyClassName.scala:49)
  at path.to.file.ParentClass(ParentClass.scala:32)
  at path.to.file.ParentClass2(ParentClass2.scala:25)
  at path.to.file.ParentClass3(ParentClass3.scala:37)
  at path.to.file.ParentClass4(ParentClass4.scala:115)
  at path.to.file.ParentClass5(ParentClass5.scala:12)
```

_______________________________________________________________________________

**Example 5:**

`if( reallyImportantThing.traceN(-1111) ) `

**Output:**

`"true" in thread eventThread:`