### PR TITLE
Make Monoid[M] => Applicative[λ[α => M]] no longer implicit

### DIFF
--- a/core/src/main/scala/scalaz/Applicative.scala
+++ b/core/src/main/scala/scalaz/Applicative.scala
@@ -114,7 +114,7 @@ object Applicative {
 
   ////
 
-  implicit def monoidApplicative[M:Monoid]: Applicative[λ[α => M]] = Monoid[M].applicative
+  def monoidApplicative[M:Monoid]: Applicative[λ[α => M]] = Monoid[M].applicative
 
   ////
 }

--- a/core/src/main/scala/scalaz/Applicative.scala
+++ b/core/src/main/scala/scalaz/Applicative.scala
@@ -114,7 +114,5 @@ object Applicative {
 
   ////
 
-  def monoidApplicative[M:Monoid]: Applicative[λ[α => M]] = Monoid[M].applicative
-
   ////
 }

--- a/example/src/main/scala/scalaz/example/TraverseUsage.scala
+++ b/example/src/main/scala/scalaz/example/TraverseUsage.scala
@@ -99,13 +99,4 @@ object TraverseUsage extends App {
 
   assert(Tag.unwrap(res1.foldMap(Tags.Disjunction(_))) === false)
   assert(Tag.unwrap(res2.foldMap(Tags.Disjunction(_))) === true)
-
-  // Here's a variation of above which might be a bit of a head
-  // scratcher, but this works because a Monoid gives rise to an
-  // Applicative Functor.  Because Boolean is not a * -> * type
-  // constructor, we need traverseU instead of traverse to find the
-  // Applicative.
-  import scalaz.Applicative.monoidApplicative
-  assert(Tag.unwrap(res1.traverseU(Tags.Disjunction(_))) === false)
-  assert(Tag.unwrap(res2.traverseU(Tags.Disjunction(_))) === true)
 }

--- a/tests/src/test/scala/scalaz/TraverseTest.scala
+++ b/tests/src/test/scala/scalaz/TraverseTest.scala
@@ -31,8 +31,8 @@ object TraverseTest extends SpecLite {
     }
 
     "traverse int function as monoidal applicative" in {
-      val s: Int = List(1, 2, 3) traverseU {_ + 1}
-      s must_===(9)
+      val s: Const[Int, _] = List(1, 2, 3) traverseU {a => Const(a + 1)}
+      s.getConst must_===(9)
     }
 
     "not blow the stack" in {


### PR DESCRIPTION
The instance is too "default instance"-y, and incoherent to boot; a compiler error is better.

This effectively reverts 186693a3869b9c887452911b6bc51d47038a3ee0.