### PR TITLE
Remove Cofree.mapBranching constraint, add Cofree.mapBranchingT

### DIFF
--- a/core/src/main/scala/scalaz/Cofree.scala
+++ b/core/src/main/scala/scalaz/Cofree.scala
@@ -46,9 +46,13 @@ sealed abstract class Cofree[S[_], A] {
   /** Returns the components of this structure in a tuple. */
   final def toPair: (A, S[Cofree[S, A]]) = (head, tail)
 
-  /** Changes the branching functor by the given natural transformation. */
-  final def mapBranching[T[_]](f: S ~> T)(implicit S: Functor[S], T: Functor[T]): Cofree[T, A] =
+  /** Changes the branching functor with the given natural transformation, using the source branching functor's fmap. */
+  final def mapBranching[T[_]](f: S ~> T)(implicit S: Functor[S]): Cofree[T, A] =
     Cofree.delay(head, f(S.map(tail)(_ mapBranching f)))
+
+  /** Changes the branching functor with the given natural transformation, using the target branching functor's fmap. */
+  final def mapBranchingT[T[_]](f: S ~> T)(implicit T: Functor[T]): Cofree[T, A] =
+    Cofree.delay(head, T.map(f(tail))(_ mapBranchingT f))
 
   /** Modifies the first branching with the given natural transformation. */
   final def mapFirstBranching(f: S ~> S): Cofree[S, A] =


### PR DESCRIPTION
Moving that functor. `mapBranching` does not use the `T` functor. `mapBranching` and `mapBranchingT`, assuming both functors exist and are lawful, always return the same result. All this allows for is a choice of constraint.