### PR TITLE
Make *> non-strict in its second argument.

### DIFF
--- a/core/src/main/scala/scalaz/syntax/ApplySyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/ApplySyntax.scala
@@ -11,8 +11,14 @@ final class ApplyOps[F[_],A] private[syntax](val self: F[A])(implicit val F: App
   /** Combine `self` and `fb` according to `Apply[F]` and discard the `A`(s) */
   final def *>[B](fb: F[B]): F[B] = F.discardLeft(self,fb)
 
+  /** Combine `self` and `fb` according to `Apply[F]` and discard the `A`(s), except 'fb' is non-strictly evaluated. */
+  final def `*>ByName`[B](fb: => F[B]): F[B] = F.discardLeft(self,fb)
+
   /** Combine `self` and `fb` according to `Apply[F]` and discard the `B`(s) */
   final def <*[B](fb: F[B]): F[A] = F.discardRight(self,fb)
+
+  /** Combine `self` and `fb` according to `Apply[F]` and discard the `B`(s), except 'fb' is non-strictly evaluated. */
+  final def `<*ByName`[B](fb: => F[B]): F[A] = F.discardRight(self,fb)
 
   /**
    * DSL for constructing Applicative expressions.

--- a/tests/src/test/scala/scalaz/ApplyTest.scala
+++ b/tests/src/test/scala/scalaz/ApplyTest.scala
@@ -43,4 +43,41 @@ object ApplyTest extends SpecLite {
   "<*>" in {
     some(9) <*> some({(_: Int) + 3}) must_===(some(12))
   }
+
+  import Scalaz.none
+
+  def err: Option[String] = sys.error("should be non-strict!")
+
+  "*>" in {
+    some(1)       *> some(2)   must_=== (some(2))
+    some(1)       *> none[Int] must_=== (none[Int])
+    none[Int]     *> none[Int] must_=== (none[Int])
+    none[Int]     *> some(2)   must_=== (none[Int])
+    (none[String] *> err).mustThrowA[RuntimeException]
+  }
+
+  "`*>ByName`" in {
+    some(1)       `*>ByName` some(2)   must_=== (some(2))
+    some(1)       `*>ByName` none[Int] must_=== (none[Int])
+    none[Int]     `*>ByName` none[Int] must_=== (none[Int])
+    none[Int]     `*>ByName` some(2)   must_=== (none[Int])
+    none[String]  `*>ByName` err       must_=== (none[String])
+  }
+
+  "<*" in {
+    some(1)       <* some(2)   must_=== (some(1))
+    some(1)       <* none[Int] must_=== (none[Int])
+    none[Int]     <* none[Int] must_=== (none[Int])
+    none[Int]     <* some(2)   must_=== (none[Int])
+    (none[String] <* err).mustThrowA[RuntimeException]
+  }
+
+  "<*ByName" in {
+    some(1)       `<*ByName` some(2)   must_=== (some(1))
+    some(1)       `<*ByName` none[Int] must_=== (none[Int])
+    none[Int]     `<*ByName` none[Int] must_=== (none[Int])
+    none[Int]     `<*ByName` some(2)   must_=== (none[Int])
+    (none[String] `<*ByName` err)      must_=== (none[String])
+  }
+
 }


### PR DESCRIPTION
Addresses #1020.

## Testing

I also added a few unit tests within this PR.

```
Welcome to Scala version 2.10.6 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_112).

import scalaz.syntax._
import scalaz.Scalaz._

scala> none[Int] *> ???
res1: Option[Nothing] = None
```