### PR TITLE
Make swap a method of Arrow, so that an instance of Arrow may override `swap`

### DIFF
--- a/core/src/main/scala/scalaz/Arrow.scala
+++ b/core/src/main/scala/scalaz/Arrow.scala
@@ -30,7 +30,7 @@ trait Arrow[=>:[_, _]] extends Split[=>:] with Strong[=>:] with Category[=>:] { 
     compose(fbc, fab)
 
   /** Swaps a pair. */
-  def swap[X, Y] = arr[(X, Y), (Y, X)] {
+  def swap[X, Y]: ((X, Y) =>: (Y, X)) = arr[(X, Y), (Y, X)] {
     case (x, y) => (y, x)
   }
 

--- a/core/src/main/scala/scalaz/Arrow.scala
+++ b/core/src/main/scala/scalaz/Arrow.scala
@@ -29,12 +29,13 @@ trait Arrow[=>:[_, _]] extends Split[=>:] with Strong[=>:] with Category[=>:] { 
   def >>>[A, B, C](fab: (A =>: B), fbc: (B =>: C)): (A =>: C) =
     compose(fbc, fab)
 
+  /** Swaps a pair. */
+  def swap[X, Y] = arr[(X, Y), (Y, X)] {
+    case (x, y) => (y, x)
+  }
+
   /** Pass `C` through untouched. */
   def second[A, B, C](f: (A =>: B)): ((C, A) =>: (C, B)) = {
-    def swap[X, Y] = arr[(X, Y), (Y, X)] {
-      case (x, y) => (y, x)
-    }
-
     >>>(<<<(first[A, B, C](f), swap), swap)
   }
 


### PR DESCRIPTION
This is a continuation of #1237