### PR TITLE
Add mapT to monad transformers (#1224)

### DIFF
--- a/core/src/main/scala/scalaz/ListT.scala
+++ b/core/src/main/scala/scalaz/ListT.scala
@@ -53,6 +53,9 @@ final case class ListT[M[_], A](run: M[List[A]]){
 
   def map[B](f: A => B)(implicit M: Functor[M]) : ListT[M, B] = new ListT(M.map(run)(_.map(f)))
 
+  def mapT[F[_], B](f: M[List[A]] => F[List[B]]): ListT[F, B] =
+    ListT(f(run))
+
   /**Don't use iteratively! */
   def tail(implicit M: Functor[M]) : ListT[M, A] = new ListT(M.map(run)(_.tail))
 
@@ -160,6 +163,7 @@ private trait ListTHoist extends Hoist[ListT] {
 
   def hoist[M[_], N[_]](f: M ~> N)(implicit M: Monad[M]): ListT[M, ?] ~> ListT[N, ?] =
     new (ListT[M, ?] ~> ListT[N, ?]) {
-      def apply[A](a: ListT[M, A]): ListT[N, A] = fromList(f(a.run))
+      def apply[A](a: ListT[M, A]): ListT[N, A] =
+        a.mapT(f)
     }
 }

--- a/core/src/main/scala/scalaz/UnwriterT.scala
+++ b/core/src/main/scala/scalaz/UnwriterT.scala
@@ -36,6 +36,8 @@ final case class UnwriterT[F[_], U, A](run: F[(U, A)]) { self =>
   def map[B](f: A => B)(implicit F: Functor[F]): UnwriterT[F, U, B] =
     unwriterT(F.map(run)(wa => (wa._1, f(wa._2))))
 
+  def mapT[G[_], V, B](f: F[(U, A)] => G[(V, B)]): UnwriterT[G, V, B] =
+    UnwriterT(f(run))
 
   def ap[B](f: => UnwriterT[F, U, A => B])(implicit F: Apply[F]): UnwriterT[F, U, B] =
     unwriterT {

--- a/effect/src/main/scala/scalaz/effect/MonadCatchIO.scala
+++ b/effect/src/main/scala/scalaz/effect/MonadCatchIO.scala
@@ -11,14 +11,9 @@ object MonadCatchIO extends MonadCatchIOFunctions {
 
   implicit def theseTMonadCatchIO[M[_]: MonadCatchIO, E: Semigroup] = new MonadCatchIO[TheseT[M, E, ?]] {
     val TheseTMonadIO = MonadIO.theseTMonadIO[M, E]
-    override def except[A](ma: TheseT[M, E, A])(handler: Throwable => TheseT[M, E, A]) = TheseT[M, E, A] {
-      val M = MonadCatchIO[M]
-      val a: M[Throwable \/ (E \&/ A)] = M.except(M.map(ma.run)(\/.right[Throwable, (E \&/ A)]))(t => M.point(-\/(t)))
-      M.bind(a) {
-        case -\/(t)    => handler(t).run
-        case \/-(r)    => M.point(r)
-      }
-    }
+    val M = MonadCatchIO[M]
+    override def except[A](ma: TheseT[M, E, A])(handler: Throwable => TheseT[M, E, A]) =
+      ma.mapT(M.except(_)(handler(_).run))
 
     override def point[A](a: => A) = TheseTMonadIO.point(a)
     override def bind[A, B](fa: TheseT[M, E, A])(f: A => TheseT[M, E, B]) = TheseTMonadIO.bind(fa)(f)

--- a/effect/src/main/scala/scalaz/effect/RegionT.scala
+++ b/effect/src/main/scala/scalaz/effect/RegionT.scala
@@ -18,6 +18,9 @@ sealed abstract class RegionT[S, P[_], A] {
 
   def runT(r: IORef[List[RefCountedFinalizer]]): P[A] =
     value.run(r)
+
+  def mapT[Q[_], B](f: P[A] => Q[B]): RegionT[S, Q, B] =
+    RegionT(Kleisli(f compose runT))
 }
 
 object RegionT extends RegionTInstances {
@@ -26,6 +29,7 @@ object RegionT extends RegionTInstances {
   }
 
   def regionT[S, P[_], A](k: Kleisli[P, IORef[List[RefCountedFinalizer]], A]): RegionT[S, P, A] = RegionT(k)
+
 }
 
 sealed abstract class RegionTInstances1 {


### PR DESCRIPTION
Added the `mapT` functions to the following transformers, as explained in https://github.com/scalaz/scalaz/issues/1244

- [x] ExceptT
- [x] KleisliT
- [x] ListT
- [x] MaybeT
- [x] OptionT
- [x] RWST
- [x] RegionT
- [x] StateT
- [x] TheseT
- [x] UnwriterT
- [x] WriterT

- The `hoist` function is a special case of `mapT` (`hoist` is `mapT` with natural transformation), so I rewrote those.
- Also, updated TheseT's MonadCatchIO instance to be more concise, using mapT.
- `Kleisli` and `StateT` already had the functionality, called `mapK`, where the `K` I think comes from `Kleisli` (confusingly). For these, I just provided a `mapT` alias while keeping the old ones for compatibility.