### PR TITLE
Enable test for Bifoldable laws

### DIFF
--- a/tests/src/test/scala/scalaz/BifoldableTest.scala
+++ b/tests/src/test/scala/scalaz/BifoldableTest.scala
@@ -1,0 +1,9 @@
+package scalaz
+
+import scalaz.scalacheck.ScalazProperties._
+import std.AllInstances._
+
+object BifoldableTest extends SpecLite {
+
+  checkAll("BifoldableLaws", bifoldable.laws[Either] )
+}


### PR DESCRIPTION
Though the laws were defined for Bifoldable, I could not find a test file to use them.