### PR TITLE
Change default Scala version to 2.12.1.

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -93,7 +93,7 @@ object build {
     mappings in (Compile, packageSrc) ++= (managedSources in Compile).value.map{ f =>
       (f, f.relativeTo((sourceManaged in Compile).value).get.getPath)
     },
-    scalaVersion := "2.10.6",
+    scalaVersion := "2.12.1",
     crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.1"),
     resolvers ++= (if (scalaVersion.value.endsWith("-SNAPSHOT")) List(Opts.resolver.sonatypeSnapshots) else Nil),
     fullResolvers ~= {_.filterNot(_.name == "jcenter")}, // https://github.com/sbt/sbt/issues/2217


### PR DESCRIPTION
Is it perhaps time to change the default Scala version to 2.11.8? This will not have much impact, since `scalaz` is cross-built anyway, but `scalaVersion` happens to be the version that is used by `publishLocal`. So I suppose if most devs are on 2.11.8, this makes sense.
