### PR TITLE
Add StrictTree to 7.2.x.

### DIFF
--- a/core/src/main/scala/scalaz/StrictTree.scala
+++ b/core/src/main/scala/scalaz/StrictTree.scala
@@ -1,0 +1,463 @@
+package scalaz
+
+import scala.collection.mutable
+import std.vector.{vectorInstance, vectorMonoid}
+
+/**
+  *
+  * @param rootLabel The label at the root of this tree.
+  * @param subForest The child nodes of this tree.
+  * @tparam A
+  */
+case class StrictTree[A](
+  rootLabel: A,
+  subForest: Vector[StrictTree[A]]
+) {
+
+  import StrictTree._
+
+  /**
+    * Run a bottom-up algorithm.
+    *
+    * This is the framework for several stackless methods, such as map.
+    *
+    * @param reduce is a function from a label and its mapped children to the new result.
+    */
+  private[scalaz] def runBottomUp[B](
+    reduce: A => mutable.Buffer[B] => B
+  ): B = {
+    val root = BottomUpStackElem[A, B](None, this)
+    val stack = mutable.Stack[BottomUpStackElem[A, B]](root)
+
+    while (stack.nonEmpty) {
+      val here = stack.elems.head
+      if (here.hasNext) {
+        val child = here.next()
+        val nextStackElem = BottomUpStackElem[A, B](Some(here), child)
+        stack.push(nextStackElem)
+      } else {
+        //The "here" node is completed, so add its result to its parents completed children.
+        val result = reduce(here.rootLabel)(here.mappedSubForest)
+        here.parent.foreach(_.mappedSubForest += result)
+        stack.pop()
+      }
+    }
+
+    reduce(root.rootLabel)(root.mappedSubForest)
+  }
+
+  /** Maps the elements of the StrictTree into a Monoid and folds the resulting StrictTree. */
+  def foldMap[B: Monoid](f: A => B): B =
+    runBottomUp(foldMapReducer(f))
+
+  def foldRight[B](z: B)(f: (A, => B) => B): B =
+    Foldable[Vector].foldRight(flatten, z)(f)
+
+  /** A 2D String representation of this StrictTree. */
+  def drawTree(implicit sh: Show[A]): String = {
+    toTree.drawTree
+  }
+
+  /** A histomorphic transform. Each element in the resulting tree
+    * is a function of the corresponding element in this tree
+    * and the histomorphic transform of its children.
+    */
+  def scanr[B](g: (A, Vector[StrictTree[B]]) => B): StrictTree[B] =
+    runBottomUp(scanrReducer(g))
+
+  /** Pre-order traversal. */
+  def flatten: Vector[A] = {
+    val stack = mutable.Stack(this)
+
+    val result = mutable.Buffer.empty[A]
+
+    while (stack.nonEmpty) {
+      val popped = stack.pop()
+      result += popped.rootLabel
+      popped.subForest.reverseIterator.foreach(stack.push)
+    }
+
+    result.toVector
+  }
+
+  def size: Int = {
+    val stack = mutable.Stack(this.subForest)
+
+    var result = 1
+
+    while (stack.nonEmpty) {
+      val popped = stack.pop()
+      result += popped.size
+      stack.pushAll(popped.map(_.subForest))
+    }
+
+    result
+  }
+
+  /** Breadth-first traversal. */
+  def levels: Vector[Vector[A]] = {
+    val f = (s: Vector[StrictTree[A]]) => {
+      Foldable[Vector].foldMap(s)((_: StrictTree[A]).subForest)
+    }
+    Vector.iterate(Vector(this), size)(f) takeWhile (!_.isEmpty) map (_ map (_.rootLabel))
+  }
+
+  def toTree: Tree[A] = {
+    Tree.Node[A](rootLabel, subForest.toStream.map(_.toTree))
+  }
+
+  /** Binds the given function across all the subtrees of this tree. */
+  def cobind[B](f: StrictTree[A] => B): StrictTree[B] = unfoldTree(this)(t => (f(t), t.subForest))
+
+  def foldNode[Z](f: A => Vector[StrictTree[A]] => Z): Z =
+    f(rootLabel)(subForest)
+
+  def map[B](f: A => B): StrictTree[B] = {
+    runBottomUp(mapReducer(f))
+  }
+
+  def flatMap[B](f: A => StrictTree[B]): StrictTree[B] = {
+    runBottomUp(flatMapReducer(f))
+  }
+
+  def traverse1[G[_] : Apply, B](f: A => G[B]): G[StrictTree[B]] = {
+    val G = Apply[G]
+
+    subForest match {
+      case Vector() => G.map(f(rootLabel))(Leaf(_))
+      case x +: xs => G.apply2(f(rootLabel), NonEmptyList.nel(x, IList.fromFoldable(xs)).traverse1(_.traverse1(f))) {
+        case (h, t) => Node(h, t.list.toVector)
+      }
+    }
+  }
+
+  def zip[B](b: StrictTree[B]): StrictTree[(A, B)] = {
+    val root = ZipStackElem[A, B](None, this, b)
+    val stack = mutable.Stack[ZipStackElem[A, B]](root)
+
+    while (stack.nonEmpty) {
+      val here = stack.elems.head
+      if (here.hasNext) {
+        val (childA, childB) = here.next()
+        val nextStackElem = ZipStackElem[A, B](Some(here), childA, childB)
+        stack.push(nextStackElem)
+      } else {
+        //The "here" node is completed, so add its result to its parents completed children.
+        val result = StrictTree((here.a.rootLabel, here.b.rootLabel), here.mappedSubForest.toVector)
+        here.parent.foreach(_.mappedSubForest += result)
+        stack.pop()
+      }
+    }
+
+    StrictTree((rootLabel, b.rootLabel), root.mappedSubForest.toVector)
+  }
+
+  /**
+    * This implementation is 24x faster than the trampolined implementation for StrictTreeTestJVM's hashCode test.
+    *
+    * @return
+    */
+  override def hashCode(): Int = {
+    runBottomUp(hashCodeReducer)
+  }
+
+  override def equals(obj: scala.Any): Boolean = {
+    obj match {
+      case other: StrictTree[A] =>
+        StrictTree.badEqInstance[A].equal(this, other)
+      case _ =>
+        false
+    }
+  }
+}
+
+sealed abstract class StrictTreeInstances {
+  implicit val strictTreeInstance: Traverse1[StrictTree] with Monad[StrictTree] with Comonad[StrictTree] with Align[StrictTree] with Zip[StrictTree] = new Traverse1[StrictTree] with Monad[StrictTree] with Comonad[StrictTree] with Align[StrictTree] with Zip[StrictTree] {
+    def point[A](a: => A): StrictTree[A] = StrictTree.Leaf(a)
+    def cobind[A, B](fa: StrictTree[A])(f: StrictTree[A] => B): StrictTree[B] = fa cobind f
+    def copoint[A](p: StrictTree[A]): A = p.rootLabel
+    override def map[A, B](fa: StrictTree[A])(f: A => B) = fa map f
+    def bind[A, B](fa: StrictTree[A])(f: A => StrictTree[B]): StrictTree[B] = fa flatMap f
+    def traverse1Impl[G[_]: Apply, A, B](fa: StrictTree[A])(f: A => G[B]): G[StrictTree[B]] = fa traverse1 f
+    override def foldRight[A, B](fa: StrictTree[A], z: => B)(f: (A, => B) => B): B = fa.foldRight(z)(f)
+    override def foldMapRight1[A, B](fa: StrictTree[A])(z: A => B)(f: (A, => B) => B) = (fa.flatten.reverse: @unchecked) match {
+      case h +: t => t.foldLeft(z(h))((b, a) => f(a, b))
+    }
+    override def foldLeft[A, B](fa: StrictTree[A], z: B)(f: (B, A) => B): B =
+      fa.flatten.foldLeft(z)(f)
+    override def foldMapLeft1[A, B](fa: StrictTree[A])(z: A => B)(f: (B, A) => B): B = fa.flatten match {
+      case h +: t => t.foldLeft(z(h))(f)
+    }
+    override def foldMap[A, B](fa: StrictTree[A])(f: A => B)(implicit F: Monoid[B]): B = fa foldMap f
+
+    //This implementation is 14x faster than the trampolined implementation for StrictTreeTestJVM's align test.
+    override def alignWith[A, B, C](f: (\&/[A, B]) => C): (StrictTree[A], StrictTree[B]) => StrictTree[C] = {
+      (a, b) =>
+        import StrictTree.AlignStackElem
+        val root = AlignStackElem[A, B, C](None, \&/(a, b))
+        val stack = mutable.Stack(root)
+
+        while (stack.nonEmpty) {
+          val here = stack.elems.head
+          if (here.hasNext) {
+            val nextChildren = here.next()
+            val nextStackElem = AlignStackElem[A, B, C](Some(here), nextChildren)
+            stack.push(nextStackElem)
+          } else {
+            //The "here" node is completed, so add its result to its parents completed children.
+            val result = StrictTree[C](f(here.trees.bimap(_.rootLabel, _.rootLabel)), here.mappedSubForest.toVector)
+            here.parent.foreach(_.mappedSubForest += result)
+            stack.pop()
+          }
+        }
+
+        StrictTree(f(root.trees.bimap(_.rootLabel, _.rootLabel)), root.mappedSubForest.toVector)
+    }
+
+    override def zip[A, B](a: => StrictTree[A], b: => StrictTree[B]): StrictTree[(A, B)] = {
+      a.zip(b)
+    }
+  }
+
+  implicit def treeEqual[A](implicit A0: Equal[A]): Equal[StrictTree[A]] =
+    new StrictTreeEqual[A] { def A = A0 }
+
+  implicit def treeOrder[A](implicit A0: Order[A]): Order[StrictTree[A]] =
+    new Order[StrictTree[A]] with StrictTreeEqual[A] {
+      def A = A0
+      import std.vector._
+      override def order(x: StrictTree[A], y: StrictTree[A]) =
+        A.order(x.rootLabel, y.rootLabel) match {
+          case Ordering.EQ =>
+            Order[Vector[StrictTree[A]]].order(x.subForest, y.subForest)
+          case x => x
+        }
+    }
+
+
+
+  /* TODO
+  def applic[A, B](f: StrictTree[A => B]) = a => StrictTree.node((f.rootLabel)(a.rootLabel), implicitly[Applic[newtypes.ZipVector]].applic(f.subForest.map(applic[A, B](_)).?)(a.subForest ?).value)
+   */
+}
+
+object StrictTree extends StrictTreeInstances {
+  /**
+   * Node represents a tree node that may have children.
+   *
+   * You can use Node for tree construction or pattern matching.
+   */
+  object Node {
+    def apply[A](root: A, forest: Vector[StrictTree[A]]): StrictTree[A] = {
+      StrictTree[A](root, forest)
+    }
+
+    def unapply[A](t: StrictTree[A]): Option[(A, Vector[StrictTree[A]])] = Some((t.rootLabel, t.subForest))
+  }
+
+  /**
+   *  Leaf represents a a tree node with no children.
+   *
+   *  You can use Leaf for tree construction or pattern matching.
+   */
+  object Leaf {
+    def apply[A](root: A): StrictTree[A] = {
+      Node(root, Vector.empty)
+    }
+
+    def unapply[A](t: StrictTree[A]): Option[A] = {
+      t match {
+        case Node(root, Vector()) =>
+          Some(root)
+        case _ =>
+          None
+      }
+    }
+  }
+
+  def unfoldForest[A, B](s: Vector[A])(f: A => (B, Vector[A])): Vector[StrictTree[B]] =
+    s.map(unfoldTree(_)(f))
+
+  def unfoldTree[A, B](v: A)(f: A => (B, Vector[A])): StrictTree[B] =
+    f(v) match {
+      case (a, bs) => Node(a, unfoldForest(bs)(f))
+    }
+
+  //Only used for .equals.
+  private def badEqInstance[A] = new StrictTreeEqual[A] {
+    override def A: Equal[A] = new Equal[A] {
+      override def equal(a1: A, a2: A): Boolean = a1.equals(a2)
+    }
+  }
+
+  /**
+    * This implementation is 16x faster than the trampolined implementation for StrictTreeTestJVM's scanr test.
+    */
+  private def scanrReducer[A, B](
+    f: (A, Vector[StrictTree[B]]) => B
+  )(rootLabel: A
+  )(subForest: mutable.Buffer[StrictTree[B]]
+  ): StrictTree[B] = {
+    val subForestVector = subForest.toVector
+    StrictTree[B](f(rootLabel, subForestVector), subForestVector)
+  }
+
+  /**
+    * This implementation is 10x faster than mapTrampoline for StrictTreeTestJVM's map test.
+    */
+  private def mapReducer[A, B](
+    f: A => B
+  )(rootLabel: A
+  )(subForest: Seq[StrictTree[B]]
+  ): StrictTree[B] = {
+    StrictTree[B](f(rootLabel), subForest.toVector)
+  }
+
+  /**
+    * This implementation is 9x faster than flatMapTrampoline for StrictTreeTestJVM's flatMap test.
+    */
+  private def flatMapReducer[A, B](
+    f: A => StrictTree[B]
+  )(root: A
+  )(subForest: Seq[StrictTree[B]]
+  ): StrictTree[B] = {
+    val StrictTree(rootLabel0, subForest0) = f(root)
+    StrictTree(rootLabel0, subForest0 ++ subForest)
+  }
+
+  /**
+    * This implementation is 9x faster than the trampolined implementation for StrictTreeTestJVM's foldMap test.
+    */
+  private def foldMapReducer[A, B: Monoid](
+    f: A => B
+  )(rootLabel: A
+  )(subForest: mutable.Buffer[B]
+  ): B = {
+    val mappedRoot = f(rootLabel)
+    val foldedForest = Foldable[Vector].fold[B](subForest.toVector)
+
+    Monoid[B].append(mappedRoot, foldedForest)
+  }
+
+  private def hashCodeReducer[A](root: A)(subForest: Seq[Int]): Int = {
+    root.hashCode ^ subForest.hashCode
+  }
+
+  private case class BottomUpStackElem[A, B](
+    parent: Option[BottomUpStackElem[A, B]],
+    tree: StrictTree[A]
+  ) extends Iterator[StrictTree[A]] {
+    private val subIterator = tree.subForest.iterator
+
+    def rootLabel = tree.rootLabel
+
+    val mappedSubForest: mutable.Buffer[B] = mutable.Buffer.empty
+
+    override def hasNext: Boolean = subIterator.hasNext
+
+    override def next(): StrictTree[A] = subIterator.next()
+  }
+
+  private case class ZipStackElem[A, B](
+    parent: Option[ZipStackElem[A, B]],
+    a: StrictTree[A],
+    b: StrictTree[B]
+  ) extends Iterator[(StrictTree[A], StrictTree[B])] {
+    private val zippedSubIterator =
+      a.subForest.iterator.zip(b.subForest.iterator)
+
+    val mappedSubForest: mutable.Buffer[StrictTree[(A, B)]] = mutable.Buffer.empty
+
+    override def hasNext: Boolean = zippedSubIterator.hasNext
+
+    override def next(): (StrictTree[A], StrictTree[B]) = zippedSubIterator.next()
+  }
+
+  private[scalaz] case class AlignStackElem[A, B, C](
+    parent: Option[AlignStackElem[A, B, C]],
+    trees: \&/[StrictTree[A], StrictTree[B]]
+  ) extends Iterator[\&/[StrictTree[A], StrictTree[B]]] {
+    private val iterators =
+      trees.bimap(_.subForest.iterator, _.subForest.iterator)
+
+    val mappedSubForest: mutable.Buffer[StrictTree[C]] = mutable.Buffer.empty
+
+    def whichHasNext: \&/[Boolean, Boolean] =
+      iterators.bimap(_.hasNext, _.hasNext)
+
+    override def hasNext: Boolean =
+      whichHasNext.fold(identity, identity, _ || _)
+
+    override def next(): \&/[StrictTree[A], StrictTree[B]] =
+      whichHasNext match {
+        case \&/(true, true) =>
+          iterators.bimap(_.next(), _.next())
+
+        case \&/(true, false) | \&/.This(true) =>
+          \&/.This(iterators.onlyThis.get.next())
+
+        case \&/(false, true) | \&/.That(true) =>
+          \&/.That(iterators.onlyThat.get.next())
+
+        case _ =>
+          throw new NoSuchElementException("reached iterator end")
+      }
+  }
+
+  implicit def ToStrictTreeUnzip[A1, A2](root: StrictTree[(A1, A2)]): StrictTreeUnzip[A1, A2] =
+    new StrictTreeUnzip[A1, A2](root)
+
+}
+
+private trait StrictTreeEqual[A] extends Equal[StrictTree[A]] {
+  def A: Equal[A]
+
+  private case class EqualStackElem(
+    a: StrictTree[A],
+    b: StrictTree[A]
+  ) {
+    val aSubIterator =
+      a.subForest.iterator
+
+    val bSubIterator =
+      b.subForest.iterator
+  }
+
+  //This implementation is 4.5x faster than the trampolined implementation for StrictTreeTestJVM's equal test.
+  override final def equal(a1: StrictTree[A], a2: StrictTree[A]): Boolean = {
+    val root = EqualStackElem(a1, a2)
+    val stack = mutable.Stack[EqualStackElem](root)
+
+    while (stack.nonEmpty) {
+      val here = stack.elems.head
+      if (A.equal(here.a.rootLabel, here.b.rootLabel)) {
+        val aNext = here.aSubIterator.hasNext
+        val bNext = here.bSubIterator.hasNext
+        (aNext, bNext) match {
+          case (true, true) =>
+            val childA = here.aSubIterator.next()
+            val childB = here.bSubIterator.next()
+            val nextStackElem = EqualStackElem(childA, childB)
+            stack.push(nextStackElem)
+          case (false, false) =>
+            stack.pop()
+          case _ =>
+            return false
+        }
+      } else return false
+    }
+
+    true
+  }
+}
+
+final class StrictTreeUnzip[A1, A2](val root: StrictTree[(A1, A2)]) extends AnyVal {
+  private def unzipCombiner(rootLabel: (A1, A2))(accumulator: Seq[(StrictTree[A1], StrictTree[A2])]): (StrictTree[A1], StrictTree[A2]) = {
+    (StrictTree(rootLabel._1, accumulator.map(_._1).toVector), StrictTree(rootLabel._2, accumulator.map(_._2).toVector))
+  }
+
+  /** Turns a tree of pairs into a pair of trees. */
+  def unzip: (StrictTree[A1], StrictTree[A2]) = {
+    root.runBottomUp[(StrictTree[A1], StrictTree[A2])](unzipCombiner)
+  }
+}

