### PR TITLE
Reduce allocations in traverse for list and vector

### DIFF
--- a/core/src/main/scala/scalaz/std/List.scala
+++ b/core/src/main/scala/scalaz/std/List.scala
@@ -59,12 +59,8 @@ trait ListInstances extends ListInstances0 {
         //  }
         //  val X = StateT.stateMonad[Boolean].traverse(List[Char]('a'))(wc)
 
-        // foldRight(l, F.point(List[B]())) {
-        //   (a, fbs) => F.apply2(f(a), fbs)(_ :: _)
-        // }
-
-        DList.fromList(l).foldr(F.point(List[B]())) {
-           (a, fbs) => F.apply2(f(a), fbs)(_ :: _)
+        l.reverse.foldLeft(F.point(Nil: List[B])) { (flb: F[List[B]], a: A) =>
+          F.apply2(f(a), flb)(_ :: _)
         }
       }
 

--- a/core/src/main/scala/scalaz/std/Vector.scala
+++ b/core/src/main/scala/scalaz/std/Vector.scala
@@ -30,8 +30,8 @@ trait VectorInstances extends VectorInstances0 {
     def unzip[A, B](a: Vector[(A, B)]) = a.unzip
 
     def traverseImpl[F[_], A, B](v: Vector[A])(f: A => F[B])(implicit F: Applicative[F]) = {
-      DList.fromIList(IList.fromFoldable(v)).foldr(F.point(empty[B])) {
-         (a, fbs) => F.apply2(f(a), fbs)(_ +: _)
+      v.foldLeft(F.point(empty[B])) { (fvb, a) =>
+        F.apply2(fvb, f(a))(_ :+ _)
       }
     }
 


### PR DESCRIPTION
The `Traverse` instance for the standard `List` converts it into an `IList`, then a `DList` of just that `IList`, then an `IList` again from that, which it then ultimately `(reverse . foldLeft)`s. Instead, I `(reverse . foldLeft)` the list directly. `Vector`'s traverse instance makes a bigger improvement, because it doesn't even require the `reverse` to be efficient.

I do not believe this PR is as efficient as the schemes proposed by @S11001001 in #1022 (if it were extended to standard `List`) or #1023, seeing as his seems to reduce the total number of `ap` calls, but this at least avoids unnecessary allocations.