### PR TITLE
change EphemeralStream.foldLeft to use a tail recursive loop

### DIFF
--- a/core/src/main/scala/scalaz/EphemeralStream.scala
+++ b/core/src/main/scala/scalaz/EphemeralStream.scala
@@ -38,13 +38,11 @@ sealed abstract class EphemeralStream[A] {
     if (isEmpty) z else f(head())(tail().foldRight(z)(f))
 
   def foldLeft[B](z: => B)(f: (=> B) => (=> A) => B): B = {
-    var t = this
-    var acc = z
-    while (!t.isEmpty) {
-      acc = f(acc)(t.head())
-      t = t.tail()
-    }
-    acc
+    @annotation.tailrec
+    def loop(t: EphemeralStream[A], acc: B): B =
+      if (t.isEmpty) acc
+      else loop(t.tail(), f(acc)(t.head()))
+    loop(this, z)
   }
 
   def filter(p: A => Boolean): EphemeralStream[A] = {


### PR DESCRIPTION
Prior to this, running the code below resulted in a runtime exception saying that the head of an empty stream was being accessed

```
val es = EphemeralStream.unfold(0)(n => if (n < 5000) Some((List.fill(10000)(500L), n+1)) else None)
es.foldLeft( ().point[IO])(io => e => io >> IO.putStrLn(e.length.shows)).unsafePerformIO
```

Note, the above still doesn't work properly. It results in an OOME, as does 

```
es.traverse_(e => IO.putStrLn(e.length.shows))
```

which is what I'm really trying to get working properly. 

Also of note is that

```
es.foldLeft( ().point[IO])(io => e => io *> IO.putStrLn(e.length.shows)).unsafePerformIO
```

DOES work. But, if you inline `*>`

```
es.foldLeft( ().point[IO])(io => e => Apply[IO].apply2(io, IO.putStrLn(e.length.shows))((_, _) => ())).unsafePerformIO
```

it does NOT work, resulting in an OOME again.

I'm still trying to puzzle this out and get `traverse_` working as expected. I will be eternally grateful to anyone that can provide some insight here.