### PR TITLE
[Scalaz 8] add Const, Semigroup and Monoid

### DIFF
--- a/base/src/main/scala/BaseHierarchy.scala
+++ b/base/src/main/scala/BaseHierarchy.scala
@@ -6,6 +6,7 @@ class BaseHierarchy extends BaseHierarchy.BH0
 
 object BaseHierarchy {
   trait BH0 extends BH1 {
+    implicit def monoidSemigroup[A](implicit A: Monoid[A]): Semigroup[A] = A.semigroup
     implicit def monadBind[M[_]](implicit M: Monad[M]): Bind[M] = M.bind
     implicit def monadApplicative[M[_]](implicit M: Monad[M]): Applicative[M] = M.applicative
     implicit def monadApply[M[_]](implicit M: Monad[M]): Apply[M] = M.applicative.apply

--- a/base/src/main/scala/data/Const.scala
+++ b/base/src/main/scala/data/Const.scala
@@ -1,0 +1,9 @@
+package scalaz
+package data
+
+final case class  Const[A, B](getConst: A){
+  def retag[C]: Const[A, C] =
+    this.asInstanceOf[Const[A, C]]
+}
+
+object Const extends ConstInstances

--- a/base/src/main/scala/data/ConstInstances.scala
+++ b/base/src/main/scala/data/ConstInstances.scala
@@ -1,0 +1,41 @@
+package scalaz
+package data
+
+import scalaz.typeclass._
+
+trait ConstInstances {
+  implicit def traverse[R]: Traversable[Const[R, ?]] = new TraversableClass[Const[R, ?]] {
+    def map[A, B](ma: Const[R, A])(f: A => B): Const[R, B] = ma.retag
+
+    def traverse[F[_], A, B](ta: Const[R, A])(f: A => F[B])(implicit F: Applicative[F]): F[Const[R, B]] =
+      F.pure(ta.retag)
+
+    def sequence[F[_], A](ta: Const[R, F[A]])(implicit F: Applicative[F]): F[Const[R, A]] =
+      F.pure(ta.retag)
+
+    def foldLeft[A, B](fa: Const[R, A], z: B)(f: (B, A) => B): B = z
+
+    def foldRight[A, B](fa: Const[R, A], z: => B)(f: (A, => B) => B): B = z
+  }
+
+  implicit def apply[R](implicit R: Semigroup[R]): Apply[Const[R, ?]] = new Apply[Const[R, ?]] {
+    def functor: Functor[Const[R, ?]] = implicitly
+    def ap[A, B](fa: Const[R, A])(f: Const[R, A => B]): Const[R, B] =
+      Const(R.append(fa.getConst, f.getConst))
+  }
+
+  implicit def applicative[R](implicit R: Monoid[R]): Applicative[Const[R, ?]] = new Applicative[Const[R, ?]] {
+    def apply: Apply[Const[R, ?]] = implicitly
+    def pure[A](a: A): Const[R, A] = Const(R.empty)
+  }
+
+  implicit def semigroup[A, B](implicit A: Semigroup[A]): Semigroup[Const[A, B]] = new Semigroup[Const[A, B]] {
+    def append(a1: Const[A, B], a2: => Const[A, B]): Const[A, B] =
+      Const(A.append(a1.getConst, a2.getConst))
+  }
+
+  implicit def monoid[A, B](implicit A: Monoid[A]): Monoid[Const[A, B]] = new Monoid[Const[A, B]] {
+    def semigroup: Semigroup[Const[A, B]] = implicitly
+    def empty: Const[A, B] = Const(A.empty)
+  }
+}

--- a/base/src/main/scala/typeclass/Monoid.scala
+++ b/base/src/main/scala/typeclass/Monoid.scala
@@ -1,0 +1,12 @@
+package scalaz
+package typeclass
+
+trait Monoid[A] {
+  def semigroup: Semigroup[A]
+
+  def empty: A
+}
+
+object Monoid {
+  def apply[A](implicit A: Monoid[A]): Monoid[A] = A
+}

--- a/base/src/main/scala/typeclass/MonoidClass.scala
+++ b/base/src/main/scala/typeclass/MonoidClass.scala
@@ -1,0 +1,6 @@
+package scalaz
+package typeclass
+
+trait MonoidClass[A] extends Monoid[A] with SemigroupClass[A]{
+  final def monoid: Monoid[A] = this
+}

--- a/base/src/main/scala/typeclass/MonoidInstances.scala
+++ b/base/src/main/scala/typeclass/MonoidInstances.scala
@@ -1,0 +1,5 @@
+package typeclass
+
+trait MonoidInstances {
+
+}

--- a/base/src/main/scala/typeclass/Semigroup.scala
+++ b/base/src/main/scala/typeclass/Semigroup.scala
@@ -1,0 +1,12 @@
+package scalaz
+package typeclass
+
+trait Semigroup[A] {
+  def append(a1: A, a2: => A): A
+}
+
+object Semigroup {
+  def apply[A](implicit A: Semigroup[A]): Semigroup[A] = A
+
+  object syntax extends SemigroupSyntax
+}

--- a/base/src/main/scala/typeclass/SemigroupClass.scala
+++ b/base/src/main/scala/typeclass/SemigroupClass.scala
@@ -1,0 +1,6 @@
+package scalaz
+package typeclass
+
+trait SemigroupClass[A] extends Semigroup[A]{
+  final def semigroup: Semigroup[A] = this
+}

--- a/base/src/main/scala/typeclass/SemigroupInstances.scala
+++ b/base/src/main/scala/typeclass/SemigroupInstances.scala
@@ -1,0 +1,6 @@
+package scalaz
+package typeclass
+
+trait SemigroupInstances {
+
+}

--- a/base/src/main/scala/typeclass/SemigroupSyntax.scala
+++ b/base/src/main/scala/typeclass/SemigroupSyntax.scala
@@ -1,0 +1,14 @@
+package scalaz
+package typeclass
+
+import scala.language.implicitConversions
+
+trait SemigroupSyntax {
+  implicit def equalOpsA[A: Semigroup](a: A): SemigroupSyntax.OpsA[A] = new SemigroupSyntax.OpsA(a)
+}
+
+object SemigroupSyntax {
+  class OpsA[A](a: A)(implicit A: Semigroup[A]) {
+    def append(other: => A): A = A.append(a, other)
+  }
+}


### PR DESCRIPTION
I wanted to see how the new typeclass encoding will deal with `Const` which previously required a trait hierarchy.