### PR TITLE
Extract `TraversableFunctions`.

### DIFF
--- a/base/src/main/scala/typeclass/TraversableFunctions.scala
+++ b/base/src/main/scala/typeclass/TraversableFunctions.scala
@@ -1,0 +1,7 @@
+package scalaz
+package typeclass
+
+trait TraversableFunctions {
+  def sequence[T[_], F[_], A](tfa: T[F[A]])(implicit F: Applicative[F], T: Traversable[T]): F[T[A]] =
+    T.sequence(tfa)
+}

--- a/base/src/main/scala/typeclass/TraversableSyntax.scala
+++ b/base/src/main/scala/typeclass/TraversableSyntax.scala
@@ -4,9 +4,6 @@ package typeclass
 import scala.language.implicitConversions
 
 trait TraversableSyntax {
-  def sequence[T[_], F[_], A](tfa: T[F[A]])(implicit F: Applicative[F], T: Traversable[T]): F[T[A]] =
-    T.sequence(tfa)
-
   implicit def traversableOps[T[_], A](ta: T[A])(implicit T: Traversable[T]): TraversableSyntax.Ops[T, A] =
     new TraversableSyntax.Ops(ta)
 }

--- a/prelude/src/main/scala/Prelude.scala
+++ b/prelude/src/main/scala/Prelude.scala
@@ -8,7 +8,8 @@ import scala.language.implicitConversions
 trait Prelude  extends data.DisjunctionFunctions
                   with data.MaybeFunctions
                   with typeclass.BindFunctions
-                  with typeclass.FunctorFunctions {
+                  with typeclass.FunctorFunctions
+                  with typeclass.TraversableFunctions {
   // Core Class
   // ==========
   type Applicative[F[_]] = typeclass.Applicative[F]


### PR DESCRIPTION
Should be the last one remaining where it was mixed with syntax (preventing inclusion in `Prelude`).