### PR TITLE
use Liskov instead of Leibniz in AssociativeOps

### DIFF
--- a/core/src/main/scala/scalaz/syntax/AssociativeSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/AssociativeSyntax.scala
@@ -4,13 +4,13 @@ package syntax
 /** Wraps a value `self` and provides methods related to `Associative` */
 final class AssociativeOps[F[_, _],A, B] private[syntax](val self: F[A, B])(implicit val F: Associative[F]) extends Ops[F[A, B]] {
   ////
-  import Leibniz.===
+  import Liskov._
 
-  final def reassociateLeft[TT, C](implicit ev: B === F[TT, C]): F[F[A, TT], C] =
-    F.reassociateLeft(ev.subst[F[A, ?]](self))
+  final def reassociateLeft[TT, C](implicit ev: F[A, B] <~< F[A, F[TT, C]]): F[F[A, TT], C] =
+    F.reassociateLeft(ev(self))
 
-  final def reassociateRight[TT, C](implicit ev: A === F[TT, C]): F[TT, F[C, B]] =
-    F.reassociateRight(ev.subst[F[?, B]](self))
+  final def reassociateRight[TT, C](implicit ev: F[A, B] <~< F[F[TT, C], B]): F[TT, F[C, B]] =
+    F.reassociateRight(ev(self))
 
   ////
 }

--- a/tests/src/test/scala/scalaz/AssociativeTest.scala
+++ b/tests/src/test/scala/scalaz/AssociativeTest.scala
@@ -1,0 +1,18 @@
+package scalaz
+
+import std.tuple._
+import syntax.associative._
+
+object AssociativeTest extends SpecLite {
+
+  def compilationTest: Unit = {
+    val a1 = (1, (2, 3))
+    val b1 = a1.reassociateLeft
+    b1: ((Int, Int), Int)
+
+    val a2: (Int \/ Int) \/ Int = \/-(42)
+    val b2 = a2.reassociateRight
+    b2: (Int \/ (Int \/ Int))
+  }
+
+}


### PR DESCRIPTION
before

```
scala> import scalaz._, std.tuple._, syntax.associative._
import scalaz._
import std.tuple._
import syntax.associative._
scala>  val a1 = (1, (2, 3))
a1: (Int, (Int, Int)) = (1,(2,3))

scala> val b1 = a1.reassociateLeft
<console>:26: error: could not find implicit value for parameter ev: scalaz.Leibniz.===[(Int, Int),(TT, C)]
       val b1 = a1.reassociateLeft
                   ^

scala> val b1 = a1.reassociateLeft[Int, Int]
b1: ((Int, Int), Int) = ((1,2),3)
```

after

````
scala> import scalaz._, std.tuple._, syntax.associative._
import scalaz._
import std.tuple._
import syntax.associative._
scala>  val a1 = (1, (2, 3))
a1: (Int, (Int, Int)) = (1,(2,3))

scala> val b1 = a1.reassociateLeft
b1: ((Int, Int), Int) = ((1,2),3)
```
