### PR TITLE
Dequeue.toBackIList bugfix

### DIFF
--- a/core/src/main/scala/scalaz/Dequeue.scala
+++ b/core/src/main/scala/scalaz/Dequeue.scala
@@ -108,7 +108,7 @@ sealed abstract class Dequeue[A] {
   def toBackIList: IList[A] = this match {
     case EmptyDequeue() => IList.empty
     case SingletonDequeue(a) => ICons(a, IList.empty)
-    case FullDequeue(front, fs, back, bs) => back.head +: (back.tail ++ (front.tail ++ (ICons(front.head, IList.empty))))
+    case FullDequeue(front, fs, back, bs) => back.head +: (back.tail ++ (front.tail reverse_::: ICons(front.head, IList.empty)))
   }
 
   /**

--- a/tests/src/test/scala/scalaz/DequeueTest.scala
+++ b/tests/src/test/scala/scalaz/DequeueTest.scala
@@ -36,6 +36,11 @@ object DequeueTest extends SpecLite {
     Dequeue.fromFoldable(l).toBackIList must_===(IList.fromFoldable(l.reverse))
   }
 
+  "toBackIList.reverse is toIList" ! forAll{ (l: List[Int]) ⇒
+    val q = l.foldLeft[Dequeue[Int]](Dequeue.empty)((q,a) ⇒ q cons a)
+    q.toBackIList.reverse must_===(q.toIList)
+  }
+
   "snoc works" ! forAll{ (l: List[Int]) ⇒
     (l.foldLeft[Dequeue[Int]](Dequeue.empty)((q,a) ⇒ q snoc a)).toStream must_=== l.toStream
   }


### PR DESCRIPTION
This PR proposes a small bugfix to `Dequeue.toBackIList`.  The issue is that when working with a `FullDequeue` with more than 2 elements, the order of the resulting `IList` is incorrect as shown in this REPL session:

````
scala> val empty = Dequeue.empty[Char]
empty: scalaz.Dequeue[Char] = EmptyDequeue

scala> ('a' +: 'b' +: 'c' +: empty).toIList
res0: scalaz.IList[Char] = [a,b,c]

scala> ('a' +: 'b' +: 'c' +: empty).toBackIList
res1: scalaz.IList[Char] = [c,b,a]

scala> ('a' +: 'b' +: 'c' +: 'd' +: empty).toIList
res2: scalaz.IList[Char] = [a,b,c,d]

scala> ('a' +: 'b' +: 'c' +: 'd' +: empty).toBackIList
res3: scalaz.IList[Char] = [d,b,c,a]
````

In `res3` the `front` list of the `FullDequeue` is `a :: b :: c :: Nil`.  The head correctly becomes the last element but `front.tail` must be reversed.