### PR TITLE
Add `Inject.unapply`.

### DIFF
--- a/core/src/main/scala/scalaz/Inject.scala
+++ b/core/src/main/scala/scalaz/Inject.scala
@@ -9,6 +9,7 @@ import std.option.{none, some}
  */
 sealed abstract class Inject[F[_], G[_]] extends (F ~> G) {
   def apply[A](fa: F[A]): G[A] = inj(fa)
+  def unapply[A](ga: G[A]): Option[F[A]] = prj(ga)
   def inj[A](fa: F[A]): G[A]
   def prj[A](ga: G[A]): Option[F[A]]
 }

--- a/tests/src/test/scala/scalaz/InjectTest.scala
+++ b/tests/src/test/scala/scalaz/InjectTest.scala
@@ -114,4 +114,24 @@ object InjectTest extends SpecLite {
     val fa = Test2(Seq("a"), Free.pure[Test2Algebra, Int](_))
     (Inject[Test2Algebra, C0].inj(fa) == Coproduct(\/-(fa))) must_===(true)
   }
+
+  "unapply from left" in {
+    val fa = Test1(Seq("a"), Free.pure[Test1Algebra, Int](_))
+    val T1A = Inject[Test1Algebra, C0]
+
+    T1A(fa) match {
+      case T1A(check) => check must_== fa
+      case _          => fail("Wrong coproduct")
+    }
+  }
+
+  "unapply from right" in {
+    val fa = Test2(Seq("a"), Free.pure[Test2Algebra, Int](_))
+    val T2A = Inject[Test2Algebra, C0]
+
+    T2A(fa) match {
+      case T2A(check) => check must_== fa
+      case _          => fail("Wrong coproduct")
+    }
+  }
 }


### PR DESCRIPTION
This makes it possible to pattern-match on unknown Coproducts, given
appropriate `Inject` constraints.

E.g.
```scala
def foo[F[_], A](fa: F[A])(implicit In: SomeComponent :<: F) = fa match {
  case In(SomeComponent(_)) => true
  case _ => false
}
```