### PR TITLE
Scalaz8: Remove redundant implicits to avoid ambiguities.

### DIFF
--- a/base/src/main/scala/data/DisjunctionInstances.scala
+++ b/base/src/main/scala/data/DisjunctionInstances.scala
@@ -19,9 +19,4 @@ trait DisjunctionInstances {
     override def flatMap[A, B](oa: L \/ A)(f: A => L \/ B): L \/ B =
       oa.fold[L \/ B](l => -\/(l))(a => f(a))
   }
-
-  implicit def applicative[L]: Applicative[L \/ ?] = monad[L].applicative
-  implicit def apply[L]: Apply[L \/ ?] = monad[L].applicative.apply
-  implicit def functor[L]: Functor[L \/ ?] = monad[L].applicative.apply.functor
-  implicit def bind[L]: Bind[L \/ ?] = monad[L].bind
 }

--- a/base/src/main/scala/data/MaybeInstances.scala
+++ b/base/src/main/scala/data/MaybeInstances.scala
@@ -5,6 +5,9 @@ import typeclass._
 import Maybe.{Just, Empty}
 
 trait MaybeInstances extends MonadClass[Maybe] {
+
+  implicit def monadInstance: Monad[Maybe] = this
+
   override def ap[A, B](ma: Maybe[A])(mf: Maybe[A => B]): Maybe[B] =
     ma.fold(a => map[A => B, B](mf)(f => f(a)), Empty())
 

--- a/base/src/main/scala/typeclass/ApplicativeClass.scala
+++ b/base/src/main/scala/typeclass/ApplicativeClass.scala
@@ -2,7 +2,7 @@ package scalaz
 package typeclass
 
 trait ApplicativeClass[F[_]] extends Applicative[F] with ApplyClass[F] {
-  implicit final def applicative: Applicative[F] = this
+  final def applicative: Applicative[F] = this
 }
 
 object ApplicativeClass {

--- a/base/src/main/scala/typeclass/BindClass.scala
+++ b/base/src/main/scala/typeclass/BindClass.scala
@@ -2,7 +2,7 @@ package scalaz
 package typeclass
 
 trait BindClass[F[_]] extends Bind[F] with ApplyClass[F] {
-  implicit final def bind: Bind[F] = this
+  final def bind: Bind[F] = this
 }
 
 object BindClass {

--- a/base/src/main/scala/typeclass/FoldableClass.scala
+++ b/base/src/main/scala/typeclass/FoldableClass.scala
@@ -2,5 +2,5 @@ package scalaz
 package typeclass
 
 trait FoldableClass[F[_]] extends Foldable[F]{
-  implicit final def foldable: Foldable[F] = this
+  final def foldable: Foldable[F] = this
 }

--- a/base/src/main/scala/typeclass/FunctorClass.scala
+++ b/base/src/main/scala/typeclass/FunctorClass.scala
@@ -2,5 +2,5 @@ package scalaz
 package typeclass
 
 trait FunctorClass[F[_]] extends Functor[F]{
-  implicit final def functor: Functor[F] = this
+  final def functor: Functor[F] = this
 }

--- a/base/src/main/scala/typeclass/MonadClass.scala
+++ b/base/src/main/scala/typeclass/MonadClass.scala
@@ -2,7 +2,7 @@ package scalaz
 package typeclass
 
 trait MonadClass[F[_]] extends Monad[F] with BindClass[F] with ApplicativeClass[F] {
-  implicit final def monad: Monad[F] = this
+  final def monad: Monad[F] = this
 }
 
 object MonadClass {

--- a/base/src/main/scala/typeclass/TraversableClass.scala
+++ b/base/src/main/scala/typeclass/TraversableClass.scala
@@ -2,5 +2,5 @@ package scalaz
 package typeclass
 
 trait TraversableClass[F[_]] extends Traversable[F] with FunctorClass[F] with FoldableClass[F] {
-  implicit final def traversable: Traversable[F] = this
+  final def traversable: Traversable[F] = this
 }


### PR DESCRIPTION
Companion objects should only declare implicits for the type classes
at the top of a hierarchy. The resolution of subclasses should be
left to BaseHierarchy, otherwise ambiguities arise.
cc @aloiscochard 

Without this patch the following fails to compile:
```scala
import scalaz._
import data.Disjunction._
import typeclass._

class Test {

  def test[A, M[_] : Applicative : Bind](ma : M[A]) {}

  def run(): Unit = {
    val  v = right(1) : String\/Int
    test(v)
  }

}
```
