### PR TITLE
Stream foldMap implementation should not overflow the stack.

### DIFF
--- a/core/src/main/scala/scalaz/std/Stream.scala
+++ b/core/src/main/scala/scalaz/std/Stream.scala
@@ -31,7 +31,7 @@ trait StreamInstances {
     override def foldLeft[A, B](fa: Stream[A], z: B)(f: (B, A) => B): B = fa.foldLeft(z)(f)
 
     override def foldMap[A, B](fa: Stream[A])(f: A => B)(implicit M: Monoid[B]) =
-      this.foldRight(fa, M.zero)((a, b) => M.append(f(a), b))
+      this.foldLeft(fa, M.zero)((b, a) => M.append(b, f(a)))
 
     override def foldRight[A, B](fa: Stream[A], z: => B)(f: (A, => B) => B): B = if (fa.isEmpty)
       z

--- a/tests/src/test/scala/scalaz/std/StreamTest.scala
+++ b/tests/src/test/scala/scalaz/std/StreamTest.scala
@@ -77,6 +77,10 @@ object StreamTest extends SpecLite {
     Foldable[Stream].foldMap(Stream.continually(false))(identity)(booleanInstance.conjunction) must_===(false)
   }
 
+  "foldMap evaluates big stream" in {
+    Foldable[Stream].foldMap(Stream.from(1).take(1000000))(_ => 1)(intInstance) must_===(1000000)
+  }
+
   "foldRight evaluates lazily" in {
     Foldable[Stream].foldRight(Stream.continually(true), true)(_ || _) must_===(true)
   }


### PR DESCRIPTION
Former `foldMap` implementation blowed the stack because of the `foldRight`. Actually I am thinking, that `foldRight` itself should be implemented in a safe way: 
`override def foldRight[A, B](fa: Stream[A], z: => B)(f: (A, => B) => B): B =   this.foldLeft(fa.reverse, z)((b, a) => f(a, b))` , but then I hit failing test:
scalaz.std.StreamTest.:foldRight evaluates lazily: Exception raised on property evaluation.
Do you think the `foldRight` on Stream should really evaluate lazily?

