### PR TITLE
Remove macro recompile message

### DIFF
--- a/project/ScalazBuild.scala
+++ b/project/ScalazBuild.scala
@@ -33,7 +33,8 @@ object Scalaz extends Build {
         case _ =>
           Nil
       }
-    }
+    },
+    incOptions ~= (_.withLogRecompileOnMacro(false))
   )
 
   lazy val root = Project(


### PR DESCRIPTION
The macro recompile message is annoying and verbose, and I think we've sufficiently isolated the syntax macros by putting them in the meta project. This PR removes them.