### PR TITLE
Reimplement Free#foldRun without the Functor contraint.

### DIFF
--- a/core/src/main/scala/scalaz/Free.scala
+++ b/core/src/main/scala/scalaz/Free.scala
@@ -243,6 +243,20 @@ sealed abstract class Free[S[_], A] {
       }
     }
 
+  /** Variant of `foldRun` that allows to interleave effect `M` at each step. */
+  final def foldRunM[M[_], B](b: B)(f: λ[α => (B, S[α])] ~> λ[α => M[(B, α)]])(implicit M0: Applicative[M], M1: BindRec[M]): M[(B, A)] =
+    M1.tailrecM((b, this)) { case (b, fa) =>
+      fa.step match {
+        case Return(a) => M0.point(\/-((b, a)))
+        case Suspend(sa) => M0.map(f((b, sa)))(\/.right)
+        case g @ Gosub(_, _) => g.a match {
+          case Suspend(sz) =>
+            M0.map(f((b, sz))) { case (b, z) => -\/((b, g.f(z))) }
+          case _ => sys.error("Unreachable code: `Gosub` returned from `step` must have `Suspend` on the left")
+        }
+      }
+    }
+
   /** Runs a trampoline all the way to the end, tail-recursively. */
   final def run(implicit ev: Free[S, A] =:= Trampoline[A]): A =
     ev(this).go(_())

--- a/example/src/main/scala/scalaz/example/TrampolineUsage.scala
+++ b/example/src/main/scala/scalaz/example/TrampolineUsage.scala
@@ -33,7 +33,8 @@ object TrampolineUsage extends App {
     val sorted = runQuickSort[Function0, Int](xs)
     println(sorted)
 
-    val (steps, sorted1) = quickSort[Function0, Int](xs).foldRun(0)((i, f) => (i + 1, f()))
+    val step = λ[λ[α => (Int, Function0[α])] ~> (Int, ?)] { case (i, f) => (i + 1, f()) }
+    val (steps, sorted1) = quickSort[Function0, Int](xs).foldRun(0)(step)
     println("sort using heap took %d steps".format(steps))
   }
 

--- a/tests/src/test/scala/scalaz/FreeTest.scala
+++ b/tests/src/test/scala/scalaz/FreeTest.scala
@@ -95,12 +95,36 @@ object FreeState {
     def get: FreeState[S, S] = Free.liftF[F, S](s => (s, s))
     def init: FreeState[S, S] = get
     def put(s: S): FreeState[S, Unit] = Free.liftF[F, Unit](_ => (s, ()))
-
   }
 
   def run[S, A](fs: FreeState[S, A])(s: S): (S, A) = {
     type F[X] = (S, S => (S, X))
     fs.foldRun(s)(λ[F ~> (S, ?)] { case (s, f) => f(s) })
+  }
+}
+
+object FreeStateT {
+  /** stack-safe state monad transformer */
+  type FreeStateT[M[_], S, A] = Free[λ[α => S => M[(S, α)]], A]
+
+  def apply[M[_], S, A](f: S => M[(S, A)]): FreeStateT[M, S, A] = Free.liftF[λ[α => S => M[(S, α)]], A](f)
+
+  implicit def monadState[M[_], S](implicit M: Applicative[M]): MonadState[FreeStateT[M, S, ?], S] =
+    new MonadState[FreeStateT[M, S, ?], S] {
+      type F[A] = S => M[(S, A)]
+
+      def point[A](a: => A): FreeStateT[M, S, A] = Free.liftF[F, A](s => M.point((s, a)))
+      def bind[A, B](fa: FreeStateT[M, S, A])(f: A => FreeStateT[M, S, B]): FreeStateT[M, S, B] = fa.flatMap(f)
+
+      def get: FreeStateT[M, S, S] = Free.liftF[F, S](s => M.point((s, s)))
+      def init: FreeStateT[M, S, S] = get
+      def put(s: S): FreeStateT[M, S, Unit] = Free.liftF[F, Unit](_ => M.point((s, ())))
+    }
+
+  def run[M[_]: Applicative: BindRec, S, A](fs: FreeStateT[M, S, A])(s: S): M[(S, A)] = {
+    type F[X] = (S, S => M[(S, X)])
+    type G[X] = M[(S, X)]
+    fs.foldRunM(s)(λ[F ~> G] { case (s, f) => f(s) })
   }
 }
 
@@ -156,6 +180,28 @@ object FreeTest extends SpecLite {
         )
 
       0 must_=== FreeState.run(go)(10000)._2
+    }
+  }
+
+  "FreeStateT" should {
+    import FreeStateT._
+
+    "be stack-safe on left-associated binds" in {
+      val ms: MonadState[FreeStateT[Option, Int, ?], Int] = FreeStateT.monadState
+
+      val go = (0 until 10000).foldLeft(ms.init)((fs, _) => fs.flatMap(_ => FreeStateT[Option, Int, Int](i => Some((i+1, i+1)))))
+
+      Option((10000, 10000)) must_=== FreeStateT.run(go)(0)
+    }
+
+    "be stack-safe on right-associated (i.e. recursive) binds" in {
+      def go: FreeStateT[Option, Int, Int] =
+        FreeStateT[Option, Int, Int](n => Some((n-1, n-1))).flatMap(i =>
+          if(i > 0) go
+          else FreeStateT[Option, Int, Int](n => Some((n, n)))
+        )
+
+      Option((0, 0)) must_=== FreeStateT.run(go)(10000)
     }
   }
 


### PR DESCRIPTION
This is in line with previous changes to drop the `Functor` constraint from `Free`.

The signature has changed from

```scala
def foldRun[B](b: B)(f: (B, S[Free[S, A]]) => (B, Free[S, A]))(implicit S: Functor[S]): (B, A)
```

to

```scala
def foldRun[B](b: B)(f: λ[α => (B, S[α])] ~> (B, ?)): (B, A)
```

I also added test that `foldRun` can be used to implement a stack-safe state monad. (Previously, `foldRun` was not tested at all.)

**EDIT:** Also added `foldRunM`:

```scala
def foldRunM[M[_], B](b: B)(f: λ[α => (B, S[α])] ~> λ[α => M[(B, α)]])(implicit M0: Applicative[M], M1: BindRec[M]): M[(B, A)]
```

and tests that show that it can be used to implement stack-safe `StateT`.