### PR TITLE
[Don't merge] Failing test case for MonadPlus[FreeT].

### DIFF
--- a/tests/src/test/scala/scalaz/FreeTTest.scala
+++ b/tests/src/test/scala/scalaz/FreeTTest.scala
@@ -36,6 +36,25 @@ object FreeTTest extends SpecLite {
     checkAll(traverse.laws[FreeTListOption])
     checkAll(monadTrans.laws[FreeTList, Option])
 
+    "lawful MonadPlus" in {
+      // give names to some expressions
+      val f: Unit => FreeTListOption[Unit] = _ => FreeT.liftM(MonadPlus[Option].empty)
+      val a = ()
+      val g = ().point[FreeTListOption]
+
+      // by the monad laws, f1 = f2
+      val f1 = a.point[FreeTListOption] flatMap f
+      val f2 = f(a)
+
+      // by the substitution property of equality,
+      // when f1 = f2, then also fg1 = fg2
+      val fg1 = MonadPlus[FreeTListOption].plus(f1, g)
+      val fg2 = MonadPlus[FreeTListOption].plus(f2, g)
+
+      // so let's check that
+      Equal[FreeTListOption[Unit]].equal(fg1, fg2)
+    }
+
     "not stack overflow with 50k binds" in {
       val expected = Applicative[FreeTListOption].point(())
       val result =


### PR DESCRIPTION
This is just to demonstrate that the implementation of the `plus` operation for `FreeT` is incorrect. This is a regression I introduced in #1117 and the tests didn't catch it. PR with the fix incoming.

FWIW, I believe the current implementation is correct for `MonadPlus` instances that satisfy the left distribution:

    plus(a, b).flatMap(f) = plus(a.flatMap(f), b.flatMap(f))

but `Option` does not, and there [doesn't seem to be consensus](https://wiki.haskell.org/MonadPlus_reform_proposal) on whether `MonadPlus` should obey the this law.