### PR TITLE
Introduce `tut` and initial `QuickStart`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ scala:
    - 2.11.8
 jdk:
   - oraclejdk8
+script: sbt ++$TRAVIS_SCALA_VERSION test:compile tutorial/tut test

--- a/project/ScalazBuild.scala
+++ b/project/ScalazBuild.scala
@@ -49,4 +49,8 @@ object Scalaz extends Build {
         Seq ( "org.scala-lang" % "scala-reflect" % scalaVersion.value
             , "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided" )
     )
+
+  lazy val tutorial     = module("tutorial")
+    .dependsOn( baze )
+    .settings(tut.Plugin.tutSettings)
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
+addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.3")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.6")
-

--- a/tutorial/src/main/tut/QuickStart.md
+++ b/tutorial/src/main/tut/QuickStart.md
@@ -1,0 +1,40 @@
+QuickStart
+==
+
+Prelude
+--
+
+Scalaz is based around a concept of `Prelude`,  a default one is provided enabling all core features.
+
+```tut
+import scalaz.Prelude._
+
+val f: Int => String \/ Double = 
+  i => if (i > 10) right(i + 0.5) else left("too small")
+
+println((8 to 12).toList.traverse(f))
+
+println((12 to 16).toList.traverse(f))
+```
+
+It's possible (or even recommended in case of a big proprietary stack) to create your own custom prelude.
+
+```tut
+{
+  import scalaz._
+
+  object AcmePrelude extends data.DisjunctionFunctions {
+    type \/[L, R] = data.Disjunction.\/[L, R]
+  }
+
+
+  import AcmePrelude._
+
+  def f(i: Int): String \/ Double = 
+    if (i > 10) right(i + 0.5) else left("too small")
+
+  println(f(42))
+}
+```
+
+*If you are a library author and are writing an extension to `scalaz`, please follow the same design principles as the `base` library itself.*


### PR DESCRIPTION
This bootstrap an initial `tutorial` module based on @tpolecat's `tut`, with a primitive QuickStart description for `Prelude`.

/cc @vmarquez