### PR TITLE
Make CofreeBind sufficiently lazy

### DIFF
--- a/core/src/main/scala/scalaz/Cofree.scala
+++ b/core/src/main/scala/scalaz/Cofree.scala
@@ -222,7 +222,7 @@ private trait CofreeBind[F[_]] extends Bind[Cofree[F, ?]] with CofreeComonad[F]{
 
   def bind[A, B](fa: Cofree[F, A])(f: A => Cofree[F, B]): Cofree[F, B] = {
     val c = f(fa.head)
-    Cofree.applyT(c.head, c.t.map(ct => G.plus(c.tail, F.map(fa.tail)(bind(_)(f))) ) )
+    Cofree.applyT(c.head, c.t.map(ct => G.plus(ct, F.map(fa.tail)(bind(_)(f))) ) )
   }
 }
 


### PR DESCRIPTION
`CofreeBind` evaluates `c.tail` for no reason.