### PR TITLE
Add method Free#resumeC, a variant of resume that doesn't require Functor.

### DIFF
--- a/core/src/main/scala/scalaz/Cofree.scala
+++ b/core/src/main/scala/scalaz/Cofree.scala
@@ -67,11 +67,11 @@ sealed abstract class Cofree[S[_], A] {
     applyCofree(x => b, g)
 
   /** Applies a function `f` to a value in this comonad and a corresponding value in the dual monad, annihilating both. */
-  final def zapWith[G[_], B, C](bs: Free[G, B])(f: (A, B) => C)(implicit G: Functor[G], d: Zap[S, G]): C =
+  final def zapWith[G[_], B, C](bs: Free[G, B])(f: (A, B) => C)(implicit d: Zap[S, G]): C =
     Zap.comonadMonadZap.zapWith(this, bs)(f)
 
   /** Applies a function in a monad to the corresponding value in this comonad, annihilating both. */
-  final def zap[G[_], B](fs: Free[G, A => B])(implicit G: Functor[G], d: Zap[S, G]): B =
+  final def zap[G[_], B](fs: Free[G, A => B])(implicit d: Zap[S, G]): B =
     zapWith(fs)((a, f) => f(a))
 }
 

--- a/core/src/main/scala/scalaz/Zap.scala
+++ b/core/src/main/scala/scalaz/Zap.scala
@@ -42,22 +42,22 @@ sealed abstract class ZapInstances {
     }
 
   /** A free monad and a cofree comonad annihilate each other */
-  implicit def monadComonadZap[F[_], G[_]](implicit d: Zap[F, G], F: Functor[F]): Zap[Free[F, ?], Cofree[G, ?]] =
+  implicit def monadComonadZap[F[_], G[_]](implicit d: Zap[F, G]): Zap[Free[F, ?], Cofree[G, ?]] =
     new Zap[Free[F, ?], Cofree[G, ?]] {
       def zapWith[A, B, C](ma: Free[F, A], wb: Cofree[G, B])(f: (A, B) => C): C =
-        ma.resume match {
+        ma.resumeC match {
           case \/-(a) => f(a, wb.head)
-          case -\/(k) => d.zapWith(k, wb.tail)(zapWith(_, _)(f))
+          case -\/(k) => d.zapWith(k.fi, wb.tail)((i, b) => zapWith(k.k(i), b)(f))
         }
     }
 
   /** A cofree comonad and a free monad annihilate each other */
-  implicit def comonadMonadZap[F[_], G[_]](implicit d: Zap[F, G], G: Functor[G]): Zap[Cofree[F, ?], Free[G, ?]] =
+  implicit def comonadMonadZap[F[_], G[_]](implicit d: Zap[F, G]): Zap[Cofree[F, ?], Free[G, ?]] =
     new Zap[Cofree[F, ?], Free[G, ?]] {
       def zapWith[A, B, C](wa: Cofree[F, A], mb: Free[G, B])(f: (A, B) => C): C =
-        mb.resume match {
+        mb.resumeC match {
           case \/-(b) => f(wa.head, b)
-          case -\/(k) => d.zapWith(wa.tail, k)(zapWith(_, _)(f))
+          case -\/(k) => d.zapWith(wa.tail, k.fi)((a, i) => zapWith(a, k.k(i))(f))
         }
     }
 }


### PR DESCRIPTION
`resumeC` returns `Coyoneda[S, Free[S, A]]` where `resume` returns `S[Free[S, A]]`.

```scala
def resume(implicit S: Functor[S]):          S[Free[S,A]] \/ A
def resumeC:                        Coyoneda[S,Free[S,A]] \/ A
```

Used to remove `Functor` constraints elsewhere.