### PR TITLE
Add Apply.apM, which allows for short-circuiting implementations.

### DIFF
--- a/core/src/main/scala/scalaz/Apply.scala
+++ b/core/src/main/scala/scalaz/Apply.scala
@@ -20,6 +20,18 @@ trait Apply[F[_]] extends Functor[F] { self =>
     */
   def ap[A,B](fa: => F[A])(f: => F[A => B]): F[B]
 
+  /** Version of `ap` that takes one parameter, the one whose `F`-action
+    * should be performed later, in an additional context `M`.
+    *
+    * The default implementation `map`s over `mfa`, so it always accesses
+    * the value inside `mfa`. However, when the effects of `f` fully
+    * determine the result, the value inside `mfa` does not need to be
+    * accessed at all. This allows for implementations that, when `M`
+    * represents lazy evaluation, never evaluate `mfa`.
+    */
+  def apM[M[_], A, B](mfa: => M[F[A]])(f: => F[A => B])(implicit M: Applicative[M]): M[F[B]] =
+    M.map(mfa)(ap(_)(f))
+
   // derived functions
 
   def traverse1[A, G[_], B](value: G[A])(f: A => F[B])(implicit G: Traverse1[G]): F[G[B]] =

--- a/core/src/main/scala/scalaz/std/List.scala
+++ b/core/src/main/scala/scalaz/std/List.scala
@@ -57,11 +57,7 @@ trait ListInstances extends ListInstances0 {
             case Nil =>
               Trampoline.done(F.point(Nil))
             case h :: t =>
-              Trampoline.suspend(
-                loop(t).flatMap{ x =>
-                  Trampoline.delay(F.apply2(f(h), x)(_ :: _))
-                }
-              )
+              F.apM(Trampoline.suspend(loop(t)))(F.map(f(h))(b => (bs: List[B]) => b :: bs))
           }
         loop(l).run
       }

--- a/core/src/main/scala/scalaz/std/Option.scala
+++ b/core/src/main/scala/scalaz/std/Option.scala
@@ -20,6 +20,11 @@ trait OptionInstances extends OptionInstances0 {
         }
         case None    => None
       }
+      override def apM[M[_], A, B](mfa: => M[Option[A]])(f: => Option[A => B])(implicit M: Applicative[M]) =
+        f match {
+          case Some(f) => M.map(mfa)(map(_)(f))
+          case None => M.point(None)
+        }
       def bind[A, B](fa: Option[A])(f: A => Option[B]) = fa flatMap f
       override def map[A, B](fa: Option[A])(f: A => B) = fa map f
       def traverseImpl[F[_], A, B](fa: Option[A])(f: A => F[B])(implicit F: Applicative[F]) =

--- a/tests/src/test/scala/scalaz/TraverseTest.scala
+++ b/tests/src/test/scala/scalaz/TraverseTest.scala
@@ -59,7 +59,7 @@ object TraverseTest extends SpecLite {
         ys ::= x
         x
       }
-      ys must_=== List(Option(1), Option(2))
+      ys must_=== List(None, Option(2), Option(1))
     }
   }
 

--- a/tests/src/test/scala/scalaz/TraverseTest.scala
+++ b/tests/src/test/scala/scalaz/TraverseTest.scala
@@ -52,6 +52,15 @@ object TraverseTest extends SpecLite {
       s.exec(0) must_=== (N)
     }
 
+    "issue 1176" in {
+      val xs = List(Option(1), Option(2), None, Option(3), Option(4))
+      var ys = List.empty[Option[Int]]
+      Traverse[List].traverse(xs){ x =>
+        ys ::= x
+        x
+      }
+      ys must_=== List(Option(1), Option(2))
+    }
   }
 
   "stream" should {


### PR DESCRIPTION
The new `Apply#apM` method is similar in spirit to `cats`'s [`Apply#map2Eval`](https://github.com/typelevel/cats/blob/1236cf8782757a154caf78ce80563146e5362adc/core/src/main/scala/cats/Apply.scala#L36-L59), but doesn't fix `M` to any particular monad (like `cats.Eval`).

There exists a default implementation that is not short-circuiting. Applicative effects that support short-circuiting should override this method. Implementation for `Option` and fix for #1176 are included in this PR.