### PR TITLE
Add derivation for MonadState using MonadTrans

### DIFF
--- a/core/src/main/scala/scalaz/MonadState.scala
+++ b/core/src/main/scala/scalaz/MonadState.scala
@@ -27,5 +27,19 @@ object MonadState {
 
   ////
 
+  implicit def promotedMonadState[G[_], F[_], S](
+    implicit
+    mpo: MonadPartialOrder[G, F],
+    ms: MonadState[F, S]
+  ): MonadState[G, S] = new MonadState[G, S] {
+
+    override def get: G[S] = mpo.promote(ms.get)
+    override def put(s: S): G[Unit] = mpo.promote(ms put s)
+
+    override def point[A](a: => A): G[A] = mpo.MG point a
+    override def bind[A, B](ga: G[A])(f: A => G[B]): G[B] = mpo.MG.bind(ga)(f)
+
+  }
+
   ////
 }

--- a/tests/src/test/scala/scalaz/StateTTest.scala
+++ b/tests/src/test/scala/scalaz/StateTTest.scala
@@ -80,4 +80,11 @@ object StateTTest extends SpecLite {
       .foldLeft(StateT((s:Int) => Trampoline.done((s,s))))( (a,b) => a.flatMap(_ => b))
     4000 must_=== result(0).run._1
   }
+
+  "MonadState must be derived for any stack of Monads" in {
+    type StateStack[A] = State[Int, A]
+    type ListStack[A] = ListT[StateStack, A]
+
+    MonadState[ListStack, Int].get.run.eval(1) must_=== List(1)
+  }
 }


### PR DESCRIPTION
I was using a stack of monads with a `StateT` and found that when I need a `MonadState` I can't get one derived on a `MonadTrans`.
Not sure if this is useful, but thought it might help someone.