### PR TITLE
Feature/8 machinist

### DIFF
--- a/base/src/main/scala/typeclass/Bind.scala
+++ b/base/src/main/scala/typeclass/Bind.scala
@@ -6,7 +6,7 @@ trait Bind[M[_]] {
   def flatMap[A, B](ma: M[A])(f: A => M[B]): M[B]
 }
 
-object Bind extends BindInstances {
+object Bind extends BindInstances with BindFunctions {
   def apply[F[_]](implicit F: Bind[F]): Bind[F] = F
 
   object syntax extends BindSyntax

--- a/base/src/main/scala/typeclass/BindFunctions.scala
+++ b/base/src/main/scala/typeclass/BindFunctions.scala
@@ -1,0 +1,6 @@
+package scalaz
+package typeclass
+
+trait BindFunctions {
+  def flatMap[M[_], A, B](ma: M[A])(f: A => M[B])(implicit M: Bind[M]): M[B] = M.flatMap(ma)(f)
+}

--- a/base/src/main/scala/typeclass/BindSyntax.scala
+++ b/base/src/main/scala/typeclass/BindSyntax.scala
@@ -2,6 +2,7 @@ package scalaz
 package typeclass
 
 import scala.language.implicitConversions
+import scala.language.experimental.macros
 
 trait BindSyntax {
   def flatMap[M[_], A, B](ma: M[A])(f: A => M[B])(implicit M: Bind[M]): M[B] = M.flatMap(ma)(f)
@@ -12,7 +13,7 @@ trait BindSyntax {
 
 object BindSyntax {
   class Ops[M[_], A](ma: M[A])(implicit M: Bind[M]) {
-    def flatMap[B](f: A => M[B]): M[B] = M.flatMap(ma)(f)
+    def flatMap[B](f: A => M[B]): M[B] = macro meta.Ops._f[A => M[B], M[B]]
   }
 }
 

--- a/base/src/main/scala/typeclass/BindSyntax.scala
+++ b/base/src/main/scala/typeclass/BindSyntax.scala
@@ -5,8 +5,6 @@ import scala.language.implicitConversions
 import scala.language.experimental.macros
 
 trait BindSyntax {
-  def flatMap[M[_], A, B](ma: M[A])(f: A => M[B])(implicit M: Bind[M]): M[B] = M.flatMap(ma)(f)
-
   implicit def bindOps[M[_], A](ma: M[A])(implicit M: Bind[M]): BindSyntax.Ops[M, A] =
     new BindSyntax.Ops(ma)
 }

--- a/base/src/main/scala/typeclass/Functor.scala
+++ b/base/src/main/scala/typeclass/Functor.scala
@@ -5,7 +5,7 @@ trait Functor[F[_]] {
   def map[A, B](ma: F[A])(f: A => B): F[B]
 }
 
-object Functor {
+object Functor extends FunctorFunctions {
   def apply[F[_]](implicit F: Functor[F]): Functor[F] = F
 
   object syntax extends FunctorSyntax

--- a/base/src/main/scala/typeclass/FunctorFunctions.scala
+++ b/base/src/main/scala/typeclass/FunctorFunctions.scala
@@ -1,0 +1,6 @@
+package scalaz
+package typeclass
+
+trait FunctorFunctions {
+  def map[F[_], A, B](fa: F[A])(f: A => B)(implicit F: Functor[F]): F[B] = F.map(fa)(f)
+}

--- a/base/src/main/scala/typeclass/FunctorSyntax.scala
+++ b/base/src/main/scala/typeclass/FunctorSyntax.scala
@@ -5,8 +5,6 @@ import scala.language.implicitConversions
 import scala.language.experimental.macros
 
 trait FunctorSyntax {
-  def map[F[_], A, B](fa: F[A])(f: A => B)(implicit F: Functor[F]): F[B] = F.map(fa)(f)
-
   implicit def functorOps[F[_], A](fa: F[A])(implicit F: Functor[F]): FunctorSyntax.Ops[F, A] =
     new FunctorSyntax.Ops(fa)
 }

--- a/base/src/main/scala/typeclass/FunctorSyntax.scala
+++ b/base/src/main/scala/typeclass/FunctorSyntax.scala
@@ -2,6 +2,7 @@ package scalaz
 package typeclass
 
 import scala.language.implicitConversions
+import scala.language.experimental.macros
 
 trait FunctorSyntax {
   def map[F[_], A, B](fa: F[A])(f: A => B)(implicit F: Functor[F]): F[B] = F.map(fa)(f)
@@ -12,7 +13,7 @@ trait FunctorSyntax {
 
 object FunctorSyntax {
   class Ops[F[_], A](self: F[A])(implicit F: Functor[F]) {
-    def map[B](f: A => B): F[B] = F.map[A, B](self)(f)
+    def map[B](f: A => B): F[B] = macro meta.Ops._f[A => B, F[B]]
     def void: F[Unit] = F.map[A, Unit](self)(_ => ())
   }
 }

--- a/meta/src/main/scala/Ops.scala
+++ b/meta/src/main/scala/Ops.scala
@@ -1,0 +1,22 @@
+package scalaz
+package meta
+
+import scala.reflect.macros.whitebox.Context
+
+// Originally inspired by http://typelevel.org/blog/2013/10/13/spires-ops-macros.html
+
+object Ops {
+  def _f[A, R](c: Context)(f: c.Expr[A]): c.Expr[R] = {
+    import c.universe._
+    val (ev, lhs) = unpack(c)
+    c.Expr[R](Apply(Apply(Select(ev, TermName(c.macroApplication.symbol.name.toString)), List(lhs)), List(f.tree)))
+  }
+
+  def unpack[T[_], A](c: Context) = {
+      import c.universe._
+      c.prefix.tree match {
+        case Apply(Apply(TypeApply(_, _), List(x)), List(ev)) => (ev, x)
+        case t => c.abort(c.enclosingPosition, "Cannot extract subject of operation (tree = %s)" format t)
+      }
+    }
+}

--- a/prelude/src/main/scala/Prelude.scala
+++ b/prelude/src/main/scala/Prelude.scala
@@ -7,6 +7,7 @@ import scala.language.implicitConversions
 
 trait Prelude  extends data.DisjunctionFunctions
                   with data.MaybeFunctions
+                  with typeclass.BindFunctions
                   with typeclass.FunctorFunctions {
   // Core Class
   // ==========

--- a/prelude/src/main/scala/Prelude.scala
+++ b/prelude/src/main/scala/Prelude.scala
@@ -5,7 +5,9 @@ import data._
 
 import scala.language.implicitConversions
 
-trait Prelude extends data.DisjunctionFunctions with data.MaybeFunctions {
+trait Prelude  extends data.DisjunctionFunctions
+                  with data.MaybeFunctions
+                  with typeclass.FunctorFunctions {
   // Core Class
   // ==========
   type Applicative[F[_]] = typeclass.Applicative[F]

--- a/project/ScalazBuild.scala
+++ b/project/ScalazBuild.scala
@@ -26,12 +26,12 @@ object Scalaz extends Build {
   ).settings(
     scalaVersion := "2.11.8"
   ).aggregate ( baze
+              , meta
               , prelude
               , benchmarks )
 
   lazy val baze         = module("base")
-
-  lazy val prelude      = module("prelude").dependsOn(baze)
+    .dependsOn( meta )
 
   lazy val benchmarks   = module("benchmarks")
     .dependsOn( baze
@@ -44,4 +44,13 @@ object Scalaz extends Build {
             , "org.scalaz" %% "scalaz-core" % "7.2.1"
             , "org.typelevel" %% "cats" % "0.5.0" )
     )
+
+  lazy val meta         = module("meta")
+    .settings(
+      libraryDependencies ++=
+        Seq ( "org.scala-lang" % "scala-reflect" % scalaVersion.value
+            , "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided" )
+    )
+
+  lazy val prelude      = module("prelude").dependsOn(baze)
 }


### PR DESCRIPTION
Here is a proposed `meta` module with `machinist` integration to provide zero-cost typeclass syntax.

It works in for-comprehension as well, sample usage:
```
scala> import scalaz.Prelude._
import scalaz.Prelude._

scala> just(42)
res0: scalaz.data.Maybe[Int] = Just(42)

scala> just(42).map(_ / 2)
res1: scalaz.data.Maybe[Int] = Just(21)

scala> for { x <- just(42) } yield (x / 2)
res2: scalaz.data.Maybe[Int] = Just(21)
```

This actually get resolved to explicit TC instance calls (more details here: http://typelevel.org/blog/2013/10/13/spires-ops-macros.html).

I'm unsure about the impact on compilation time but I think we should go for it, it's easy to change later and we won't pollute our data type with typeclass syntax methods.