### PR TITLE
Configure external links in ScalaDoc

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,5 +12,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
 
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "0.2.2")
+
 // https://github.com/sbt/sbt/issues/2217
 fullResolvers ~= {_.filterNot(_.name == "jcenter")}


### PR DESCRIPTION
I found that Scalaz's Scaladoc does not link to Scala standard library and other dependencies. This patch fixes the problem.

I myself am the maintainer of [sbt-api-mappings](https://github.com/ThoughtWorksInc/sbt-api-mappings).