### PR TITLE
Add lazy constructor/map/flatMap on IList (experimental)

### DIFF
--- a/core/src/main/scala/scalaz/DList.scala
+++ b/core/src/main/scala/scalaz/DList.scala
@@ -36,12 +36,12 @@ final class DList[A] private[scalaz](f: IList[A] => Trampoline[IList[A]]) {
 
   /** List elimination of head and tail. */
   def uncons[B](z: => B, f: (A, DList[A]) => B): B =
-   (apply(IList.empty) >>= {
+   (apply(IList.empty) >>= ((_ : IList[A]).value match {
       case INil() => return_(z)
       case ICons(x, xs) =>
         val r = f(x, fromIList(xs))
         return_(r)
-    }).run
+    })).run
 
   /** Get the first element of the list, if any. */
   def headOption: Option[A] = uncons(None, (x, _) => Some(x))

--- a/core/src/main/scala/scalaz/Dequeue.scala
+++ b/core/src/main/scala/scalaz/Dequeue.scala
@@ -31,12 +31,12 @@ sealed abstract class Dequeue[A] {
   def uncons: Maybe[(A, Dequeue[A])] = this match {
     case EmptyDequeue() => Maybe.empty
     case SingletonDequeue(a) => Just((a, EmptyDequeue()))
-    case FullDequeue(OneAnd(f, INil()), 1, OneAnd(single,INil()), 1) => Just((f, SingletonDequeue(single)))
-    case FullDequeue(OneAnd(f, INil()), 1, OneAnd(x, ICons(xx, xs)), bs) => {
+    case FullDequeue(OneAnd(f, IList(INil())), 1, OneAnd(single,IList(INil())), 1) => Just((f, SingletonDequeue(single)))
+    case FullDequeue(OneAnd(f, IList(INil())), 1, OneAnd(x, IList(ICons(xx, xs))), bs) => {
       val xsr = reverseNEL(OneAnd(xx, xs))
       Just((f, FullDequeue(xsr, bs-1, OneAnd(x, IList.empty), 1)))
     }
-    case FullDequeue(OneAnd(f, ICons(ff, fs)), s, back, bs) => Just(f, FullDequeue(OneAnd(ff, fs), s-1, back, bs))
+    case FullDequeue(OneAnd(f, IList(ICons(ff, fs))), s, back, bs) => Just(f, FullDequeue(OneAnd(ff, fs), s-1, back, bs))
   }
 
   /**
@@ -45,13 +45,13 @@ sealed abstract class Dequeue[A] {
   def unsnoc: Maybe[(A, Dequeue[A])] = this match {
     case EmptyDequeue() => Maybe.empty
     case SingletonDequeue(a) => Just((a, EmptyDequeue()))
-    case FullDequeue(OneAnd(single, INil()), 1, OneAnd(b, INil()), 1) => Just((b, SingletonDequeue(single)))
-    case FullDequeue(OneAnd(x, ICons(xx,xs)), fs, OneAnd(b, INil()), 1) => {
+    case FullDequeue(OneAnd(single, IList(INil())), 1, OneAnd(b, IList(INil())), 1) => Just((b, SingletonDequeue(single)))
+    case FullDequeue(OneAnd(x, IList(ICons(xx,xs))), fs, OneAnd(b, IList(INil())), 1) => {
       val xsr = reverseNEL(OneAnd(xx, xs))
       Just((b, FullDequeue(OneAnd(x, IList.empty), 1, xsr, fs-1)))
     }
 
-    case FullDequeue(front, fs, OneAnd(b, ICons(bb,bs)), s) => Just((b, FullDequeue(front, fs, OneAnd(bb,bs), s-1)))
+    case FullDequeue(front, fs, OneAnd(b, IList(ICons(bb,bs))), s) => Just((b, FullDequeue(front, fs, OneAnd(bb,bs), s-1)))
   }
 
 
@@ -185,8 +185,8 @@ object Dequeue extends DequeueInstances {
   private def reverseNEL[A](fa: NonEmptyIList[A]): NonEmptyIList[A] = {
     @annotation.tailrec
     def loop(xs: IList[A], acc: IList[A]): NonEmptyIList[A] =
-      (xs: @unchecked) match {
-        case ICons(h, INil()) =>
+      (xs.value: @unchecked) match {
+        case ICons(h, IList(INil())) =>
           OneAnd(h, acc)
         case ICons(h, t) =>
           loop(t, h :: acc)

--- a/core/src/main/scala/scalaz/Foldable.scala
+++ b/core/src/main/scala/scalaz/Foldable.scala
@@ -275,7 +275,7 @@ trait Foldable[F[_]]  { self =>
   def splitBy[A, B: Equal](fa: F[A])(f: A => B): IList[(B, NonEmptyList[A])] =
     foldRight(fa, IList[(B, NonEmptyList[A])]())((a, bas) => {
       val fa = f(a)
-      bas match {
+      bas.value match {
         case INil() => IList.single((fa, NonEmptyList.nel(a, IList.empty)))
         case ICons((b, as), tail) => if (Equal[B].equal(fa, b)) ICons((b, a <:: as), tail) else ICons((fa, NonEmptyList.nel(a, IList.empty)), bas)
       }
@@ -286,7 +286,7 @@ trait Foldable[F[_]]  { self =>
     */
   def splitByRelation[A](fa: F[A])(r: (A, A) => Boolean): IList[NonEmptyList[A]] =
     foldRight(fa, IList[NonEmptyList[A]]())((a, neas) => {
-      neas match {
+      neas.value match {
         case INil() => IList.single(NonEmptyList.nel(a, IList.empty))
         case ICons(nea, tail) => if (r(a, nea.head)) ICons(a <:: nea, tail) else ICons(NonEmptyList.nel(a, IList.empty), neas)
       }

--- a/core/src/main/scala/scalaz/NonEmptyList.scala
+++ b/core/src/main/scala/scalaz/NonEmptyList.scala
@@ -9,7 +9,7 @@ final class NonEmptyList[A] private[scalaz](val head: A, val tail: IList[A]) {
 
   def <::(b: A): NonEmptyList[A] = nel(b, head :: tail)
 
-  def <:::(bs: IList[A]): NonEmptyList[A] = bs match {
+  def <:::(bs: IList[A]): NonEmptyList[A] = bs.value match {
     case INil() => this
     case ICons(b, bs) => nel(b, bs ::: list)
   }
@@ -33,12 +33,12 @@ final class NonEmptyList[A] private[scalaz](val head: A, val tail: IList[A]) {
   }
 
   def distinct(implicit A: Order[A]): NonEmptyList[A] =
-    (list.distinct: @unchecked) match {
+    (list.distinct.value: @unchecked) match {
       case ICons(x, xs) => nel(x, xs)
     }
 
   def traverse1[F[_], B](f: A => F[B])(implicit F: Apply[F]): F[NonEmptyList[B]] = {
-    tail match {
+    tail.value match {
       case INil() => F.map(f(head))(nel(_, IList.empty))
       case ICons(b, bs) => F.apply2(f(head), OneAnd.oneAndTraverse[IList].traverse1(OneAnd(b, bs))(f)) {
         case (h, t) => nel(h, t.head :: t.tail)
@@ -54,7 +54,7 @@ final class NonEmptyList[A] private[scalaz](val head: A, val tail: IList[A]) {
 
   def zipperEnd: Zipper[A] = {
     import Stream._
-    tail.reverse match {
+    tail.reverse.value match {
       case INil()     => zipper(empty, head, empty)
       case ICons(t, ts) => zipper(ts.toStream :+ head, t, empty)
     }
@@ -72,20 +72,20 @@ final class NonEmptyList[A] private[scalaz](val head: A, val tail: IList[A]) {
   def tails: NonEmptyList[NonEmptyList[A]] = {
     @annotation.tailrec
     def tails0(as: NonEmptyList[A], accum: IList[NonEmptyList[A]]): NonEmptyList[NonEmptyList[A]] =
-      as.tail match {
+      as.tail.value match {
         case INil() => nel(as, accum).reverse
         case ICons(h, t) => tails0(nel(h, t), as :: accum)
       }
     tails0(this, IList.empty)
   }
 
-  def reverse: NonEmptyList[A] = (list.reverse: @unchecked) match {
+  def reverse: NonEmptyList[A] = (list.reverse.value: @unchecked) match {
     case ICons(x, xs) => nel(x, xs)
   }
 
   /** @since 7.0.2 */
 
-  def sortBy[B](f: A => B)(implicit o: Order[B]): NonEmptyList[A] = (list.sortBy(f): @unchecked) match {
+  def sortBy[B](f: A => B)(implicit o: Order[B]): NonEmptyList[A] = (list.sortBy(f).value: @unchecked) match {
     case ICons(x, xs) => nel(x, xs)
   }
 
@@ -96,7 +96,7 @@ final class NonEmptyList[A] private[scalaz](val head: A, val tail: IList[A]) {
     }
 
   /** @since 7.0.2 */
-  def sorted(implicit o: Order[A]): NonEmptyList[A] = (list.sorted(o): @unchecked) match {
+  def sorted(implicit o: Order[A]): NonEmptyList[A] = (list.sorted(o).value: @unchecked) match {
     case ICons(x, xs) => nel(x, xs)
   }
 
@@ -116,7 +116,7 @@ final class NonEmptyList[A] private[scalaz](val head: A, val tail: IList[A]) {
   def zipWithIndex: NonEmptyList[(A, Int)] = {
     @annotation.tailrec
     def loop(as: IList[A], i: Int, acc: IList[(A, Int)]): IList[(A, Int)] =
-      as match {
+      as.value match {
         case ICons(x, y) => loop(y, i + 1, (x, i) :: acc)
         case _ => acc.reverse
       }
@@ -148,7 +148,7 @@ object NonEmptyList extends NonEmptyListInstances {
   def nels[A](h: A, t: A*): NonEmptyList[A] =
     nel(h, IList(t: _*))
 
-  def lift[A, B](f: NonEmptyList[A] => B): IList[A] => Option[B] = {
+  def lift[A, B](f: NonEmptyList[A] => B): IList[A] => Option[B] = _.value match {
     case INil() ⇒ None
     case ICons(h, t) ⇒ Some(f(NonEmptyList.nel(h, t)))
   }
@@ -216,7 +216,7 @@ sealed abstract class NonEmptyListInstances extends NonEmptyListInstances0 {
         f(fa.head) || Foldable[IList].any(fa.tail)(f)
 
       def tailrecM[A, B](a: A)(f: A => NonEmptyList[A \/ B]): NonEmptyList[B] =
-        (BindRec[IList].tailrecM[A, B](a)(a => f(a).list): @unchecked) match {
+        (BindRec[IList].tailrecM[A, B](a)(a => f(a).list).value: @unchecked) match {
           case ICons(h, t) => NonEmptyList.nel(h, t)
         }
     }

--- a/tests/src/test/scala/scalaz/IListTest.scala
+++ b/tests/src/test/scala/scalaz/IListTest.scala
@@ -36,9 +36,9 @@ object IListTest extends SpecLite {
   }
 
   "intersperse vs benchmark" ! forAll { (a: IList[Int], b: Int) =>
-    def intersperse[A](value: IList[A], a: A): IList[A] = value match {
+    def intersperse[A](value: IList[A], a: A): IList[A] = value.value match {
       case INil() => INil()
-      case ICons(x, INil()) => x :: INil()
+      case ICons(x, IList(INil())) => x :: INil()
       case ICons(h, t) => h :: a :: intersperse(t, a)
     }
     a.intersperse(b) must_=== intersperse(a, b)

--- a/tests/src/test/scala/scalaz/NonEmptyListTest.scala
+++ b/tests/src/test/scala/scalaz/NonEmptyListTest.scala
@@ -77,7 +77,7 @@ object NonEmptyListTest extends SpecLite {
   }
   "correctness of tails" ! forAll { xs: NonEmptyList[Int] =>
     import NonEmptyList._
-    xs.tails must_=== nel(xs, xs.tail match {
+    xs.tails must_=== nel(xs, xs.tail.value match {
       case INil() => INil()
       case ICons(h, t) => nel(h, t).tails.list
     })


### PR DESCRIPTION
This an experiment to add a lazy constructor (`byNeed`) to `IList`.

The main downside is that you cannot pattern match directly anymore. Eg.
```scala
  def uncons[B](n: => B, c: (A, IList[A]) => B): B =
    this match {
      case INil() => n
      case ICons(h, t) => c(h, t)
    }
```
must be changed to either:
```scala
  def uncons[B](n: => B, c: (A, IList[A]) => B): B =
    this.value match {
      case INil() => n
      case ICons(h, t) => c(h, t)
    }
```
or
```scala
  def uncons[B](n: => B, c: (A, IList[A]) => B): B =
    this match {
      case IList(INil()) => n
      case IList(ICons(h, t)) => c(h, t)
    }
```

One usage of this `byNeed` constructor is [`mapLazy`](https://github.com/jbgi/scalaz/blob/6b416fcbd5cab89073c606bc2ebdbfec5167510f/core/src/main/scala/scalaz/IList.scala#L254), which may be used to implement efficiently things like: 
```scala
veryLargeList.mapLazy(f).take(10)
```

This approach could be generalized to other data types, and remove the need for `LazyOption` / `LazyEither`.