### PR TITLE
Fixes binary incompatibility with scalacheck 1.12.x

### DIFF
--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazProperties.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazProperties.scala
@@ -238,7 +238,7 @@ object ScalazProperties {
 
   private def resizeProp(p: Prop, max: Int): Prop = new Prop{
     def apply(params: Gen.Parameters) =
-      p(params.resize(params.size % (max + 1)))
+      p(params.withSize(params.size % (max + 1)))
   }
 
   object traverse {


### PR DESCRIPTION
Sadly we are still stuck on 7.1, but other parts of our stack have forced us to use scalacheck 1.12.x. This results in a runtime error when running the traverse laws. 

Can we please apply this band aid to get a scalacheck-binding 7.1.9 that doesn't use the deprecated at 1.11.x and removed in 1.12.x Arbitrary.resize function? 

It would help us out greatly, and I see the last scalaz 7.1.8 was fixing something very similar, so I figured that further fixes in that regard would be helpful. :)