### PR TITLE
Add method MonadTrans#wrapEffect plus syntax for it.

### DIFF
--- a/core/src/main/scala/scalaz/MonadTrans.scala
+++ b/core/src/main/scala/scalaz/MonadTrans.scala
@@ -9,6 +9,9 @@ trait MonadTrans[F[_[_], _]] {
   final def liftMU[GA](a: GA)(implicit G: Unapply[Monad, GA]): F[G.M, G.A] =
     liftM[G.M, G.A](G(a))(G.TC)
 
+  def wrapEffect[G[_]: Monad, A](a: G[F[G, A]]): F[G, A] =
+    apply[G].join(liftM(a))
+
   /** The [[scalaz.Monad]] implied by this transformer. */
   implicit def apply[G[_] : Monad]: Monad[F[G, ?]]
 

--- a/core/src/main/scala/scalaz/StreamT.scala
+++ b/core/src/main/scala/scalaz/StreamT.scala
@@ -383,6 +383,8 @@ private trait StreamTHoist extends Hoist[StreamT] {
 
   def liftM[G[_], A](a: G[A])(implicit G: Monad[G]): StreamT[G, A] = StreamT[G, A](G.map(a)(Yield(_, empty)))
 
+  override def wrapEffect[G[_]: Monad, A](a: G[StreamT[G, A]]): StreamT[G, A] = StreamT.wrapEffect(a)
+
   def hoist[M[_], N[_]](f: M ~> N)(implicit M: Monad[M]): StreamT[M, ?] ~> StreamT[N, ?] =
     λ[StreamT[M, ?] ~> StreamT[N, ?]](a =>
       StreamT(f(M.map(a.step)(

--- a/core/src/main/scala/scalaz/syntax/MonadTransSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadTransSyntax.scala
@@ -1,0 +1,10 @@
+package scalaz
+package syntax
+
+trait ToMonadTransOps {
+  implicit def MonadTransGFGA[F[_[_], _], G[_], A](gfga: G[F[G, A]]) = new MonadTransGFGA[F, G, A](gfga)
+}
+
+final class MonadTransGFGA[F[_[_], _], G[_], A](val self: G[F[G, A]]) extends AnyVal {
+  def wrapEffect(implicit F: MonadTrans[F], G: Monad[G]): F[G, A] = F.wrapEffect(self)
+}

--- a/core/src/main/scala/scalaz/syntax/Syntax.scala
+++ b/core/src/main/scala/scalaz/syntax/Syntax.scala
@@ -102,6 +102,12 @@ trait Syntaxes {
   object monadError extends ToMonadErrorOps
 
   //
+  // Type classes over (* -> *) -> * -> *
+  //
+
+  object monadTrans extends ToMonadTransOps
+
+  //
   // Data
   //
 
@@ -163,3 +169,4 @@ trait ToTypeClassOps
   with ToBitraverseOps with ToComposeOps with ToCategoryOps
   with ToArrowOps with ToFoldableOps with ToChoiceOps with ToSplitOps with ToZipOps with ToUnzipOps with ToMonadTellOps with ToMonadListenOps with ToMonadErrorOps
   with ToFoldable1Ops with ToTraverse1Ops with ToOptionalOps with ToCatchableOps with ToAlignOps
+  with ToMonadTransOps

--- a/example/src/main/scala/scalaz/example/MonadTransUsage.scala
+++ b/example/src/main/scala/scalaz/example/MonadTransUsage.scala
@@ -1,0 +1,27 @@
+package scalaz.example
+
+import scalaz._
+import scalaz.std.option._
+import scalaz.syntax.all._
+
+object MonadTransUsage extends App {
+
+  def syntaxUsage[A, B, C](ga: Option[A], gfb: Option[MaybeT[Option, B]], f: (A, B) => Option[C]): MaybeT[Option, C] = {
+    for {
+      a <- ga.liftM[MaybeT]
+      b <- gfb.wrapEffect
+      c <- f(a, b).liftM[MaybeT]
+    } yield c
+  }
+
+  def syntaxUsage2[F[_[_], _], G[_], A, B, C](ga: G[A], gfb: G[F[G, B]], f: (A, B) => G[C])(implicit F: MonadTrans[F], G: Monad[G]): F[G, C] = {
+    import F.apply
+
+    for {
+      a <- ga.liftM[F]
+      b <- gfb.wrapEffect
+      c <- f(a, b).liftM
+    } yield c
+  }
+
+}


### PR DESCRIPTION
Add method

```scala
trait MonadTrans[F[_[_], _]] {

  def wrapEffect[G[_]: Monad, A](a: G[F[G, A]]): F[G, A] =
    apply[G].join(liftM(a))

}
```

which is a generalization of the [`wrapEffect` method we have on `StreamT`](https://github.com/scalaz/scalaz/blob/f53658f4f5218622949d1f72a32f1bf82c416e0b/core/src/main/scala/scalaz/StreamT.scala#L304) to any monad transformer.

Added syntax allows to use it as a postfix operator:

```scala
val ms: M[StreamT[M, A]] = ???

val s: StreamT[M, A] = ms.wrapEffect
```

Note: the syntax would be usable for more monad transformers if we adressed #1305.