### PR TITLE
Move to build.sbt-based build definition

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,28 @@
+lazy val root = Project(
+  id = "root",
+  base = file(".")
+).settings(
+  scalaVersion := "2.11.8"
+).aggregate ( baze
+            , meta
+            , benchmarks )
+
+lazy val baze         = module("base")
+  .dependsOn( meta )
+
+lazy val benchmarks   = module("benchmarks")
+  .dependsOn( baze )
+  .enablePlugins(JmhPlugin)
+  .settings(
+    libraryDependencies ++=
+      Seq ( "org.scala-lang" % "scala-reflect" % scalaVersion.value
+          , "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided"
+          , "org.scalaz" %% "scalaz-core" % "7.2.7")
+  )
+
+lazy val meta         = module("meta")
+  .settings(
+    libraryDependencies ++=
+      Seq ( "org.scala-lang" % "scala-reflect" % scalaVersion.value
+          , "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided" )
+  )

--- a/project/ScalazBuild.scala
+++ b/project/ScalazBuild.scala
@@ -1,8 +1,6 @@
 import sbt._
 import Keys._
 
-import pl.project13.scala.sbt.JmhPlugin
-
 object Scalaz extends Build {
   val testDeps = Seq("org.scalacheck" %% "scalacheck" % "1.13.4" % "test")
 
@@ -35,33 +33,4 @@ object Scalaz extends Build {
       }
     }
   )
-
-  lazy val root = Project(
-    id = "root",
-    base = file(".")
-  ).settings(
-    scalaVersion := "2.11.8"
-  ).aggregate ( baze
-              , meta
-              , benchmarks )
-
-  lazy val baze         = module("base")
-    .dependsOn( meta )
-
-  lazy val benchmarks   = module("benchmarks")
-    .dependsOn( baze )
-    .enablePlugins(JmhPlugin)
-    .settings(
-      libraryDependencies ++=
-        Seq ( "org.scala-lang" % "scala-reflect" % scalaVersion.value
-            , "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided"
-            , "org.scalaz" %% "scalaz-core" % "7.2.7")
-    )
-
-  lazy val meta         = module("meta")
-    .settings(
-      libraryDependencies ++=
-        Seq ( "org.scala-lang" % "scala-reflect" % scalaVersion.value
-            , "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided" )
-    )
 }


### PR DESCRIPTION
Move Scalaz 8 to a build.sbt-based build, because Build.scala-style definitions are deprecated and will be removed in SBT 1.0.