### PR TITLE
Laws for MonadPartialOrder: must be injective monad homomorphism.

### DIFF
--- a/core/src/main/scala/scalaz/MonadTrans.scala
+++ b/core/src/main/scala/scalaz/MonadTrans.scala
@@ -16,13 +16,18 @@ trait MonadTrans[F[_[_], _]] {
   implicit def apply[G[_] : Monad]: Monad[F[G, ?]]
 
   trait MonadTransLaw {
+    // For each monad `G[_]`, `liftM` must be injective monad homomorphism from `G` to `F[G, ?]`.
+
     /** Lifted `point` is `point` of this transformer's monad. */
-    def identity[G[_], A](a: A)(implicit G: Monad[G], FA: Equal[F[G, A]]): Boolean =
+    def pointPreserving[G[_], A](a: A)(implicit G: Monad[G], FA: Equal[F[G, A]]): Boolean =
       FA.equal(liftM(G.point(a)), Monad[F[G, ?]].point(a))
 
     /** `bind` and then `liftM` is the same as `liftM` and then `bind` */
-    def composition[G[_], A, B](ga: G[A], f: A => G[B])(implicit G: Monad[G], FB: Equal[F[G, B]]): Boolean =
+    def bindPreserving[G[_], A, B](ga: G[A], f: A => G[B])(implicit G: Monad[G], FB: Equal[F[G, B]]): Boolean =
       FB.equal(liftM(Monad[G].bind(ga)(f)), Monad[F[G, ?]].bind(liftM(ga))(a => liftM(f(a))))
+
+    def injective[G[_], A](g1: G[A], g2: G[A])(implicit G: Monad[G], GA: Equal[G[A]], FA: Equal[F[G, A]]): Boolean =
+      if(!GA.equal(g1, g2)) !FA.equal(liftM(g1), liftM(g2)) else true
   }
   def monadTransLaw = new MonadTransLaw {}
 }
@@ -59,11 +64,21 @@ trait MonadPartialOrder[G[_], F[_]] extends NaturalTransformation[F, G] { self =
     }
 
   def transform[T[_[_], _]: MonadTrans]: MonadPartialOrder[T[G, ?], F] =
-    new MonadPartialOrder[T[G, ?], F] {
-      val MG = MonadTrans[T].apply[G](self.MG)
-      val MF = self.MF
-      def promote[A](m2: F[A]) = MonadTrans[T].liftM(self.promote(m2))(self.MG)
-    }
+    compose[T[G, ?]](MonadPartialOrder.transformer[G, T])
+
+  trait MonadPartialOrderLaw {
+    // MonadPartialOrder is required to be injective monad homomorphism
+
+    def pointPreserving[A](a: A)(implicit GA: Equal[G[A]]): Boolean =
+      GA.equal(promote(MF.point(a)), MG.point(a))
+
+    def bindPreserving[A, B](fa: F[A], f: A => F[B])(implicit GB: Equal[G[B]]): Boolean =
+      GB.equal(promote(MF.bind(fa)(f)), MG.bind(promote(fa))(a => promote(f(a))))
+
+    def injective[A](f1: F[A], f2: F[A])(implicit FA: Equal[F[A]], GA: Equal[G[A]]): Boolean =
+      if(!FA.equal(f1, f2)) !GA.equal(promote(f1), promote(f2)) else true
+  }
+  def monadPartialOrderLaw = new MonadPartialOrderLaw {}
 }
 
 sealed abstract class MonadPartialOrderFunctions1 {
@@ -80,8 +95,12 @@ sealed abstract class MonadPartialOrderFunctions extends MonadPartialOrderFuncti
       def promote[A](m: M[A]) = m
     }
 
