### PR TITLE
Add lefts and rights functions to MonadPlus

### DIFF
--- a/core/src/main/scala/scalaz/MonadPlus.scala
+++ b/core/src/main/scala/scalaz/MonadPlus.scala
@@ -20,12 +20,16 @@ trait MonadPlus[F[_]] extends Monad[F] with ApplicativePlus[F] { self =>
   def unite[T[_], A](value: F[T[A]])(implicit T: Foldable[T]): F[A] =
     bind(value)((ta) => T.foldMap(ta)(a => point(a))(monoid[A]))
 
+  /** Generalized version of Haskell's `lefts` */
+  def lefts[G[_, _], A, B](value: F[G[A, B]])(implicit G: Bifoldable[G]): F[A] =
+    bind(value)((aa) => G.leftFoldable.foldMap(aa)(a => point(a))(monoid[A]))
+
+  /** Generalized version of Haskell's `rights` */
+  def rights[G[_, _], A, B](value: F[G[A, B]])(implicit G: Bifoldable[G]): F[B] =
+    bind(value)((bb) => G.rightFoldable.foldMap(bb)(b => point(b))(monoid[B]))
+
   /** Generalized version of Haskell's `partitionEithers` */
-  def separate[G[_, _], A, B](value: F[G[A, B]])(implicit G: Bifoldable[G]): (F[A], F[B]) = {
-    val lefts  = bind(value)((aa) => G.leftFoldable.foldMap(aa)(a => point(a))(monoid[A]))
-    val rights = bind(value)((bb) => G.rightFoldable.foldMap(bb)(b => point(b))(monoid[B]))
-    (lefts, rights)
-  }
+  def separate[G[_, _], A, B](value: F[G[A, B]])(implicit G: Bifoldable[G]): (F[A], F[B]) = (lefts(value), rights(value))
 
   /** A version of `unite` that infers the type constructor `T`. */
   final def uniteU[T](value: F[T])(implicit T: Unapply[Foldable, T]): F[T.A] =

--- a/core/src/main/scala/scalaz/syntax/MonadPlusSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadPlusSyntax.scala
@@ -19,6 +19,11 @@ final class MonadPlusOps[F[_],A] private[syntax](val self: F[A])(implicit val F:
     val ftb: F[T[B]] = ev.subst(self)
     F.unite[T, B](ftb)
   }
+  final def lefts[G[_, _], B, C](implicit ev: A === G[B, C], G: Bifoldable[G]): F[B] =
+    F.lefts(ev.subst(self))
+
+  final def rights[G[_, _], B, C](implicit ev: A === G[B, C], G: Bifoldable[G]): F[C] =
+    F.rights(ev.subst(self))
 
   final def separate[G[_, _], B, C](implicit ev: A === G[B, C], G: Bifoldable[G]): (F[B], F[C]) =
     F.separate(ev.subst(self))

--- a/tests/src/test/scala/scalaz/MonadPlusTest.scala
+++ b/tests/src/test/scala/scalaz/MonadPlusTest.scala
@@ -13,6 +13,32 @@ object MonadPlusTest extends SpecLite {
     MonadPlus[List].uniteU(List(\/.right(1), \/.left("a"), \/.right(2))) must_===(List(1, 2))
   }
 
+  "lefts" in {
+    import \&/._
+    import syntax.monadPlus._
+
+    List(\/.right(1), \/.left("a"), \/.right(2)).lefts must_===(List("a"))
+
+    List(1 -> "a", 2 -> "b").lefts must_===(List(1, 2))
+
+    Vector[Int \&/ String](This(1), Both(3, "a"), That("b")).lefts must_===(Vector(1, 3))
+
+    Stream(Success(1), Failure("a"), Success(2)).lefts must_===(Stream("a"))
+  }
+
+  "rights" in {
+    import \&/._
+    import syntax.monadPlus._
+
+    List(\/.right(1), \/.left("a"), \/.right(2)).rights must_===(List(1, 2))
+
+    List(1 -> "a", 2 -> "b").rights must_===(List("a", "b"))
+
+    Vector[Int \&/ String](This(1), Both(3, "a"), That("b")).rights must_===(Vector("a", "b"))
+
+    Stream(Success(1), Failure("a"), Success(2)).rights must_===(Stream(1, 2))
+  }
+
   "separate" in {
     import \&/._
     import syntax.monadPlus._


### PR DESCRIPTION
I was reimplementing something similar to Haskell's `lefts` and `rights` but @tpolecat pointed out that there was already `separate` in MonadPlus which already does the same and it's more general.

`lefts` and `rights` were already present in `MonadPlus` but were private, so this commit exposes them publicly.