### PR TITLE
ContT syntax.

### DIFF
--- a/core/src/main/scala/scalaz/syntax/ContTOps.scala
+++ b/core/src/main/scala/scalaz/syntax/ContTOps.scala
@@ -1,0 +1,14 @@
+package scalaz
+package syntax
+
+final class ContTOps[M[_], A](val self: M[A]) extends AnyVal {
+  final def cps[R](implicit M: Bind[M]): ContT[M, R, A] =
+    ContT((f: A => M[R]) => M.bind(self)(f))
+
+  final def cps_(implicit M: Bind[M]): ContT[M, Unit, A] =
+    cps[Unit]
+}
+
+trait ToContTOps {
+  implicit def ToContTOps[M[_], A](ma: M[A]) = new ContTOps(ma)
+}

--- a/core/src/main/scala/scalaz/syntax/Syntax.scala
+++ b/core/src/main/scala/scalaz/syntax/Syntax.scala
@@ -131,6 +131,8 @@ trait Syntaxes {
 
   object tag extends ToTagOps
 
+  object contT extends ToContTOps
+
   //
   // Mixed
   //
@@ -152,6 +154,7 @@ trait ToDataOps
   with ToNelOps
   with ToTheseOps
   with ToMaybeOps
+  with ToContTOps
 
 trait ToTypeClassOps
   extends ToSemigroupOps with ToMonoidOps with ToEqualOps with ToShowOps

--- a/example/src/main/scala/scalaz/example/ContTUsage.scala
+++ b/example/src/main/scala/scalaz/example/ContTUsage.scala
@@ -1,0 +1,14 @@
+package scalaz.example
+
+import scalaz._
+import scalaz.syntax.all._
+
+object ContTUsage extends App {
+
+  def syntaxUsage[M[_]: Bind, R, A, B, C](ma: M[A], cmb: ContT[M, R, B], f: (A, B) => M[C]): ContT[M, R, C] = for {
+    a <- ma.cps[R]
+    b <- cmb
+    c <- f(a, b).cps[R]
+  } yield c
+
+}


### PR DESCRIPTION
Add syntax

 - `ma.cps[R]` to convert `M[A]` to `ContT[M, R, A]`
 - `ma.cps_` to convert `M[A]` to `ContT[M, Unit, A]`