### PR TITLE
extend stateTMonadPlus type with MonadState

### DIFF
--- a/core/src/main/scala/scalaz/StateT.scala
+++ b/core/src/main/scala/scalaz/StateT.scala
@@ -162,7 +162,7 @@ sealed abstract class StateTInstances2 extends StateTInstances3 {
 }
 
 sealed abstract class StateTInstances1 extends StateTInstances2 {
-  implicit def stateTMonadPlus[S, F[_]](implicit F0: MonadPlus[F]): MonadPlus[StateT[F, S, ?]] =
+  implicit def stateTMonadPlus[S, F[_]](implicit F0: MonadPlus[F]): MonadPlus[StateT[F, S, ?]] with MonadState[StateT[F, S, ?], S] =
     new StateTMonadStateMonadPlus[S, F] {
       implicit def F: MonadPlus[F] = F0
     }


### PR DESCRIPTION
This PR annotates stateTMonadPlus type as `MonadPlus[StateT[F, S, ?]] with MonadState[StateT[F, S, ?], S]`

Motivation:
It is impossible to use both stateTMonadPlus and stateTMonadState due to ambiguity, but it is necessary in some cases.