--- a/core/src/main/scala/scalaz/Tree.scala
+++ b/core/src/main/scala/scalaz/Tree.scala
@@ -1,7 +1,8 @@
 package scalaz
 
+import scalaz.Free.Trampoline
+import scalaz.Trampoline._
 import std.stream.{streamInstance, streamMonoid}
-import Free.Trampoline
 
 /**
  * A multi-way tree, also known as a rose tree. Also known as Cofree[Stream, A].
@@ -16,9 +17,16 @@ sealed abstract class Tree[A] {
   /** The child nodes of this tree. */
   def subForest: Stream[Tree[A]]
 
+  def foldMapTrampoline[B: Monoid](f: A => B): Trampoline[B] = {
+    for {
+      root <- delay(f(rootLabel))
+      subForests <- Foldable[Stream].foldMap[Tree[A], Trampoline[B]](subForest)(_.foldMapTrampoline(f))
+    } yield Monoid[B].append(root, subForests)
+  }
+
   /** Maps the elements of the Tree into a Monoid and folds the resulting Tree. */
   def foldMap[B: Monoid](f: A => B): B =
-    Monoid[B].append(f(rootLabel), Foldable[Stream].foldMap[Tree[A], B](subForest)((_: Tree[A]).foldMap(f)))
+    foldMapTrampoline[B](f).run
 
   def foldRight[B](z: => B)(f: (A, => B) => B): B =
     Foldable[Stream].foldRight(flatten, z)(f)
