### PR TITLE
Make StreamT#asStream stack-safe

### DIFF
--- a/core/src/main/scala/scalaz/StreamT.scala
+++ b/core/src/main/scala/scalaz/StreamT.scala
@@ -163,7 +163,7 @@ sealed class StreamT[M[_], A](val step: M[StreamT.Step[A, StreamT[M, A]]]) {
    * this stream, up to two elements might be evaluated.
    */
   def asStream(implicit ev: M[Step[A, StreamT[M, A]]] =:= Id[Step[A, StreamT[Id, A]]]): Stream[A] = {
-    def go(s: StreamT[Id, A]): Stream[A] = s.uncons match {
+    def go(s: StreamT[Id, A]): Stream[A] = s.unconsRec match {
       case None => Stream.empty[A]
       case Some((a, s1)) => Stream.cons(a, go(s1))
     }

--- a/core/src/main/scala/scalaz/StreamT.scala
+++ b/core/src/main/scala/scalaz/StreamT.scala
@@ -15,16 +15,31 @@ sealed class StreamT[M[_], A](val step: M[StreamT.Step[A, StreamT[M, A]]]) {
        , skip = s => s.uncons
        , done = M.point(None)
        ))
+
+  def unconsRec(implicit M: Monad[M], B: BindRec[M]): M[Option[(A, StreamT[M, A])]] = {
+    def proceed(s: StreamT[M, A]): M[StreamT[M, A] \/ Option[(A, StreamT[M, A])]] =
+      M.map(s.step) (
+        _( yieldd = (a, s) => \/-(Some((a, s)))
+         , skip = s => -\/(s)
+         , done = \/-(None)
+         ))
+
+    B.tailrecM(proceed)(this)
+  }
   
   def ::(a: => A)(implicit M: Applicative[M]): StreamT[M, A] = StreamT[M, A](M.point(Yield(a, this)))
     
   def isEmpty(implicit M: Monad[M]): M[Boolean] = M.map(uncons)(!_.isDefined)
+  def isEmptyRec(implicit M: Monad[M], B: BindRec[M]): M[Boolean] = M.map(unconsRec)(!_.isDefined)
 
   def head(implicit M: Monad[M]): M[A] = M.map(uncons)(_.getOrElse(sys.error("head: empty StreamT"))._1)
+  def headRec(implicit M: Monad[M], B: BindRec[M]): M[A] = M.map(unconsRec)(_.getOrElse(sys.error("head: empty StreamT"))._1)
     
   def headOption(implicit M: Monad[M]): M[Option[A]] = M.map(uncons)(_.map(_._1))
+  def headOptionRec(implicit M: Monad[M], B: BindRec[M]): M[Option[A]] = M.map(unconsRec)(_.map(_._1))
   
   def tailM(implicit M: Monad[M]): M[StreamT[M, A]] = M.map(uncons)(_.getOrElse(sys.error("tailM: empty StreamT"))._2)
+  def tailMRec(implicit M: Monad[M], B: BindRec[M]): M[StreamT[M, A]] = M.map(unconsRec)(_.getOrElse(sys.error("tailM: empty StreamT"))._2)
 
   def trans[N[_]](t: M ~> N)(implicit M: Functor[M], N: Functor[N]): StreamT[N, A] =
     StreamT(t(M.map(this.step)(
@@ -112,11 +127,30 @@ sealed class StreamT[M[_], A](val step: M[StreamT.Step[A, StreamT[M, A]]]) {
        , done = M.point(z)
        )
     }
-  
+
+  def foldLeftRec[B](z: B)(f: (B, A) => B)(implicit M: Monad[M], B: BindRec[M]): M[B] = {
+    def proceed(sb: (StreamT[M, A], B)): M[(StreamT[M, A], B) \/ B] =
+      M.map(sb._1.step) {
+        _( yieldd = (a, s) => -\/((s, f(sb._2, a)))
+         , skip = s => -\/((s, sb._2))
+         , done = \/-(sb._2)
+         )
+      }
+
+    B.tailrecM(proceed)((this, z))
+  }
+
   def toStream(implicit M: Monad[M]): M[Stream[A]] = M.map(rev)(_.reverse)
-    
+
+  def toStreamRec(implicit M: Monad[M], B: BindRec[M]): M[Stream[A]] = M.map(revRec)(_.reverse)
+
   def foldRight[B](z: => B)(f: (=> A, => B) => B)(implicit M: Monad[M]): M[B] =
     M.map(rev) {
+      _.foldLeft(z)((a, b) => f(b, a))
+    }
+
+  def foldRightRec[B](z: => B)(f: (=> A, => B) => B)(implicit M: Monad[M], B: BindRec[M]): M[B] =
+    M.map(revRec) {
       _.foldLeft(z)((a, b) => f(b, a))
     }
 
@@ -133,10 +167,23 @@ sealed class StreamT[M[_], A](val step: M[StreamT.Step[A, StreamT[M, A]]]) {
     foldLeft(0)(addOne _)
   }
 
+  def lengthRec(implicit m: Monad[M], B: BindRec[M]): M[Int] =
+    foldLeftRec(0)((c, a) => 1 + c)
+
   def foreach(f: A => M[Unit])(implicit M: Monad[M]): M[Unit] = M.bind(step) {
     case Yield(a,s) => M.bind(f(a))(_ => s().foreach(f))
     case Skip(s) => s().foreach(f)
     case Done => M.pure(())
+  }
+
+  def foreachRec(f: A => M[Unit])(implicit M: Monad[M], B: BindRec[M]): M[Unit] = {
+    def proceed(s: StreamT[M, A]): M[StreamT[M, A] \/ Unit] = M.bind(s.step) {
+      case Yield(a, s1) => M.map(f(a))(_ => -\/(s1()))
+      case Skip(s1) => M.pure(-\/(s1()))
+      case Done => M.pure(\/-(()))
+    }
+
+    B.tailrecM(proceed)(this)
   }
   
   private def stepMap[B](f: Step[A, StreamT[M, A]] => Step[B, StreamT[M, B]])(implicit M: Functor[M]): StreamT[M, B] = StreamT(M.map(step)(f))
@@ -152,6 +199,20 @@ sealed class StreamT[M[_], A](val step: M[StreamT.Step[A, StreamT[M, A]]]) {
          )
       }
     loop(this, Stream.Empty)
+  }
+
+  private def revRec(implicit M: Monad[M], B: BindRec[M]): M[Stream[A]] = {
+    def loop(ss: (StreamT[M, A], Stream[A])): M[(StreamT[M, A], Stream[A]) \/ Stream[A]] = {
+      val (xs, ys) = ss
+      M.map(xs.step) {
+        _( yieldd = (a, s) => -\/((s, a #:: ys))
+         , skip = s => -\/((s, ys))
+         , done = \/-(ys)
+         )
+      }
+    }
+
+    B.tailrecM(loop)((this, Stream.Empty))
   }
 }
 

--- a/tests/src/test/scala/scalaz/StreamTTest.scala
+++ b/tests/src/test/scala/scalaz/StreamTTest.scala
@@ -59,6 +59,102 @@ object StreamTTest extends SpecLite {
   checkAll(monoid.laws[StreamTOpt[Int]])
   checkAll(monadPlus.laws[StreamTOpt])
   checkAll(foldable.laws[StreamTOpt])
+
+  "StreamT[Id, _] with 100,000 initial skips" should {
+    import Id.Id
+
+    val s = {
+      def nastyStream(n: Int, value: String): StreamT[Id, String] =
+        if(n > 0) StreamT[Id, String](StreamT.Skip(nastyStream(n-1, value)))
+        else value :: StreamT.empty[Id, String]
+
+      nastyStream(100000, "foo")
+    }
+
+    "not stack-overflow on unconsRec" in {
+      s.unconsRec.get._1 must_=== "foo"
+    }
+
+    "stack-overflow on uncons" in {
+      (s.uncons).mustThrowA[StackOverflowError]
+    }
+
+    "not stack-overflow on isEmptyRec" in {
+      s.isEmptyRec must_=== false
+    }
+
+    "stack-overflow on isEmpty" in {
+      (s.isEmpty).mustThrowA[StackOverflowError]
+    }
+
+    "not stack-overflow on headRec" in {
+      s.headRec must_=== "foo"
+    }
+
+    "stack-overflow on head" in {
+      (s.head).mustThrowA[StackOverflowError]
+    }
+
+    "not stack-overflow on headOptionRec" in {
+      s.headOptionRec must_=== Some("foo")
+    }
+
+    "stack-overflow on headOption" in {
+      (s.headOption).mustThrowA[StackOverflowError]
+    }
+
+    "not stack-overflow on tailMRec" in {
+      s.tailMRec.step mustMatch {
+        case StreamT.Done() => true
+      }
+    }
+
+    "stack-overflow on tailM" in {
+      (s.tailM).mustThrowA[StackOverflowError]
+    }
+
+    "not stack-overflow on foreachRec" in {
+      var acc = ""
+      s.foreachRec(a => acc += a)
+      acc must_=== "foo"
+    }
+
+    "stack-overflow on foreach" in {
+      (s.foreach(a => ())).mustThrowA[StackOverflowError]
+    }
+
+    "not stack-overflow on foldRightRec" in {
+      s.foldRightRec("")((a, b) => a + b) must_=== "foo"
+    }
+
+    "stack-overflow on foldRight" in {
+      (s.foldRight("")((a, b) => a + b)).mustThrowA[StackOverflowError]
+    }
+
+    "not stack-overflow on foldLeftRec" in {
+      s.foldLeftRec("")((b, a) => b + a) must_=== "foo"
+    }
+
+    "stack-overflow on foldLeft" in {
+      (s.foldLeft("")((b, a) => b + a)).mustThrowA[StackOverflowError]
+    }
+
+    "not stack-overflow on lengthRec" in {
+      s.lengthRec must_=== 1
+    }
+
+    "stack-overflow on length" in {
+      (s.length).mustThrowA[StackOverflowError]
+    }
+
+    "not stack-overflow on toStreamRec" in {
+      s.toStreamRec.toList must_=== List("foo")
+    }
+
+    "stack-overflow on toStream" in {
+      (s.toStream).mustThrowA[StackOverflowError]
+    }
+  }
   
   object instances {
     def semigroup[F[_]: Functor, A] = Semigroup[StreamT[F, A]]

--- a/tests/src/test/scala/scalaz/StreamTTest.scala
+++ b/tests/src/test/scala/scalaz/StreamTTest.scala
@@ -178,6 +178,10 @@ object StreamTTest extends SpecLite {
     "stack-overflow on toStream" in {
       (s.toStream).mustThrowA[StackOverflowError]
     }
+
+    "not stack-overflow on asStream" in {
+      s.asStream.toList must_=== List("foo")
+    }
   }
   
   object instances {


### PR DESCRIPTION
This is just a merge of #1129 and #1130 (please review those first), resolving merge conflict and using stack-safe `unconsRec` (added in #1130) in `asStream` (added in #1129).