### PR TITLE
Improve IMap based on haskell/containers v0.5.7.1 updates

### DIFF
--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -610,6 +610,16 @@ sealed abstract class ==>>[A, B] {
         l.foldrWithKey(f(kx, x, r.foldrWithKey(z)(f)))(f)
     }
 
+  def foldMapWithKey[C](f: (A, B) => C)(implicit F: Monoid[C]): C =
+    this match {
+      case Tip() =>
+        F.zero
+      case Bin(k, x, Tip(), Tip()) =>
+        f(k, x)
+      case Bin(k, x, l, r) =>
+        F.append(l.foldMapWithKey(f), F.append(f(k, x), r.foldMapWithKey(f)))
+    }
+
   /* Unions */
   def union(other: A ==>> B)(implicit k: Order[A]): A ==>> B = {
     def hedgeUnion(blo: Option[A], bhi: Option[A], m1: A ==>> B, m2: A ==>> B): A ==>> B =

--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -551,6 +551,20 @@ sealed abstract class ==>>[A, B] {
         Bin(kx, f(kx, x), l.mapWithKey(f), r.mapWithKey(f))
     }
 
+  def traverseWithKey[F[_], C](f: (A, B) => F[C])(implicit G: Applicative[F]): F[A ==>> C] =
+    this match {
+      case Tip() =>
+        G.point(Tip())
+      case Bin(kx, x, Tip(), Tip()) =>
+        G.apply(f(kx, x)) { x2 =>
+          Bin(kx, x2, Tip(), Tip())
+        }
+      case Bin(kx, x, l, r) =>
+        G.apply3(l.traverseWithKey(f), f(kx, x), r.traverseWithKey(f)) {
+          (l2, x2, r2) => Bin(kx, x2, l2, r2)
+        }
+    }
+
   def mapAccum[C](z: C)(f: (C, B) => (C, B)): (C, A ==>> B) =
     mapAccumWithKey(z)((a2, _, x2) => f(a2, x2))
 

--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -1167,7 +1167,7 @@ object ==>> extends MapInstances {
     xs.foldLeft(empty[A, B])((a, c) => a.unionWith(c)(f))
 
   private[scalaz] final val ratio = 2
-  private[scalaz] final val delta = 4
+  private[scalaz] final val delta = 3
 
   private[scalaz] def balance[A, B](k: A, x: B, l: A ==>> B, r: A ==>> B): A ==>> B = {
     if (l.size + r.size <= 1)

--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -252,6 +252,39 @@ sealed abstract class ==>>[A, B] {
     }
   }
 
+  @tailrec
+  final def lookupGE(k: A)(implicit o: Order[A]): Option[(A, B)] = {
+    @tailrec
+    def goSome(kx: A, x: B, t: A ==>> B): Option[(A, B)] =
+      t match {
+        case Tip() =>
+          some((kx, x))
+        case Bin(ky, y, l, r) =>
+          o.order(k, ky) match {
+            case LT =>
+              goSome(ky, y, l)
+            case EQ =>
+              some((ky, y))
+            case GT =>
+              goSome(kx, x, r)
+          }
+      }
+
+    this match {
+      case Tip() =>
+        none
+      case Bin(kx, x, l, r) =>
+        o.order(k, kx) match {
+          case LT =>
+            goSome(kx, x, l)
+          case EQ =>
+            some((kx, x))
+          case GT =>
+            r.lookupGE(k)
+        }
+    }
+  }
+
   def values: List[B] =
     foldrWithKey(List.empty[B])((_, x, xs) => x :: xs)
 

--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -233,6 +233,25 @@ sealed abstract class ==>>[A, B] {
     }
   }
 
+  @tailrec
+  final def lookupGT(k: A)(implicit o: Order[A]): Option[(A, B)] = {
+    @tailrec
+    def goSome(kx: A, x: B, t: A ==>> B): Option[(A, B)] =
+      t match {
+        case Tip() =>
+          some((kx, x))
+        case Bin(ky, y, l, r) =>
+          if (o.greaterThanOrEqual(k, ky)) goSome(kx, x, r) else goSome(ky, y, l)
+      }
+
+    this match {
+      case Tip() =>
+        none
+      case Bin(kx, x, l, r) =>
+        if (o.greaterThanOrEqual(k, kx)) r.lookupGT(k) else goSome(kx, x, l)
+    }
+  }
+
   def values: List[B] =
     foldrWithKey(List.empty[B])((_, x, xs) => x :: xs)
 

--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -253,6 +253,39 @@ sealed abstract class ==>>[A, B] {
   }
 
   @tailrec
+  final def lookupLE(k: A)(implicit o: Order[A]): Option[(A, B)] = {
+    @tailrec
+    def goSome(kx: A, x: B, t: A ==>> B): Option[(A, B)] =
+      t match {
+        case Tip() =>
+          some((kx, x))
+        case Bin(ky, y, l, r) =>
+          o.order(k, ky) match {
+            case LT =>
+              goSome(kx, x, l)
+            case EQ =>
+              some((ky, y))
+            case GT =>
+              goSome(ky, y, r)
+          }
+      }
+
+    this match {
+      case Tip() =>
+        none
+      case Bin(kx, x, l, r) =>
+        o.order(k, kx) match {
+          case LT =>
+            l.lookupLE(k)
+          case EQ =>
+            some((kx, x))
+          case GT =>
+            goSome(kx, x, r)
+        }
+    }
+  }
+
+  @tailrec
   final def lookupGE(k: A)(implicit o: Order[A]): Option[(A, B)] = {
     @tailrec
     def goSome(kx: A, x: B, t: A ==>> B): Option[(A, B)] =

--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -443,7 +443,7 @@ sealed abstract class ==>>[A, B] {
       }
     }
 
-  private def deleteFindMax(t: Bin[A, B]): ((A, B), A ==>> B) =
+  def deleteFindMax(t: Bin[A, B]): ((A, B), A ==>> B) =
     t match {
       case Bin(k, x, l, Tip()) =>
         ((k,x), l)
@@ -452,7 +452,7 @@ sealed abstract class ==>>[A, B] {
         (km, balanceL(k, x, l, r2))
     }
 
-  private def deleteFindMin(t: Bin[A, B]): ((A, B), A ==>> B) =
+  def deleteFindMin(t: Bin[A, B]): ((A, B), A ==>> B) =
     t match {
       case Bin(k, x, Tip(), r) =>
         ((k, x), r)

--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -424,8 +424,8 @@ sealed abstract class ==>>[A, B] {
       case (l, Tip()) =>
         l
       case (l @ Bin(kx, x, lx, rx), r @ Bin(ky, y, ly, ry)) =>
-        if (delta * l.size <= r.size) balance(ky, y, l.merge(ly), ry)
-        else if (delta * r.size <= l.size) balance(kx, x, lx, rx.merge(r))
+        if (delta * l.size < r.size) balance(ky, y, l.merge(ly), ry)
+        else if (delta * r.size < l.size) balance(kx, x, lx, rx.merge(r))
         else glue(l, r)
     }
 
@@ -908,8 +908,8 @@ sealed abstract class ==>>[A, B] {
       case (l, Tip()) =>
         l.insertMax(kx, x)
       case (l @ Bin(ky, y, ly, ry), r @ Bin(kz, z, lz, rz)) =>
-        if (delta * l.size <= r.size) balance(kz, z, l.join(kx, x, lz), rz)
-        else if (delta * r.size <= l.size) balance(ky, y, ly, ry.join(kx, x, r))
+        if (delta * l.size < r.size) balance(kz, z, l.join(kx, x, lz), rz)
+        else if (delta * r.size < l.size) balance(ky, y, ly, ry.join(kx, x, r))
         else Bin(kx, x, l, r)
     }
 
@@ -1172,9 +1172,9 @@ object ==>> extends MapInstances {
   private[scalaz] def balance[A, B](k: A, x: B, l: A ==>> B, r: A ==>> B): A ==>> B = {
     if (l.size + r.size <= 1)
       Bin(k, x, l, r)
-    else if (r.size >= delta * l.size)
+    else if (r.size > delta * l.size)
       rotateL(k, x, l, r)
-    else if (l.size >= delta * r.size)
+    else if (l.size > delta * r.size)
       rotateR(k, x, l, r)
     else
       Bin(k, x, l, r)

--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -1228,6 +1228,14 @@ object ==>> extends MapInstances {
   final def fromFoldableWithKey[F[_]: Foldable, A: Order, B](fa: F[(A, B)])(f: (A, B, B) => B): A ==>> B =
     Foldable[F].foldLeft(fa, empty[A, B])((a, c) => a.insertWithKey(f, c._1, c._2))
 
+  final def fromSet[A: Order, B](s: ISet[A])(f: A => B): A ==>> B =
+    s match {
+      case ISet.Tip() =>
+        empty
+      case ISet.Bin(x, l, r) =>
+        Bin(x, f(x), fromSet(l)(f), fromSet(r)(f))
+    }
+
   final def unions[A: Order, B](xs: List[A ==>> B]): A ==>> B =
     xs.foldLeft(empty[A, B])((a, c) => a.union(c))
 

--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -214,6 +214,25 @@ sealed abstract class ==>>[A, B] {
         }
     }
 
+  @tailrec
+  final def lookupLT(k: A)(implicit o: Order[A]): Option[(A, B)] = {
+    @tailrec
+    def goSome(kx: A, x: B, t: A ==>> B): Option[(A, B)] =
+      t match {
+        case Tip() =>
+          some((kx, x))
+        case Bin(ky, y, l, r) =>
+          if (o.lessThanOrEqual(k, ky)) goSome(kx, x, l) else goSome(ky, y, r)
+      }
+
+    this match {
+      case Tip() =>
+        none
+      case Bin(kx, x, l, r) =>
+        if (o.lessThanOrEqual(k, kx)) l.lookupLT(k) else goSome(kx, x, r)
+    }
+  }
+
   def values: List[B] =
     foldrWithKey(List.empty[B])((_, x, xs) => x :: xs)
 

--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -567,16 +567,16 @@ sealed abstract class ==>>[A, B] {
     difference(other)
 
   def difference[C](other: A ==>> C)(implicit o: Order[A]): A ==>> B = {
-    def hedgeDiff(cmplo: A => Ordering, cmphi: A => Ordering, a: A ==>> B, b: A ==>> C): A ==>> B =
+    def hedgeDiff(blo: Option[A], bhi: Option[A], a: A ==>> B, b: A ==>> C): A ==>> B =
       (a, b) match {
         case (Tip(), _) =>
           empty
         case (Bin(kx, x, l, r), Tip()) =>
-          link(kx, x, l filterGt cmplo, r filterLt cmphi)
+          link(kx, x, l filterGt blo, r filterLt bhi)
         case (t, Bin(kx, _, l, r)) =>
-          val cmpkx = (k: A) => o.order(kx, k)
-          val aa = hedgeDiff(cmplo, cmpkx, t.trim(cmplo, cmpkx), l)
-          val bb = hedgeDiff(cmpkx, cmphi, t.trim(cmpkx, cmphi), r)
+          val bmi = some(kx)
+          val aa = hedgeDiff(blo, bmi, ==>>.trim(blo, bmi, t), l)
+          val bb = hedgeDiff(bmi, bhi, ==>>.trim(bmi, bhi, t), r)
           aa merge bb
       }
 
@@ -586,7 +586,7 @@ sealed abstract class ==>>[A, B] {
       case (t1, Tip()) =>
         t1
       case (t1, t2) =>
-        hedgeDiff(Function const LT, Function const GT, t1, t2)
+        hedgeDiff(None, None, t1, t2)
     }
   }
 

--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -871,6 +871,12 @@ sealed abstract class ==>>[A, B] {
         }
     }
 
+  def splitRoot: List[A ==>> B] =
+    this match {
+      case Tip()           => List.empty[A ==>> B]
+      case Bin(k, x, l, r) => List(l, singleton(k, x), r)
+    }
+
   // Utility functions
   // Because the following functions depend on some public interface, such as deleteFindMax,
   // they can't be moved to object ==>> unlike other utility functions, balance(...) for example.

--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -1,7 +1,9 @@
 package scalaz
 
-// http://www.haskell.org/ghc/docs/7.0.2/html/libraries/containers-0.4.0.0/src/Data-Map.html
-
+/**
+ * @see [[http://hackage.haskell.org/package/containers-0.5.7.1/docs/mini_Data-Map-Strict.html]]
+ * @see [[https://github.com/haskell/containers/blob/v0.5.7.1/Data/Map/Base.hs]]
+ */
 import Ordering.{ EQ, LT, GT }
 
 import std.anyVal._
@@ -1223,6 +1225,13 @@ object ==>> extends MapInstances {
 
   final def fromListWithKey[A: Order, B](l: List[(A, B)])(f: (A, B, B) => B): A ==>> B =
     l.foldLeft(empty[A, B])((a, c) => a.insertWithKey(f, c._1, c._2))
+
+  /* TODO: Ordered lists
+    , fromAscList
+    , fromAscListWith
+    , fromAscListWithKey
+    , fromDistinctAscList
+  */
 
   /* Foldable operations */
   final def fromFoldable[F[_]: Foldable, A: Order, B](fa: F[(A, B)]): A ==>> B =

--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -563,11 +563,11 @@ sealed abstract class ==>>[A, B] {
   }
 
   // Difference functions
-  def \\(other: A ==>> B)(implicit o: Order[A]): A ==>> B =
+  def \\[C](other: A ==>> C)(implicit o: Order[A]): A ==>> B =
     difference(other)
 
-  def difference(other: A ==>> B)(implicit o: Order[A]): A ==>> B = {
-    def hedgeDiff(cmplo: A => Ordering, cmphi: A => Ordering, a: A ==>> B, b: A ==>> B): A ==>> B =
+  def difference[C](other: A ==>> C)(implicit o: Order[A]): A ==>> B = {
+    def hedgeDiff(cmplo: A => Ordering, cmphi: A => Ordering, a: A ==>> B, b: A ==>> C): A ==>> B =
       (a, b) match {
         case (Tip(), _) =>
           empty

--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -590,10 +590,10 @@ sealed abstract class ==>>[A, B] {
     }
   }
 
-  def differenceWith[C](other: A ==>> C, f: (B, C) => Option[B])(implicit o: Order[A]): A ==>> B =
-    differenceWithKey(other, (_: A, b: B, c: C) => f(b, c))
+  def differenceWith[C](other: A ==>> C)(f: (B, C) => Option[B])(implicit o: Order[A]): A ==>> B =
+    differenceWithKey(other)((_: A, b: B, c: C) => f(b, c))
 
-  def differenceWithKey[C](other: A ==>> C, f: (A, B, C) => Option[B])(implicit o: Order[A]): A ==>> B = {
+  def differenceWithKey[C](other: A ==>> C)(f: (A, B, C) => Option[B])(implicit o: Order[A]): A ==>> B = {
     def hedgeDiffWithKey(cmplo: A => Ordering, cmphi: A => Ordering, a: A ==>> B, b: A ==>> C): A ==>> B =
       (a, b) match {
         case (Tip(), _) =>

--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -531,7 +531,7 @@ sealed abstract class ==>>[A, B] {
   }
 
   def unionWith(other: A ==>> B)(f: (B, B) => B)(implicit o: Order[A]): A ==>> B =
-    unionWithKey(other)((_: A, b: B, c: B) => f(b, c))
+    unionWithKey(other)((_, b, c) => f(b, c))
 
   def unionWithKey(other: A ==>> B)(f: (A, B, B) => B)(implicit o: Order[A]): A ==>> B =
     mergeWithKey(this, other)((a, b, c) => some(f(a, b, c)))(x => x, x => x)
@@ -565,7 +565,7 @@ sealed abstract class ==>>[A, B] {
   }
 
   def differenceWith[C](other: A ==>> C)(f: (B, C) => Option[B])(implicit o: Order[A]): A ==>> B =
-    differenceWithKey(other)((_: A, b: B, c: C) => f(b, c))
+    differenceWithKey(other)((_, b, c) => f(b, c))
 
   def differenceWithKey[C](other: A ==>> C)(f: (A, B, C) => Option[B])(implicit o: Order[A]): A ==>> B =
     mergeWithKey(this, other)(f)(x => x, _ => empty)
@@ -575,7 +575,7 @@ sealed abstract class ==>>[A, B] {
     intersectionWithKey(other)((_, x, _: C) => x)
 
   def intersectionWith[C, D](other: A ==>> C)(f: (B, C) => D)(implicit o: Order[A]): A ==>> D =
-    intersectionWithKey(other)((_, x, y: C) => f(x, y))
+    intersectionWithKey(other)((_, x, y) => f(x, y))
 
   def intersectionWithKey[C, D](other: A ==>> C)(f: (A, B, C) => D)(implicit o: Order[A]): A ==>> D =
     mergeWithKey(this, other)((a, b, c) => some(f(a, b, c)))(_ => empty, _ => empty)

--- a/tests/src/test/scala/scalaz/MapTest.scala
+++ b/tests/src/test/scala/scalaz/MapTest.scala
@@ -17,8 +17,33 @@ object MapTest extends SpecLite {
   import ==>>._
 
   def structurallySound[A: Order: Show, B: Equal: Show](m: A ==>> B) = {
+    isSortedByKey(m)
+    isBalanced(m)
+  }
+
+  private def isSortedByKey[A: Order: Show, B: Equal: Show](m: A ==>> B) = {
     val al = m.toAscList
     al must_===(al.sortBy(_._1)(Order[A].toScalaOrdering))
+  }
+
+  private def isBalanced[A, B](m: A ==>> B) = {
+    def isWeightsValid(l: A ==>> B, r: A ==>> B): Boolean = {
+      val sizeL = if (l.size == 0) 1 else l.size
+      val sizeR = if (r.size == 0) 1 else r.size
+
+      (sizeL <= sizeR * delta) && (sizeR <= sizeL * delta)
+    }
+
+    def go(mab: A ==>> B): Boolean =
+      mab match {
+        case Tip() =>
+          true
+        case Bin(_, _, l, r) =>
+          if (isWeightsValid(l, r)) go(l) && go(r)
+          else false
+      }
+
+    go(m) must_=== true
   }
 
   "findLeft/findRight" in {

--- a/tests/src/test/scala/scalaz/MapTest.scala
+++ b/tests/src/test/scala/scalaz/MapTest.scala
@@ -236,6 +236,12 @@ object MapTest extends SpecLite {
       fromList(List((3,"a"), (5,"b"))).lookupGT(3) must_=== Some((5, "b"))
     }
 
+    "value lookupGE" in {
+      fromList(List((3,"a"), (5,"b"))).lookupGE(6) must_=== None
+      fromList(List((3,"a"), (5,"b"))).lookupGE(5) must_=== Some((5, "b"))
+      fromList(List((3,"a"), (5,"b"))).lookupGE(4) must_=== Some((5, "b"))
+    }
+
     "lookup" ! forAll { (a: Byte ==>> Int, n: Byte) =>
       a.lookup(n) must_=== a.toList.find(_._1 == n).map(_._2)
     }
@@ -281,6 +287,23 @@ object MapTest extends SpecLite {
           a.lookupGT(k) must_=== a.elemAt(i+1)
           if (k != Int.MinValue) {
             a.lookupGT(k-1) must_=== Some((k, v))
+          }
+        }
+      }
+    }
+
+    "lookupGE" ! forAll { (a: Int ==>> Int) =>
+      if (a.size == 0) {
+        val r = Random.nextInt()
+        a.lookupGE(r) must_=== None
+      }
+      else {
+        (0 until a.keys.size).foreach { i =>
+          val (k, v) = a.elemAt(i).get
+
+          a.lookupGE(k) must_=== Some((k, v))
+          if (k != Int.MaxValue) {
+            a.lookupGE(k+1) must_=== a.elemAt(i+1)
           }
         }
       }

--- a/tests/src/test/scala/scalaz/MapTest.scala
+++ b/tests/src/test/scala/scalaz/MapTest.scala
@@ -226,6 +226,11 @@ object MapTest extends SpecLite {
       d.lookupIndex(6).isDefined must_== false
     }
 
+    "value lookupLT" in {
+      fromList(List((3,"a"), (5,"b"))).lookupLT(3) must_=== None
+      fromList(List((3,"a"), (5,"b"))).lookupLT(4) must_=== Some((3, "a"))
+    }
+
     "lookup" ! forAll { (a: Byte ==>> Int, n: Byte) =>
       a.lookup(n) must_=== a.toList.find(_._1 == n).map(_._2)
     }
@@ -239,6 +244,23 @@ object MapTest extends SpecLite {
       a.lookupIndex(n) must_=== (if(x < 0) None else Some(x))
       a.lookupIndex(n).foreach{ b =>
         a.elemAt(b).map(_._1) must_=== Some(n)
+      }
+    }
+
+    "lookupLT" ! forAll { (a: Int ==>> Int) =>
+      if (a.size == 0) {
+        val r = Random.nextInt()
+        a.lookupLT(r) must_=== None
+      }
+      else {
+        (0 until a.keys.size).foreach { i =>
+          val (k, v) = a.elemAt(i).get
+
+          a.lookupLT(k) must_=== a.elemAt(i-1)
+          if (k != Int.MaxValue) {
+            a.lookupLT(k+1) must_=== Some((k, v))
+          }
+        }
       }
     }
   }

--- a/tests/src/test/scala/scalaz/MapTest.scala
+++ b/tests/src/test/scala/scalaz/MapTest.scala
@@ -231,6 +231,11 @@ object MapTest extends SpecLite {
       fromList(List((3,"a"), (5,"b"))).lookupLT(4) must_=== Some((3, "a"))
     }
 
+    "value lookupGT" in {
+      fromList(List((3,"a"), (5,"b"))).lookupGT(5) must_=== None
+      fromList(List((3,"a"), (5,"b"))).lookupGT(3) must_=== Some((5, "b"))
+    }
+
     "lookup" ! forAll { (a: Byte ==>> Int, n: Byte) =>
       a.lookup(n) must_=== a.toList.find(_._1 == n).map(_._2)
     }
@@ -259,6 +264,23 @@ object MapTest extends SpecLite {
           a.lookupLT(k) must_=== a.elemAt(i-1)
           if (k != Int.MaxValue) {
             a.lookupLT(k+1) must_=== Some((k, v))
+          }
+        }
+      }
+    }
+
+    "lookupGT" ! forAll { (a: Int ==>> Int) =>
+      if (a.size == 0) {
+        val r = Random.nextInt()
+        a.lookupGT(r) must_=== None
+      }
+      else {
+        (0 until a.keys.size).foreach { i =>
+          val (k, v) = a.elemAt(i).get
+
+          a.lookupGT(k) must_=== a.elemAt(i+1)
+          if (k != Int.MinValue) {
+            a.lookupGT(k-1) must_=== Some((k, v))
           }
         }
       }

--- a/tests/src/test/scala/scalaz/MapTest.scala
+++ b/tests/src/test/scala/scalaz/MapTest.scala
@@ -719,6 +719,55 @@ object MapTest extends SpecLite {
         rec(a)
       }
     }
+
+    "trimLookupLo sound" ! forAll { a: Int ==>> Int =>
+      def checkValidity(a: Int ==>> Int, lk: Int, hk: Option[Int]) = {
+        val (x, m) = trimLookupLo(lk, hk, a)
+        structurallySound(m)
+
+        val t1 = a.lookup(lk)
+        val t2 = trim(Some(lk), hk, a)
+        (x, m) must_=== (t1, t2)
+      }
+
+      a match {
+        case Tip() =>
+          val lk = Random.nextInt()
+          val hk = lk + 1
+          checkValidity(a, lk, Some(hk))
+          checkValidity(a, lk, None)
+
+        case Bin(_, _, _, _) =>
+          def rec(m: Int ==>> Int): Unit = {
+            m match {
+              case Tip() =>
+                ()
+              case Bin(k, x, l, r) =>
+                checkValidity(m, k, None)
+
+                if (k == Int.MinValue) {
+                  checkValidity(m, k, Some(k+1))
+
+                  rec(r)
+                }
+                else if (k == Int.MaxValue) {
+                  checkValidity(m, k-1, Some(k))
+                  checkValidity(m, k-1, None)
+
+                  rec(l)
+                }
+                else {
+                  checkValidity(m, k-1, Some(k+1))
+                  checkValidity(m, k-1, None)
+
+                  rec(l)
+                  rec(r)
+                }
+            }
+          }
+        rec(a)
+      }
+    }
   }
 
   "==>> list operations" should {

--- a/tests/src/test/scala/scalaz/MapTest.scala
+++ b/tests/src/test/scala/scalaz/MapTest.scala
@@ -928,6 +928,18 @@ object MapTest extends SpecLite {
     }
   }
 
+  "==>> fromSet" should {
+    "fromSet" in {
+      fromSet(ISet.fromList(List[Int](3, 5))){ i: Int => List.fill(i)('a').mkString } must_=== fromList(List(5 -> "aaaaa", 3 -> "aaa"))
+      fromSet(ISet.fromList(List[Int]())){ i: Int => i } must_=== empty
+    }
+
+    "fromSet" ! forAll { (a: ISet[Int]) =>
+      val li = a.toList.map(i => (i, i))
+      fromSet(a)(i => i) must_=== fromList(li)
+    }
+  }
+
   /*"==>> validity" should {
     "valid" in {
       fromList(List(3 -> "b", 5 -> "a")).isValid must_== true

--- a/tests/src/test/scala/scalaz/MapTest.scala
+++ b/tests/src/test/scala/scalaz/MapTest.scala
@@ -777,6 +777,13 @@ object MapTest extends SpecLite {
       val f = (k: Int, a: String, result: String) => result + "(" + k.toString + ":" + a + ")"
       fromList(List(5 -> "a", 3 -> "b")).foldrWithKey("Map: ")(f) must_== "Map: (5:a)(3:b)"
     }
+
+    "foldMapWithKey" ! forAll { a: Byte ==>> Byte =>
+      val f = (i: Byte, j: Byte) => i.toInt + j.toInt
+      val res = a.toList.foldLeft(0: Int)((acc, kv) => acc + kv._1.toInt + kv._2.toInt)
+
+      a.foldMapWithKey(f)(intInstance) must_=== res
+    }
   }
 
   "==>> trim" should {

--- a/tests/src/test/scala/scalaz/MapTest.scala
+++ b/tests/src/test/scala/scalaz/MapTest.scala
@@ -745,6 +745,28 @@ object MapTest extends SpecLite {
     }
   }
 
+  "==>> traverse" should {
+    "traverseWithKey" in {
+      val f = (k: Int, v: Char) => if (k%2 == 1) Some((v + 1).toChar) else None
+
+      empty.traverseWithKey(f) must_=== Some(empty)
+      fromList(List(1 -> 'a', 5 -> 'e')).traverseWithKey(f) must_=== Some(fromList(List(1 -> 'b', 5 -> 'f')))
+      fromList(List(2 -> 'a')).traverseWithKey(f) must_=== None
+    }
+
+    "traverseWithKey" ! forAll { (a: Int ==>> Char, b: Byte) =>
+      val fSome = (k: Int, v: Char) => some((v + b).toChar)
+      def fNone(key: Int) = (k: Int, v: Char) => if (k == key) None else some((v + b).toChar)
+
+      val li = a.toList.map(kv => (kv._1, fSome(kv._1, kv._2).get))
+      a.traverseWithKey(fSome) must_=== Some(fromList(li))
+
+      a.toList.foreach { kv =>
+        a.traverseWithKey(fNone(kv._1)) must_=== None
+      }
+    }
+  }
+
   "==>> fold" should {
     "fold" in {
       val f = (a: Int, b: String) => a + b.length

--- a/tests/src/test/scala/scalaz/MapTest.scala
+++ b/tests/src/test/scala/scalaz/MapTest.scala
@@ -333,6 +333,23 @@ object MapTest extends SpecLite {
     }
   }
 
+  "split" should {
+    "splitRoot" ! forAll { a: Int ==>> Int =>
+      a match {
+        case Tip() =>
+          a.splitRoot must_=== List.empty[Int ==>> Int]
+        case Bin(k, x, l, r) =>
+          val List(l2, kv, r2) = a.splitRoot
+          structurallySound(l2)
+          structurallySound(r2)
+          l2 must_=== l
+          r2 must_=== r
+          kv must_=== singleton(k, x)
+          l2.union(r2).union(kv) must_=== a
+      }
+    }
+  }
+
   "updateAt" should {
     "succeed" in {
       // TODO: This is a problem as the function 'updateAt' is not total - any thoughts?

--- a/tests/src/test/scala/scalaz/MapTest.scala
+++ b/tests/src/test/scala/scalaz/MapTest.scala
@@ -236,6 +236,12 @@ object MapTest extends SpecLite {
       fromList(List((3,"a"), (5,"b"))).lookupGT(3) must_=== Some((5, "b"))
     }
 
+    "value lookupLE" in {
+      fromList(List((3,"a"), (5,"b"))).lookupLE(2) must_=== None
+      fromList(List((3,"a"), (5,"b"))).lookupLE(3) must_=== Some((3, "a"))
+      fromList(List((3,"a"), (5,"b"))).lookupLE(4) must_=== Some((3, "a"))
+    }
+
     "value lookupGE" in {
       fromList(List((3,"a"), (5,"b"))).lookupGE(6) must_=== None
       fromList(List((3,"a"), (5,"b"))).lookupGE(5) must_=== Some((5, "b"))
@@ -287,6 +293,23 @@ object MapTest extends SpecLite {
           a.lookupGT(k) must_=== a.elemAt(i+1)
           if (k != Int.MinValue) {
             a.lookupGT(k-1) must_=== Some((k, v))
+          }
+        }
+      }
+    }
+
+    "lookupLE" ! forAll { (a: Int ==>> Int) =>
+      if (a.size == 0) {
+        val r = Random.nextInt()
+        a.lookupLE(r) must_=== None
+      }
+      else {
+        (0 until a.keys.size).foreach { i =>
+          val (k, v) = a.elemAt(i).get
+
+          a.lookupLE(k) must_=== Some((k, v))
+          if (k != Int.MinValue) {
+            a.lookupLE(k-1) must_=== a.elemAt(i-1)
           }
         }
       }

--- a/tests/src/test/scala/scalaz/MapTest.scala
+++ b/tests/src/test/scala/scalaz/MapTest.scala
@@ -419,12 +419,12 @@ object MapTest extends SpecLite {
 
     "differenceWith" in {
       val f = (al: String, ar: String) => if (al == "b") Some(al + ":" + ar) else None
-      fromList(List(5 -> "a", 3 -> "b")).differenceWith(fromList(List(5 -> "A", 3 -> "B", 7 -> "C")), f) must_===(singleton(3, "b:B"))
+      fromList(List(5 -> "a", 3 -> "b")).differenceWith(fromList(List(5 -> "A", 3 -> "B", 7 -> "C")))(f) must_===(singleton(3, "b:B"))
     }
 
     "differenceWithKey" in {
       val f = (k: Int, al: String, ar: String) => if (al == "b") Some(k.toString + ":" + al + "|" + ar) else None
-      fromList(List(5 -> "a", 3 -> "b")).differenceWithKey(fromList(List(5 -> "A", 3 -> "B", 10 -> "C")), f) must_===(singleton(3, "3:b|B"))
+      fromList(List(5 -> "a", 3 -> "b")).differenceWithKey(fromList(List(5 -> "A", 3 -> "B", 10 -> "C")))(f) must_===(singleton(3, "3:b|B"))
     }
   }
 


### PR DESCRIPTION
Our implementation is based on v0.4.0. Since haskell's Data.Map of v0.5.7.1 has a lot of improvement compared to that of v0.4.0, we can expect a better result by catching up the latest haskell's implementation.

## Main changes
### 1. Modify a re-balancing parameter `delta` from 4 to 3
As Milan Straka(a.k.a foxik from haskell/containers) and Kazu Yamamoto discussed [1, 2], we can expect insertion speed-up and deletion slow-down by changing the value. Actually only valid delta value with `ratio = 2` is 3 or 4 as proved by Yoichi Hirai and Kazuhiko Yamamoto, and Milan Straka[3, 4].
    One justification to set 3, I think, is we'd expect more insertion operations than deletion operations. Even though deletion is executed more than the number of times insertion is called, it doesn't really hurt us as it means we do deletion onto an empty map which indicates `O(1)`.
    [1] [Proposal: Further performance improvements of Data.Map by Kazu](https://mail.haskell.org/pipermail/libraries/2010-September/014254.html)
    [2] [Proposal: Further performance improvements of Data.Map by Milan](https://mail.haskell.org/pipermail/libraries/2010-September/014343.html)
   [3] [Balancing weight-balanced trees](https://yoichihirai.com/bst.pdf)
   [4] [Adams' Trees Revisited - Correct and Efficient Implementation](http://fox.ucw.cz/papers/bbtree/)

###  2. Apply the `correct` algorithm for key comparison
As Kazu Yamamoto pointed it out[1], we shouldn't use equality to check the validity of the size of subtrees. Milan told me the reason as below why equality was used when I fixed the old documentation of Data.Map. You can also find [the comment](https://github.com/haskell/containers/pull/191#issuecomment-199256260) from [my PR](https://github.com/haskell/containers/pull/191) :)
   - `The reason why (<=) had to be used before was that with delta=5 using (<) can be shown easily to not keep tree balance. Hence whoever implemented it, tried (<=), and the QuickCheck could not find a problem -- which happened several years later in [#4242](https://ghc.haskell.org/trac/ghc/ticket/4242).`

This change actually leads us to slow down deletion operation speed like you can find the benchmark result of [this commit](https://github.com/monkey-mas/scalaz/commit/da1912304799d44b3be12e7165bbfd7ec0387c52). I, however, think this is acceptable as the updated implementation follows the correct (`f-balance`) algorithm as mentioned by Kazu[1].

### 3. Improve functionality including tree re-balancing
As you can see from the benchmark results below, most of the functionality was improved.

###  4. Deprecate some functions
I deprecated some functions that used to be public functions and should've been treated as `private` functions. I did this as some functions are exposed to users even though they shouldn't. I talked about it with @xuwei-k, and this might not be a good idea as this breaks binary-compatibility. we might need discussion?

###  5. Add new functions
I added some new functions introduced (and "property-based" tests as well ;) )


## Benchmark
To justify these changes with regard to the performance, benchmark(average execution time) was measured using [OpenJDK: jmh](http://openjdk.java.net/projects/code-tools/jmh/) 

### Setup information
```
OS: Ubuntu 14.0.4 (with Linux kernel version 3.13.0-86-generic)
CPU: Intel(R) Core(TM) i7-2600 CPU @ 3.40GHz
VM version: JDK 1.8.0_77, VM 25.77-b03
JVM heap size: 8G(8192M)
sbt-plugin: [sbt-jmh](https://github.com/ktoso/sbt-jmh) (0.2.6(auto plugin) / OpenJDK:jmh version 1.11.3)
Warm-up trial: 30 times
Actual trial: 50 times
```

### Benchmark strategy
`insert`:
  - `Asc` means that we insert elements starting from 1 to one million.
  - `Dsc` means that we insert elements starting from one million to 1.
  - `Rand` means that we insert elements chosen from a pseudo-randomly shuffled list with one million elements.

`delete`:
  - `Asc` means that we delete elements starting from 1 to one million from a pseudo-randomly shuffled list with one million elements.
  - `Dsc` means that we delete elements starting from one million to 1 a pseudo-randomly shuffled list with one million elements.
  - `Rand` means that we delete elements chosen from a pseudo-randomly shuffled list with one million elements.

`union`:
  - `E_O` means that we do operations using two maps, one of which contains even elements from 2 to one million and the other of which has odd elements from 1 to one million.
  - `Rand` means that we do operations using two maps, one of which contains a pseudo-randomly shuffled list(say `a`) with 500,000 elements chosen from 1 to one million and the other of which(say `b`) has elements that `a` does not have.
  - `Rand2` means that we union b and a unlike we do `union a and b` in `Rand` benchmark.


`difference / intersection`:
  - `E_O` means that we do operations using two maps, one of which contains even elements from 2 to one million and the other of which has elements from 1 to one million.
  - `Rand` means that we do operations using two maps, one of which contains a pseudo-randomly shuffled list with 500,000 elements chosen from 1 to one million.
  - `Rand2` means that we do operations using two maps, one of which contains a pseudo-randomly shuffled list with 500,000 elements that are not used in `Rand` sample data.

### Benchmark results
  - `Original` refers to the latest commit [5efbdbd](https://github.com/monkey-mas/scalaz/commit/5efbdbd95968dd939df401f628360ec09c1b0015) of `series/7.3.x`.
  - `IMap_rm_eq` refers to the commit after we changed [delta to 3](https://github.com/monkey-mas/scalaz/commit/ecadcc866ea9944fcaf12941d19e2c4b589215f6) and [key-comparison](https://github.com/monkey-mas/scalaz/commit/da1912304799d44b3be12e7165bbfd7ec0387c52).
  - `IMap_balanceLR` refers to [the commit](https://github.com/monkey-mas/scalaz/commit/497a24490d6c764e7d5e2a9436e47160bbe0fbe1) after we improved our balance functions.
  - `IMap_latest` refers to [the latest commit](https://github.com/scalaz/scalaz/pull/1171/commits/73f6a086fcc415461e019005ffa37a0df9f05ac0) of this PR where all the changes are applied.

You can see the actual benchmark sample data and code from [here](https://github.com/monkey-mas/scalaz/blob/compare-map-benchmark/src/main/scala/jmh/MapBenchmark.scala) and results from [here](https://github.com/monkey-mas/scalaz/tree/compare-map-benchmark/result)
To execute the benchmark that I've done, please try the command below.
```
sbt -mem 8192 "jmh:run -i 50 -wi 30 -f 1 -t 1 -bm avgt"
```

Following are the benchmark result bar charts:

![insertion](https://docs.google.com/spreadsheets/d/1KtC_roQQ-rgVileQLBKHsQoTI22bkXljsHBUII0F5oE/pubchart?oid=1495078630&format=image)
![delete](https://docs.google.com/spreadsheets/d/1KtC_roQQ-rgVileQLBKHsQoTI22bkXljsHBUII0F5oE/pubchart?oid=692757716&format=image)
![difference](https://docs.google.com/spreadsheets/d/1KtC_roQQ-rgVileQLBKHsQoTI22bkXljsHBUII0F5oE/pubchart?oid=1764410888&format=image)
![intersection](https://docs.google.com/spreadsheets/d/1KtC_roQQ-rgVileQLBKHsQoTI22bkXljsHBUII0F5oE/pubchart?oid=798851732&format=image)
![union](https://docs.google.com/spreadsheets/d/1KtC_roQQ-rgVileQLBKHsQoTI22bkXljsHBUII0F5oE/pubchart?oid=753980869&format=image)