@@ -28,8 +36,8 @@ sealed abstract class Tree[A] {
     val reversedLines = draw.run
     val first = new StringBuilder(reversedLines.head.toString.reverse)
     val rest = reversedLines.tail
-    rest.foldLeft(first) { (acc, elem) => 
-      acc.append("\n").append(elem.toString.reverse) 
+    rest.foldLeft(first) { (acc, elem) =>
+      acc.append("\n").append(elem.toString.reverse)
     }.append("\n").toString
   }
 
@@ -42,7 +50,7 @@ sealed abstract class Tree[A] {
     Node(g(rootLabel, c.value), c.value)
   }
 
-  /** A 2D String representation of this Tree, separated into lines. 
+  /** A 2D String representation of this Tree, separated into lines.
     * Uses reversed StringBuilders for performance, because they are
     * prepended to.
     **/
@@ -70,8 +78,8 @@ sealed abstract class Tree[A] {
       }
       s
     }
-    
-    drawSubTrees(subForest).map { subtrees => 
+
+    drawSubTrees(subForest).map { subtrees =>
       new StringBuilder(sh.shows(rootLabel).reverse) +: subtrees
     }
   }
@@ -90,6 +98,23 @@ sealed abstract class Tree[A] {
       Foldable[Stream].foldMap(s)((_: Tree[A]).subForest)
     }
     Stream.iterate(Stream(this))(f) takeWhile (!_.isEmpty) map (_ map (_.rootLabel))
