### PR TITLE
Uncurry ephemeralstream fold and Reducer constructors

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Task.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Task.scala
@@ -252,8 +252,8 @@ object Task {
         val RR: Reducer[Throwable \/ A, Throwable \/ M] =
           Reducer[Throwable \/ A, Throwable \/ M](
             _.map(R.unit),
-            c => AE.apply2(c, _)(R.cons(_, _)),
-            m => AE.apply2(m, _)(R.snoc(_, _))
+            AE.apply2(_, _)(R.cons(_, _)),
+            AE.apply2(_, _)(R.snoc(_, _))
           )(Monoid.liftMonoid[Throwable \/ ?, M])
         new Task(F.reduceUnordered(fs.map(_.get))(RR))
       }

--- a/core/src/main/scala/scalaz/EphemeralStream.scala
+++ b/core/src/main/scala/scalaz/EphemeralStream.scala
@@ -95,7 +95,7 @@ sealed abstract class EphemeralStream[A] {
   }
 
   def reverse: EphemeralStream[A] = {
-    apply(foldLeft(Nil: List[A])((xs, x) => x :: xs) : _*)
+    foldLeft(emptyEphemeralStream[A])((xs, x) => cons(x, xs))
   }
 
   def zip[B](b: => EphemeralStream[B]): EphemeralStream[(A, B)] =

--- a/core/src/main/scala/scalaz/EphemeralStream.scala
+++ b/core/src/main/scala/scalaz/EphemeralStream.scala
@@ -64,7 +64,7 @@ sealed abstract class EphemeralStream[A] {
     foldRight[EphemeralStream[B]](emptyEphemeralStream)((h, t) => f(h) ++ t)
 
   def map[B](f: A => B): EphemeralStream[B] =
-    flatMap(x => EphemeralStream(f(x)))
+    foldRight[EphemeralStream[B]](emptyEphemeralStream)((h, t) => cons(f(h), t))
 
   def length =
     foldLeft(0)((c, _) => 1 + c)


### PR DESCRIPTION
This make EphemeralStream foldLeft/foldRight accept uncurried function.

Both args are always applied at the same times anyway.
This make it closer to Foldable api and should improve perf a little.

Also changed EphemeralStream reverse implementation to skip List creation.
This also allows to preserve head cell laziness.