### PR TITLE
Adds `or` to NaturalTransformation

### DIFF
--- a/core/src/main/scala/scalaz/NaturalTransformation.scala
+++ b/core/src/main/scala/scalaz/NaturalTransformation.scala
@@ -21,6 +21,16 @@ trait NaturalTransformation[-F[_], +G[_]] {
 
   def andThen[H[_]](f: G ~> H): F ~> H =
     f compose self
+
+  /**
+    * Combines this [[scalaz.NaturalTransformation]] with another one to create one
+    * that can transform [[scalaz.Coproduct]].
+    *
+    * The current NaturalTransformation will be used to transform the Left (`F`) value of
+    * the [[scalaz.Coproduct]] while the other one will be used to transform the Right (`H`) value.
+    */
+  def or[H[_], F0[A] <: F[A], G0[A] >: G[A]](hg: H ~> G0): Coproduct[F0, H, ?] ~> G0 =
+    λ[Coproduct[F0, H, ?] ~> G0](_.fold(self, hg))
 }
 
 trait NaturalTransformations {


### PR DESCRIPTION
Closes #1222 

~~I couldn't add this directly on `NaturalTransformation` because of the variance markers on that trait for `F[_]` and `G[_]`~~