### PR TITLE
Cast-free type tags

### DIFF
--- a/core/src/main/scala/scalaz/Tag.scala
+++ b/core/src/main/scala/scalaz/Tag.scala
@@ -3,24 +3,29 @@ package scalaz
 import Id._
 
 object Tag {
+  @inline val k: TagKind = IdTagKind
+
   /** `subst` specialized to `Id`.
     *
     * @todo According to Miles, @specialized doesn't help here. Maybe manually specialize.
     */
-  @inline def apply[@specialized A, T](a: A): A @@ T = a.asInstanceOf[A @@ T]
+  @inline def apply[@specialized A, T](a: A): A @@ T = k(a)
 
   /** `unsubst` specialized to `Id`. */
-  @inline def unwrap[@specialized A, T](a: A @@ T): A = unsubst[A, Id, T](a)
+  @inline def unwrap[@specialized A, T](a: A @@ T): A = k unwrap a
 
   /** Add a tag `T` to `A`.
     *
-    * NB: It is unsafe to `subst` or `unsubst` a tag in an `F` that is
+    * NB: It is unwise to `subst` or `unsubst` a tag in an `F` that is
     * sensitive to the `A` type within.  For example, if `F` is a
-    * GADT, rather than a normal ADT, it is probably unsafe.  For
-    * "normal" types like `List` and function types, it is safe.  More
-    * broadly, if it is possible to write a ''legal''
-    * [[scalaz.InvariantFunctor]] over the parameter, `subst` of that
-    * parameter is safe.
+    * GADT, rather than a normal ADT, it will be type-correct, but
+    * probably not what you expect.  For "normal" types like `List`
+    * and function types, it is safe.  More broadly, if it is possible
+    * to write a ''legal'' [[scalaz.InvariantFunctor]] over the
+    * parameter, `subst` of that parameter is safe.  This is because
+    * `subst` effectively provides evidence that a type and all its
+    * tagged variants are equal; tagging works to discriminate types
+    * because that fact is not implicit to the compiler.
     *
     * We do not have a
     * <a href="https://ghc.haskell.org/trac/ghc/wiki/Roles">type role</a>
@@ -29,13 +34,13 @@ object Tag {
     * is safe if and only if the parameter has "representational" or
     * "phantom" role.
     */
-  def subst[A, F[_], T](fa: F[A]): F[A @@ T] = fa.asInstanceOf[F[A @@ T]]
+  @inline def subst[A, F[_], T](fa: F[A]): F[A @@ T] = k subst fa
 
   /** Add a tag `T` to `G[_]` */
-  def subst1[G[_], F[_[_]], T](fa: F[G]): F[λ[α => G[α] @@ T]] = fa.asInstanceOf[F[λ[α => G[α] @@ T]]]
+  def subst1[G[_], F[_[_]], T](fa: F[G]): F[λ[α => G[α] @@ T]] = k subst1 fa
 
   /** Remove the tag `T`, leaving `A`. */
-  def unsubst[A, F[_], T](fa: F[A @@ T]): F[A] = fa.asInstanceOf[F[A]]
+  @inline def unsubst[A, F[_], T](fa: F[A @@ T]): F[A] = k unsubst fa
 
   /** @see `Tag.of` */
   final class TagOf[T] private[Tag]()
@@ -78,4 +83,24 @@ object Tag {
     * type parameters.
     */
   def of[T]: TagOf[T] = new TagOf[T]
+}
+
+sealed abstract class TagKind {
+  type @@[A, T]
+
+  def subst[A, F[_], T](fa: F[A]): F[A @@ T]
+  def subst1[G[_], F[_[_]], T](fa: F[G]): F[λ[α => G[α] @@ T]]
+  def unsubst[A, F[_], T](fa: F[A @@ T]): F[A]
+  def apply[@specialized A, T](a: A): A @@ T
+  def unwrap[@specialized A, T](a: A @@ T): A
+}
+
+private[scalaz] object IdTagKind extends TagKind {
+  type @@[A, T] = A
+
+  @inline override def subst[A, F[_], T](fa: F[A]): F[A] = fa
+  @inline override def unsubst[A, F[_], T](fa: F[A]): F[A] = fa
+  @inline override def subst1[G[_], F[_[_]], T](fa: F[G]): F[G] = fa
+  @inline override def apply[@specialized A, T](a: A): A = a
+  @inline override def unwrap[@specialized A, T](a: A): A = a
 }

--- a/core/src/main/scala/scalaz/package.scala
+++ b/core/src/main/scala/scalaz/package.scala
@@ -96,8 +96,6 @@ package object scalaz {
 
   implicit val idInstance: Traverse1[Id] with Monad[Id] with BindRec[Id] with Comonad[Id] with Distributive[Id] with Zip[Id] with Unzip[Id] with Align[Id] with Cozip[Id] with Optional[Id] = Id.id
 
-  private[scalaz] type Tagged[A, T] = {type Tag = T; type Self = A}
-
   /**
    * Tag a type `T` with `Tag`.
    *
@@ -107,7 +105,7 @@ package object scalaz {
    *
    * Credit to Miles Sabin for the idea.
    */
-  type @@[T, Tag] = Tagged[T, Tag]
+  type @@[T, Tag] = scalaz.Tag.k.@@[T, Tag]
 
   /** A [[scalaz.NaturalTransformation]][F, G]. */
   type ~>[-F[_], +G[_]] = NaturalTransformation[F, G]

--- a/tests/src/test/scala/scalaz/TagTest.scala
+++ b/tests/src/test/scala/scalaz/TagTest.scala
@@ -7,6 +7,14 @@ import Tags.{Multiplication => Mult}
 import org.scalacheck.Prop.forAll
 
 object TagTest extends SpecLite {
+  "k.@@" should {
+    "be abstract" in {
+      val r = (List[Int](42) ++ List[Int @@ Mult]()).toSet
+      r: Set[Any]
+      true
+    }
+  }
+
   "of.subst" should {
     "substitute" ! forAll {xs: List[Int] =>
       (Tag unwrap Foldable[List].fold(Tag.of[Mult].subst(xs))


### PR DESCRIPTION
By replacing the structural type with an abstract [existential] type, the `subst`/`unsubst` code sees that a tagged type is equal to the untagged type, so it doesn't need to cast.

* Now, `subst` cannot be used to derive `unsafeCoerce` in concert with singleton type patterns.
* Tags/untags no longer form an optimization barrier for inlining optimizers, because there are neither internal nor external inconsistencies when tagging.