### PR TITLE
Phantom functor

### DIFF
--- a/base/src/main/scala/typeclass/Phantom.scala
+++ b/base/src/main/scala/typeclass/Phantom.scala
@@ -1,0 +1,10 @@
+package scalaz
+package typeclass
+
+trait Phantom[F[_]] {
+  def pmap[A, B](ma: F[A]): F[B]
+}
+
+object Phantom extends PhantomFunctions with PhantomSyntax {
+  def apply[F[_]](implicit F: Phantom[F]): Phantom[F] = F
+}

--- a/base/src/main/scala/typeclass/PhantomClass.scala
+++ b/base/src/main/scala/typeclass/PhantomClass.scala
@@ -1,0 +1,23 @@
+package scalaz
+package typeclass
+
+trait PhantomClass[F[_]] extends Phantom[F] with Functor[F] with Contravariant[F] {
+  final def phantom: Phantom[F] = this
+}
+
+object PhantomClass {
+  trait Template[F[_]] extends PhantomClass[F] with MapContramap[F]
+
+  trait MapContramap[F[_]] extends PhantomClass[F] {
+    self: Phantom[F] with Functor[F] with Contravariant[F] =>
+    override def map[A, B](ma: F[A])(f: (A) => B): F[B] = pmap(ma)
+
+    override def contramap[A, B](ma: F[A])(f: (B) => A): F[B] = pmap(ma)
+  }
+
+  trait Pmap[F[_]] extends PhantomClass[F] {
+    self: Phantom[F] with Functor[F] with Contravariant[F] =>
+    override def pmap[A, B](ma: F[A]): F[B] = contramap(map(ma)(_ => ()))(_ => ())
+  }
+}
+

--- a/base/src/main/scala/typeclass/PhantomFunctions.scala
+++ b/base/src/main/scala/typeclass/PhantomFunctions.scala
@@ -1,0 +1,6 @@
+package scalaz
+package typeclass
+
+trait PhantomFunctions {
+  def pmap[F[_], A, B](fa: F[A])(implicit F: Phantom[F]): F[B] = F.pmap(fa)
+}

--- a/base/src/main/scala/typeclass/PhantomInstances.scala
+++ b/base/src/main/scala/typeclass/PhantomInstances.scala
@@ -1,0 +1,12 @@
+package scalaz
+package typeclass
+
+import scalaz.data.Const
+
+trait PhantomInstances { instances =>
+  implicit def const[R]: Phantom[Const[R, ?]] = new PhantomClass.MapContramap[Const[R, ?]] {
+
+    def pmap[A, B](ma: Const[R, A]): Const[R, B] = ma.retag[B]
+
+  }
+}

--- a/base/src/main/scala/typeclass/PhantomSyntax.scala
+++ b/base/src/main/scala/typeclass/PhantomSyntax.scala
@@ -1,0 +1,16 @@
+package scalaz
+package typeclass
+
+import scala.language.implicitConversions
+import scala.language.experimental.macros
+
+trait PhantomSyntax {
+  implicit def phantomOps[F[_], A](fa: F[A])(implicit F: Phantom[F]): PhantomSyntax.Ops[F, A] =
+    new PhantomSyntax.Ops(fa)
+}
+
+object PhantomSyntax {
+  class Ops[F[_], A](self: F[A])(implicit F: Phantom[F]) {
+    def pmap[B]: F[B] = macro meta.Ops._f0[F[B]]
+  }
+}


### PR DESCRIPTION
Phantom-variant functors. All `F[A]`s with lawful `Functor[F]` *and* `Contravariant[F]` have no occurrences of `A` in their definition, and thus the `A` can be freely changed to any other `B` without changing the data within; the `A` is *phantom-variant*. More succinctly, all values of type `F[A]` are also values of type `F[B]` for all `A` and `B`, which is witnessed by `pmap[A, B](fa: F[A]): F[B]`. See http://typelevel.org/blog/2016/02/04/variance-and-functors.html.

Note that this has no laws further than `Functor[F]` and `Contravariant[F]`, which interact with one another. I'm not sure where `pmap` should go otherwise, if this is too large an obstacle to include this type class.