### PR TITLE
[WIP] Workaround for ambiguous implicits issue in MTL-style, fixes #1110

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Task.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Task.scala
@@ -287,8 +287,8 @@ class Task[+A](val get: Future[Throwable \/ A]) {
 
 object Task {
 
-  implicit val taskInstance: Nondeterminism[Task] with BindRec[Task] with Catchable[Task] with MonadError[Task,Throwable] =
-    new Nondeterminism[Task] with BindRec[Task] with Catchable[Task] with MonadError[Task, Throwable] {
+  implicit val taskInstance: Nondeterminism[Task] with BindRec[Task] with Catchable[Task] with MonadError[Task,Throwable] with Monad[Task] =
+    new Nondeterminism[Task] with BindRec[Task] with Catchable[Task] with MonadError[Task, Throwable] with Monad[Task] {
       val F = Nondeterminism[Future]
       def point[A](a: => A) = Task.point(a)
       def bind[A,B](a: Task[A])(f: A => Task[B]): Task[B] =

--- a/core/src/main/scala/scalaz/Adjunction.scala
+++ b/core/src/main/scala/scalaz/Adjunction.scala
@@ -116,7 +116,8 @@ sealed abstract class AdjunctionInstances {
       override def rightAdjunct[A, B](a: () => A)(f: A => B): B = f(a())
     }
 
-  implicit def writerReaderAdjunction[E]: Adjunction[Writer[E, ?], Reader[E, ?]] =
+  implicit def writerReaderAdjunction[E]: Adjunction[Writer[E, ?], Reader[E, ?]] = {
+    implicit val instance: Apply[Reader[E, ?]] = Kleisli.kleisliIdApply[E]
     new Adjunction[Writer[E, ?], Reader[E, ?]] {
       override def leftAdjunct[A, B](a: => A)(f: Writer[E, A] => B): Reader[E, B] =
         Reader(e => f(Writer(e, a)))
@@ -125,5 +126,6 @@ sealed abstract class AdjunctionInstances {
         f(a)(e)
       }
     }
+  }
 }
 

--- a/core/src/main/scala/scalaz/Bitraverse.scala
+++ b/core/src/main/scala/scalaz/Bitraverse.scala
@@ -84,7 +84,7 @@ trait Bitraverse[F[_, _]] extends Bifunctor[F] with Bifoldable[F] { self =>
   /** Bitraverse `fa` with a `Kleisli[G, S, C]` and `Kleisli[G, S, D]`, internally using a `Trampoline` to avoid stack overflow. */
   def bitraverseKTrampoline[S, G[_] : Applicative, A, B, C, D](fa: F[A, B])(f: A => Kleisli[G, S, C])(g: B => Kleisli[G, S, D]): Kleisli[G, S, F[C, D]] = {
     import Free._
-    implicit val A = Kleisli.kleisliMonadReader[Trampoline, S].compose(Applicative[G])
+    implicit val A = Kleisli.kleisliMonadReader[Trampoline, S].instance.compose(Applicative[G])
 
     Kleisli[G, S, F[C, D]](s => {
       val kl = bitraverse[λ[α => Kleisli[Trampoline, S, G[α]]], A, B, C, D](fa)(z => Kleisli[Id, S, G[C]](i => f(z)(i)).lift[Trampoline])(z => Kleisli[Id, S, G[D]](i => g(z)(i)).lift[Trampoline])

--- a/core/src/main/scala/scalaz/EitherT.scala
+++ b/core/src/main/scala/scalaz/EitherT.scala
@@ -226,13 +226,15 @@ object EitherT extends EitherTInstances {
     implicit u1: Unapply[Functor, FAB]{type A = AB}, u2: Unapply2[Bifunctor, AB]{type A = A0; type B = B0}, l: Leibniz.===[AB, A0 \/ B0])
       : EitherT[u1.M, A0, B0] = eitherT(l.subst[u1.M](u1(fab)))
 
-  def monadTell[F[_], W, A](implicit MT0: MonadTell[F, W]): EitherTMonadTell[F, W, A] = new EitherTMonadTell[F, W, A]{
-    def MT = MT0
-  }
+  def monadTell[F[_], W, A](implicit MT0: MonadTell[F, W]): MonadTell[EitherT[F, A, ?], W] with Monad[EitherT[F, A, ?]] =
+    new EitherTMonadTell[F, W, A] {
+      def MT = MT0
+    }
 
-  def monadListen[F[_], W, A](implicit ML0: MonadListen[F, W]): EitherTMonadListen[F, W, A] = new EitherTMonadListen[F, W, A]{
-    def MT = ML0
-  }
+  def monadListen[F[_], W, A](implicit ML0: MonadListen[F, W]): MonadListen[EitherT[F, A, ?], W] with Monad[EitherT[F, A, ?]] =
+    new EitherTMonadListen[F, W, A] {
+      def MT = ML0
+    }
 
   /** Construct a left disjunction value. */
   def left[F[_], A, B](a: F[A])(implicit F: Functor[F]): EitherT[F, A, B] =
@@ -293,7 +295,7 @@ sealed abstract class EitherTInstances4 {
 }
 
 sealed abstract class EitherTInstances3 extends EitherTInstances4 {
-  implicit def eitherTMonadError[F[_], E](implicit F0: Monad[F]): MonadError[EitherT[F, E, ?], E] =
+  implicit def eitherTMonadError[F[_], E](implicit F0: Monad[F]): MonadError[EitherT[F, E, ?], E] with Monad[EitherT[F, E, ?]] =
     new EitherTMonadError[F, E] {
       implicit def F = F0
     }
@@ -459,25 +461,25 @@ private trait EitherTHoist[A] extends Hoist[λ[(α[_], β) => EitherT[α, A, β]
 private[scalaz] trait EitherTMonadTell[F[_], W, A] extends MonadTell[EitherT[F, A, ?], W] with EitherTMonad[F, A] with EitherTHoist[A] {
   def MT: MonadTell[F, W]
 
-  implicit def F = MT
+  implicit def F = MT.instance
 
   def writer[B](w: W, v: B): EitherT[F, A, B] =
     liftM[F, B](MT.writer(w, v))
 
   def left[B](v: => A): EitherT[F, A, B] =
-    EitherT.left[F, A, B](MT.point(v))
+    EitherT.left[F, A, B](F.point(v))
 
   def right[B](v: => B): EitherT[F, A, B] =
-    EitherT.right[F, A, B](MT.point(v))
+    EitherT.right[F, A, B](F.point(v))
 }
 
 private[scalaz] trait EitherTMonadListen[F[_], W, A] extends MonadListen[EitherT[F, A, ?], W] with EitherTMonadTell[F, W, A] {
   implicit def MT: MonadListen[F, W]
 
   def listen[B](ma: EitherT[F, A, B]): EitherT[F, A, (B, W)] = {
-    val tmp = MT.bind[(A \/ B, W), A \/ (B, W)](MT.listen(ma.run)){
-      case (-\/(a), _) => MT.point(-\/(a))
-      case (\/-(b), w) => MT.point(\/-((b, w)))
+    val tmp = MT.instance.bind[(A \/ B, W), A \/ (B, W)](MT.listen(ma.run)){
+      case (-\/(a), _) => MT.instance.point(-\/(a))
+      case (\/-(b), w) => MT.instance.point(\/-((b, w)))
     }
 
     EitherT[F, A, (B, W)](tmp)

--- a/core/src/main/scala/scalaz/FreeT.scala
+++ b/core/src/main/scala/scalaz/FreeT.scala
@@ -175,20 +175,20 @@ sealed abstract class FreeT[S[_], M[_], A] {
 }
 
 sealed abstract class FreeTInstances6 {
-  implicit def freeTMonadTell[S[_], M[_], E](implicit M1: MonadTell[M, E]): MonadTell[FreeT[S, M, ?], E] =
+  implicit def freeTMonadTell[S[_], M[_], E](implicit M1: MonadTell[M, E]): MonadTell[FreeT[S, M, ?], E] with Monad[FreeT[S, M, ?]] =
     new MonadTell[FreeT[S, M, ?], E] with FreeTMonad[S, M] {
-      override def M = implicitly
+      override def M = M1.instance
       override def writer[A](w: E, v: A) =
-        FreeT.liftM(M1.writer(w, v))
+        FreeT.liftM(M1.writer(w, v))(M)
     }
 }
 
 sealed abstract class FreeTInstances5 extends FreeTInstances6 {
-  implicit def freeTMonadReader[S[_], M[_], E](implicit M1: MonadReader[M, E]): MonadReader[FreeT[S, M, ?], E] =
+  implicit def freeTMonadReader[S[_], M[_], E](implicit M1: MonadReader[M, E]): MonadReader[FreeT[S, M, ?], E] with Monad[FreeT[S, M, ?]] =
     new MonadReader[FreeT[S, M, ?], E] with FreeTMonad[S, M] {
-      override def M = implicitly
+      override def M = M1.instance
       override def ask =
-        FreeT.liftM(M1.ask)
+        FreeT.liftM(M1.ask)(M)
       override def local[A](f: E => E)(fa: FreeT[S, M, A]) =
         fa.hoist(new (M ~> M){
           def apply[A](a: M[A]) = M1.local(f)(a)
@@ -197,24 +197,24 @@ sealed abstract class FreeTInstances5 extends FreeTInstances6 {
 }
 
 sealed abstract class FreeTInstances4 extends FreeTInstances5 {
-  implicit def freeTMonadState[S[_], M[_], E](implicit M1: MonadState[M, E]): MonadState[FreeT[S, M, ?], E] =
+  implicit def freeTMonadState[S[_], M[_], E](implicit M1: MonadState[M, E]): MonadState[FreeT[S, M, ?], E] with Monad[FreeT[S, M, ?]] =
     new MonadState[FreeT[S, M, ?], E] with FreeTMonad[S, M] {
-      override def M = implicitly
+      override def M = M1.instance
       override def init =
-        FreeT.liftM(M1.init)
+        FreeT.liftM(M1.init)(M)
       override def get =
-        FreeT.liftM(M1.get)
+        FreeT.liftM(M1.get)(M)
       override def put(s: E) =
-        FreeT.liftM(M1.put(s))
+        FreeT.liftM(M1.put(s))(M)
     }
 }
 
 sealed abstract class FreeTInstances3 extends FreeTInstances4 {
-  implicit def freeTMonadError[S[_], M[_]: BindRec, E](implicit E: MonadError[M, E]): MonadError[FreeT[S, M, ?], E] =
+  implicit def freeTMonadError[S[_], M[_]: BindRec, E](implicit E: MonadError[M, E]): MonadError[FreeT[S, M, ?], E] with Monad[FreeT[S, M, ?]] =
     new MonadError[FreeT[S, M, ?], E] with FreeTMonad[S, M] {
-      override def M = implicitly
+      override def M = E.instance
       override def handleError[A](fa: FreeT[S, M, A])(f: E => FreeT[S, M, A]) =
-        FreeT.liftM[S, M, FreeT[S, M, A]](E.handleError(fa.toM)(f.andThen(_.toM)))(M).flatMap(identity)
+        FreeT.liftM[S, M, FreeT[S, M, A]](E.handleError(fa.toM(M))(f.andThen(_.toM(M))))(M).flatMap(identity)
       override def raiseError[A](e: E) =
         FreeT.liftM(E.raiseError[A](e))(M)
     }

--- a/core/src/main/scala/scalaz/Kleisli.scala
+++ b/core/src/main/scala/scalaz/Kleisli.scala
@@ -147,14 +147,14 @@ sealed abstract class KleisliInstances8 extends KleisliInstances9 {
 }
 
 sealed abstract class KleisliInstances7 extends KleisliInstances8 {
-  implicit def kleisliBindRec[F[_], R](implicit F0: BindRec[F]): BindRec[Kleisli[F, R, ?]] =
+  implicit def kleisliBindRec[F[_], R](implicit F0: BindRec[F]): BindRec[Kleisli[F, R, ?]] with Bind[Kleisli[F, R, ?]] =
     new KleisliBindRec[F, R] {
       implicit def F: BindRec[F] = F0
     }
 }
 
 sealed abstract class KleisliInstances6 extends KleisliInstances7 {
-  implicit def kleisliApplicativePlus[F[_], R](implicit F0: ApplicativePlus[F]): ApplicativePlus[Kleisli[F, R, ?]] =
+  implicit def kleisliApplicativePlus[F[_], R](implicit F0: ApplicativePlus[F]): ApplicativePlus[Kleisli[F, R, ?]] with Applicative[Kleisli[F, R, ?]] =
     new ApplicativePlus[Kleisli[F, R, ?]] with KleisliApplicative[F, R] with KleisliPlusEmpty[F, R] {
       implicit def F: ApplicativePlus[F] = F0
     }
@@ -166,21 +166,21 @@ sealed abstract class KleisliInstances6 extends KleisliInstances7 {
 }
 
 sealed abstract class KleisliInstances5 extends KleisliInstances6 {
-  implicit def kleisliMonadError[F[_], E, R](implicit F0: MonadError[F, E]): MonadError[Kleisli[F, R, ?], E] =
+  implicit def kleisliMonadError[F[_], E, R](implicit F0: MonadError[F, E]): MonadError[Kleisli[F, R, ?], E] with Monad[Kleisli[F, R, ?]] =
     new KleisliMonadError[F, E, R] {
-      implicit def F = F0
+      implicit def FE = F0
     }
 }
 
 sealed abstract class KleisliInstances4 extends KleisliInstances5 {
-  implicit def kleisliMonadPlus[F[_], A](implicit F0: MonadPlus[F]): MonadPlus[Kleisli[F, A, ?]] =
+  implicit def kleisliMonadPlus[F[_], A](implicit F0: MonadPlus[F]): MonadPlus[Kleisli[F, A, ?]] with Monad[Kleisli[F, A, ?]] =
     new KleisliMonadPlus[F, A] {
       implicit def F = F0
     }
 }
 
 sealed abstract class KleisliInstances3 extends KleisliInstances4 {
-  implicit def kleisliMonadReader[F[_], R](implicit F0: Monad[F]): MonadReader[Kleisli[F, R, ?], R] =
+  implicit def kleisliMonadReader[F[_], R](implicit F0: Monad[F]): MonadReader[Kleisli[F, R, ?], R] with Monad[Kleisli[F, R, ?]] =
     new KleisliMonadReader[F, R] {
       implicit def F: Monad[F] = F0
     }
@@ -224,7 +224,7 @@ abstract class KleisliInstances extends KleisliInstances0 {
   implicit def kleisliContravariant[F[_], A]: Contravariant[Kleisli[F, ?, A]] =
     new KleisliContravariant[F, A] {}
 
-  implicit def kleisliIdMonadReader[R]: MonadReader[Kleisli[Id, R, ?], R] =
+  implicit def kleisliIdMonadReader[R]: MonadReader[Kleisli[Id, R, ?], R] with Monad[Kleisli[Id, R, ?]] =
     kleisliMonadReader[Id, R]
 
   implicit def kleisliMonoid[F[_], A, B](implicit FB0: Monoid[F[B]]): Monoid[Kleisli[F, A, B]] =
@@ -345,7 +345,7 @@ private trait KleisliHoist[R] extends Hoist[Kleisli[?[_], R, ?]] {
     Kleisli(_ => a)
 
   implicit def apply[G[_] : Monad]: Monad[Kleisli[G, R, ?]] =
-    Kleisli.kleisliMonadReader
+    Kleisli.kleisliMonadReader[G, R].instance
 }
 
 private trait KleisliMonadPlus[F[_], R] extends MonadPlus[Kleisli[F, R, ?]] with KleisliPlusEmpty[F, R] with KleisliMonad[F, R] {
@@ -353,13 +353,14 @@ private trait KleisliMonadPlus[F[_], R] extends MonadPlus[Kleisli[F, R, ?]] with
 }
 
 private trait KleisliMonadError[F[_], E, R] extends MonadError[Kleisli[F, R, ?], E] with KleisliMonad[F, R] {
-  implicit def F: MonadError[F, E]
+  implicit def FE: MonadError[F, E]
+  implicit def F = FE.instance
 
   def handleError[A](fa: Kleisli[F, R, A])(f: E => Kleisli[F, R, A]): Kleisli[F, R, A] =
-    Kleisli.kleisli[F, R, A](r => F.handleError(fa.run(r))(e => f(e).run(r)))
+    Kleisli.kleisli[F, R, A](r => FE.handleError(fa.run(r))(e => f(e).run(r)))
 
   def raiseError[A](e: E): Kleisli[F, R, A] =
-    Kleisli.kleisli[F, R, A](_ => F.raiseError(e))
+    Kleisli.kleisli[F, R, A](_ => FE.raiseError(e))
 }
 
 private trait KleisliContravariant[F[_], X] extends Contravariant[Kleisli[F, ?, X]] {

--- a/core/src/main/scala/scalaz/LazyEitherT.scala
+++ b/core/src/main/scala/scalaz/LazyEitherT.scala
@@ -189,7 +189,7 @@ sealed abstract class LazyEitherTInstances1 {
       def iso = LazyEitherT.lazyEitherTLeftProjectionEIso2[F, L]
     }
 
-  implicit def lazyEitherTMonadError[F[_], L](implicit F0: Monad[F]): MonadError[LazyEitherT[F, L, ?], L] =
+  implicit def lazyEitherTMonadError[F[_], L](implicit F0: Monad[F]): MonadError[LazyEitherT[F, L, ?], L] with Monad[LazyEitherT[F, L, ?]] =
     new LazyEitherTMonadError[F, L] {
       implicit def F = F0
     }

--- a/core/src/main/scala/scalaz/MonadError.scala
+++ b/core/src/main/scala/scalaz/MonadError.scala
@@ -5,8 +5,9 @@ package scalaz
  *
  */
 ////
-trait MonadError[F[_], S] extends Monad[F] { self =>
+trait MonadError[F[_], S] { self: Monad[F] =>
   ////
+  val instance: Monad[F] = self
 
   def raiseError[A](e: S): F[A]
   def handleError[A](fa: F[A])(f: S => F[A]): F[A]
@@ -22,7 +23,7 @@ trait MonadError[F[_], S] extends Monad[F] { self =>
   def monadErrorLaw = new MonadErrorLaw {}
 
   ////
-  val monadErrorSyntax = new scalaz.syntax.MonadErrorSyntax[F, S] { def F = MonadError.this }
+  val monadErrorSyntax = new scalaz.syntax.MonadErrorSyntax[F, S] { def FS = MonadError.this }
 }
 
 object MonadError {

--- a/core/src/main/scala/scalaz/MonadListen.scala
+++ b/core/src/main/scala/scalaz/MonadListen.scala
@@ -1,12 +1,12 @@
 package scalaz
 
-trait MonadListen[F[_], W] extends MonadTell[F, W] {
+trait MonadListen[F[_], W] extends MonadTell[F, W] { self: Monad[F] =>
   def listen[A](ma: F[A]): F[(A, W)]
 
   def pass[A](ma: F[(A, W => W)]): F[A] =
     bind(listen(ma)){ case ((a, f), w) => writer(f(w), a) }
 
-  val monadListenSyntax = new scalaz.syntax.MonadListenSyntax[F, W]{def F = MonadListen.this}
+  val monadListenSyntax = new scalaz.syntax.MonadListenSyntax[F, W]{def FS = MonadListen.this}
 }
 
 object MonadListen {

--- a/core/src/main/scala/scalaz/MonadReader.scala
+++ b/core/src/main/scala/scalaz/MonadReader.scala
@@ -5,8 +5,9 @@ package scalaz
  *
  */
 ////
-trait MonadReader[F[_], S] extends Monad[F] { self =>
+trait MonadReader[F[_], S] { self: Monad[F] =>
   ////
+  val instance: Monad[F] = self
 
   def ask: F[S]
   def local[A](f: S => S)(fa: F[A]): F[A]

--- a/core/src/main/scala/scalaz/MonadState.scala
+++ b/core/src/main/scala/scalaz/MonadState.scala
@@ -6,8 +6,9 @@ package scalaz
  *
  */
 ////
-trait MonadState[F[_], S] extends Monad[F] { self =>
+trait MonadState[F[_], S] { self: Monad[F] =>
   ////
+  val instance: Monad[F] = self
 
   def state[A](a: A): F[A] = bind(init)(s => point(a))
   def constantState[A](a: A, s: => S): F[A] = bind(put(s))(_ => point(a))

--- a/core/src/main/scala/scalaz/MonadTell.scala
+++ b/core/src/main/scala/scalaz/MonadTell.scala
@@ -5,14 +5,16 @@ package scalaz
  *
  */
 ////
-trait MonadTell[F[_], S] extends Monad[F] { self =>
+trait MonadTell[F[_], S] { self: Monad[F] =>
+  val instance: Monad[F] = self
+
   ////
   def writer[A](w: S, v: A): F[A]
 
   def tell(w: S): F[Unit] = writer(w, ())
 
   ////
-  val monadTellSyntax = new scalaz.syntax.MonadTellSyntax[F, S] { def F = MonadTell.this }
+  val monadTellSyntax = new scalaz.syntax.MonadTellSyntax[F, S] { def FS = MonadTell.this }
 }
 
 object MonadTell {

--- a/core/src/main/scala/scalaz/OptionT.scala
+++ b/core/src/main/scala/scalaz/OptionT.scala
@@ -114,7 +114,7 @@ sealed abstract class OptionTInstances3 {
 }
 
 sealed abstract class OptionTInstances2 extends OptionTInstances3 {
-  implicit def optionTBindRec[F[_]](implicit F0: Monad[F], B0: BindRec[F]): BindRec[OptionT[F, ?]] =
+  implicit def optionTBindRec[F[_]](implicit F0: Monad[F], B0: BindRec[F]): BindRec[OptionT[F, ?]] with Bind[OptionT[F, ?]] =
     new OptionTBindRec[F] {
       implicit def F = F0
       implicit def B = B0
@@ -127,14 +127,14 @@ sealed abstract class OptionTInstances1 extends OptionTInstances2 {
       implicit def F: Foldable[F] = F0
     }
 
-  implicit def optionTMonadError[F[_], E](implicit F0: MonadError[F, E]): MonadError[OptionT[F, ?], E] =
+  implicit def optionTMonadError[F[_], E](implicit F0: MonadError[F, E]): MonadError[OptionT[F, ?], E] with Monad[OptionT[F, ?]] =
     new OptionTMonadError[F, E] {
-      def F = F0
+      def FE = F0
     }
 }
 
 sealed abstract class OptionTInstances0 extends OptionTInstances1 {
-  implicit def optionTMonadPlus[F[_]](implicit F0: Monad[F]): MonadPlus[OptionT[F, ?]] =
+  implicit def optionTMonadPlus[F[_]](implicit F0: Monad[F]): MonadPlus[OptionT[F, ?]] with Monad[OptionT[F, ?]] =
     new OptionTMonadPlus[F] {
       implicit def F: Monad[F] = F0
     }
@@ -167,12 +167,12 @@ object OptionT extends OptionTInstances {
   def none[M[_], A](implicit M: Applicative[M]): OptionT[M, A] =
     OptionT.optionT[M].apply[A](M.point(None))
 
-  def monadTell[F[_], W, A](implicit MT0: MonadTell[F, W]): MonadTell[OptionT[F, ?], W] =
+  def monadTell[F[_], W, A](implicit MT0: MonadTell[F, W]): MonadTell[OptionT[F, ?], W] with Monad[OptionT[F, ?]] =
     new OptionTMonadTell[F, W] {
       def MT = MT0
     }
 
-  def monadListen[F[_], W, A](implicit ML0: MonadListen[F, W]): MonadListen[OptionT[F, ?], W] =
+  def monadListen[F[_], W, A](implicit ML0: MonadListen[F, W]): MonadListen[OptionT[F, ?], W] with Monad[OptionT[F, ?]] =
     new OptionTMonadListen[F, W] {
       def MT = ML0
     }
@@ -219,13 +219,14 @@ private trait OptionTMonad[F[_]] extends Monad[OptionT[F, ?]] with OptionTBind[F
 }
 
 private trait OptionTMonadError[F[_], E] extends MonadError[OptionT[F, ?], E] with OptionTMonad[F] {
-  override def F: MonadError[F, E]
+  def FE: MonadError[F, E]
+  def F = FE.instance
 
   override def raiseError[A](e: E) =
-    OptionT[F, A](F.map(F.raiseError[A](e))(Some(_)))
+    OptionT[F, A](F.map(FE.raiseError[A](e))(Some(_)))
 
   override def handleError[A](fa: OptionT[F, A])(f: E => OptionT[F, A]) =
-    OptionT[F, A](F.handleError(fa.run)(f(_).run))
+    OptionT[F, A](FE.handleError(fa.run)(f(_).run))
 }
 
 private trait OptionTFoldable[F[_]] extends Foldable.FromFoldr[OptionT[F, ?]] {
@@ -263,7 +264,7 @@ private trait OptionTMonadPlus[F[_]] extends MonadPlus[OptionT[F, ?]] with Optio
 private trait OptionTMonadTell[F[_], W] extends MonadTell[OptionT[F, ?], W] with OptionTMonad[F] with OptionTHoist {
   def MT: MonadTell[F, W]
 
-  implicit def F = MT
+  implicit def F = MT.instance
 
   def writer[A](w: W, v: A): OptionT[F, A] =
     liftM[F, A](MT.writer(w, v))
@@ -273,9 +274,9 @@ private trait OptionTMonadListen[F[_], W] extends MonadListen[OptionT[F, ?], W] 
   def MT: MonadListen[F, W]
 
   def listen[A](ma: OptionT[F, A]): OptionT[F, (A, W)] = {
-    val tmp = MT.bind[(Option[A], W), Option[(A, W)]](MT.listen(ma.run)) {
-      case (None, _) => MT.point(None)
-      case (Some(a), w) => MT.point(Some(a, w))
+    val tmp = F.bind[(Option[A], W), Option[(A, W)]](MT.listen(ma.run)) {
+      case (None, _) => F.point(None)
+      case (Some(a), w) => F.point(Some(a, w))
     }
 
     OptionT.optionT[F].apply[(A, W)](tmp)

--- a/core/src/main/scala/scalaz/ReaderWriterStateT.scala
+++ b/core/src/main/scala/scalaz/ReaderWriterStateT.scala
@@ -104,7 +104,8 @@ sealed abstract class ReaderWriterStateTInstances0 extends IndexedReaderWriterSt
   implicit def rwstMonad[F[_], R, W, S](implicit W0: Monoid[W], F0: Monad[F]):
   MonadReader[ReaderWriterStateT[F, R, W, S, ?], R] with
   MonadState[ReaderWriterStateT[F, R, W, S, ?], S] with
-  MonadListen[ReaderWriterStateT[F, R, W, S, ?], W] =
+  MonadListen[ReaderWriterStateT[F, R, W, S, ?], W] with
+  Monad[ReaderWriterStateT[F, R, W, S, ?]] =
     new ReaderWriterStateTMonad[F, R, W, S] {
       implicit def F = F0
       implicit def W = W0
@@ -143,7 +144,7 @@ private trait IndexedReaderWriterStateTPlusEmpty[F[_], R, W, S1, S2]
 private trait IndexedReaderWriterStateTFunctor[F[_], R, W, S1, S2] extends Functor[IndexedReaderWriterStateT[F, R, W, S1, S2, ?]] {
   implicit def F: Functor[F]
 
-  override final def map[A, B](fa: IndexedReaderWriterStateT[F, R, W, S1, S2, A])(f: A => B): IndexedReaderWriterStateT[F, R, W, S1, S2, B] = fa map f
+  override def map[A, B](fa: IndexedReaderWriterStateT[F, R, W, S1, S2, A])(f: A => B): IndexedReaderWriterStateT[F, R, W, S1, S2, B] = fa map f
 }
 
 private trait ReaderWriterStateTBind[F[_], R, W, S] extends Bind[ReaderWriterStateT[F, R, W, S, ?]] with IndexedReaderWriterStateTFunctor[F, R, W, S, S] {
@@ -184,9 +185,12 @@ private trait ReaderWriterStateTMonad[F[_], R, W, S]
   extends MonadReader[ReaderWriterStateT[F, R, W, S, ?], R]
   with MonadState[ReaderWriterStateT[F, R, W, S, ?], S]
   with MonadListen[ReaderWriterStateT[F, R, W, S, ?], W]
-  with ReaderWriterStateTBind[F, R, W, S] {
+  with ReaderWriterStateTBind[F, R, W, S]
+  with Monad[ReaderWriterStateT[F, R, W, S, ?]] {
   implicit def F: Monad[F]
   implicit def W: Monoid[W]
+
+  override implicit val instance: Monad[ReaderWriterStateT[F, R, W, S, ?]] = this
 
   def point[A](a: => A): ReaderWriterStateT[F, R, W, S, A] =
     ReaderWriterStateT((_, s) => F.point((W.zero, a, s)))

--- a/core/src/main/scala/scalaz/StateT.scala
+++ b/core/src/main/scala/scalaz/StateT.scala
@@ -155,7 +155,7 @@ sealed abstract class StateTInstances3 extends IndexedStateTInstances {
 }
 
 sealed abstract class StateTInstances2 extends StateTInstances3 {
-  implicit def stateTMonadState[S, F[_]](implicit F0: Monad[F]): MonadState[StateT[F, S, ?], S] =
+  implicit def stateTMonadState[S, F[_]](implicit F0: Monad[F]): MonadState[StateT[F, S, ?], S] with Monad[StateT[F, S, ?]] =
     new StateTMonadState[S, F] {
       implicit def F: Monad[F] = F0
     }
@@ -174,7 +174,7 @@ sealed abstract class StateTInstances0 extends StateTInstances1 {
 }
 
 abstract class StateTInstances extends StateTInstances0 {
-  implicit def stateMonad[S]: MonadState[State[S, ?], S] =
+  implicit def stateMonad[S]: MonadState[State[S, ?], S] with Monad[State[S, ?]] =
       StateT.stateTMonadState[S, Id](Id.id)
 }
 
@@ -240,7 +240,7 @@ private trait StateTBindRec[S, F[_]] extends StateTBind[S, F] with BindRec[State
     }))
 }
 
-private trait StateTMonadState[S, F[_]] extends MonadState[StateT[F, S, ?], S] with StateTBind[S, F] {
+private trait StateTMonadState[S, F[_]] extends MonadState[StateT[F, S, ?], S] with Monad[StateT[F, S, ?]] with StateTBind[S, F] {
   implicit def F: Monad[F]
 
   def point[A](a: => A): StateT[F, S, A] = {

--- a/core/src/main/scala/scalaz/Traverse.scala
+++ b/core/src/main/scala/scalaz/Traverse.scala
@@ -89,7 +89,7 @@ trait Traverse[F[_]] extends Functor[F] with Foldable[F] { self =>
   /** Traverse `fa` with a `Kleisli[G, S, B]`, internally using a `Trampoline` to avoid stack overflow. */
   def traverseKTrampoline[S, G[_] : Applicative, A, B](fa: F[A])(f: A => Kleisli[G, S, B]): Kleisli[G, S, F[B]] = {
     import Free._
-    implicit val A = Kleisli.kleisliMonadReader[Trampoline, S].compose(Applicative[G])
+    implicit val A = Kleisli.kleisliMonadReader[Trampoline, S].instance.compose(Applicative[G])
     Kleisli[G, S, F[B]](s => {
       val kl = traverse[λ[α => Kleisli[Trampoline, S, G[α]]], A, B](fa)(z => Kleisli[Id, S, G[B]](i => f(z)(i)).lift[Trampoline]).run(s)
       kl.run

--- a/core/src/main/scala/scalaz/std/Either.scala
+++ b/core/src/main/scala/scalaz/std/Either.scala
@@ -63,8 +63,8 @@ trait EitherInstances extends EitherInstances0 {
   }
 
   /** Right biased monad */
-  implicit def eitherMonad[L]: Traverse[Either[L, ?]] with MonadError[Either[L, ?], L] with BindRec[Either[L, ?]] with Cozip[Either[L, ?]] =
-    new Traverse[Either[L, ?]] with MonadError[Either[L, ?], L] with BindRec[Either[L, ?]] with Cozip[Either[L, ?]] {
+  implicit def eitherMonad[L]: Traverse[Either[L, ?]] with MonadError[Either[L, ?], L] with Monad[Either[L, ?]] with BindRec[Either[L, ?]] with Cozip[Either[L, ?]] =
+    new Traverse[Either[L, ?]] with MonadError[Either[L, ?], L] with Monad[Either[L, ?]] with BindRec[Either[L, ?]] with Cozip[Either[L, ?]] {
       def bind[A, B](fa: Either[L, A])(f: A => Either[L, B]) = fa match {
         case Left(a)  => Left(a)
         case Right(b) => f(b)

--- a/core/src/main/scala/scalaz/std/Future.scala
+++ b/core/src/main/scala/scalaz/std/Future.scala
@@ -7,14 +7,14 @@ import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{ Try, Success => TSuccess }
 
 trait FutureInstances1 {
-  implicit def futureInstance(implicit ec: ExecutionContext): Nondeterminism[Future] with Cobind[Future] with MonadError[Future, Throwable] with Catchable[Future] =
+  implicit def futureInstance(implicit ec: ExecutionContext): Nondeterminism[Future] with Cobind[Future] with MonadError[Future, Throwable] with Monad[Future] with Catchable[Future] =
     new FutureInstance
 
   implicit def futureSemigroup[A](implicit m: Semigroup[A], ec: ExecutionContext): Semigroup[Future[A]] =
     Semigroup.liftSemigroup[Future, A]
 }
 
-private class FutureInstance(implicit ec: ExecutionContext) extends Nondeterminism[Future] with Cobind[Future] with MonadError[Future, Throwable] with Catchable[Future] {
+private class FutureInstance(implicit ec: ExecutionContext) extends Nondeterminism[Future] with Cobind[Future] with MonadError[Future, Throwable] with Monad[Future] with Catchable[Future] {
   def point[A](a: => A): Future[A] = Future(a)
   def bind[A, B](fa: Future[A])(f: A => Future[B]): Future[B] = fa flatMap f
   override def map[A, B](fa: Future[A])(f: A => B): Future[B] = fa map f

--- a/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
@@ -24,9 +24,10 @@ trait ToMonadErrorOps extends ToMonadOps {
 
 trait MonadErrorSyntax[F[_], S] extends MonadSyntax[F] {
   implicit def ToMonadErrorOps[A](v: F[A]): MonadErrorOps[F, S, A] =
-    new MonadErrorOps[F, S, A](v)(MonadErrorSyntax.this.F)
+    new MonadErrorOps[F, S, A](v)(MonadErrorSyntax.this.FS)
 
-  def F: MonadError[F, S]
+  def FS: MonadError[F, S]
+  def F = FS.instance
   ////
 
   ////

--- a/core/src/main/scala/scalaz/syntax/MonadListenSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadListenSyntax.scala
@@ -4,7 +4,7 @@ package syntax
 final class MonadListenOps[F[_], W, A] private[syntax](self: F[A])(implicit ML: MonadListen[F, W]) {
 
   final def written: F[W] =
-    ML.map(ML.listen(self)){ case (_, w) => w }
+    ML.instance.map(ML.listen(self)){ case (_, w) => w }
 
   final def listen: F[(A, W)] =
     ML.listen[A](self)

--- a/core/src/main/scala/scalaz/syntax/MonadTellSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadTellSyntax.scala
@@ -5,10 +5,10 @@ package syntax
 final class MonadTellOps[F[_], S, A] private[syntax](self: F[A])(implicit val F: MonadTell[F, S]) {
   ////
 
-  final def :++>(w: => S): F[A] = F.bind(self)(a => F.map(F.tell(w))(_ => a))
+  final def :++>(w: => S): F[A] = F.instance.bind(self)(a => F.instance.map(F.tell(w))(_ => a))
 
   final def :++>>(f: A => S): F[A] =
-    F.bind(self)(a => F.map(F.tell(f(a)))(_ => a))
+    F.instance.bind(self)(a => F.instance.map(F.tell(f(a)))(_ => a))
 
   ////
 }
@@ -24,9 +24,10 @@ trait ToMonadTellOps extends ToMonadOps {
 
 trait MonadTellSyntax[F[_], S] extends MonadSyntax[F] {
   implicit def ToMonadTellOps[A](v: F[A]): MonadTellOps[F, S, A] =
-    new MonadTellOps[F, S, A](v)(MonadTellSyntax.this.F)
+    new MonadTellOps[F, S, A](v)(MonadTellSyntax.this.FS)
 
-  def F: MonadTell[F, S]
+  def FS: MonadTell[F, S]
+  def F = FS.instance
   ////
 
   ////

--- a/effect/src/main/scala/scalaz/effect/MonadIO.scala
+++ b/effect/src/main/scala/scalaz/effect/MonadIO.scala
@@ -52,7 +52,10 @@ object MonadIO {
 
   implicit def streamTMonadIO[F[_]: MonadIO: Applicative] = fromLiftIO[StreamT[F, ?]]
 
-  implicit def kleisliMonadIO[F[_]: MonadIO, E] = fromLiftIO[Kleisli[F, E, ?]]
+  implicit def kleisliMonadIO[F[_]: MonadIO, E] = {
+    implicit val instance: Monad[Kleisli[F, E, ?]] = MonadReader[Kleisli[F, E, ?], E].instance
+    fromLiftIO[Kleisli[F, E, ?]]
+  }
 
   implicit def writerTMonadIO[F[_]: MonadIO, W: Monoid] = fromLiftIO[WriterT[F, W, ?]]
 

--- a/example/src/main/scala/scalaz/example/MTLUsage.scala
+++ b/example/src/main/scala/scalaz/example/MTLUsage.scala
@@ -1,0 +1,21 @@
+package scalaz
+package example
+
+import scalaz.syntax.monad._
+
+object MTLUsage extends App {
+  def app[F[_]](implicit R: MonadReader[F, Int], S: MonadError[F, String]): F[Int] = {
+    implicit val instance = R.instance
+    for {
+      a <- R.ask
+      b <- S.raiseError[Int]("error")
+    } yield a + b
+  }
+
+  type App[A] = Kleisli[String \/ ?, Int, A]
+  // Hello SI-2712
+  implicit val readerInstance = Kleisli.kleisliMonadReader[String \/ ?, Int]
+  implicit val errorInstance = Kleisli.kleisliMonadError[String \/ ?, String, Int]
+
+  val application: App[Int] = app[App]
+}

--- a/project/GenTypeClass.scala
+++ b/project/GenTypeClass.scala
@@ -48,8 +48,8 @@ object TypeClass {
   lazy val isEmpty = TypeClass("IsEmpty", *->*, extendsList = Seq(plusEmpty))
   lazy val optional = TypeClass("Optional", *->*)
 
-  lazy val applicativePlus = TypeClass("ApplicativePlus", *->*, extendsList = Seq(applicative, plusEmpty))
-  lazy val monadPlus = TypeClass("MonadPlus", *->*, extendsList = Seq(monad, applicativePlus))
+  // lazy val applicativePlus = TypeClass("ApplicativePlus", *->*, extendsList = Seq(applicative, plusEmpty))
+  // lazy val monadPlus = TypeClass("MonadPlus", *->*, extendsList = Seq(monad, applicativePlus))
 
   lazy val associative = TypeClass("Associative", *^*->*)
   lazy val bifunctor = TypeClass("Bifunctor", *^*->*)
@@ -72,13 +72,13 @@ object TypeClass {
   lazy val monadControlIO = TypeClass("MonadControlIO", *->*, extendsList = Seq(liftControlIO, monad), pack = Seq("scalaz", "effect"))
   lazy val resource = TypeClass("Resource", *, pack = Seq("scalaz", "effect"))
 
-  lazy val monadState = TypeClass("MonadState", |*->*|->*, extendsList = Seq(monad), createSyntax = false)
-  lazy val monadError = TypeClass("MonadError", |*->*|->*, extendsList = Seq(monad))
-  lazy val monadTell = TypeClass("MonadTell", |*->*|->*, extendsList = Seq(monad))
-  lazy val monadReader = TypeClass("MonadReader", |*->*|->*, extendsList = Seq(monad), createSyntax = false)
+  // lazy val monadState = TypeClass("MonadState", |*->*|->*, createSyntax = false)
+  // lazy val monadError = TypeClass("MonadError", |*->*|->*)
+  // lazy val monadTell = TypeClass("MonadTell", |*->*|->*)
+  // lazy val monadReader = TypeClass("MonadReader", |*->*|->*, createSyntax = false)
   lazy val comonadStore = TypeClass("ComonadStore", |*->*|->*, extendsList = Seq(comonad), createSyntax = false)
 
-  lazy val bindRec = TypeClass("BindRec", *->*, extendsList = Seq(bind))
+  // lazy val bindRec = TypeClass("BindRec", *->*, extendsList = Seq(bind))
 
   def core: List[TypeClass] = List(semigroup,
     monoid,
@@ -105,8 +105,8 @@ object TypeClass {
     cobind,
     comonad,
     plus,
-    applicativePlus,
-    monadPlus,
+    // applicativePlus,
+    // monadPlus,
     foldable,
     foldable1,
     traverse,
@@ -125,12 +125,12 @@ object TypeClass {
     strong,
     proChoice,
     arrow,
-    monadState,
-    monadError,
-    monadTell,
-    monadReader,
-    comonadStore,
-    bindRec
+    // monadState,
+    // monadError,
+    // monadTell,
+    // monadReader,
+    comonadStore
+    // bindRec
   )
   lazy val concurrent = Seq[TypeClass]()
   def effect = Seq(liftIO, monadIO, liftControlIO, monadControlIO, resource)

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazProperties.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazProperties.scala
@@ -607,13 +607,15 @@ object ScalazProperties {
     def errorsStopComputation[F[_], E, A](implicit me: MonadError[F, E], eq: Equal[F[A]], ae: Arbitrary[E], aa: Arbitrary[A]) =
       forAll(me.monadErrorLaw.errorsStopComputation[A] _)
 
-    def laws[F[_], E](implicit me: MonadError[F, E], am: Arbitrary[F[Int]], afap: Arbitrary[F[Int => Int]], aeq: Equal[F[Int]], ae: Arbitrary[E], afea: Arbitrary[E => F[Int]]) =
+    def laws[F[_], E](implicit me: MonadError[F, E], am: Arbitrary[F[Int]], afap: Arbitrary[F[Int => Int]], aeq: Equal[F[Int]], ae: Arbitrary[E], afea: Arbitrary[E => F[Int]]) = {
+      implicit val monadInstance: Monad[F] = me.instance
       newProperties("monad error"){ p =>
         p.include(monad.laws[F])
         p.property("raisedErrorsHandled") = raisedErrorsHandled[F, E, Int]
         p.property("errorsRaised") = errorsRaised[F, E, Int]
         p.property("errorsStopComputation") = errorsStopComputation[F, E, Int]
       }
+    }
   }
 
   object monadTrans {


### PR DESCRIPTION
Work in progress, but putting it up to get some feedback.

This is a proposed workaround to make MTL-style a bit nicer in the current subtype encoding. Assuming nobody has objections I will do similar for the other MTL type classes:

- [x] MonadError
- [x] MonadListen
- [ ] MonadReader
- [ ] MonadState
- [x] MonadTell

Unsure if we want it for these:

- [ ] ApplicativePlus/MonadPlus
- [ ] BindRec

Pinging @puffnfresh @aloiscochard 