### PR TITLE
Flip arguments of tailrecM to improve type inference.

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Task.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Task.scala
@@ -304,7 +304,7 @@ object Task {
       }
       def fail[A](e: Throwable): Task[A] = new Task(Future.now(-\/(e)))
       def attempt[A](a: Task[A]): Task[Throwable \/ A] = a.attempt
-      def tailrecM[A, B](f: A => Task[A \/ B])(a: A): Task[B] = Task.tailrecM(f)(a)
+      def tailrecM[A, B](a: A)(f: A => Task[A \/ B]): Task[B] = Task.tailrecM(a)(f)
       def raiseError[A](e: Throwable): Task[A] = fail(e)
       def handleError[A](fa: Task[A])(f: Throwable => Task[A]): Task[A] =
         fa.handleWith { case t => f(t) }
@@ -453,9 +453,9 @@ object Task {
   def fromDisjunction[A <: Throwable, B](x: A \/ B): Task[B] =
     x.fold(Task.fail, Task.now)
 
-  def tailrecM[A, B](f: A => Task[A \/ B])(a: A): Task[B] =
+  def tailrecM[A, B](a: A)(f: A => Task[A \/ B]): Task[B] =
     f(a).flatMap {
-      case -\/(a0) => tailrecM(f)(a0)
+      case -\/(a0) => tailrecM(a0)(f)
       case \/-(b) => point(b)
     }
 

--- a/core/src/main/scala/scalaz/BindRec.scala
+++ b/core/src/main/scala/scalaz/BindRec.scala
@@ -16,10 +16,10 @@ package scalaz
 trait BindRec[F[_]] extends Bind[F] { self =>
   ////
 
-  def tailrecM[A, B](f: A => F[A \/ B])(a: A): F[B]
+  def tailrecM[A, B](a: A)(f: A => F[A \/ B]): F[B]
 
   override def forever[A, B](fa: F[A]): F[B] =
-    tailrecM[Unit, B](u => map(fa)(_ => -\/(u)))(())
+    tailrecM[Unit, B](())(u => map(fa)(_ => -\/(u)))
 
   /**The product of BindRec `F` and `G`, `[x](F[x], G[x]])`, is a BindRec */
   def product[G[_]](implicit G0: BindRec[G]): BindRec[λ[α => (F[α], G[α])]] =
@@ -30,13 +30,13 @@ trait BindRec[F[_]] extends Bind[F] { self =>
 
   trait BindRecLaw extends BindLaw {
     def tailrecBindConsistency[A](a: A, f: A => F[A])(implicit FA: Equal[F[A]]): Boolean = {
-      val bounce = tailrecM[(Boolean, A), A] {
+      val bounce = tailrecM[(Boolean, A), A]((false, a)) {
         case (bounced, a0) =>
           if (!bounced)
             map(f(a0))(a1 => -\/((true, a1)))
           else
             map(f(a0))(\/.right)
-      }((false, a))
+      }
 
       FA.equal(bind(f(a))(f), bounce)
     }

--- a/core/src/main/scala/scalaz/Cokleisli.scala
+++ b/core/src/main/scala/scalaz/Cokleisli.scala
@@ -62,7 +62,7 @@ private trait CokleisliMonad[F[_], R] extends Monad[Cokleisli[F, R, ?]] with Bin
   override def ap[A, B](fa: => Cokleisli[F, R, A])(f: => Cokleisli[F, R, A => B]) = f flatMap (fa map _)
   def point[A](a: => A) = Cokleisli(_ => a)
   def bind[A, B](fa: Cokleisli[F, R, A])(f: A => Cokleisli[F, R, B]) = fa flatMap f
-  def tailrecM[A, B](f: A => Cokleisli[F, R, A \/ B])(a: A): Cokleisli[F, R, B] = {
+  def tailrecM[A, B](a: A)(f: A => Cokleisli[F, R, A \/ B]): Cokleisli[F, R, B] = {
     @annotation.tailrec
     def go(a0: A)(r: F[R]): B =
       f(a0).run(r) match {

--- a/core/src/main/scala/scalaz/DList.scala
+++ b/core/src/main/scala/scalaz/DList.scala
@@ -110,8 +110,8 @@ sealed abstract class DListInstances {
     def traverseImpl[F[_], A, B](fa: DList[A])(f: A => F[B])(implicit F: Applicative[F]): F[DList[B]] =
       fa.foldr(F.point(DList[B]()))((a, fbs) => F.apply2(f(a), fbs)(_ +: _))
 
-    def tailrecM[A, B](f: A => DList[A \/ B])(a: A): DList[B] =
-      DList.fromIList(BindRec[IList].tailrecM[A, B](f(_).toIList)(a))
+    def tailrecM[A, B](a: A)(f: A => DList[A \/ B]): DList[B] =
+      DList.fromIList(BindRec[IList].tailrecM[A, B](a)(f(_).toIList))
   }
   implicit def dlistEqual[A: Equal]: Equal[DList[A]] = {
     import std.list._

--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -441,10 +441,10 @@ sealed abstract class DisjunctionInstances1 extends DisjunctionInstances2 {
         fa map f
 
       @scala.annotation.tailrec
-      def tailrecM[A, B](f: A => L \/ (A \/ B))(a: A): L \/ B =
+      def tailrecM[A, B](a: A)(f: A => L \/ (A \/ B)): L \/ B =
         f(a) match {
           case l @ -\/(_) => l
-          case \/-(-\/(a0)) => tailrecM(f)(a0)
+          case \/-(-\/(a0)) => tailrecM(a0)(f)
           case \/-(rb @ \/-(_)) => rb
         }
 

--- a/core/src/main/scala/scalaz/EitherT.scala
+++ b/core/src/main/scala/scalaz/EitherT.scala
@@ -375,12 +375,12 @@ private trait EitherTBindRec[F[_], E] extends BindRec[EitherT[F, E, ?]] with Eit
   implicit def F: Monad[F]
   implicit def B: BindRec[F]
 
-  final def tailrecM[A, B](f: A => EitherT[F, E, A \/ B])(a: A): EitherT[F, E, B] =
+  final def tailrecM[A, B](a: A)(f: A => EitherT[F, E, A \/ B]): EitherT[F, E, B] =
     EitherT(
-      B.tailrecM[A, E \/ B](a => F.map(f(a).run) {
+      B.tailrecM[A, E \/ B](a)(a => F.map(f(a).run) {
         // E \/ (A \/ B) => A \/ (E \/ B) is _.sequenceU but can't use here
         _.fold(e => \/-(-\/(e)), _.fold(\/.left, b => \/-(\/-(b))))
-      })(a)
+      })
     )
 }
 

--- a/core/src/main/scala/scalaz/EphemeralStream.scala
+++ b/core/src/main/scala/scalaz/EphemeralStream.scala
@@ -216,7 +216,7 @@ sealed abstract class EphemeralStreamInstances {
         if (these.isEmpty) None else Some(these.head())
       }
     }
-    def tailrecM[A, B](f: A => EphemeralStream[A \/ B])(a: A): EphemeralStream[B] = {
+    def tailrecM[A, B](a: A)(f: A => EphemeralStream[A \/ B]): EphemeralStream[B] = {
       def go(s: EphemeralStream[A \/ B]): EphemeralStream[B] = {
         @annotation.tailrec
         def rec(abs: EphemeralStream[A \/ B]): EphemeralStream[B] =

--- a/core/src/main/scala/scalaz/IList.scala
+++ b/core/src/main/scala/scalaz/IList.scala
@@ -650,7 +650,7 @@ sealed abstract class IListInstances extends IListInstance0 {
       override def widen[A, B](fa: IList[A])(implicit ev: A <~< B): IList[B] =
         fa.widen[B]
 
-      def tailrecM[A, B](f: A => IList[A \/ B])(a: A): IList[B] = {
+      def tailrecM[A, B](a: A)(f: A => IList[A \/ B]): IList[B] = {
         @tailrec
         def go(xs: IList[IList[A \/ B]], bs: IList[B]): IList[B] =
           xs match {

--- a/core/src/main/scala/scalaz/Id.scala
+++ b/core/src/main/scala/scalaz/Id.scala
@@ -68,9 +68,9 @@ trait IdInstances {
       override def toMaybe[A](a: Id[A])           : Maybe[A]   = Maybe.Just(a)
 
       @tailrec
-      def tailrecM[A, B](f: A => A \/ B)(a: A): B =
+      def tailrecM[A, B](a: A)(f: A => A \/ B): B =
         f(a) match {
-          case -\/(a0) => tailrecM(f)(a0)
+          case -\/(a0) => tailrecM(a0)(f)
           case \/-(b) => b
         }
     }

--- a/core/src/main/scala/scalaz/IdT.scala
+++ b/core/src/main/scala/scalaz/IdT.scala
@@ -107,8 +107,8 @@ private trait IdTBind[F[_]] extends Bind[IdT[F, ?]] with IdTApply[F] {
 private trait IdTBindRec[F[_]] extends BindRec[IdT[F, ?]] with IdTBind[F] {
   implicit def F: BindRec[F]
 
-  final def tailrecM[A, B](f: A => IdT[F, A \/ B])(a: A): IdT[F, B] =
-    IdT(F.tailrecM[A, B](a => F.map(f(a).run)(identity))(a))
+  final def tailrecM[A, B](a: A)(f: A => IdT[F, A \/ B]): IdT[F, B] =
+    IdT(F.tailrecM[A, B](a)(a => F.map(f(a).run)(identity)))
 }
 
 private trait IdTMonad[F[_]] extends Monad[IdT[F, ?]] with IdTApplicative[F] with IdTBind[F] {

--- a/core/src/main/scala/scalaz/Isomorphism.scala
+++ b/core/src/main/scala/scalaz/Isomorphism.scala
@@ -252,7 +252,7 @@ trait IsomorphismBind[F[_], G[_]] extends Bind[F] with IsomorphismApply[F, G] {
 trait IsomorphismBindRec[F[_], G[_]] extends BindRec[F] with IsomorphismBind[F, G] {
   implicit def G: BindRec[G]
 
-  def tailrecM[A, B](f: A => F[A \/ B])(a: A): F[B] = iso.from(G.tailrecM(f andThen iso.unlift[A \/ B].to)(a))
+  def tailrecM[A, B](a: A)(f: A => F[A \/ B]): F[B] = iso.from(G.tailrecM(a)(f andThen iso.unlift[A \/ B].to))
 }
 
 trait IsomorphismMonad[F[_], G[_]] extends Monad[F] with IsomorphismApplicative[F, G] with IsomorphismBind[F, G] {

--- a/core/src/main/scala/scalaz/Kleisli.scala
+++ b/core/src/main/scala/scalaz/Kleisli.scala
@@ -316,8 +316,8 @@ private trait KleisliApplicative[F[_], R] extends Applicative[Kleisli[F, R, ?]] 
 private trait KleisliBindRec[F[_], R] extends BindRec[Kleisli[F, R, ?]] with KleisliBind[F, R] {
   implicit def F: BindRec[F]
 
-  def tailrecM[A, B](f: A => Kleisli[F, R, A \/ B])(a: A): Kleisli[F, R, B] =
-    Kleisli(r => F.tailrecM(f(_: A).run(r))(a))
+  def tailrecM[A, B](a: A)(f: A => Kleisli[F, R, A \/ B]): Kleisli[F, R, B] =
+    Kleisli(r => F.tailrecM(a)(f(_).run(r)))
 }
 
 private trait KleisliMonad[F[_], R] extends Monad[Kleisli[F, R, ?]] with KleisliApplicative[F, R] with KleisliBind[F, R] {

--- a/core/src/main/scala/scalaz/LazyEither.scala
+++ b/core/src/main/scala/scalaz/LazyEither.scala
@@ -197,12 +197,12 @@ sealed abstract class LazyEitherInstances {
         fa.left.flatMap(e => f(e))
 
       @annotation.tailrec
-      def tailrecM[A, B](f: A => LazyEither[E, A \/ B])(a: A): LazyEither[E, B] =
+      def tailrecM[A, B](a: A)(f: A => LazyEither[E, A \/ B]): LazyEither[E, B] =
         f(a) match {
           case LazyLeft(l) => LazyLeft(l)
           case LazyRight(r) => r() match {
             case \/-(b) => LazyEither.lazyRight(b)
-            case -\/(a0) => tailrecM(f)(a0)
+            case -\/(a0) => tailrecM(a0)(f)
           }
         }
     }

--- a/core/src/main/scala/scalaz/LazyEitherT.scala
+++ b/core/src/main/scala/scalaz/LazyEitherT.scala
@@ -368,11 +368,11 @@ private trait LazyEitherTBitraverse[F[_]] extends Bitraverse[LazyEitherT[F, ?, ?
 private trait LazyEitherTBindRec[F[_], E] extends BindRec[LazyEitherT[F, E, ?]] with LazyEitherTMonad[F, E] {
   implicit def B: BindRec[F]
 
-  final def tailrecM[A, B](f: A => LazyEitherT[F, E, A \/ B])(a: A): LazyEitherT[F, E, B] =
+  final def tailrecM[A, B](a: A)(f: A => LazyEitherT[F, E, A \/ B]): LazyEitherT[F, E, B] =
     LazyEitherT(
-      B.tailrecM[A, LazyEither[E, B]](a => F.map(f(a).run) {
+      B.tailrecM[A, LazyEither[E, B]](a)(a => F.map(f(a).run) {
         _.fold(e => \/-(LazyEither.lazyLeft(e)), _.map(b => LazyEither.lazyRight(b)))
-      })(a)
+      })
     )
 }
 

--- a/core/src/main/scala/scalaz/LazyOption.scala
+++ b/core/src/main/scala/scalaz/LazyOption.scala
@@ -141,12 +141,12 @@ sealed abstract class LazyOptionInstances {
       override def isDefined[A](fa: LazyOption[A]): Boolean = fa.isDefined
 
       @scala.annotation.tailrec
-      def tailrecM[A, B](f: A => LazyOption[A \/ B])(a: A): LazyOption[B] =
+      def tailrecM[A, B](a: A)(f: A => LazyOption[A \/ B]): LazyOption[B] =
         f(a) match {
           case LazyNone => LazyNone
           case LazySome(t) => t() match {
             case \/-(b) => lazySome(b)
-            case -\/(a0) => tailrecM(f)(a0)
+            case -\/(a0) => tailrecM(a0)(f)
           }
         }
     }

--- a/core/src/main/scala/scalaz/LazyOptionT.scala
+++ b/core/src/main/scala/scalaz/LazyOptionT.scala
@@ -149,11 +149,11 @@ private trait LazyOptionTMonad[F[_]] extends MonadPlus[LazyOptionT[F, ?]] with L
 private trait LazyOptionTBindRec[F[_]] extends BindRec[LazyOptionT[F, ?]] with LazyOptionTMonad[F] {
   implicit def B: BindRec[F]
 
-  final def tailrecM[A, B](f: A => LazyOptionT[F, A \/ B])(a: A): LazyOptionT[F, B] =
+  final def tailrecM[A, B](a: A)(f: A => LazyOptionT[F, A \/ B]): LazyOptionT[F, B] =
     LazyOptionT(
-      B.tailrecM[A, LazyOption[B]](a => F.map(f(a).run) {
+      B.tailrecM[A, LazyOption[B]](a)(a => F.map(f(a).run) {
         _.fold(_.map(b => LazyOption.lazySome(b)), \/-(LazyOption.lazyNone))
-      })(a)
+      })
     )
 }
 

--- a/core/src/main/scala/scalaz/Maybe.scala
+++ b/core/src/main/scala/scalaz/Maybe.scala
@@ -283,10 +283,10 @@ sealed abstract class MaybeInstances {
       def bind[A, B](fa: Maybe[A])(f: A => Maybe[B]) = fa flatMap f
 
       @scala.annotation.tailrec
-      def tailrecM[A, B](f: A => Maybe[A \/ B])(a: A): Maybe[B] =
+      def tailrecM[A, B](a: A)(f: A => Maybe[A \/ B]): Maybe[B] =
         f(a) match {
           case Empty() => Empty()
-          case Just(-\/(a)) => tailrecM(f)(a)
+          case Just(-\/(a)) => tailrecM(a)(f)
           case Just(\/-(b)) => Just(b)
         }
 

--- a/core/src/main/scala/scalaz/MaybeT.scala
+++ b/core/src/main/scala/scalaz/MaybeT.scala
@@ -173,11 +173,11 @@ private trait MaybeTMonad[F[_]] extends Monad[MaybeT[F, ?]] {
 private trait MaybeTBindRec[F[_]] extends BindRec[MaybeT[F, ?]] with MaybeTMonad[F] {
   implicit def B: BindRec[F]
 
-  final def tailrecM[A, B](f: A => MaybeT[F, A \/ B])(a: A): MaybeT[F, B] =
+  final def tailrecM[A, B](a: A)(f: A => MaybeT[F, A \/ B]): MaybeT[F, B] =
     MaybeT(
-      B.tailrecM[A, Maybe[B]](a => F.map(f(a).run) {
+      B.tailrecM[A, Maybe[B]](a)(a => F.map(f(a).run) {
         _.cata(_.map(Maybe.just), \/-(Maybe.empty))
-      })(a)
+      })
     )
 }
 

--- a/core/src/main/scala/scalaz/Name.scala
+++ b/core/src/main/scala/scalaz/Name.scala
@@ -47,9 +47,9 @@ object Name {
       def distributeImpl[G[_], A, B](fa: G[A])(f: A => Name[B])(implicit G: Functor[G]) =
         Name(G.map(fa)(a => f(a).value))
       @tailrec
-      def tailrecM[A, B](f: A => Name[A \/ B])(a: A): Name[B] =
+      def tailrecM[A, B](a: A)(f: A => Name[A \/ B]): Name[B] =
         f(a).value match {
-          case -\/(a0) => tailrecM(f)(a0)
+          case -\/(a0) => tailrecM(a0)(f)
           case \/-(b) => Name(b)
         }
     }
@@ -85,9 +85,9 @@ object Need {
       def distributeImpl[G[_], A, B](fa: G[A])(f: A => Need[B])(implicit G: Functor[G]) =
         Need(G.map(fa)(a => f(a).value))
       @tailrec
-      def tailrecM[A, B](f: A => Need[A \/ B])(a: A): Need[B] =
+      def tailrecM[A, B](a: A)(f: A => Need[A \/ B]): Need[B] =
         f(a).value match {
-          case -\/(a0) => tailrecM(f)(a0)
+          case -\/(a0) => tailrecM(a0)(f)
           case \/-(b) => Need(b)
         }
     }
@@ -116,9 +116,9 @@ object Value {
       def distributeImpl[G[_], A, B](fa: G[A])(f: A => Value[B])(implicit G: Functor[G]) =
         Value(G.map(fa)(a => f(a).value))
       @tailrec
-      def tailrecM[A, B](f: A => Value[A \/ B])(a: A): Value[B] =
+      def tailrecM[A, B](a: A)(f: A => Value[A \/ B]): Value[B] =
         f(a).value match {
-          case -\/(a0) => tailrecM(f)(a0)
+          case -\/(a0) => tailrecM(a0)(f)
           case \/-(b) => Value(b)
         }
     }

--- a/core/src/main/scala/scalaz/NonEmptyList.scala
+++ b/core/src/main/scala/scalaz/NonEmptyList.scala
@@ -215,8 +215,8 @@ sealed abstract class NonEmptyListInstances extends NonEmptyListInstances0 {
       override def any[A](fa: NonEmptyList[A])(f: A => Boolean) =
         f(fa.head) || Foldable[IList].any(fa.tail)(f)
 
-      def tailrecM[A, B](f: A => NonEmptyList[A \/ B])(a: A): NonEmptyList[B] =
-        (BindRec[IList].tailrecM[A, B](a => f(a).list)(a): @unchecked) match {
+      def tailrecM[A, B](a: A)(f: A => NonEmptyList[A \/ B]): NonEmptyList[B] =
+        (BindRec[IList].tailrecM[A, B](a)(a => f(a).list): @unchecked) match {
           case ICons(h, t) => NonEmptyList.nel(h, t)
         }
     }

--- a/core/src/main/scala/scalaz/NullArgument.scala
+++ b/core/src/main/scala/scalaz/NullArgument.scala
@@ -157,7 +157,7 @@ sealed abstract class NullArgumentInstances extends NullArgumentInstances0 {
         NullArgument.always(a)
       override def bind[A, B](a: NullArgument[X, A])(f: A => NullArgument[X, B]) =
         a flatMap f
-      override def tailrecM[A, B](f: A => NullArgument[X, A \/ B])(a: A) =
+      override def tailrecM[A, B](a: A)(f: A => NullArgument[X, A \/ B]) =
         NullArgument{ t =>
           @annotation.tailrec
           def go(a0: A): B =

--- a/core/src/main/scala/scalaz/NullResult.scala
+++ b/core/src/main/scala/scalaz/NullResult.scala
@@ -200,8 +200,8 @@ sealed abstract class NullResultInstances extends NullResultInstances0 {
   implicit def nullResultMonadPlus[X]: MonadPlus[NullResult[X, ?]] with BindRec[NullResult[X, ?]] =
     new MonadPlus[NullResult[X, ?]] with BindRec[NullResult[X, ?]] {
       import std.option._
-      override def tailrecM[A, B](f: A => NullResult[X, A \/ B])(a: A) =
-        NullResult(r => BindRec[Option].tailrecM(f(_: A)(r))(a))
+      override def tailrecM[A, B](a: A)(f: A => NullResult[X, A \/ B]) =
+        NullResult(r => BindRec[Option].tailrecM(a)(f(_)(r)))
       override def map[A, B](a: NullResult[X, A])(f: A => B) =
         a map f
       override def ap[A, B](a: => NullResult[X, A])(f: => NullResult[X, A => B]) =

--- a/core/src/main/scala/scalaz/OptionT.scala
+++ b/core/src/main/scala/scalaz/OptionT.scala
@@ -204,11 +204,11 @@ private trait OptionTBindRec[F[_]] extends BindRec[OptionT[F, ?]] with OptionTBi
   implicit def F: Monad[F]
   implicit def B: BindRec[F]
 
-  final def tailrecM[A, B](f: A => OptionT[F, A \/ B])(a: A): OptionT[F, B] =
+  final def tailrecM[A, B](a: A)(f: A => OptionT[F, A \/ B]): OptionT[F, B] =
     OptionT(
-      B.tailrecM[A, Option[B]](a0 => F.map(f(a0).run) {
+      B.tailrecM[A, Option[B]](a)(a0 => F.map(f(a0).run) {
         _.fold(\/.right[A, Option[B]](None: Option[B]))(_.map(Some.apply))
-      })(a)
+      })
     )
 }
 

--- a/core/src/main/scala/scalaz/Product.scala
+++ b/core/src/main/scala/scalaz/Product.scala
@@ -41,8 +41,8 @@ private trait ProductBindRec[F[_], G[_]] extends BindRec[λ[α => (F[α], G[α])
 
   implicit def G: BindRec[G]
 
-  override def tailrecM[A, B](f: A => (F[A \/ B], G[A \/ B]))(a: A) =
-    (F.tailrecM(f.andThen(_._1))(a), G.tailrecM(f.andThen(_._2))(a))
+  override def tailrecM[A, B](a: A)(f: A => (F[A \/ B], G[A \/ B])) =
+    (F.tailrecM(a)(f.andThen(_._1)), G.tailrecM(a)(f.andThen(_._2)))
 }
 
 private trait ProductMonad[F[_], G[_]] extends Monad[λ[α => (F[α], G[α])]] with ProductBind[F, G] with ProductApplicative[F, G] {

--- a/core/src/main/scala/scalaz/ReaderWriterStateT.scala
+++ b/core/src/main/scala/scalaz/ReaderWriterStateT.scala
@@ -158,7 +158,7 @@ private trait ReaderWriterStateTBindRec[F[_], R, W, S] extends BindRec[ReaderWri
   implicit def F: BindRec[F]
   implicit def A: Monad[F]
 
-  def tailrecM[A, B](f: A => ReaderWriterStateT[F, R, W, S, A \/ B])(a: A): ReaderWriterStateT[F, R, W, S, B] = {
+  def tailrecM[A, B](a: A)(f: A => ReaderWriterStateT[F, R, W, S, A \/ B]): ReaderWriterStateT[F, R, W, S, B] = {
     def go(r: R)(t: (W, A, S)): F[(W, A, S) \/ (W, B, S)] =
       F.map(f(t._2).run(r, t._3)) {
         case (w0, e, s0) =>
@@ -167,7 +167,7 @@ private trait ReaderWriterStateTBindRec[F[_], R, W, S] extends BindRec[ReaderWri
       }
 
     ReaderWriterStateT((r, s) => F.bind(f(a).run(r, s)) {
-      case (w, -\/(a0), s0) => F.tailrecM(go(r))(w, a0, s0)
+      case (w, -\/(a0), s0) => F.tailrecM((w, a0, s0))(go(r))
       case (w, \/-(b), s0) => A.point((w, b, s0))
     })
   }

--- a/core/src/main/scala/scalaz/StateT.scala
+++ b/core/src/main/scala/scalaz/StateT.scala
@@ -229,18 +229,15 @@ private trait StateTBindRec[S, F[_]] extends StateTBind[S, F] with BindRec[State
   implicit def F: Monad[F]
   implicit def B: BindRec[F]
 
-  def tailrecM[A, B](f: A => StateT[F, S, A \/ B])(a: A): StateT[F, S, B] = {
-    def go(t: (S, A)): F[(S, A) \/ (S, B)] = {
+  def tailrecM[A, B](a: A)(f: A => StateT[F, S, A \/ B]): StateT[F, S, B] =
+    IndexedStateT(s => B.tailrecM((s, a))(t => {
       F.map(f(t._2)(t._1)) { case (s, m) =>
         m match {
           case -\/(a0) => -\/((s, a0))
           case \/-(b) => \/-((s, b))
         }
       }
-    }
-
-    IndexedStateT(s => B.tailrecM(go)((s, a)))
-  }
+    }))
 }
 
 private trait StateTMonadState[S, F[_]] extends MonadState[StateT[F, S, ?], S] with StateTBind[S, F] {

--- a/core/src/main/scala/scalaz/These.scala
+++ b/core/src/main/scala/scalaz/These.scala
@@ -322,7 +322,7 @@ object \&/ extends TheseInstances {
     }
 
   @annotation.tailrec
-  def tailrecM[L, A, B](f: A => L \&/ (A \/ B))(a: A)(implicit L: Semigroup[L]): L \&/ B = {
+  def tailrecM[L, A, B](a: A)(f: A => L \&/ (A \/ B))(implicit L: Semigroup[L]): L \&/ B = {
     def go(l0: L)(a0: A): L \&/ (A \/ B) =
       f(a0) match {
         case This(l1) => \&/.This(L.append(l0, l1))
@@ -332,9 +332,9 @@ object \&/ extends TheseInstances {
 
     f(a) match {
       case t @ This(l) => t
-      case That(-\/(a0)) => tailrecM(f)(a0)
+      case That(-\/(a0)) => tailrecM(a0)(f)
       case That(\/-(b)) => \&/.That(b)
-      case Both(l, -\/(a0)) => tailrecM(go(l))(a0)
+      case Both(l, -\/(a0)) => tailrecM(a0)(go(l))
       case Both(l, \/-(b)) => \&/.Both(l, b)
     }
   }
@@ -349,8 +349,8 @@ sealed abstract class TheseInstances0 extends TheseInstances1 {
 
   implicit def TheseInstance0[L: Semigroup]: Monad[L \&/ ?] with BindRec[L \&/ ?] =
     new Monad[L \&/ ?] with BindRec[L \&/ ?] {
-      def tailrecM[A, B](f: A => L \&/ (A \/ B))(a: A): L \&/ B =
-        \&/.tailrecM(f)(a)
+      def tailrecM[A, B](a: A)(f: A => L \&/ (A \/ B)): L \&/ B =
+        \&/.tailrecM(a)(f)
 
       override def map[A, B](x: L \&/ A)(f: A => B) =
         x map f

--- a/core/src/main/scala/scalaz/WriterT.scala
+++ b/core/src/main/scala/scalaz/WriterT.scala
@@ -346,7 +346,7 @@ private trait WriterTBindRec[F[_], W] extends BindRec[WriterT[F, W, ?]] with Wri
   implicit def F: BindRec[F]
   implicit def A: Applicative[F]
 
-  def tailrecM[A, B](f: A => WriterT[F, W, A \/ B])(a: A): WriterT[F, W, B] = {
+  def tailrecM[A, B](a: A)(f: A => WriterT[F, W, A \/ B]): WriterT[F, W, B] = {
     def go(t: (W, A)): F[(W, A) \/ (W, B)] =
       F.map(f(t._2).run) {
         case (w0, e) =>
@@ -355,7 +355,7 @@ private trait WriterTBindRec[F[_], W] extends BindRec[WriterT[F, W, ?]] with Wri
       }
 
     WriterT(F.bind(f(a).run) {
-      case (w, -\/(a0)) => F.tailrecM(go)((w, a0))
+      case (w, -\/(a0)) => F.tailrecM((w, a0))(go)
       case (w, \/-(b)) => A.point((w, b))
     })
   }

--- a/core/src/main/scala/scalaz/std/Either.scala
+++ b/core/src/main/scala/scalaz/std/Either.scala
@@ -101,10 +101,10 @@ trait EitherInstances extends EitherInstances0 {
         }
 
       @scala.annotation.tailrec
-      def tailrecM[A, B](f: A => Either[L, A \/ B])(a: A): Either[L, B] =
+      def tailrecM[A, B](a: A)(f: A => Either[L, A \/ B]): Either[L, B] =
         f(a) match {
           case Left(l) => Left(l)
-          case Right(-\/(a)) => tailrecM(f)(a)
+          case Right(-\/(a)) => tailrecM(a)(f)
           case Right(\/-(b)) => Right(b)
         }
     }

--- a/core/src/main/scala/scalaz/std/Function.scala
+++ b/core/src/main/scala/scalaz/std/Function.scala
@@ -42,7 +42,7 @@ sealed trait FunctionInstances0 extends FunctionInstances1 {
       def distributeImpl[G[_]: Functor, A, B](fa: G[A])(f: A => (=> T) => B): (=> T) => G[B] =
         t => Functor[G].map(fa)(a => f(a)(t))
 
-      def tailrecM[A, B](f: A => (=> T) => A \/ B)(a: A): (=> T) => B =
+      def tailrecM[A, B](a: A)(f: A => (=> T) => A \/ B): (=> T) => B =
         t => {
           @scala.annotation.tailrec
           def go(a0: A): B =
@@ -85,7 +85,7 @@ trait FunctionInstances extends FunctionInstances0 {
       def distributeImpl[G[_], A, B](fa: G[A])(f: A => () => B)(implicit G: Functor[G]): () => G[B] =
         () => G.map(fa)(a => f(a)())
 
-      def tailrecM[A, B](f: A => () => A \/ B)(a: A): () => B =
+      def tailrecM[A, B](a: A)(f: A => () => A \/ B): () => B =
         () => {
           @scala.annotation.tailrec
           def go(a0: A): B =
@@ -143,7 +143,7 @@ trait FunctionInstances extends FunctionInstances0 {
       def distributeImpl[G[_]: Functor, A, B](fa: G[A])(f: A => T => B): T => G[B] =
         t => Functor[G].map(fa)(a => f(a)(t))
 
-      def tailrecM[A, B](f: A => T => A \/ B)(a: A): T => B =
+      def tailrecM[A, B](a: A)(f: A => T => A \/ B): T => B =
         t => {
           @scala.annotation.tailrec
           def go(a0: A): B =
@@ -168,7 +168,7 @@ trait FunctionInstances extends FunctionInstances0 {
       def bind[A, B](fa: (T1, T2) => A)(f: (A) => (T1, T2) => B) =
         (t1, t2) => f(fa(t1, t2))(t1, t2)
 
-      def tailrecM[A, B](f: A => (T1, T2) => A \/ B)(a: A): (T1, T2) => B =
+      def tailrecM[A, B](a: A)(f: A => (T1, T2) => A \/ B): (T1, T2) => B =
         (t1, t2) => {
           @scala.annotation.tailrec
           def go(a0: A): B =
@@ -188,7 +188,7 @@ trait FunctionInstances extends FunctionInstances0 {
       def bind[A, B](fa: (T1, T2, T3) => A)(f: (A) => (T1, T2, T3) => B) =
         (t1, t2, t3) => f(fa(t1, t2, t3))(t1, t2, t3)
 
-      def tailrecM[A, B](f: A => (T1, T2, T3) => A \/ B)(a: A): (T1, T2, T3) => B =
+      def tailrecM[A, B](a: A)(f: A => (T1, T2, T3) => A \/ B): (T1, T2, T3) => B =
         (t1, t2, t3) => {
           @scala.annotation.tailrec
           def go(a0: A): B =
@@ -208,7 +208,7 @@ trait FunctionInstances extends FunctionInstances0 {
       def bind[A, B](fa: (T1, T2, T3, T4) => A)(f: (A) => (T1, T2, T3, T4) => B) =
         (t1, t2, t3, t4) => f(fa(t1, t2, t3, t4))(t1, t2, t3, t4)
 
-      def tailrecM[A, B](f: A => (T1, T2, T3, T4) => A \/ B)(a: A): (T1, T2, T3, T4) => B =
+      def tailrecM[A, B](a: A)(f: A => (T1, T2, T3, T4) => A \/ B): (T1, T2, T3, T4) => B =
         (t1, t2, t3, t4) => {
           @scala.annotation.tailrec
           def go(a0: A): B =
@@ -228,7 +228,7 @@ trait FunctionInstances extends FunctionInstances0 {
       def bind[A, B](fa: (T1, T2, T3, T4, T5) => A)(f: (A) => (T1, T2, T3, T4, T5) => B) =
         (t1, t2, t3, t4, t5) => f(fa(t1, t2, t3, t4, t5))(t1, t2, t3, t4, t5)
 
-      def tailrecM[A, B](f: A => (T1, T2, T3, T4, T5) => A \/ B)(a: A): (T1, T2, T3, T4, T5) => B =
+      def tailrecM[A, B](a: A)(f: A => (T1, T2, T3, T4, T5) => A \/ B): (T1, T2, T3, T4, T5) => B =
         (t1, t2, t3, t4, t5) => {
           @scala.annotation.tailrec
           def go(a0: A): B =
@@ -248,7 +248,7 @@ trait FunctionInstances extends FunctionInstances0 {
       def bind[A, B](fa: (T1, T2, T3, T4, T5, T6) => A)(f: (A) => (T1, T2, T3, T4, T5, T6) => B) =
         (t1, t2, t3, t4, t5, t6) => f(fa(t1, t2, t3, t4, t5, t6))(t1, t2, t3, t4, t5, t6)
 
-      def tailrecM[A, B](f: A => (T1, T2, T3, T4, T5, T6) => A \/ B)(a: A): (T1, T2, T3, T4, T5, T6) => B =
+      def tailrecM[A, B](a: A)(f: A => (T1, T2, T3, T4, T5, T6) => A \/ B): (T1, T2, T3, T4, T5, T6) => B =
         (t1, t2, t3, t4, t5, t6) => {
           @scala.annotation.tailrec
           def go(a0: A): B =
@@ -268,7 +268,7 @@ trait FunctionInstances extends FunctionInstances0 {
       def bind[A, B](fa: (T1, T2, T3, T4, T5, T6, T7) => A)(f: (A) => (T1, T2, T3, T4, T5, T6, T7) => B) =
         (t1, t2, t3, t4, t5, t6, t7) => f(fa(t1, t2, t3, t4, t5, t6, t7))(t1, t2, t3, t4, t5, t6, t7)
 
-      def tailrecM[A, B](f: A => (T1, T2, T3, T4, T5, T6, T7) => A \/ B)(a: A): (T1, T2, T3, T4, T5, T6, T7) => B =
+      def tailrecM[A, B](a: A)(f: A => (T1, T2, T3, T4, T5, T6, T7) => A \/ B): (T1, T2, T3, T4, T5, T6, T7) => B =
         (t1, t2, t3, t4, t5, t6, t7) => {
           @scala.annotation.tailrec
           def go(a0: A): B =
@@ -288,7 +288,7 @@ trait FunctionInstances extends FunctionInstances0 {
       def bind[A, B](fa: (T1, T2, T3, T4, T5, T6, T7, T8) => A)(f: (A) => (T1, T2, T3, T4, T5, T6, T7, T8) => B) =
         (t1, t2, t3, t4, t5, t6, t7, t8) => f(fa(t1, t2, t3, t4, t5, t6, t7, t8))(t1, t2, t3, t4, t5, t6, t7, t8)
 
-      def tailrecM[A, B](f: A => (T1, T2, T3, T4, T5, T6, T7, T8) => A \/ B)(a: A): (T1, T2, T3, T4, T5, T6, T7, T8) => B =
+      def tailrecM[A, B](a: A)(f: A => (T1, T2, T3, T4, T5, T6, T7, T8) => A \/ B): (T1, T2, T3, T4, T5, T6, T7, T8) => B =
         (t1, t2, t3, t4, t5, t6, t7, t8) => {
           @scala.annotation.tailrec
           def go(a0: A): B =

--- a/core/src/main/scala/scalaz/std/List.scala
+++ b/core/src/main/scala/scalaz/std/List.scala
@@ -114,7 +114,7 @@ trait ListInstances extends ListInstances0 {
       override def all[A](fa: List[A])(p: A => Boolean): Boolean =
         fa.forall(p)
 
-      def tailrecM[A, B](f: A => List[A \/ B])(a: A): List[B] = {
+      def tailrecM[A, B](a: A)(f: A => List[A \/ B]): List[B] = {
         val bs = List.newBuilder[B]
         @scala.annotation.tailrec
         def go(xs: List[List[A \/ B]]): Unit =

--- a/core/src/main/scala/scalaz/std/Option.scala
+++ b/core/src/main/scala/scalaz/std/Option.scala
@@ -73,10 +73,10 @@ trait OptionInstances extends OptionInstances0 {
       override def getOrElse[A](o: Option[A])(d: => A) = o getOrElse d
 
       @scala.annotation.tailrec
-      def tailrecM[A, B](f: A => Option[A \/ B])(a: A): Option[B] =
+      def tailrecM[A, B](a: A)(f: A => Option[A \/ B]): Option[B] =
         f(a) match {
           case None => None
-          case Some(-\/(a)) => tailrecM(f)(a)
+          case Some(-\/(a)) => tailrecM(a)(f)
           case Some(\/-(b)) => Some(b)
         }
     }

--- a/core/src/main/scala/scalaz/std/Stream.scala
+++ b/core/src/main/scala/scalaz/std/Stream.scala
@@ -92,7 +92,7 @@ trait StreamInstances {
         else
           f(\&/.Both(a.head, b.head)) #:: alignWith(f)(a.tail, b.tail)
 
-    def tailrecM[A, B](f: A => Stream[A \/ B])(a: A): Stream[B] = {
+    def tailrecM[A, B](a: A)(f: A => Stream[A \/ B]): Stream[B] = {
       def go(s: Stream[A \/ B]): Stream[B] = {
         @annotation.tailrec def rec(abs: Stream[A \/ B]): Stream[B] =
           abs match {

--- a/core/src/main/scala/scalaz/std/Vector.scala
+++ b/core/src/main/scala/scalaz/std/Vector.scala
@@ -56,7 +56,7 @@ trait VectorInstances extends VectorInstances0 {
       r
     }
 
-    def tailrecM[A, B](f: A => Vector[A \/ B])(a: A): Vector[B] = {
+    def tailrecM[A, B](a: A)(f: A => Vector[A \/ B]): Vector[B] = {
       val bs = Vector.newBuilder[B]
       @scala.annotation.tailrec
       def go(xs: List[Vector[A \/ B]]): Unit =

--- a/project/TupleNInstances.scala
+++ b/project/TupleNInstances.scala
@@ -41,7 +41,7 @@ private[std] trait Tuple${n}BindRec[$tparams] extends BindRec[($tparams, ?)] wit
     (${(1 until n).map(i => s"_$i.append(fa._$i, t._$i)").mkString(", ")}, t._$n)
   }
 
-  override def tailrecM[A, B](f: A => ($tparams, A \\/ B))(a: A): ($tparams, B) = {
+  override def tailrecM[A, B](a: A)(f: A => ($tparams, A \\/ B)): ($tparams, B) = {
     @annotation.tailrec
     def go(${(1 until n).map(i => s"s$i: A$i").mkString(", ")})(z: A): ($tparams, B) =
       f(z) match {

--- a/tests/src/test/scala/scalaz/FreeTTest.scala
+++ b/tests/src/test/scala/scalaz/FreeTTest.scala
@@ -39,12 +39,12 @@ object FreeTTest extends SpecLite {
     "not stack overflow with 50k binds" in {
       val expected = Applicative[FreeTListOption].point(())
       val result =
-        BindRec[FreeTListOption].tailrecM((i: Int) =>
+        BindRec[FreeTListOption].tailrecM(0)(i =>
           if (i < 50000)
             Applicative[FreeTListOption].point(\/.left[Int, Unit](i + 1))
           else
             Applicative[FreeTListOption].point(\/.right[Int, Unit](()))
-        )(0)
+        )
 
       Equal[FreeTListOption[Unit]].equal(expected, result)
     }

--- a/tests/src/test/scala/scalaz/LazyEitherTTest.scala
+++ b/tests/src/test/scala/scalaz/LazyEitherTTest.scala
@@ -28,9 +28,9 @@ object LazyEitherTTest extends SpecLite {
     val times = 10000
 
     val result =
-      BindRec[LazyEitherId].tailrecM[Int, Int] {
+      BindRec[LazyEitherId].tailrecM(0) {
         i => LazyEitherT[Id, Int, Int \/ Int](LazyEither.lazyRight(if (i < 10000) \/.left(i + 1) else \/.right(i)))
-      }(0)
+      }
     result.getOrElse(0) must_=== times
   }
 

--- a/tests/src/test/scala/scalaz/LazyEitherTest.scala
+++ b/tests/src/test/scala/scalaz/LazyEitherTest.scala
@@ -23,9 +23,9 @@ object LazyEitherTest extends SpecLite {
     val times = 10000
 
     val result =
-      BindRec[LazyEither[Int, ?]].tailrecM[Int, Int] {
+      BindRec[LazyEither[Int, ?]].tailrecM(0) {
         i => LazyEither.lazyRight(if (i < 10000) \/.left(i + 1) else \/.right(i))
-      }(0)
+      }
     result.getOrElse(0) must_=== times
   }
 }

--- a/tests/src/test/scala/scalaz/LazyOptionTTest.scala
+++ b/tests/src/test/scala/scalaz/LazyOptionTTest.scala
@@ -19,9 +19,9 @@ object LazyOptionTTest extends SpecLite {
     val times = 10000
 
     val result =
-      BindRec[LazyOptionId].tailrecM[Int, Int] {
+      BindRec[LazyOptionId].tailrecM(0) {
         i => LazyOptionT[Id, Int \/ Int](LazyOption.lazySome(if (i < 10000) \/.left(i + 1) else \/.right(i)))
-      }(0)
+      }
     result.getOrElse(0) must_=== times
   }
 

--- a/tests/src/test/scala/scalaz/LazyOptionTest.scala
+++ b/tests/src/test/scala/scalaz/LazyOptionTest.scala
@@ -24,9 +24,9 @@ object LazyOptionTest extends SpecLite {
     val times = 10000
 
     val result =
-      BindRec[LazyOption].tailrecM[Int, Int] {
+      BindRec[LazyOption].tailrecM(0) {
         i => LazyOption.lazySome(if (i < 10000) \/.left(i + 1) else \/.right(i))
-      }(0)
+      }
     result.getOrElse(0) must_=== times
   }
 


### PR DESCRIPTION
This is a proposal to flip the order of `tailrecM` parameters to improve type inference.

The original signature is

```scala
def tailrecM[A, B](f: A => F[A \/ B])(a: A): F[B]
```

The signature proposed in this PR is

```scala
def tailrecM[A, B](a: A)(f: A => F[A \/ B]): F[B]
```

The new signature allows to pass the function argument `f` as a lambda, without having to explicitly specify type arguments of `tailrecM` or `f`'s parameter type.

This PR is mostly a mechanical flipping of arguments, though I did inline some local `def`s as lambdas to demonstrate the gained type inference (see e.g. changes to `Free`/`FreeT`).

I think this flipped argument order is more consistent with the argument order of `bind`, which in `scalaz` is also flipped compared to Haskell/PureScript.

This is, of course, a breaking change.

FWIW, I [suggested](https://github.com/typelevel/cats/issues/616#issuecomment-219555071) the same in `cats` and they went with it.