### PR TITLE
revert deletion in favor of deprecation

### DIFF
--- a/core/src/main/scala/scalaz/syntax/IdOps.scala
+++ b/core/src/main/scala/scalaz/syntax/IdOps.scala
@@ -16,6 +16,24 @@ final class IdOps[A](val self: A) extends AnyVal {
   final def ▹[B](f: A => B): B =
     f(self)
 
+  /**Applies `self` to the provide function for its side effect, and returns `self`. The Kestrel combinator.
+   * Mostly for use with dodgy libraries that give you values that need additional initialization or
+   * mutation before they're valid to use.
+   *
+   * The name `tap` comes from the Ruby method: [[http://ruby-doc.org/core-2.0.0/Object.html#method-i-tap]]
+   * which allows you to "tap into" a method call chain, in order to perform operations on intermediate
+   * results within the chain.  `unsafe` because it enables side effects.
+   */
+  final def unsafeTap(f: A => Any): A = {
+    f(self); self
+  }
+
+  /** Alias for `unsafeTap`. */
+  final def <|(f: A => Any): A = unsafeTap(f)
+
+  /** Alias for `unsafeTap`. */
+  final def ◃(f: A => Any): A = unsafeTap(f)
+
   final def squared: (A, A) =
     (self, self)
 

--- a/core/src/main/scala/scalaz/syntax/IdOps.scala
+++ b/core/src/main/scala/scalaz/syntax/IdOps.scala
@@ -24,14 +24,17 @@ final class IdOps[A](val self: A) extends AnyVal {
    * which allows you to "tap into" a method call chain, in order to perform operations on intermediate
    * results within the chain.  `unsafe` because it enables side effects.
    */
+  @deprecated("will be removed in 7.4", "7.3")
   final def unsafeTap(f: A => Any): A = {
     f(self); self
   }
 
   /** Alias for `unsafeTap`. */
+  @deprecated("will be removed in 7.4", "7.3")
   final def <|(f: A => Any): A = unsafeTap(f)
 
   /** Alias for `unsafeTap`. */
+  @deprecated("will be removed in 7.4", "7.3")
   final def ◃(f: A => Any): A = unsafeTap(f)
 
   final def squared: (A, A) =


### PR DESCRIPTION
This reverts 8fd1b3b and adds deprecation notices. I think it's important not to break source compatibility without a deprecation cycle.

Many scalaz users (including me) need to interact with side-effect APIs and this method ends up being useful, but I'm fine removing it as long as there's some warning. Others may want to object generally.
