### PR TITLE
Add stack-safe versions of StreamT[M, A] operations

### DIFF
--- a/core/src/main/scala/scalaz/StreamT.scala
+++ b/core/src/main/scala/scalaz/StreamT.scala
@@ -15,16 +15,31 @@ sealed class StreamT[M[_], A](val step: M[StreamT.Step[A, StreamT[M, A]]]) {
        , skip = s => s.uncons
        , done = M.point(None)
        ))
+
+  def unconsRec(implicit M: Monad[M], B: BindRec[M]): M[Option[(A, StreamT[M, A])]] = {
+    def proceed(s: StreamT[M, A]): M[StreamT[M, A] \/ Option[(A, StreamT[M, A])]] =
+      M.map(s.step) (
+        _( yieldd = (a, s) => \/-(Some((a, s)))
+         , skip = s => -\/(s)
+         , done = \/-(None)
+         ))
+
+    B.tailrecM(proceed)(this)
+  }
   
   def ::(a: => A)(implicit M: Applicative[M]): StreamT[M, A] = StreamT[M, A](M.point(Yield(a, this)))
     
   def isEmpty(implicit M: Monad[M]): M[Boolean] = M.map(uncons)(!_.isDefined)
+  def isEmptyRec(implicit M: Monad[M], B: BindRec[M]): M[Boolean] = M.map(unconsRec)(!_.isDefined)
 
   def head(implicit M: Monad[M]): M[A] = M.map(uncons)(_.getOrElse(sys.error("head: empty StreamT"))._1)
+  def headRec(implicit M: Monad[M], B: BindRec[M]): M[A] = M.map(unconsRec)(_.getOrElse(sys.error("head: empty StreamT"))._1)
     
   def headOption(implicit M: Monad[M]): M[Option[A]] = M.map(uncons)(_.map(_._1))
+  def headOptionRec(implicit M: Monad[M], B: BindRec[M]): M[Option[A]] = M.map(unconsRec)(_.map(_._1))
   
   def tailM(implicit M: Monad[M]): M[StreamT[M, A]] = M.map(uncons)(_.getOrElse(sys.error("tailM: empty StreamT"))._2)