+  }
+
+  def toStrictTree: StrictTree[A] = {
+    import std.vector.vectorInstance
+
+    def trampolined(t: Tree[A]): Trampoline[StrictTree[A]] = {
+      t match {
+        case Tree.Leaf(root) =>
+          Trampoline.done(StrictTree.Leaf(root))
+        case Tree.Node(root, forest) =>
+          for {
+            strictForest <- Applicative[Trampoline].traverse(forest.toVector)(trampolined)
+          } yield StrictTree(root, strictForest)
+      }
+    }
+
+    trampolined(this).run
   }
 
   /** Binds the given function across all the subtrees of this tree. */
@@ -127,6 +152,7 @@ sealed abstract class Tree[A] {
       }
     }
   }
+
 }
 
 sealed abstract class TreeInstances {
@@ -147,7 +173,7 @@ sealed abstract class TreeInstances {
       case h #:: t => t.foldLeft(z(h))(f)
     }
     override def foldMap[A, B](fa: Tree[A])(f: A => B)(implicit F: Monoid[B]): B = fa foldMap f
-    def alignWith[A, B, C](f: (\&/[A, B]) ⇒ C) = { 
+    def alignWith[A, B, C](f: (\&/[A, B]) ⇒ C) = {
       def align(ta: Tree[A], tb: Tree[B]): Tree[C] =
         Tree.Node(f(\&/(ta.rootLabel, tb.rootLabel)), Align[Stream].alignWith[Tree[A], Tree[B], Tree[C]]({
           case \&/.This(sta) ⇒ sta map {a ⇒ f(\&/.This(a))}
@@ -250,6 +276,28 @@ object Tree extends TreeInstances {
 
 private trait TreeEqual[A] extends Equal[Tree[A]] {
   def A: Equal[A]
-  override final def equal(a1: Tree[A], a2: Tree[A]) =
-    A.equal(a1.rootLabel, a2.rootLabel) && a1.subForest.corresponds(a2.subForest)(equal _)
+
+  override final def equal(a1: Tree[A], a2: Tree[A]) = {
+    def corresponds[B](a1: Stream[Tree[A]], a2: Stream[Tree[A]]): Trampoline[Boolean] = {
+      (a1.isEmpty, a2.isEmpty) match {
+        case (true, true) => Trampoline.done(true)
+        case (_, true) | (true, _) => Trampoline.done(false)
+        case _ =>
+          for {
+            heads <- trampolined(a1.head, a2.head)
+            tails <- corresponds(a1.tail, a2.tail)
+          } yield heads && tails
+      }
+    }
+
+    def trampolined(a1: Tree[A], a2: Tree[A]): Trampoline[Boolean] = {
+      for {
+        roots <- Trampoline.done(A.equal(a1.rootLabel, a2.rootLabel))
+        subForests <- corresponds(a1.subForest, a2.subForest)
+      } yield roots && subForests
+    }
+
+    trampolined(a1, a2).run
+  }
+
 }

--- a/core/src/main/scala/scalaz/syntax/StrictTreeOps.scala
+++ b/core/src/main/scala/scalaz/syntax/StrictTreeOps.scala
@@ -1,0 +1,12 @@
+package scalaz
+package syntax
+
+final class StrictTreeOps[A](val self: A) extends AnyVal {
+  def strictNode(subForest: StrictTree[A]*): StrictTree[A] = StrictTree(self, subForest.toVector)
+
+  def strictLeaf: StrictTree[A] = StrictTree.Leaf(self)
+}
+
+trait ToStrictTreeOps {
+  implicit def ToStrictTreeOps[A](a: A): StrictTreeOps[A] = new StrictTreeOps(a)
+}

--- a/core/src/main/scala/scalaz/syntax/Syntax.scala
+++ b/core/src/main/scala/scalaz/syntax/Syntax.scala
@@ -109,6 +109,8 @@ trait Syntaxes {
 
   object tree extends ToTreeOps
 
+  object strictTree extends ToStrictTreeOps
+
   object reducer extends ToReducerOps
 
   object writer extends ToWriterOps
@@ -140,6 +142,7 @@ trait Syntaxes {
 trait ToDataOps
   extends ToIdOps
   with ToTreeOps
+  with ToStrictTreeOps
   with ToReducerOps
   with ToWriterOps
   with ToStateOps

--- a/example/src/main/scala/scalaz/example/MixedBag.scala
+++ b/example/src/main/scala/scalaz/example/MixedBag.scala
@@ -61,6 +61,23 @@ object MixedBag extends App {
     m assert_=== "12345"
   }
 
+  def strictTree() {
+    import std.string._
+    import syntax.semigroup._
+    import syntax.equal._
+    import syntax.strictTree._
+    import syntax.traverse._
+    import std.vector._
+
+    val tree: StrictTree[Int] = 1.strictNode(2.strictNode(3.strictLeaf), 4.strictLeaf, 5.strictLeaf)
+    val r = tree.foldRight(".")((i, s) => i.toString |+| s)
+    r assert_=== "12345."
+    val f = tree.flatten.foldMap(_.toString)
+    f assert_=== "12345"
+    val m = tree.foldMap(_.toString)
+    m assert_=== "12345"
+  }
+
   def kleisiArrow() {
     import Kleisli._
     import std.option._

--- a/tests/jvm/src/test/scala/scalaz/StrictTreeTestJVM.scala
+++ b/tests/jvm/src/test/scala/scalaz/StrictTreeTestJVM.scala
@@ -1,0 +1,99 @@
+package scalaz
+
+import scalaz.scalacheck.ScalazArbitrary._
+import StrictTree._
+import org.scalacheck.Gen
+import org.scalacheck.Prop.forAll
+import std.AllInstances._
+
+object StrictTreeTestJVM extends SpecLite {
+
+  val E = Equal[StrictTree[Int]]
+
+  "ScalazArbitrary.strictTreeGenSized" ! forAll(Gen.choose(1, 200)){ size =>
+    val gen = strictTreeGenSized[Unit](size)
+    Stream.continually(gen.sample).flatten.take(10).map(Foldable[StrictTree].length(_)).forall(_ == size)
+  }
+
+  def genTree(size: Int): StrictTree[Int] =
+    (1 to size).foldLeft(Leaf(0))((x, y) => Node(y, Vector(x)))
+
+  val size = 1000000
+
+  val deepTree = genTree(size)
+
+  "deep foldMap should not cause a stack overflow" ! {
+    deepTree.foldMap(identity)
+    true
+  }
+
+  "deep foldRight should not cause a stack overflow" ! {
+    deepTree.foldRight[Int](0)(_ + _)
+    true
+  }
+
+  "deep flatten should not cause a stack overflow" ! {
+    deepTree.flatten
+    true
+  }
+
+  "deep levels should not cause a stack overflow" ! {
+    deepTree.levels
+    true
+  }
+
+  "deep scanr should not cause a stack overflow" ! {
+    def f(a: Int, b: Seq[StrictTree[Int]]): Int = a + b.size
+    deepTree.scanr[Int](f _)
+    true
+  }
+
+  "deep size should not cause a stack overflow" ! {
+    deepTree.size
+    true
+  }
+
+  "deep Equal.equal should not cause a stack overflow" ! {
+    E.equal(deepTree, deepTree)
+  }
+
+  "deep hashCode should not cause a stack overflow" ! {
+    deepTree.hashCode
+    true
+  }
+
+  "deep equals should not cause a stack overflow" ! {
+    deepTree.equals(deepTree)
+  }
+
+  "deep toTree should not cause a stack overflow" ! {
+    deepTree.toTree
+    true
+  }
+
+  "deep map should not cause a stack overflow" ! {
+    deepTree.map(_ + 1)
+    true
+  }
+
+  "deep flatMap should not cause a stack overflow" ! {
+    deepTree.flatMap(Leaf(_))
+    true
+  }
+
+  "deep align should not cause a stack overflow" ! {
+    Align[StrictTree].align(deepTree, deepTree)
+    true
+  }
+
+  "deep zip should not cause a stack overflow" ! {
+    Zip[StrictTree].zip(deepTree, deepTree)
+    true
+  }
+
+  "deep unzip should not cause a stack overflow" ! {
+    Zip[StrictTree].zip(deepTree, deepTree).unzip
+    true
+  }
+
+}

--- a/tests/jvm/src/test/scala/scalaz/TreeTestJVM.scala
+++ b/tests/jvm/src/test/scala/scalaz/TreeTestJVM.scala
@@ -4,18 +4,44 @@ import scalaz.scalacheck.ScalazArbitrary._
 import Tree._
 import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll
+import std.AllInstances._
 
 object TreeTestJVM extends SpecLite {
+
+  val E = Equal[Tree[Int]]
 
   "ScalazArbitrary.treeGenSized" ! forAll(Gen.choose(1, 200)){ size =>
     val gen = treeGenSized[Unit](size)
     Stream.continually(gen.sample).flatten.take(10).map(Foldable[Tree].length(_)).forall(_ == size)
   }
 
+  def genTree(size: Int): Tree[Int] =
+    (1 to size).foldLeft(Leaf(0))((x, y) => Node(y, Stream(x)))
+
+  val size = 1000000
+
+  val deepTree = genTree(size)
+
+  "deep foldMap should not cause a stack overflow" ! {
+    deepTree.foldMap(identity) must_== (1 to size).sum
+  }
+
   "deep Tree flatten should not cause a stack overflow" ! {
-    val size = 1000000
-    val tree = (1 to size).foldLeft(Leaf(0))((x, y) => Node(y, Stream(x)))
-    tree.flatten must_== (size to 0 by -1).toStream
+    deepTree.flatten must_== (size to 0 by -1).toStream
+  }
+
+  "deep Equal.equal should not cause a stack overflow" ! {
+    E.equal(deepTree, deepTree) must_== true
+  }
+
+  "deep Tree toStrictTree should not cause a stack overflow" ! {
+    val expectedTree = StrictTreeTestJVM.deepTree
+    val actualTree = deepTree.toStrictTree
+    StrictTreeTestJVM.E.equal(actualTree, expectedTree) must_== true
+  }
+
+  "deep flatMap should not cause a stack overflow" ! {
+    E.equal(deepTree.flatMap(Leaf(_)), deepTree) must_== true
   }
 
 }

--- a/tests/src/test/scala/scalaz/StrictTreeTest.scala
+++ b/tests/src/test/scala/scalaz/StrictTreeTest.scala
@@ -1,0 +1,60 @@
+package scalaz
+
+import std.AllInstances._
+import scalaz.scalacheck.ScalazProperties._
+import scalaz.scalacheck.ScalazArbitrary._
+import StrictTree._
+import org.scalacheck.Prop.forAll
+
+object StrictTreeTest extends SpecLite {
+
+  checkAll("StrictTree", order.laws[StrictTree[Int]])
+  checkAll("StrictTree", traverse1.laws[StrictTree])
+  checkAll("StrictTree", applicative.laws[StrictTree])
+  checkAll("StrictTree", comonad.laws[StrictTree])
+  checkAll("StrictTree", align.laws[StrictTree])
+  checkAll("StrictTree", zip.laws[StrictTree])
+
+  checkAll(FoldableTests.anyAndAllLazy[Tree])
+
+  "indexed" ! forAll { xs: StrictTree[Byte] =>
+    val F = Traverse[StrictTree]
+    val a = F.indexed(xs)
+    Equal[StrictTree[Byte]].equal(a.map(_._2), xs) must_=== true
+    F.toList(a) must_=== F.toList(xs).zipWithIndex.map{case (a, b) => (b, a)}
+  }
+
+  "A tree must can be rendered as an ASCII string" ! {
+    Node(1, Vector(Node(2, Vector(Leaf(3))), Leaf(4))).drawTree must_== Seq(
+      "1",
+      "|",
+      "+- 2",
+      "|  |",
+      "|  `- 3",
+      "|",
+      "`- 4").mkString("", "\n", "\n")
+  }
+
+  "Equals.equal works" ! forAll { (s: StrictTree[Byte]) =>
+    val E = Equal[StrictTree[Byte]]
+    E.equal(s, s) must_== true
+  }
+
+  "flatMap((Leaf(_)) is identity" ! forAll { (s: StrictTree[Byte]) =>
+    val actualTree = s.flatMap(Leaf(_))
+    Equal[StrictTree[Byte]].equal(actualTree, s) must_== true
+  }
+
+  "flatten is the same as the lazy Tree's flatten" ! forAll { (s: StrictTree[Byte]) =>
+    s.flatten must_=== s.toTree.flatten.toVector
+  }
+
+  "StrictTree#toTree and Tree#toStrictTree are inverses" ! forAll { (s: StrictTree[Byte]) =>
+    Equal[StrictTree[Byte]].equal(s, s.toTree.toStrictTree) must_=== true
+  }
+
+  "size gives the same number of elements as flatten" ! forAll { (s: StrictTree[Byte]) =>
+    s.flatten.size must_=== s.size
+  }
+
+}


### PR DESCRIPTION
Duplicate of #1137 for 7.2.x. The binary incompatibility is

```
[error]  * method strictTree()scalaz.syntax.Syntaxes#strictTree# in trait scalaz.syntax.Syntaxes is present only in current version
```

Does anyone know how to resolve this? It's not obvious to me.
