### PR TITLE
StreamT#foldLeft stack safety

### DIFF
--- a/core/src/main/scala/scalaz/StreamT.scala
+++ b/core/src/main/scala/scalaz/StreamT.scala
@@ -105,7 +105,7 @@ sealed class StreamT[M[_], A](val step: M[StreamT.Step[A, StreamT[M, A]]]) {
      )
   }
 
-  def foldLeft[B](z: => B)(f: (=> B, => A) => B)(implicit M: Monad[M]): M[B] =
+  def foldLeft[B](z: B)(f: (B, A) => B)(implicit M: Monad[M]): M[B] =
     M.bind(step) {
       _( yieldd = (a, s) => s.foldLeft(f(z, a))(f)
        , skip = s => s.foldLeft(z)(f)
@@ -128,10 +128,8 @@ sealed class StreamT[M[_], A](val step: M[StreamT.Step[A, StreamT[M, A]]]) {
        )
     }
 
-  def length(implicit m: Monad[M]): M[Int] = {
-    def addOne(c: => Int, a: => A) = 1 + c
-    foldLeft(0)(addOne _)
-  }
+  def length(implicit m: Monad[M]): M[Int] =
+    foldLeft(0)((c, a) => 1 + c)
 
   def foreach(f: A => M[Unit])(implicit M: Monad[M]): M[Unit] = M.bind(step) {
     case Yield(a,s) => M.bind(f(a))(_ => s().foreach(f))

--- a/tests/src/test/scala/scalaz/StreamTTest.scala
+++ b/tests/src/test/scala/scalaz/StreamTTest.scala
@@ -55,6 +55,20 @@ object StreamTTest extends SpecLite {
       StreamT.fromStream(s.some).foldMap(_.toString) must_==(s.foldMap(_.toString))
   }
 
+  "trampolined StreamT" should {
+    import Free.Trampoline
+
+    val n = 100000L
+    val s = StreamT.unfoldM[Trampoline, Long, Long](n)(i =>
+      Trampoline.done(if(i > 0) Some((i, i-1)) else None))
+
+    val expected = n*(n+1)/2
+
+    "not stack overflow on foldRight" in {
+      s.foldRight(0L)((x, y) => x + y).run must_=== expected
+    }
+  }
+
   checkAll(equal.laws[StreamTOpt[Int]])
   checkAll(monoid.laws[StreamTOpt[Int]])
   checkAll(monadPlus.laws[StreamTOpt])

--- a/tests/src/test/scala/scalaz/StreamTTest.scala
+++ b/tests/src/test/scala/scalaz/StreamTTest.scala
@@ -64,6 +64,10 @@ object StreamTTest extends SpecLite {
 
     val expected = n*(n+1)/2
 
+    "not stack overflow on foldLeft" in {
+      s.foldLeft(0L)((x, y) => x + y).run must_=== expected
+    }
+
     "not stack overflow on foldRight" in {
       s.foldRight(0L)((x, y) => x + y).run must_=== expected
     }


### PR DESCRIPTION
This PR contains a fix for #1123 by making the arguments of `foldLeft` by-value.