+  def tailMRec(implicit M: Monad[M], B: BindRec[M]): M[StreamT[M, A]] = M.map(unconsRec)(_.getOrElse(sys.error("tailM: empty StreamT"))._2)
 
   def trans[N[_]](t: M ~> N)(implicit M: Functor[M], N: Functor[N]): StreamT[N, A] =
     StreamT(t(M.map(this.step)(
@@ -112,7 +127,19 @@ sealed class StreamT[M[_], A](val step: M[StreamT.Step[A, StreamT[M, A]]]) {
        , done = M.point(z)
        )
     }
-  
+
+  def foldLeftRec[B](z: B)(f: (B, A) => B)(implicit M: Monad[M], B: BindRec[M]): M[B] = {
+    def proceed(sb: (StreamT[M, A], B)): M[(StreamT[M, A], B) \/ B] =
+      M.map(sb._1.step) {
+        _( yieldd = (a, s) => -\/((s, f(sb._2, a)))
+         , skip = s => -\/((s, sb._2))
+         , done = \/-(sb._2)
+         )
+      }
+
+    B.tailrecM(proceed)((this, z))
+  }
+
   /**
    * **Warning:** Requires evaluation of the whole stream. Depending on
    * the monad `M`, the evaluation will happen either immediately, or
@@ -121,6 +148,8 @@ sealed class StreamT[M[_], A](val step: M[StreamT.Step[A, StreamT[M, A]]]) {
    */
   def toStream(implicit M: Monad[M]): M[Stream[A]] = M.map(rev)(_.reverse)
 
+  def toStreamRec(implicit M: Monad[M], B: BindRec[M]): M[Stream[A]] = M.map(revRec)(_.reverse)
+
   /**
    * Converts this `StreamT` to a lazy `Stream`, i.e. without forcing
    * evaluation of all elements. Note, however, that at least one element
@@ -128,16 +157,21 @@ sealed class StreamT[M[_], A](val step: M[StreamT.Step[A, StreamT[M, A]]]) {
    * this stream, up to two elements might be evaluated.
    */
   def asStream(implicit ev: M[Step[A, StreamT[M, A]]] =:= Id[Step[A, StreamT[Id, A]]]): Stream[A] = {
-    def go(s: StreamT[Id, A]): Stream[A] = s.uncons match {
+    def go(s: StreamT[Id, A]): Stream[A] = s.unconsRec match {
       case None => Stream.empty[A]
       case Some((a, s1)) => Stream.cons(a, go(s1))
     }
 
     go(StreamT(ev(step)))
   }
-    
+
   def foldRight[B](z: => B)(f: (=> A, => B) => B)(implicit M: Monad[M]): M[B] =
     M.map(rev) {
+      _.foldLeft(z)((a, b) => f(b, a))
+    }
+
+  def foldRightRec[B](z: => B)(f: (=> A, => B) => B)(implicit M: Monad[M], B: BindRec[M]): M[B] =
+    M.map(revRec) {
       _.foldLeft(z)((a, b) => f(b, a))
     }
 
@@ -163,10 +197,23 @@ sealed class StreamT[M[_], A](val step: M[StreamT.Step[A, StreamT[M, A]]]) {
   def length(implicit m: Monad[M]): M[Int] =
     foldLeft(0)((c, a) => 1 + c)
 
+  def lengthRec(implicit m: Monad[M], B: BindRec[M]): M[Int] =
+    foldLeftRec(0)((c, a) => 1 + c)
+
   def foreach(f: A => M[Unit])(implicit M: Monad[M]): M[Unit] = M.bind(step) {
     case Yield(a,s) => M.bind(f(a))(_ => s().foreach(f))
     case Skip(s) => s().foreach(f)
     case Done => M.pure(())
+  }
+
+  def foreachRec(f: A => M[Unit])(implicit M: Monad[M], B: BindRec[M]): M[Unit] = {
+    def proceed(s: StreamT[M, A]): M[StreamT[M, A] \/ Unit] = M.bind(s.step) {
+      case Yield(a, s1) => M.map(f(a))(_ => -\/(s1()))
+      case Skip(s1) => M.pure(-\/(s1()))
+      case Done => M.pure(\/-(()))
+    }
+
+    B.tailrecM(proceed)(this)
   }
   
   private def stepMap[B](f: Step[A, StreamT[M, A]] => Step[B, StreamT[M, B]])(implicit M: Functor[M]): StreamT[M, B] = StreamT(M.map(step)(f))
@@ -182,6 +229,20 @@ sealed class StreamT[M[_], A](val step: M[StreamT.Step[A, StreamT[M, A]]]) {
          )
       }
     loop(this, Stream.Empty)
+  }
+
+  private def revRec(implicit M: Monad[M], B: BindRec[M]): M[Stream[A]] = {
+    def loop(ss: (StreamT[M, A], Stream[A])): M[(StreamT[M, A], Stream[A]) \/ Stream[A]] = {
+      val (xs, ys) = ss
+      M.map(xs.step) {
+        _( yieldd = (a, s) => -\/((s, a #:: ys))
+         , skip = s => -\/((s, ys))
+         , done = \/-(ys)
+         )
+      }
+    }
+
+    B.tailrecM(loop)((this, Stream.Empty))
   }
 }
 

--- a/tests/src/test/scala/scalaz/StreamTTest.scala
+++ b/tests/src/test/scala/scalaz/StreamTTest.scala
@@ -144,32 +144,16 @@ object StreamTTest extends SpecLite {
       s.unconsRec.get._1 must_=== "foo"
     }
 
-    "stack-overflow on uncons" in {
-      (s.uncons).mustThrowA[StackOverflowError]
-    }
-
     "not stack-overflow on isEmptyRec" in {
       s.isEmptyRec must_=== false
-    }
-
-    "stack-overflow on isEmpty" in {
-      (s.isEmpty).mustThrowA[StackOverflowError]
     }
 
     "not stack-overflow on headRec" in {
       s.headRec must_=== "foo"
     }
 
-    "stack-overflow on head" in {
-      (s.head).mustThrowA[StackOverflowError]
-    }
-
     "not stack-overflow on headOptionRec" in {
       s.headOptionRec must_=== Some("foo")
-    }
-
-    "stack-overflow on headOption" in {
-      (s.headOption).mustThrowA[StackOverflowError]
     }
 
     "not stack-overflow on tailMRec" in {
@@ -178,50 +162,26 @@ object StreamTTest extends SpecLite {
       }
     }
 
-    "stack-overflow on tailM" in {
-      (s.tailM).mustThrowA[StackOverflowError]
-    }
-
     "not stack-overflow on foreachRec" in {
       var acc = ""
       s.foreachRec(a => acc += a)
       acc must_=== "foo"
     }
 
-    "stack-overflow on foreach" in {
-      (s.foreach(a => ())).mustThrowA[StackOverflowError]
-    }
-
     "not stack-overflow on foldRightRec" in {
       s.foldRightRec("")((a, b) => a + b) must_=== "foo"
-    }
-
-    "stack-overflow on foldRight" in {
-      (s.foldRight("")((a, b) => a + b)).mustThrowA[StackOverflowError]
     }
 
     "not stack-overflow on foldLeftRec" in {
       s.foldLeftRec("")((b, a) => b + a) must_=== "foo"
     }
 
-    "stack-overflow on foldLeft" in {
-      (s.foldLeft("")((b, a) => b + a)).mustThrowA[StackOverflowError]
-    }
-
     "not stack-overflow on lengthRec" in {
       s.lengthRec must_=== 1
     }
 
-    "stack-overflow on length" in {
-      (s.length).mustThrowA[StackOverflowError]
-    }
-
     "not stack-overflow on toStreamRec" in {
       s.toStreamRec.toList must_=== List("foo")
-    }
-
-    "stack-overflow on toStream" in {
-      (s.toStream).mustThrowA[StackOverflowError]
     }
 
     "not stack-overflow on asStream" in {


### PR DESCRIPTION
`StreamT[M, A]` operations can be written in a stack-safe fashion when `M` is a tail-recursive monad (i.e. when `M[_]: BindRec`), without the need for trampolining the stream. This PR adds these stack-safe versions.

~~With each test I also added a negative test for the original operation that stack-overflows.~~ I deleted those negative tests, because I was not able to test for stack overflow in a platform-independent manner (`StackOverflowError` on JVM vs. `RangeError` in JS).