### PR TITLE
Add some Lens and Store methods accepting arguments wrapped in a funtor.

### DIFF
--- a/core/src/main/scala/scalaz/Lens.scala
+++ b/core/src/main/scala/scalaz/Lens.scala
@@ -45,23 +45,22 @@ sealed abstract class LensFamily[A1, A2, B1, B2] {
   def set(a: A1, b: B2): A2 =
     run(a).put(b)
 
+  def setf[X[_]](a: A1, b: X[B2])(implicit XF: Functor[X]): X[A2] =
+    run(a).putf(b)
+
   def st: State[A1, B1] =
     State(s => (s, get(s)))
 
   /** Modify the value viewed through the lens */
-  def mod(f: B1 => B2, a: A1): A2 = {
-    val (p, q) = run(a).run
-    p(f(q))
-  }
+  def mod(f: B1 => B2, a: A1): A2 =
+    run(a).puts(f)
 
   def =>=(f: B1 => B2): A1 => A2 =
     mod(f, _)
 
   /** Modify the value viewed through the lens, returning a functor `X` full of results. */
-  def modf[X[_]](f: B1 => X[B2], a: A1)(implicit XF: Functor[X]): X[A2] = {
-    val c = run(a)
-    XF.map(f(c.pos))(c put _)
-  }
+  def modf[X[_]](f: B1 => X[B2], a: A1)(implicit XF: Functor[X]): X[A2] =
+    run(a).putsf(f)
 
   def =>>=[X[_]](f: B1 => X[B2])(implicit XF: Functor[X]): A1 => X[A2] =
     modf(f, _)

--- a/core/src/main/scala/scalaz/StoreT.scala
+++ b/core/src/main/scala/scalaz/StoreT.scala
@@ -33,6 +33,12 @@ final case class IndexedStoreT[F[_], +I, A, B](run: (F[A => B], I)) {
   def puts(f: I => A)(implicit F: Functor[F]): F[B] =
     put(f(pos))
 
+  def putf[G[_]](a: G[A])(implicit F: Functor[F], G: Functor[G]): G[F[B]] =
+    G.map(a)(put(_))
+
+  def putsf[G[_]](f: I => G[A])(implicit F: Functor[F], G: Functor[G]): G[F[B]] =
+    putf(f(pos))
+
   def set: F[A => B] =
     run._1
 


### PR DESCRIPTION
 - LensFamily:
   - `setf`: functor-accepting version of `set`, analogous to how
     `modf` already is a functor-accepting version of `mod`.
 - IndexedStoreT:
   - `putf`: functor-accepting version of `put`.
   - `putsf`: functor-accepting version of `puts`.