### PR TITLE
adds a Semigroup and Monoid for IdT

### DIFF
--- a/core/src/main/scala/scalaz/IdT.scala
+++ b/core/src/main/scala/scalaz/IdT.scala
@@ -60,6 +60,9 @@ sealed abstract class IdTInstances0 extends IdTInstances1 {
 
   implicit def idTOrder[F[_], A](implicit F: Order[F[A]]): Order[IdT[F, A]] =
     F.contramap(_.run)
+
+  implicit def idTMonoid[F[_]: PlusEmpty, A]: Semigroup[IdT[F, A]] =
+    Monoid.monoidInvariantFunctor.xmap(PlusEmpty[F].monoid[A], IdT.apply, _.run)
 }
 
 sealed abstract class IdTInstances extends IdTInstances0 {

--- a/core/src/main/scala/scalaz/IdT.scala
+++ b/core/src/main/scala/scalaz/IdT.scala
@@ -72,6 +72,9 @@ sealed abstract class IdTInstances extends IdTInstances0 {
 
   implicit def idTEqual[F[_], A](implicit F: Equal[F[A]]): Equal[IdT[F, A]] =
     F.contramap(_.run)
+
+  implicit def idTSemigroup[F[_]: Plus, A]: Semigroup[IdT[F, A]] =
+    Semigroup.semigroupInvariantFunctor.xmap(Plus[F].semigroup[A], IdT.apply, _.run)
 }
 
 object IdT extends IdTInstances

--- a/core/src/main/scala/scalaz/IdT.scala
+++ b/core/src/main/scala/scalaz/IdT.scala
@@ -61,8 +61,8 @@ sealed abstract class IdTInstances0 extends IdTInstances1 {
   implicit def idTOrder[F[_], A](implicit F: Order[F[A]]): Order[IdT[F, A]] =
     F.contramap(_.run)
 
-  implicit def idTMonoid[F[_]: PlusEmpty, A]: Semigroup[IdT[F, A]] =
-    Monoid.monoidInvariantFunctor.xmap(PlusEmpty[F].monoid[A], IdT.apply, _.run)
+  implicit def idTSemigroup[F[_]: Plus, A]: Semigroup[IdT[F, A]] =
+    Semigroup.semigroupInvariantFunctor.xmap(Plus[F].semigroup[A], IdT.apply, _.run)
 }
 
 sealed abstract class IdTInstances extends IdTInstances0 {
@@ -76,8 +76,8 @@ sealed abstract class IdTInstances extends IdTInstances0 {
   implicit def idTEqual[F[_], A](implicit F: Equal[F[A]]): Equal[IdT[F, A]] =
     F.contramap(_.run)
 
-  implicit def idTSemigroup[F[_]: Plus, A]: Semigroup[IdT[F, A]] =
-    Semigroup.semigroupInvariantFunctor.xmap(Plus[F].semigroup[A], IdT.apply, _.run)
+  implicit def idTMonoid[F[_]: PlusEmpty, A]: Monoid[IdT[F, A]] =
+    Monoid.monoidInvariantFunctor.xmap(PlusEmpty[F].monoid[A], IdT.apply, _.run)
 }
 
 object IdT extends IdTInstances

--- a/tests/src/test/scala/scalaz/IdTTest.scala
+++ b/tests/src/test/scala/scalaz/IdTTest.scala
@@ -13,6 +13,7 @@ object IdTTest extends SpecLite {
     def foldable[F[_] : Foldable] = Foldable[IdT[F, ?]]
     def traverse[F[_] : Traverse] = Traverse[IdT[F, ?]]
     def semigroup[F[_] : Plus, A] = Semigroup[IdT[F, A]]
+    def monoid[F[_] : PlusEmpty, A] = Monoid[IdT[F, A]]
 
     // checking absence of ambiguity
     def equal[F[_], A](implicit F: Order[F[A]]) = Equal[IdT[F, A]]

--- a/tests/src/test/scala/scalaz/IdTTest.scala
+++ b/tests/src/test/scala/scalaz/IdTTest.scala
@@ -12,6 +12,7 @@ object IdTTest extends SpecLite {
     def monad[F[_] : Monad] = Monad[IdT[F, ?]]
     def foldable[F[_] : Foldable] = Foldable[IdT[F, ?]]
     def traverse[F[_] : Traverse] = Traverse[IdT[F, ?]]
+    def semigroup[F[_] : Plus, A] = Semigroup[IdT[F, A]]
 
     // checking absence of ambiguity
     def equal[F[_], A](implicit F: Order[F[A]]) = Equal[IdT[F, A]]


### PR DESCRIPTION
adds a Semigroup for IdT if there is a Plus instance for the underlying F type.

From https://hackage.haskell.org/package/reducers-3.12.1/docs/Data-Semigroup-Alt.html