### PR TITLE
Only memoize EphemeralStream on request (#memoized).

### DIFF
--- a/core/src/main/scala/scalaz/EphemeralStream.scala
+++ b/core/src/main/scala/scalaz/EphemeralStream.scala
@@ -142,6 +142,10 @@ sealed abstract class EphemeralStream[A] {
 
   def zipWithIndex: EphemeralStream[(A, Int)] =
     zip(iterate(0)(_ + 1))
+
+  def memoized: EphemeralStream[A] =
+    if (isEmpty) this
+    else cons(weakMemo(head())(), weakMemo(tail().memoized)())
 }
 
 sealed abstract class EphemeralStreamInstances {
@@ -251,8 +255,8 @@ object EphemeralStream extends EphemeralStreamInstances {
   def cons[A](a: => A, as: => EphemeralStream[A]) = new EphemeralStream[A] {
     def isEmpty = false
 
-    val head = weakMemo(a)
-    val tail = weakMemo(as)
+    val head = () => a
+    val tail = () => as
   }
 
   def unfold[A, B](b: => B)(f: B => Option[(A, B)]): EphemeralStream[A] =

--- a/core/src/main/scala/scalaz/EphemeralStream.scala
+++ b/core/src/main/scala/scalaz/EphemeralStream.scala
@@ -145,7 +145,7 @@ sealed abstract class EphemeralStream[A] {
 
   def memoized: EphemeralStream[A] =
     if (isEmpty) this
-    else cons(weakMemo(head())(), weakMemo(tail().memoized)())
+    else consImpl(weakMemo(head()), weakMemo(tail().memoized))
 }
 
 sealed abstract class EphemeralStreamInstances {
@@ -252,12 +252,15 @@ object EphemeralStream extends EphemeralStreamInstances {
     def tail: () => Nothing = () => sys.error("tail of empty stream")
   }
 
-  def cons[A](a: => A, as: => EphemeralStream[A]) = new EphemeralStream[A] {
+  private def consImpl[A](a: () => A, as: () => EphemeralStream[A]) = new EphemeralStream[A] {
     def isEmpty = false
 
-    val head = () => a
-    val tail = () => as
+    val head = a
+    val tail = as
   }
+
+  def cons[A](a: => A, as: => EphemeralStream[A]): EphemeralStream[A] =
+    consImpl(() => a, () => as)
 
   def unfold[A, B](b: => B)(f: B => Option[(A, B)]): EphemeralStream[A] =
     f(b) match {


### PR DESCRIPTION
I agree with @dmitryleskov's [conclusions about the standard use of weak memoization for `EphemeralStream`](http://blog.dmitryleskov.com/programming/scala/stream-hygiene-iii-scalaz-ephemeralstream-fills-quite-a-canyon/); it's unnecessary churn for most applications, especially when building "wholemeal"—memoizing the final stream may be desirable, but almost certainly not the intermediates.  And it's impossible to "opt out".

This flips the memoization to "opt in"; you can invoke `.memoized` and the whole stream will be memoized.  Otherwise, it will be treated just like an ordinary by-name cons list.

There are no binary compatibility breaks, but the behavior change may discourage backporting.

Incidentally, `EphemeralStream` is worth comparing to #1193.