### PR TITLE
Reduce running time of tests.

### DIFF
--- a/tests/jvm/src/test/scala/scalaz/NonEmptyListTestJVM.scala
+++ b/tests/jvm/src/test/scala/scalaz/NonEmptyListTestJVM.scala
@@ -7,7 +7,7 @@ object NonEmptyListTestJVM extends SpecLite {
   "NonEmptyList.foldRight1 large list" in {
     import NonEmptyList._
     import syntax.foldable1._
-    nel(0, IList.fromList(List.fill(10000000)(1))).foldRight1(_ + _) must_== 10000000
+    nel(0, IList.fromList(List.fill(100000)(1))).foldRight1(_ + _) must_== 100000
   }
   "no stack overflow large list traverse" in {
     import syntax.traverse._
@@ -15,8 +15,8 @@ object NonEmptyListTestJVM extends SpecLite {
     (largeNel map Option.apply).sequence must_===(Option(largeNel))
   }
   "stack-safety of tails" in {
-    val largeNel = NonEmptyList.nel(0, IList.fill(1000000)(0))
-    largeNel.tails.size must_== 1000001
+    val largeNel = NonEmptyList.nel(0, IList.fill(100000)(0))
+    largeNel.tails.size must_== 100001
   }
 
 }

--- a/tests/jvm/src/test/scala/scalaz/StrictTreeTestJVM.scala
+++ b/tests/jvm/src/test/scala/scalaz/StrictTreeTestJVM.scala
@@ -18,7 +18,7 @@ object StrictTreeTestJVM extends SpecLite {
   def genTree(size: Int): StrictTree[Int] =
     (1 to size).foldLeft(Leaf(0))((x, y) => Node(y, Vector(x)))
 
-  val size = 1000000
+  val size = 100000
 
   val deepTree = genTree(size)
 

--- a/tests/jvm/src/test/scala/scalaz/TreeTestJVM.scala
+++ b/tests/jvm/src/test/scala/scalaz/TreeTestJVM.scala
@@ -18,7 +18,7 @@ object TreeTestJVM extends SpecLite {
   def genTree(size: Int): Tree[Int] =
     (1 to size).foldLeft(Leaf(0))((x, y) => Node(y, Stream(x)))
 
-  val size = 1000000
+  val size = 100000
 
   val deepTree = genTree(size)
 


### PR DESCRIPTION
This reduces the running time of `testsJVM/test` on my laptop from 622s to 87s and avoids 7 `OutOfMemoryError`s during tests.