### PR TITLE
Adapt to fix in overload resolution in Scala 2.12

### DIFF
--- a/core/src/main/scala/scalaz/EitherT.scala
+++ b/core/src/main/scala/scalaz/EitherT.scala
@@ -279,7 +279,8 @@ object EitherT extends EitherTInstances with EitherTFunctions {
 }
 
 sealed abstract class EitherTInstances3 {
-  implicit def eitherTMonadError[F[_], E](implicit F0: Monad[F]): MonadError[({type λ[α, β] = EitherT[F, α, β]})#λ, E] = new EitherTMonadError[F, E] {
+  // non-implicit defintion left here for binary backwards compatibility
+  protected def eitherTMonadError[F[_], E](implicit F0: Monad[F]): MonadError[({type λ[α, β] = EitherT[F, α, β]})#λ, E] = new EitherTMonadError[F, E] {
     implicit def F = F0
   }
 }
@@ -316,7 +317,11 @@ sealed abstract class EitherTInstances0 extends EitherTInstances1 {
   }
 }
 
-sealed abstract class EitherTInstances extends EitherTInstances0 {
+sealed abstract class EitherTInstances00 extends EitherTInstances0 {
+   override implicit def eitherTMonadError[F[_], E](implicit F0: Monad[F]): MonadError[({type λ[α, β] = EitherT[F, α, β]})#λ, E] = super.eitherTMonadError[F, E]
+}
+
+sealed abstract class EitherTInstances extends EitherTInstances00 {
   implicit def eitherTBitraverse[F[_]](implicit F0: Traverse[F]): Bitraverse[({type λ[α, β]=EitherT[F, α, β]})#λ] = new EitherTBitraverse[F] {
     implicit def F = F0
   }


### PR DESCRIPTION
Static overload resolution (which also governs which competing implicit
to select) was buggy in Scala 2.11 when a pair of competing methods had
a higher-kinded type parameter.

Here's a minimization of the bug:

```
trait M1[A]; trait M2[A] extends M1[A]

trait N1[A[_]]; trait N2[A[_]] extends N1[A]

object Test {
  type D = DummyImplicit
  def m[A](implicit d: D): M1[A] = ???
  def m[A](implicit d1: D, d2: D): M2[A] = ???
  m // not ambiguous M1[_] <:< M2[_]

  def n[A[_]](implicit d: D): N1[A] = ???
  def n[A[_]](implicit d1: D, d2: D): N2[A] = ???
  n // was not ambiguous in 2.11:
    // existentialAbtraction(A :: Nil, N2[A]) did not notice that `N2[A]` contained
    // `A` (because it was eta expanded to [_]A[_] before matching for `case TypeRef(_, ASymbol, _)`)
}
```

This inconsistency will be plugged in Scala 2.12:

  https://github.com/scala/scala/pull/5263

Using that version of Scala, the community build:

  https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-integrate-community-build/482/console

uncovered a place in Scalaz where the usual pattern of laying out type class
instaces wasn't adhered to: the `MonadError` instance for `EitherT`) was
placed in a proper super class of the class that contains the `Monad`
instance, rather than the other way around.

This commit moves the `MonadError` instance on a new rung of the implicit ladder.
The original definition has been left in place to remain binary compatible.

Furthermore, I beleive that the new location of the implicit will
be compatible with 2.11 clients. There are existing tests for unambiguous
implicit resolution in EitherTTest.