### PR TITLE
Add StreamT#asStream: conversion of StreamT[Id, A] to a lazy Stream[A].

### DIFF
--- a/core/src/main/scala/scalaz/StreamT.scala
+++ b/core/src/main/scala/scalaz/StreamT.scala
@@ -113,7 +113,28 @@ sealed class StreamT[M[_], A](val step: M[StreamT.Step[A, StreamT[M, A]]]) {
        )
     }
   
+  /**
+   * **Warning:** Requires evaluation of the whole stream. Depending on
+   * the monad `M`, the evaluation will happen either immediately, or
+   * will be deferred until the resulting `Stream` is extracted from the
+   * returned `M`.
+   */
   def toStream(implicit M: Monad[M]): M[Stream[A]] = M.map(rev)(_.reverse)
+
+  /**
+   * Converts this `StreamT` to a lazy `Stream`, i.e. without forcing
+   * evaluation of all elements. Note, however, that at least one element
+   * of this stream will be evaluated, and depending on the structure of
+   * this stream, up to two elements might be evaluated.
+   */
+  def asStream(implicit ev: M[Step[A, StreamT[M, A]]] =:= Id[Step[A, StreamT[Id, A]]]): Stream[A] = {
+    def go(s: StreamT[Id, A]): Stream[A] = s.uncons match {
+      case None => Stream.empty[A]
+      case Some((a, s1)) => Stream.cons(a, go(s1))
+    }
+
+    go(StreamT(ev(step)))
+  }
     
   def foldRight[B](z: => B)(f: (=> A, => B) => B)(implicit M: Monad[M]): M[B] =
     M.map(rev) {

--- a/tests/src/test/scala/scalaz/StreamTTest.scala
+++ b/tests/src/test/scala/scalaz/StreamTTest.scala
@@ -13,6 +13,30 @@ object StreamTTest extends SpecLite {
       StreamT.fromStream(ass).toStream must_===(ass)
   }
 
+  "fromStream / asStream" ! forAll {
+    import Id._
+    (as: Stream[Int]) =>
+      StreamT.fromStream[Id, Int](as).asStream must_===(as)
+  }
+
+  "asStream" should {
+    "be lazy" in {
+      var highestTouched = 0
+
+      val s1 = StreamT.unfold(1)(i => {
+        highestTouched = math.max(i, highestTouched)
+        if(i < 100) Some((i, i+1)) else None
+      })
+
+      val s2 = s1.asStream
+
+      // test that at most 2 elements were evaluated in the conversion
+      // (the fact that 2 are actually evaluated is a consequence of
+      // how Stream.cons and StreamT.unfold are implemented)
+      highestTouched mustBe_< 3
+    }
+  }
+
   "filter all" ! forAll {
     (ass: StreamT[Stream, Int]) =>
       ass.filter(_ => true) must_===(ass)


### PR DESCRIPTION
`StreamT[M, A]#toStream` requires evaluation of the whole stream, either eagerly, or later (depending on the monad `M`). As a consequence, it cannot be used on an infinite `StreamT`.

This PR adds a method `asStream`, which works only if `M =:= Id`, but the resulting `Stream` is lazy.