### PR TITLE
Add missing Isomorphism instances (#1225)

### DIFF
--- a/core/src/main/scala/scalaz/Isomorphism.scala
+++ b/core/src/main/scala/scalaz/Isomorphism.scala
@@ -26,7 +26,7 @@ sealed abstract class IsomorphismsLow0 extends IsomorphismsLow1 {
   }
 }
 
-sealed abstract class Isomorphisms extends IsomorphismsLow0{
+sealed abstract class Isomorphisms extends IsomorphismsLow0 {
 
   /**Isomorphism for arrows of kind * -> * -> * */
   trait Iso[Arr[_, _], A, B] {
@@ -184,8 +184,6 @@ trait IsomorphismSemigroup[F, G] extends Semigroup[F] {
 trait IsomorphismMonoid[F, G] extends Monoid[F] with IsomorphismSemigroup[F, G] {
   implicit def G: Monoid[G]
 
-  def iso: F <=> G
-
   def zero: F = iso.from(G.zero)
 }
 
@@ -210,7 +208,19 @@ trait IsomorphismOrder[F, G] extends Order[F] {
 
   def iso: F <=> G
 
-  def order(x: F, y: F): Ordering = G.order(iso.to(x), iso.to(y))
+  override def order(x: F, y: F): Ordering = G.order(iso.to(x), iso.to(y))
+}
+
+trait IsomorphismEnum[F, G] extends Enum[F] {
+  implicit def G: Enum[G]
+
+  def iso: F <=> G
+
+  def succ(a: F): F =
+    iso.from(G.succ(iso.to(a)))
+
+  def pred(a: F): F =
+    iso.from(G.pred(iso.to(a)))
 }
 
 trait IsomorphismFunctor[F[_], G[_]] extends Functor[F] {
@@ -226,13 +236,47 @@ trait IsomorphismContravariant[F[_], G[_]] extends Contravariant[F] {
 
   def iso: F <~> G
 
-  def contramap[A, B](r: F[A])(f: B => A): F[B] = iso.from(G.contramap(iso.to(r))(f))
+  override def contramap[A, B](r: F[A])(f: B => A): F[B] = iso.from(G.contramap(iso.to(r))(f))
 }
+
+trait IsomorphismInvariantFunctor[F[_], G[_]] extends InvariantFunctor[F]  {
+  implicit def G: InvariantFunctor[G]
+
+  def iso: F <~> G
+
+  override def xmap[A, B](ma: F[A], f: A => B, g: B => A): F[B] =
+    iso.from(G.xmap(iso.to(ma), f, g))
+}
+
+trait IsomorphismDivide[F[_], G[_]] extends Divide[F] with IsomorphismContravariant[F, G] {
+  implicit def G: Divide[G]
+
+  override def divide[A, B, C](fa: F[A], fb: F[B])(f: C => (A, B)): F[C] =
+    iso.from(G.divide(iso.to(fa), iso.to(fb))(f))
+}
+
+trait IsomorphismDivisible[F[_], G[_]] extends Divisible[F] with IsomorphismDivide[F, G] {
+  implicit def G: Divisible[G]
+
+  override def conquer[A]: F[A] =
+    iso.from(G.conquer)
+}
+
 
 trait IsomorphismApply[F[_], G[_]] extends Apply[F] with IsomorphismFunctor[F, G] {
   implicit def G: Apply[G]
 
   override def ap[A, B](fa: => F[A])(f: => F[A => B]): F[B] = iso.from(G.ap(iso.to(fa))(iso.to(f)))
+}
+
+trait IsomorphismAlign[F[_], G[_]] extends Align[F] with IsomorphismFunctor[F, G] {
+  implicit def G: Align[G]
+
+  import \&/._
+
+  override def alignWith[A, B, C](f: A \&/ B => C): (F[A], F[B]) => F[C] = {
+    case (fa, fb) => iso.from(G.alignWith(f)(iso.to(fa), iso.to(fb)))
+  }
 }
 
 trait IsomorphismApplicative[F[_], G[_]] extends Applicative[F] with IsomorphismApply[F, G] {
@@ -252,19 +296,60 @@ trait IsomorphismBind[F[_], G[_]] extends Bind[F] with IsomorphismApply[F, G] {
 trait IsomorphismBindRec[F[_], G[_]] extends BindRec[F] with IsomorphismBind[F, G] {
   implicit def G: BindRec[G]
 
-  def tailrecM[A, B](f: A => F[A \/ B])(a: A): F[B] = iso.from(G.tailrecM(f andThen iso.unlift[A \/ B].to)(a))
+  override def tailrecM[A, B](f: A => F[A \/ B])(a: A): F[B] = iso.from(G.tailrecM(f andThen iso.unlift[A \/ B].to)(a))
 }
 
 trait IsomorphismMonad[F[_], G[_]] extends Monad[F] with IsomorphismApplicative[F, G] with IsomorphismBind[F, G] {
   implicit def G: Monad[G]
 }
 
+trait IsomorphismMonadReader[F[_], G[_], E] extends MonadReader[F, E] with IsomorphismMonad[F, G] {
+  implicit def G: MonadReader[G, E]
+
+  override def ask: F[E] = iso.from(G.ask)
+
+  override def local[A](f: (E) => E)(fa: F[A]): F[A] =
+    iso.from(G.local(f)(iso.to(fa)))
+}
+
+trait IsomorphismMonadState[F[_], G[_], S] extends MonadState[F, S] with IsomorphismMonad[F, G] {
+  implicit def G: MonadState[G, S]
+
+  override def init: F[S] = iso.from(G.init)
+
+  override def get: F[S] = iso.from(G.get)
+
+  override def put(s: S): F[Unit] = iso.from(G.put(s))
+}
+
+
+trait IsomorphismMonadTell[F[_], G[_], S] extends MonadTell[F, S] with IsomorphismMonad[F, G] {
+  implicit def G: MonadTell[G, S]
+
+  override def writer[A](w: S, v: A): F[A] = iso.from(G.writer(w, v))
+}
+
+trait IsomorphismMonadError[F[_], G[_], S] extends MonadError[F, S] with IsomorphismMonad[F, G] {
+  implicit def G: MonadError[G, S]
+
+  override def raiseError[A](e: S): F[A] =
+    iso.from(G.raiseError(e))
+
+  override def handleError[A](fa: F[A])(f: S => F[A]): F[A] =
+    iso.from(G.handleError(iso.to(fa))(s => iso.to(f(s))))
+}
+
+trait IsomorphismNondeterminism[F[_], G[_]] extends Nondeterminism[F] with IsomorphismMonad[F, G] {
+  implicit def G: Nondeterminism[G]
+
+  override def chooseAny[A](head: F[A], tail: Seq[F[A]]): F[(A, Seq[F[A]])] =
+    iso.from(G.map(G.chooseAny(iso.to(head), tail.map(iso.to))){case (a, b) => (a, b.map(iso.from))})
+}
+
 trait IsomorphismCobind[F[_], G[_]] extends Cobind[F] with IsomorphismFunctor[F, G] {
   implicit def G: Cobind[G]
 
-  def iso: F <~> G
-
-  def cobind[A, B](fa: F[A])(f: F[A] => B): F[B] = iso.from(G.cobind(iso.to(fa))(f.compose(iso.from.apply)))
+  override def cobind[A, B](fa: F[A])(f: F[A] => B): F[B] = iso.from(G.cobind(iso.to(fa))(f.compose(iso.from.apply)))
 
   override def cojoin[A](a: F[A]): F[F[A]] = iso.from(G.map(G.cojoin(iso.to(a)))(iso.from.apply))
 }
@@ -272,7 +357,19 @@ trait IsomorphismCobind[F[_], G[_]] extends Cobind[F] with IsomorphismFunctor[F,
 trait IsomorphismComonad[F[_], G[_]] extends Comonad[F] with IsomorphismCobind[F, G] {
   implicit def G: Comonad[G]
 
-  def copoint[A](p: F[A]): A = G.copoint(iso.to(p))
+  override def copoint[A](p: F[A]): A = G.copoint(iso.to(p))
+}
+
+
+trait IsomorphismComonadStore[F[_], G[_], S] extends ComonadStore[F, S] with IsomorphismComonad[F, G] {
+  implicit def G: ComonadStore[G, S]
+
+  override def pos[A](w: F[A]): S
+    = G.pos(iso.to(w))
+
+  override def peek[A](s: S, w: F[A]): A
+    = G.peek(s, iso.to(w))
+
 }
 
 trait IsomorphismPlus[F[_], G[_]] extends Plus[F] {
@@ -287,6 +384,13 @@ trait IsomorphismEmpty[F[_], G[_]] extends PlusEmpty[F] with IsomorphismPlus[F, 
   implicit def G: PlusEmpty[G]
 
   def empty[A]: F[A] = iso.from(G.empty[A])
+}
+
+trait IsomorphismIsEmpty[F[_], G[_]] extends IsEmpty[F] with IsomorphismEmpty[F, G] {
+  implicit def G: IsEmpty[G]
+
+  def isEmpty[A](fa: F[A]): Boolean =
+    G.isEmpty(iso.to(fa))
 }
 
 trait IsomorphismApplicativePlus[F[_], G[_]] extends ApplicativePlus[F] with IsomorphismEmpty[F, G] with IsomorphismApplicative[F, G] {
@@ -311,8 +415,6 @@ trait IsomorphismFoldable[F[_], G[_]] extends Foldable[F] {
 
 trait IsomorphismTraverse[F[_], G[_]] extends Traverse[F] with IsomorphismFoldable[F, G] with IsomorphismFunctor[F, G] {
   implicit def G: Traverse[G]
-
-  def iso: F <~> G
 
   protected[this] override final def naturalTrans: F ~> G = iso.to
 
@@ -346,14 +448,143 @@ trait IsomorphismOptional[F[_], G[_]] extends Optional[F] {
     G.pextract(iso.to(fa)).leftMap(iso.from)
 }
 
-trait IsomorphismBifunctor[F[_, _], G[_, _]] extends Bifunctor[F] {
+trait IsomorphismCatchable[F[_], G[_]] extends Catchable[F] {
+  implicit def G: Catchable[G]
+
+  def iso: F <~> G
+
+  override def attempt[A](f: F[A]): F[Throwable \/ A] =
+    iso.from(G.attempt(iso.to(f)))
+
+  override def fail[A](err: Throwable): F[A] =
+    iso.from(G.fail(err))
+}
+
+
+trait IsomorphismCozip[F[_], G[_]] extends Cozip[F] {
+  implicit def G: Cozip[G]
+
+  def iso: F <~> G
+
+  def cozip[A, B](x: F[A \/ B]): (F[A] \/ F[B]) =
+    G.cozip(iso.to(x)).bimap(iso.from.apply _, iso.from.apply _)
+}
+
+
+trait IsomorphismZip[F[_], G[_]] extends Zip[F] {
+  implicit def G: Zip[G]
+
+  def iso: F <~> G
+
+  def zip[A, B](a: => F[A], b: => F[B]): F[(A, B)] =
+    iso.from(G.zip(iso.to(a), iso.to(b)))
+}
+
+trait IsomorphismUnzip[F[_], G[_]] extends Unzip[F] {
+  implicit def G: Unzip[G]
+
+  def iso: F <~> G
+
+  def unzip[A, B](a: F[(A, B)]): (F[A], F[B]) =
+    G.unzip(iso.to(a)) match {
+      case (f, s) => (iso.from(f), iso.from(s))
+    }
+}
+
+trait IsomorphismAssociative[F[_, _], G[_, _]] extends Associative[F] {
+  implicit def G: Associative[G] with Bifunctor[G] // TODO: is this needed? (I think so)
+
   def iso: F <~~> G
 
+  override def reassociateLeft[A, B, C](f: F[A, F[B, C]]): F[F[A, B], C] =
+    iso.from(G.leftMap(G.reassociateLeft(G.rightMap(iso.to(f))(iso.to.apply _)))(iso.from.apply _))
+
+  override def reassociateRight[A, B, C](f: F[F[A, B], C]): F[A, F[B, C]] =
+    iso.from(G.rightMap(G.reassociateRight(G.leftMap(iso.to(f))(iso.to.apply _)))(iso.from.apply _))
+}
+
+
+trait IsomorphismBifunctor[F[_, _], G[_, _]] extends Bifunctor[F] {
   implicit def G: Bifunctor[G]
+
+  def iso: F <~~> G
 
   override def bimap[A, B, C, D](fab: F[A, B])(f: A => C, g: B => D): F[C, D] =
     iso.from(G.bimap(iso.to(fab))(f, g))
 }
+
+
+trait IsomorphismProfunctor[F[_, _], G[_, _]] extends Profunctor[F] {
+  implicit def G: Profunctor[G]
+
+  def iso: F <~~> G
+
+  override def mapfst[A, B, C](fab: F[A, B])(f: C => A): F[C, B] =
+    iso.from(G.mapfst(iso.to(fab))(f))
+
+  override def mapsnd[A, B, C](fab: F[A, B])(f: B => C): F[A, C] =
+    iso.from(G.mapsnd(iso.to(fab))(f))
+
+}
+
+trait IsomorphismProChoice[F[_, _], G[_, _]] extends ProChoice[F] with IsomorphismProfunctor[F, G] {
+  implicit def G: ProChoice[G]
+
+  override def left[A, B, C](fa: F[A, B]): F[(A \/ C), (B \/ C)] =
+   iso.from(G.left(iso.to(fa)))
+
+  override def right[A, B, C](fa: F[A, B]): F[(C \/ A), (C \/ B)] =
+   iso.from(G.right(iso.to(fa)))
+}
+
+trait IsomorphismStrong[F[_, _], G[_, _]] extends Strong[F] with IsomorphismProfunctor[F, G] {
+  implicit def G: Strong[G]
+
+  override def first[A, B, C](fa: F[A, B]): F[(A, C), (B, C)] =
+   iso.from(G.first(iso.to(fa)))
+
+  override def second[A, B, C](fa: F[A, B]): F[(C, A), (C, B)] =
+   iso.from(G.second(iso.to(fa)))
+}
+
+trait IsomorphismCompose[F[_, _], G[_, _]] extends Compose[F] {
+  implicit def G: Compose[G]
+
+  def iso: F <~~> G
+
+  override def compose[A, B, C](f: F[B, C], g: F[A, B]): F[A, C] =
+    iso.from(G.compose(iso.to(f), iso.to(g)))
+}
+
+trait IsomorphismCategory[F[_, _], G[_, _]] extends Category[F] with IsomorphismCompose[F, G] {
+  implicit def G: Category[G]
+
+  override def id[A]: F[A, A] =
+    iso.from(G.id)
+}
+
+
+trait IsomorphismChoice[F[_, _], G[_, _]] extends Choice[F] with IsomorphismCategory[F, G] {
+  implicit def G: Choice[G]
+
+  override def choice[A, B, C](f: => F[A, C], g: => F[B, C]): F[(A \/ B), C] =
+    iso.from(G.choice(iso.to(f), iso.to(g)))
+}
+
+trait IsomorphismSplit[F[_, _], G[_, _]] extends Split[F] with IsomorphismCompose[F, G] {
+  implicit def G: Split[G]
+
+  override def split[A, B, C, D](f: F[A, B], g: F[C, D]): F[(A,  C), (B, D)] =
+    iso.from(G.split(iso.to(f), iso.to(g)))
+}
+
+trait IsomorphismArrow[F[_, _], G[_, _]] extends Arrow[F] with IsomorphismSplit[F, G] with IsomorphismStrong[F, G] with IsomorphismCategory[F, G] {
+  implicit def G: Arrow[G]
+
+  override def arr[A, B](f: A => B): F[A, B] =
+    iso.from(G.arr(f))
+}
+
 
 trait IsomorphismBifoldable[F[_, _], G[_, _]] extends Bifoldable[F] {
   protected[this] def biNaturalTrans: F ~~> G

--- a/effect/src/main/scala/scalaz/effect/IO.scala
+++ b/effect/src/main/scala/scalaz/effect/IO.scala
@@ -216,6 +216,14 @@ object IO extends IOInstances {
   type RunInBase[M[_], Base[_]] =
   Forall[λ[α => M[α] => Base[M[α]]]]
 
+  import scalaz.Isomorphism.<~>
+
+  /** Hoist RunInBase given a natural isomorphism between the two functors */
+  def hoistRunInBase[F[_], G[_]](r: RunInBase[G, IO])(implicit iso: F <~> G): RunInBase[F, IO] =
+    new RunInBase[F, IO] {
+      def apply[B] = (x: F[B]) => r.apply(iso.to(x)).map(iso.from(_))
+    }
+
   /** Construct an IO action from a world-transition function. */
   def io[A](f: Tower[IvoryTower] => Trampoline[(Tower[IvoryTower], A)]): IO[A] =
     new IO[A] {

--- a/effect/src/main/scala/scalaz/effect/Isomorphism.scala
+++ b/effect/src/main/scala/scalaz/effect/Isomorphism.scala
@@ -1,0 +1,52 @@
+package scalaz
+package effect
+
+import scalaz.{IsomorphismFunctor, IsomorphismMonad}
+import scalaz.Isomorphism.{<~>, <=>}
+
+//
+// Derive a type class instance through an Isomorphism for the effect type classes
+//
+
+trait IsomorphismResource[F, G] extends Resource[F] {
+  implicit def G: Resource[G]
+
+  def iso: F <=> G
+
+  override def close(f: F): IO[Unit] =
+    G.close(iso.to(f))
+}
+
+trait IsomorphismLiftIO[F[_], G[_]] extends LiftIO[F] {
+  implicit def G: LiftIO[G]
+
+  def iso: F <~> G
+
+  override def liftIO[A](ioa: IO[A]): F[A] = iso.from(G.liftIO(ioa))
+}
+
+trait IsomorphismMonadIO[F[_], G[_]] extends MonadIO[F] with IsomorphismLiftIO[F, G] with IsomorphismMonad[F, G] {
+  implicit def G: MonadIO[G]
+}
+
+trait IsomorphismMonadCatchIO[F[_], G[_]] extends MonadCatchIO[F] with IsomorphismMonadIO[F, G] {
+  implicit def G: MonadCatchIO[G]
+
+  override def except[A](ma: F[A])(handler: (Throwable) => F[A]): F[A] =
+    iso.from(G.except(iso.to(ma))(t => iso.to(handler(t))))
+}
+
+trait IsomorphismLiftControlIO[F[_], G[_]] extends LiftControlIO[F] {
+  import IO._
+
+  implicit def G: LiftControlIO[G]
+
+  implicit def iso: F <~> G
+
+  override def liftControlIO[A](f: RunInBase[F, IO] => IO[A]): F[A] =
+    iso.from(G.liftControlIO(f compose hoistRunInBase[F, G]))
+}
+
+trait IsomorphismMonadControlIO[F[_], G[_]] extends MonadControlIO[F] with IsomorphismLiftControlIO[F, G] with IsomorphismMonad[F, G] {
+  implicit def G: MonadControlIO[G]
+}


### PR DESCRIPTION
This adds Isomorphism*s for the following type classes:
- [x] Align
- [x] Arrow
- [x] Associative
- [x] Catchable
- [x] Category
- [x] Choice
- [x] ComonadStore
- [x] Compose
- [x] Cozip
- [x] Divide
- [x] Divisible
- [x] Enum
- [x] InvariantFunctor
- [x] IsEmpty
- [x] LiftControlIO
- [x] LiftIO
- [x] MonadControlIO
- [x] MonadError
- [x] MonadIO
- [x] MonadReader
- [x] MonadState
- [x] MonadTell
- [x] Nondeterminism
- [x] PlusEmpty (see note below)
- [x] ProChoice
- [x] Profunctor
- [x] Resource
- [x] Split
- [x] Strong
- [x] Unzip
- [x] Zip

A few things to note:
- `PlusEmpty` did have an iso already, but instead of `IsomorphismPlusEmpty`, this is called `IsomorphismEmpty`. I did not change it, but I think it should be changed.
- There is a separate `Isomorphism.scala` in the `effect` package for the `effect` (MonadIO and friends) type classes.
- I added a `hoistRunInBase` to IO.scala, which turns a `RunInBase[F, X]` to `RunInBase[G, X]`, given that there is a natural isomorphism between F and G - this is useful for writing `IsomorhpismLiftControlIO`. `hoist` might not be the best name for this, since it is symmetric.
- `IsomorphismAssociative` - I'm almost certain that this one requires a `Bifunctor[G]` instance (along with `Associative[G]`) so that we can map the natural transformations over both holes, which is needed for converting between `F` and `G`, as `Associative` assumes a nested type structure. Note that `Profunctor[G]` would also work here, since we we have a natural isomorphism, and that just means that the other direction would need to be mapped over the first hole, if that hole was contravariant. However, having looked at the existing `Associative` instances, they seem to be traditionally Bifunctors (Either and Tuple2).
- Added some `override` modifiers to the existing functions to keep things unified.