### PR TITLE
Remove by-nameness from :-ending methods, due to SI-1980

### DIFF
--- a/core/src/main/scala/scalaz/Cord.scala
+++ b/core/src/main/scala/scalaz/Cord.scala
@@ -63,13 +63,13 @@ final case class Cord(self: FingerTree[Int, String]) {
    * Prepends a `String` to the beginning of this `Cord`.
    * Time complexity: O(1)
    */
-  def +:(x: => String): Cord = cord(x +: self)
+  def +:(x: String): Cord = cord(x +: self)
 
   /**
    * Prepends a `Char` to the beginning of this `Cord`.
    * Time complexity: O(1)
    */
-  def -:(x: => Char): Cord = cord(x.toString +: self)
+  def -:(x: Char): Cord = cord(x.toString +: self)
 
   /**
    * Appends a `Char` to the end of this `Cord`.

--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -26,14 +26,13 @@ import Liskov.<~<
  */
 sealed abstract class \/[+A, +B] extends Product with Serializable {
   final class SwitchingDisjunction[X](r: => X) {
-    def <<?:(left: => X): X =
-      \/.this match {
-        case -\/(_) => left
-        case \/-(_) => r
-      }
+    def <<?:(left: X): X =
+      foldConst(left, r)
   }
 
   /** If this disjunction is right, return the given X value, otherwise, return the X value given to the return value. */
+  @deprecated("Due to SI-1980, <<?: will always evaluate its left argument; use foldConst instead",
+              since = "7.3.0")
   def :?>>[X](right: => X): SwitchingDisjunction[X] =
     new SwitchingDisjunction[X](right)
 
@@ -56,6 +55,13 @@ sealed abstract class \/[+A, +B] extends Product with Serializable {
     this match {
       case -\/(a) => l(a)
       case \/-(b) => r(b)
+    }
+
+  /** Evaluate `l` and return if left, otherwise, `r`. */
+  def foldConst[X](l: => X, r: => X): X =
+    this match {
+      case -\/(a) => l
+      case \/-(b) => r
     }
 
   /** Spin in tail-position on the right value of this disjunction. */

--- a/core/src/main/scala/scalaz/FingerTree.scala
+++ b/core/src/main/scala/scalaz/FingerTree.scala
@@ -386,17 +386,16 @@ sealed abstract class FingerTree[V, A](implicit measurer: Reducer[A, V]) {
   def fold[B](empty: V => B, single: (V, A) => B, deep: (V, Finger[V, A], => FingerTree[V, Node[V, A]], Finger[V, A]) => B): B
 
   /** Prepends an element to the left of the tree. O(1). */
-  def +:(a: => A): FingerTree[V, A] = {
+  def +:(a: A): FingerTree[V, A] = {
     implicit val nm = nodeMeasure[A, V]
-    val az = Need(a)
     fold(
-      v => single(measurer.cons(az.value, v), az.value),
-      (v, b) => deep(measurer.cons(az.value, v), one(az.value), empty[V, Node[V, A]], one(b)),
+      v => single(measurer.cons(a, v), a),
+      (v, b) => deep(measurer.cons(a, v), one(a), empty[V, Node[V, A]], one(b)),
       (v, pr, m, sf) => {
         val mz = m
         pr match {
-          case Four(vf, b, c, d, e) => deep(measurer.cons(az.value, v), two(az.value, b), node3(c, d, e) +: mz, sf)
-          case _ => deep(measurer.cons(az.value, v), az.value +: pr, mz, sf)
+          case Four(vf, b, c, d, e) => deep(measurer.cons(a, v), two(a, b), node3(c, d, e) +: mz, sf)
+          case _ => deep(measurer.cons(a, v), a +: pr, mz, sf)
       }})
   }
 
@@ -416,13 +415,11 @@ sealed abstract class FingerTree[V, A](implicit measurer: Reducer[A, V]) {
   }
 
   /** Replace the first element of the tree with the given value. O(1) */
-  def |-:(a: => A): FingerTree[V, A] = {
-    val az = Need(a)
+  def |-:(a: A): FingerTree[V, A] =
     fold(
       v => sys.error("Replacing first element of an empty FingerTree"),
-      (v, b) => single(az.value),
-      (v, pr, m, sf) => deep(az.value |-: pr, m, sf))
-  }
+      (v, b) => single(a),
+      (v, pr, m, sf) => deep(a |-: pr, m, sf))
 
   /** Replace the last element of the tree with the given value. O(1) */
   def :-|(a: => A): FingerTree[V, A] = {
@@ -1065,7 +1062,7 @@ final class IndSeq[A](val self: FingerTree[Int, A]) {
   }
   def ++(xs: IndSeq[A]): IndSeq[A] = indSeq(self <++> xs.self)
   def :+(x: => A): IndSeq[A] = indSeq(self :+ x)
-  def +:(x: => A): IndSeq[A] = indSeq(x +: self)
+  def +:(x: A): IndSeq[A] = indSeq(x +: self)
   def length: Int = self.measure
   def tail: IndSeq[A] = indSeq(self.tail)
   def init: IndSeq[A] = indSeq(self.init)

--- a/core/src/main/scala/scalaz/StreamT.scala
+++ b/core/src/main/scala/scalaz/StreamT.scala
@@ -25,7 +25,7 @@ sealed class StreamT[M[_], A](val step: M[StreamT.Step[A, StreamT[M, A]]]) {
          ))
     )
 
-  def ::(a: => A)(implicit M: Applicative[M]): StreamT[M, A] = StreamT[M, A](M.point(Yield(a, this)))
+  def ::(a: A)(implicit M: Applicative[M]): StreamT[M, A] = StreamT[M, A](M.point(Yield(a, this)))
 
   def isEmpty(implicit M: Monad[M]): M[Boolean] = M.map(uncons)(!_.isDefined)
   def isEmptyRec(implicit M: BindRec[M]): M[Boolean] = M.map(unconsRec)(!_.isDefined)

--- a/core/src/main/scala/scalaz/Validation.scala
+++ b/core/src/main/scala/scalaz/Validation.scala
@@ -42,8 +42,18 @@ sealed abstract class Validation[+E, +A] extends Product with Serializable {
   }
 
   /** If this validation is success, return the given X value, otherwise, return the X value given to the return value. */
+  @deprecated("Due to SI-1980, <<?: will always evaluate its left argument; use foldConst instead",
+              since = "7.3.0")
   def :?>>[X](success: => X): SwitchingValidation[X] =
     new SwitchingValidation[X](success)
+
+  /** If this validation is success, return `success`, otherwise, return
+    * `fail`.
+    */
+  def foldConst[X](fail: => X, success: => X): X = this match {
+    case Failure(_) => fail
+    case Success(_) => success
+  }
 
   /** Return `true` if this validation is success. */
   def isSuccess: Boolean = this match {

--- a/core/src/main/scala/scalaz/WriterT.scala
+++ b/core/src/main/scala/scalaz/WriterT.scala
@@ -36,7 +36,7 @@ final case class WriterT[F[_], W, A](run: F[(W, A)]) { self =>
   def :++>>(f: A => W)(implicit F: Functor[F], W: Semigroup[W]): WriterT[F, W, A] =
     mapValue(wa => (W.append(wa._1, f(wa._2)), wa._2))
 
-  def <++:(w: => W)(implicit F: Functor[F], W: Semigroup[W]): WriterT[F, W, A] =
+  def <++:(w: W)(implicit F: Functor[F], W: Semigroup[W]): WriterT[F, W, A] =
     mapWritten(W.append(w, _))
 
   def <<++:(f: A => W)(implicit F: Functor[F], s: Semigroup[W]): WriterT[F, W, A] =

--- a/iteratee/src/main/scala/scalaz/iteratee/EnumeratorT.scala
+++ b/iteratee/src/main/scala/scalaz/iteratee/EnumeratorT.scala
@@ -13,7 +13,7 @@ trait EnumeratorT[E, F[_]] { self =>
   def map[B](f: E => B)(implicit ev: Monad[F]): EnumeratorT[B, F] =
     EnumerateeT.map[E, B, F](f) run self
 
-  def #::(e: => E)(implicit F: Monad[F]): EnumeratorT[E, F] = {
+  def #::(e: E)(implicit F: Monad[F]): EnumeratorT[E, F] = {
     new EnumeratorT[E, F] {
       def apply[A] = _.mapCont(_(elInput(e))) &= self
     }


### PR DESCRIPTION
* Deprecate :?>> on \/, EitherT, Validation; suggest new `foldConst` instead.
* Remove => on :-suffixed methods where users are unlikely to have been bothered by these never having been lazy in the first place.

Addresses #528.