-  implicit def transformer[M[_]: Monad, F[_[_], _]: MonadTrans]: MonadPartialOrder[F[M, ?], M] =
-    id[M].transform[F]
+  implicit def transformer[M[_], F[_[_], _]](implicit M: Monad[M], F: MonadTrans[F]): MonadPartialOrder[F[M, ?], M] =
+    new MonadPartialOrder[F[M, ?], M] {
+      val MG = F[M]
+      val MF = M
+      def promote[A](m: M[A]) = F.liftM(m)
+    }
 }
 
 object MonadPartialOrder extends MonadPartialOrderFunctions

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazProperties.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazProperties.scala
@@ -617,15 +617,34 @@ object ScalazProperties {
   }
 
   object monadTrans {
-    def identity[F[_[_], _], G[_], A](implicit F: MonadTrans[F], G: Monad[G], A: Arbitrary[A], Eq: Equal[F[G, A]]): Prop =
-      forAll(F.monadTransLaw.identity[G, A] _)
-    def composition[F[_[_], _], G[_], A, B](implicit F: MonadTrans[F], G: Monad[G], GA: Arbitrary[G[A]], AGB: Arbitrary[A => G[B]], Eq: Equal[F[G, B]]): Prop =
-      forAll(F.monadTransLaw.composition[G, A, B] _)
+    def pointPreserving[F[_[_], _], G[_], A](implicit F: MonadTrans[F], G: Monad[G], A: Arbitrary[A], Eq: Equal[F[G, A]]): Prop =
+      forAll(F.monadTransLaw.pointPreserving[G, A] _)
+    def bindPreserving[F[_[_], _], G[_], A, B](implicit F: MonadTrans[F], G: Monad[G], GA: Arbitrary[G[A]], AGB: Arbitrary[A => G[B]], Eq: Equal[F[G, B]]): Prop =
+      forAll(F.monadTransLaw.bindPreserving[G, A, B] _)
+    def injective[F[_[_], _], G[_], A](implicit F: MonadTrans[F], G: Monad[G], GA: Arbitrary[G[A]], EqG: Equal[G[A]], EqF: Equal[F[G, A]]): Prop =
+      forAll(F.monadTransLaw.injective[G, A] _)
 
-    def laws[F[_[_], _], G[_]](implicit F: MonadTrans[F], G: Monad[G], AGI: Arbitrary[G[Int]], Eq: Equal[F[G, Int]]): Properties =
+    def laws[F[_[_], _], G[_]](implicit F: MonadTrans[F], G: Monad[G], AGI: Arbitrary[G[Int]], EqG: Equal[G[Int]], EqF: Equal[F[G, Int]]): Properties =
       newProperties("monadTrans") { p =>
-        p.property("identity") = identity[F, G, Int]
-        p.property("composition") = composition[F, G, Int, Int]
+        p.property("pointPreserving") = pointPreserving[F, G, Int]
+        p.property("bindPreserving") = bindPreserving[F, G, Int, Int]
+        p.property("injective") = injective[F, G, Int]
+      }
+  }
+
+  object monadPartialOrder {
+    def pointPreserving[G[_], F[_], A](implicit GF: MonadPartialOrder[G, F], A: Arbitrary[A], Eq: Equal[G[A]]): Prop =
+      forAll(GF.monadPartialOrderLaw.pointPreserving[A] _)
+    def bindPreserving[G[_], F[_], A, B](implicit GF: MonadPartialOrder[G, F], FA: Arbitrary[F[A]], AGB: Arbitrary[A => F[B]], Eq: Equal[G[B]]): Prop =
+      forAll(GF.monadPartialOrderLaw.bindPreserving[A, B] _)
+    def injective[G[_], F[_], A](implicit GF: MonadPartialOrder[G, F], FA: Arbitrary[F[A]], EqF: Equal[F[A]], EqG: Equal[G[A]]): Prop =
+      forAll(GF.monadPartialOrderLaw.injective[A] _)
+
+    def laws[G[_], F[_]](implicit GF: MonadPartialOrder[G, F], AFI: Arbitrary[F[Int]], EqF: Equal[F[Int]], EqG: Equal[G[Int]]): Properties =
+      newProperties("monadPartialOrder") { p =>
+        p.property("pointPreserving") = pointPreserving[G, F, Int]
+        p.property("bindPreserving") = bindPreserving[G, F, Int, Int]
+        p.property("injective") = injective[G, F, Int]
       }
   }
 }


### PR DESCRIPTION
This is an attempt to give reasonable laws for `MonadPartialOrder` (a.k.a. `|>=|`). At the very least, it should be
 - a _monad homomorphism_ (preserve `point` and `bind`); and
 - _injective_, as the expectation is that translation to the "bigger" monad doesn't lose any information.

Since we provide `MonadPartialOrder` instances for monad transformers, I added the injectivity requirement on `MonadTrans` as well. This shouldn't be constraining in practice, since (I believe) we expect transformers to be injective (not lose information in `liftM`) anyway. (I think that due to parametricity, the only otherwise lawful transformer instances this rules out are the ones that ignore the monad type parameter altogether, such as `type FakeTrans[M[_], A] = Foo[A]`.)

(I also renamed the other two `MonadTrans` laws, as I think I named them inappropriately before.)

Additional minor change: Avoid instantiating the reflexive identity instance when creating `MonadPartialOrder` instance for transformers.

Note: These new `MonadPartialOrder` laws are not used anywhere in tests yet. This is because the only instances we provide are for transformers, and transformer laws already have all the laws of `MonadPartialOrder`. However, if we start providing other instances, such as `List |>=| Option` or `ReaderWriterStateT[F, R, W, S, ?] |>=| WriterT[F, W, ?]`, there will now be laws to test.