### PR TITLE
Default executor uses at least 4 threads

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Strategy.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Strategy.scala
@@ -36,7 +36,7 @@ trait Strategys extends StrategysLow {
    * where N is equal to the number of available processors.
    */
   val DefaultExecutorService: ExecutorService = {
-    Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors, DefaultDaemonThreadFactory)
+    Executors.newFixedThreadPool(Math.max(4, Runtime.getRuntime.availableProcessors), DefaultDaemonThreadFactory)
   }
 
   /**


### PR DESCRIPTION
Related to https://github.com/scalaz/scalaz/issues/1105, here's a PR for making the default executor thread pool size at least 4, to avoid nasty deadlocks on 1-core machines.