### PR TITLE
Add transformer instance for RegionT (via Hoist)

### DIFF
--- a/effect/src/main/scala/scalaz/effect/RegionT.scala
+++ b/effect/src/main/scala/scalaz/effect/RegionT.scala
@@ -36,6 +36,21 @@ sealed abstract class RegionTInstances1 {
   implicit def RegionTMonad[S, M[_]](implicit M0: Monad[M]): Monad[RegionT[S, M, ?]] = new RegionTMonad[S, M] {
     implicit def M = M0
   }
+
+  implicit def RegionTHoist[S] = new Hoist[λ[(α[_], β) => RegionT[S, α, β]]] {
+    def hoist[M[_]: Monad, N[_]](f: M ~> N) =
+      new (RegionT[S, M, ?] ~> RegionT[S, N, ?]) {
+        override def apply[B](fa: RegionT[S, M, B]): RegionT[S, N, B] =
+          RegionT(Kleisli(r => f.apply(fa.runT(r))))
+      }
+
+      override def liftM[M[_]: Monad, B](a: M[B]): RegionT[S, M, B] =
+        RegionT(Kleisli(r => a))
+
+      override implicit def apply[M[_]: Monad]: Monad[RegionT[S, M, ?]] =
+        RegionTMonad[S, M]
+  }
+
 }
 
 sealed abstract class RegionTInstances extends RegionTInstances1 {


### PR DESCRIPTION
RegionT is a legal monad transformer, but it didn't have a MonadTrans instance defined, so I added it.