### PR TITLE
Lazy non-empty right fold for streams; more efficient left fold too

### DIFF
--- a/core/src/main/scala/scalaz/EphemeralStream.scala
+++ b/core/src/main/scala/scalaz/EphemeralStream.scala
@@ -169,6 +169,8 @@ sealed abstract class EphemeralStreamInstances {
       if(fa.isEmpty) z else f(fa.head(), foldRight(fa.tail(), z)(f))
     override def foldMap[A, B](fa: EphemeralStream[A])(f: A => B)(implicit M: Monoid[B]) =
       this.foldRight(fa, M.zero)((a, b) => M.append(f(a), b))
+    override def foldMap1Opt[A, B](fa: EphemeralStream[A])(f: A => B)(implicit B: Semigroup[B]) =
+      foldMapRight1Opt(fa)(f)((l, r) => B.append(f(l), r))
     override def foldLeft[A, B](fa: EphemeralStream[A], z: B)(f: (B, A) => B) =
       fa.foldLeft(z)(b => a => f(b, a))
 

--- a/core/src/main/scala/scalaz/std/Stream.scala
+++ b/core/src/main/scala/scalaz/std/Stream.scala
@@ -38,6 +38,9 @@ trait StreamInstances {
     override def foldMap[A, B](fa: Stream[A])(f: A => B)(implicit M: Monoid[B]) =
       this.foldRight(fa, M.zero)((a, b) => M.append(f(a), b))
 
+    override def foldMap1Opt[A, B](fa: Stream[A])(f: A => B)(implicit B: Semigroup[B]) =
+      foldMapRight1Opt(fa)(f)((l, r) => B.append(f(l), r))
+
     override def foldMapRight1Opt[A, B](fa: Stream[A])(z: A => B)(f: (A, => B) => B): Option[B] = {
       def rec(hd: A, tl: Stream[A]): B = tl match {
         case Stream.Empty => z(hd)

--- a/tests/src/test/scala/scalaz/EphemeralStreamTest.scala
+++ b/tests/src/test/scala/scalaz/EphemeralStreamTest.scala
@@ -124,6 +124,16 @@ object EphemeralStreamTest extends SpecLite {
     Foldable[EphemeralStream].foldMap(infiniteStream)(identity)(booleanInstance.conjunction) must_===(false)
   }
 
+  "foldMap1Opt identity" ! forAll {
+    xs: EphemeralStream[Int] =>
+    Foldable[EphemeralStream].foldMap1Opt(xs)(Vector(_)).getOrElse(Vector.empty) must_===(Foldable[EphemeralStream].toVector(xs))
+  }
+
+  "foldMap1Opt evaluates lazily" in {
+    val infiniteStream = EphemeralStream.iterate(false)(identity)
+    Foldable[EphemeralStream].foldMap1Opt(infiniteStream)(identity)(booleanInstance.conjunction) must_===(Some(false))
+  }
+
   "foldRight evaluates lazily" in {
     val infiniteStream = EphemeralStream.iterate(true)(identity)
     Foldable[EphemeralStream].foldRight(infiniteStream, true)(_ || _) must_===(true)

--- a/tests/src/test/scala/scalaz/EphemeralStreamTest.scala
+++ b/tests/src/test/scala/scalaz/EphemeralStreamTest.scala
@@ -129,6 +129,25 @@ object EphemeralStreamTest extends SpecLite {
     Foldable[EphemeralStream].foldRight(infiniteStream, true)(_ || _) must_===(true)
   }
 
+  "foldMapLeft1Opt identity" ! forAll {
+    (xs: EphemeralStream[Int]) =>
+    Foldable[EphemeralStream].foldMapLeft1Opt(xs.reverse)(EphemeralStream(_))((xs, x) => x ##:: xs) must_===(
+      if (xs.isEmpty) None else Some(xs)
+    )
+  }
+
+  "foldMapRight1Opt identity" ! forAll {
+    (xs: EphemeralStream[Int]) =>
+    Foldable[EphemeralStream].foldMapRight1Opt(xs)(EphemeralStream(_))(_ ##:: _) must_===(
+      if (xs.isEmpty) None else Some(xs)
+    )
+  }
+
+  "foldMapRight1Opt evaluates lazily" in {
+    val infiniteStream = EphemeralStream.iterate(true)(identity)
+    Foldable[EphemeralStream].foldMapRight1Opt(infiniteStream)(identity)(_ || _) must_===(Some(true))
+  }
+
   "zipL" in {
     val size = 100
     val infinite = EphemeralStream.iterate(0)(_ + 1)

--- a/tests/src/test/scala/scalaz/std/StreamTest.scala
+++ b/tests/src/test/scala/scalaz/std/StreamTest.scala
@@ -81,6 +81,24 @@ object StreamTest extends SpecLite {
     Foldable[Stream].foldRight(Stream.continually(true), true)(_ || _) must_===(true)
   }
 
+  "foldMapLeft1Opt identity" ! forAll {
+    (xs: Stream[Int]) =>
+    Foldable[Stream].foldMapLeft1Opt(xs.reverse)(Stream(_))((xs, x) => x #:: xs) must_===(
+      if (xs.isEmpty) None else Some(xs)
+    )
+  }
+
+  "foldMapRight1Opt identity" ! forAll {
+    (xs: Stream[Int]) =>
+    Foldable[Stream].foldMapRight1Opt(xs)(Stream(_))(_ #:: _) must_===(
+      if (xs.isEmpty) None else Some(xs)
+    )
+  }
+
+  "foldMapRight1Opt evaluates lazily" in {
+    Foldable[Stream].foldMapRight1Opt(Stream.continually(true))(identity)(_ || _) must_===(Some(true))
+  }
+
   "zipL" in {
     val size = 100
     val infinite = Stream.from(1)

--- a/tests/src/test/scala/scalaz/std/StreamTest.scala
+++ b/tests/src/test/scala/scalaz/std/StreamTest.scala
@@ -77,6 +77,15 @@ object StreamTest extends SpecLite {
     Foldable[Stream].foldMap(Stream.continually(false))(identity)(booleanInstance.conjunction) must_===(false)
   }
 
+  "foldMap1Opt identity" ! forAll {
+    xs: Stream[Int] =>
+    Foldable[Stream].foldMap1Opt(xs)(Stream(_)).getOrElse(Stream.empty) must_===(xs)
+  }
+
+  "foldMap1Opt evaluates lazily" in {
+    Foldable[Stream].foldMap1Opt(Stream.continually(false))(identity)(booleanInstance.conjunction) must_===(Some(false))
+  }
+
   "foldRight evaluates lazily" in {
     Foldable[Stream].foldRight(Stream.continually(true), true)(_ || _) must_===(true)
   }


### PR DESCRIPTION
Lifting a `Semigroup` into `Option` to get a `Monoid` unfortunately makes an always-strict `mappend`, meaning a strict fold.  Here we avoid that for `Stream` and `EphemeralStream`'s `foldMapRight1Opt` by taking advantage of their structure.