### PR TITLE
Make FreeT#hoist and FreeT#interpret stack safe

### DIFF
--- a/tests/src/test/scala/scalaz/FreeTTest.scala
+++ b/tests/src/test/scala/scalaz/FreeTTest.scala
@@ -100,9 +100,25 @@ object FreeTTest extends SpecLite {
       Equal[FreeTListOption[Int]].equal(a, b)
     }
 
+    "hoist stack-safety" in {
+      val a = (0 until 50000).foldLeft(Applicative[FreeTListOption].point(()))(
+        (fu, i) => fu.flatMap(u => Applicative[FreeTListOption].point(u))
+      )
+
+      val b = a.f.hoist(NaturalTransformation.refl) // used to overflow
+    }
+
     "interpret" ! forAll { a: FreeTListOption[Int] =>
       val b = FreeTListOption(a.f.interpret(NaturalTransformation.refl))
       Equal[FreeTListOption[Int]].equal(a, b)
+    }
+
+    "interpret stack-safety" in {
+      val a = (0 until 50000).foldLeft(Applicative[FreeTListOption].point(()))(
+        (fu, i) => fu.flatMap(u => Applicative[FreeTListOption].point(u))
+      )
+
+      val b = a.f.interpret(NaturalTransformation.refl) // used to overflow
     }
 
     "foldMap should be consistent with runM" ! forAll { a: FreeTListOption[Int] =>


### PR DESCRIPTION
~~This is based off a pending PR #1157  to avoid merge conflicts. See only the latest commit for the stack-safety fix. I can rebase if necessary.~~