### PR TITLE
deprecate unsafetap

### DIFF
--- a/core/src/main/scala/scalaz/syntax/IdOps.scala
+++ b/core/src/main/scala/scalaz/syntax/IdOps.scala
@@ -24,14 +24,17 @@ final class IdOps[A](val self: A) extends AnyVal {
    * which allows you to "tap into" a method call chain, in order to perform operations on intermediate
    * results within the chain.  `unsafe` because it enables side effects.
    */
+  @deprecated("will be removed in 7.3", "7.2")
   final def unsafeTap(f: A => Any): A = {
     f(self); self
   }
 
   /** Alias for `unsafeTap`. */
+  @deprecated("will be removed in 7.3", "7.2")
   final def <|(f: A => Any): A = unsafeTap(f)
 
   /** Alias for `unsafeTap`. */
+  @deprecated("will be removed in 7.3", "7.2")
   final def ◃(f: A => Any): A = unsafeTap(f)
 
   final def squared: (A, A) =


### PR DESCRIPTION
Deprecates `unsafeTap` in 7.2.x, which has been removed in 7.3.x via 8fd1b3b. See discussion in #1128.