### PR TITLE
Add mapConst, tapM and a syntax alias mechanism

### DIFF
--- a/base/src/main/scala/data/ConstInstances.scala
+++ b/base/src/main/scala/data/ConstInstances.scala
@@ -7,20 +7,24 @@ import FoldableClass._
 import TraversableClass._
 
 trait ConstInstances {
-  implicit def traverse[R]: Traversable[Const[R, ?]] = new TraversableClass[Const[R, ?]] with FoldRight[Const[R, ?]] with Traverse[Const[R, ?]] {
-    def map[A, B](ma: Const[R, A])(f: A => B): Const[R, B] = ma.retag
+  implicit def traverse[R]: Traversable[Const[R, ?]] =
+    new TraversableClass[Const[R, ?]]
+      with FunctorClass.Map[Const[R, ?]]
+      with FoldRight[Const[R, ?]]
+      with Traverse[Const[R, ?]] {
+      def map[A, B](ma: Const[R, A])(f: A => B): Const[R, B] = ma.retag
 
-    def traverse[F[_], A, B](ta: Const[R, A])(f: A => F[B])(implicit F: Applicative[F]): F[Const[R, B]] =
-      F.pure(ta.retag)
+      def traverse[F[_], A, B](ta: Const[R, A])(f: A => F[B])(implicit F: Applicative[F]): F[Const[R, B]] =
+        F.pure(ta.retag)
 
-    def foldLeft[A, B](fa: Const[R, A], z: B)(f: (B, A) => B): B = z
+      def foldLeft[A, B](fa: Const[R, A], z: B)(f: (B, A) => B): B = z
 
-    def foldRight[A, B](fa: Const[R, A], z: => B)(f: (A, => B) => B): B = z
+      def foldRight[A, B](fa: Const[R, A], z: => B)(f: (A, => B) => B): B = z
 
-    override def toList[A](fa: Const[R, A]): List[A] = Nil
-  }
+      override def toList[A](fa: Const[R, A]): List[A] = Nil
+    }
 
-  implicit def functor[R]: Functor[Const[R, ?]] = new Functor[Const[R, ?]] {
+  implicit def functor[R]: Functor[Const[R, ?]] = new FunctorClass.Template[Const[R, ?]] {
     def map[A, B](fa: Const[R, A])(f: A => B): Const[R, B] =
       fa.retag[B]
   }

--- a/base/src/main/scala/data/DisjunctionInstances.scala
+++ b/base/src/main/scala/data/DisjunctionInstances.scala
@@ -10,6 +10,9 @@ trait DisjunctionInstances {
     override def map[A, B](ma: L \/ A)(f: A => B): L \/ B =
       ma.fold[L \/ B](l => -\/(l))(r => \/-(f(r)))
 
+    override def mapConst[A, B](ma: L \/ A)(c: B): L \/ B =
+      ma.fold[L \/ B](-\/(_))(_ => \/-(c))
+
     override def ap[A, B](ma: L \/ A)(mf: L \/ (A => B)): L \/ B =
       ma.fold[L \/ B](l => -\/(l))(a => map[(A => B), B](mf)(f => f(a)))
 
@@ -18,5 +21,8 @@ trait DisjunctionInstances {
 
     override def flatMap[A, B](oa: L \/ A)(f: A => L \/ B): L \/ B =
       oa.fold[L \/ B](l => -\/(l))(a => f(a))
+
+    override def tapM[A, B](ma: L \/ A)(f: (A) => L \/ B): L \/ A =
+      ma.fold[L \/ A](-\/(_))(f(_).fold[L \/ A](-\/(_))(_ => ma))
   }
 }

--- a/base/src/main/scala/data/IdentityInstances.scala
+++ b/base/src/main/scala/data/IdentityInstances.scala
@@ -10,5 +10,7 @@ trait IdentityInstances {
     override def pure[A](a: A): Identity[A] = Identity(a)
     override def flatMap[A, B](oa: Identity[A])(f: A => Identity[B]): Identity[B] = f(oa.run)
     override def flatten[A](ma: Identity[Identity[A]]): Identity[A] = ma.run
+    override def mapConst[A, B](ma: Identity[A])(c: B): Identity[B] = Identity(c)
+    override def tapM[A, B](ma: Identity[A])(f: (A) => Identity[B]): Identity[A] = ma
   }
 }

--- a/base/src/main/scala/data/MaybeInstances.scala
+++ b/base/src/main/scala/data/MaybeInstances.scala
@@ -18,8 +18,14 @@ trait MaybeInstances extends MonadClass.Template[Maybe] with TraversableClass[Ma
   override def flatMap[A, B](ma: Maybe[A])(f: A => Maybe[B]): Maybe[B] =
     ma.fold(a => f(a), empty)
 
+  override def tapM[A, B](ma: Maybe[A])(f: A => Maybe[B]): Maybe[A] =
+    ma.fold(a => f(a).fold(_ => ma, empty), empty)
+
   override def map[A, B](ma: Maybe[A])(f: A => B): Maybe[B] =
     ma.fold(a => just(f(a)), empty)
+
+  override def mapConst[A, B](ma: Maybe[A])(b: B): Maybe[B] =
+    ma.fold(_ => just(b), empty)
 
   override def pure[A](a: A): Maybe[A] =
     just(a)

--- a/base/src/main/scala/typeclass/ApplicativeSyntax.scala
+++ b/base/src/main/scala/typeclass/ApplicativeSyntax.scala
@@ -10,5 +10,7 @@ trait ApplicativeSyntax {
 object ApplicativeSyntax {
   class OpsA[A](a: A) {
     def pure[F[_]](implicit F: Applicative[F]): F[A] = F.pure(a)
+    def visit[F[_]](f: PartialFunction[A, F[A]])(implicit F: Applicative[F]) =
+      f.applyOrElse[A, F[A]](a, _ => F.pure(a))
   }
 }

--- a/base/src/main/scala/typeclass/Bind.scala
+++ b/base/src/main/scala/typeclass/Bind.scala
@@ -4,10 +4,12 @@ package typeclass
 trait Bind[M[_]] {
   def apply: Apply[M]
   def flatMap[A, B](ma: M[A])(f: A => M[B]): M[B]
+  def tapM[A, B](ma: M[A])(f: A => M[B]): M[A]
   def flatten[A](ma: M[M[A]]): M[A]
 }
 
 object Bind extends BindInstances with BindFunctions with BindSyntax {
+  trait TapM
   def apply[M[_]](implicit M: Bind[M]): Bind[M] = M
 
   object syntax extends BindSyntax

--- a/base/src/main/scala/typeclass/BindSyntax.scala
+++ b/base/src/main/scala/typeclass/BindSyntax.scala
@@ -12,6 +12,8 @@ trait BindSyntax {
 object BindSyntax {
   class Ops[M[_], A](ma: M[A])(implicit M: Bind[M]) {
     def flatMap[B](f: A => M[B]): M[B] = macro meta.Ops._f1[A => M[B], M[B]]
+    def tapM[B](f: A => M[B]): M[A] = macro meta.Ops._f1[A => M[B], M[A]]
+    def >>=|[B](f: A => M[B]): M[A] = macro meta.Ops._f1t[A => M[B], M[B], Bind.TapM]
   }
 }
 

--- a/base/src/main/scala/typeclass/Functor.scala
+++ b/base/src/main/scala/typeclass/Functor.scala
@@ -3,8 +3,10 @@ package typeclass
 
 trait Functor[F[_]] {
   def map[A, B](ma: F[A])(f: A => B): F[B]
+  def mapConst[A, B](ma: F[A])(c: B): F[B]
 }
 
 object Functor extends FunctorFunctions with FunctorSyntax {
+  private[scalaz] trait MapConst
   def apply[F[_]](implicit F: Functor[F]): Functor[F] = F
 }

--- a/base/src/main/scala/typeclass/FunctorClass.scala
+++ b/base/src/main/scala/typeclass/FunctorClass.scala
@@ -4,3 +4,11 @@ package typeclass
 trait FunctorClass[F[_]] extends Functor[F]{
   final def functor: Functor[F] = this
 }
+
+object FunctorClass {
+  trait Template[M[_]] extends Functor[M] with Map[M]
+
+  trait Map[M[_]] { self: Functor[M] =>
+    override def mapConst[A, B](ma: M[A])(c: B): M[B] = map(ma)(_ => c)
+  }
+}

--- a/base/src/main/scala/typeclass/FunctorSyntax.scala
+++ b/base/src/main/scala/typeclass/FunctorSyntax.scala
@@ -12,7 +12,9 @@ trait FunctorSyntax {
 object FunctorSyntax {
   class Ops[F[_], A](self: F[A])(implicit F: Functor[F]) {
     def map[B](f: A => B): F[B] = macro meta.Ops._f1[A => B, F[B]]
-    def void: F[Unit] = F.map[A, Unit](self)(_ => ())
+    def mapConst[B](f: B): F[B] = macro meta.Ops._f1[B, F[B]]
+    def >|[B](f: B): F[B] = macro meta.Ops._f1t[B, F[B], Functor.MapConst]
+    def void: F[Unit] = F.mapConst(self)(())
   }
 }
 

--- a/base/src/main/scala/typeclass/MonadInstances.scala
+++ b/base/src/main/scala/typeclass/MonadInstances.scala
@@ -7,6 +7,11 @@ trait MonadInstances {
     override def flatMap[A, B](oa: Option[A])(f: A => Option[B]): Option[B] = oa.flatMap(f)
     override def map[A, B](oa: Option[A])(f: A => B): Option[B] = oa.map(f)
     override def pure[A](a: A): Option[A] = Option(a)
+    override def mapConst[A, B](ma: Option[A])(c: B): Option[B] = ???
+    override def tapM[A, B](ma: Option[A])(f: (A) => Option[B]): Option[A] = ma match {
+      case Some(s) => if (f(s).isDefined) ma else None
+      case None => None
+    }
   }
 
   implicit val list: Monad[List] = new MonadClass.Template[List] {
@@ -14,6 +19,9 @@ trait MonadInstances {
     override def flatMap[A, B](xs: List[A])(f: A => List[B]): List[B] = xs.flatMap(f)
     override def map[A, B](xs: List[A])(f: A => B): List[B] = xs.map(f)
     override def pure[A](a: A): List[A] = List(a)
+    override def mapConst[A, B](ma: List[A])(c: B): List[B] = ma.foldLeft[List[B]](Nil)((l, _) => c :: l)
+    override def tapM[A, B](ma: List[A])(f: (A) => List[B]): List[A] =
+      ma.foldLeft[List[A]](ma)((l, a) => mapConst(f(a))(a) )
   }
   
   implicit val function: Monad[Function0] = new MonadClass.Template[Function0] {
@@ -21,7 +29,8 @@ trait MonadInstances {
     override def map[A, B](fab: Function0[A])(f: A => B): Function0[B] = () => f(fab())
     override def flatMap[A, B](fab: Function0[A])(f: A => Function0[B]): Function0[B] = () => f(fab())()
     override def pure[A](a: A): Function0[A] = () => a
-
+    override def mapConst[A, B](ma: () => A)(c: B): () => B = () => c
+    override def tapM[A, B](ma: () => A)(f: (A) => () => B): () => A = ma
   }
 
   implicit def function1[C]: Monad[Function1[C, ?]] = new MonadClass.Template[Function1[C, ?]] {
@@ -29,5 +38,7 @@ trait MonadInstances {
     override def map[A, B](fab: Function1[C, A])(f: A => B): Function1[C, B] = fab andThen f
     override def flatMap[A, B](fab: Function1[C, A])(f: A => Function1[C, B]): Function1[C, B] = (c: C) => f(fab(c))(c)
     override def pure[A](a: A): Function1[C, A] = (c: C) => a
+    override def mapConst[A, B](ma: (C) => A)(b: B): (C) => B = (c: C) => b
+    override def tapM[A, B](ma: (C) => A)(f: (A) => (C) => B): (C) => A = (c: C) => ma(c)
   }
 }

--- a/base/src/main/scala/typeclass/TraversableInstances.scala
+++ b/base/src/main/scala/typeclass/TraversableInstances.scala
@@ -18,6 +18,8 @@ trait TraversableInstances {
     override def toList[A](xs: List[A]): List[A] = xs
 
     override def map[A, B](fa: List[A])(f: A => B) = fa.map(f)
+
+    override def mapConst[A, B](ma: List[A])(c: B): List[B] = ma.foldLeft[List[B]](Nil)((l, _) => c :: l)
   }
 
   implicit def tuple2[C]: Traversable[Tuple2[C, ?]] = new TraversableClass[Tuple2[C, ?]] with Traverse[Tuple2[C, ?]] with FoldRight[Tuple2[C, ?]] {
@@ -31,5 +33,7 @@ trait TraversableInstances {
     override def toList[A](ta: Tuple2[C, A]): List[A] = List(ta._2)
 
     override def map[A, B](ta: Tuple2[C, A])(f: A =>B): Tuple2[C, B] = (ta._1, f(ta._2))
+
+    override def mapConst[A, B](ma: Tuple2[C, A])(c: B): Tuple2[C, B] = (ma._1, c)
   }
 }

--- a/meta/src/main/scala/Ops.scala
+++ b/meta/src/main/scala/Ops.scala
@@ -13,11 +13,19 @@ object Ops {
     val (ev, lhs) = unpack(c)
     c.Expr[R](Apply(Select(ev, TermName(c.macroApplication.symbol.name.toString)), List(lhs)))
   }
-  
+
   def _f1[A, R](c: Context)(f: c.Expr[A]): c.Expr[R] = {
     import c.universe._
     val (ev, lhs) = unpack(c)
     c.Expr[R](Apply(Apply(Select(ev, TermName(c.macroApplication.symbol.name.toString)), List(lhs)), List(f.tree)))
+  }
+
+  def _f1t[A, R, T](c: Context)(f: c.Expr[A])(implicit tTag: c.WeakTypeTag[T]): c.Expr[R] = {
+    import c.universe._
+    val methodNameEnd = tTag.tpe.typeSymbol.name.encodedName.toString
+    val uncappedMethodName = String.valueOf(Character.toLowerCase(methodNameEnd.charAt(0))) + methodNameEnd.substring(1)
+    val (ev, lhs) = unpack(c)
+    c.Expr[R](Apply(Apply(Select(ev, TermName(uncappedMethodName)), List(lhs)), List(f.tree)))
   }
 
   def _f2[A, B, R](c: Context)(f: c.Expr[A])(g: c.Expr[B]): c.Expr[R] = {
@@ -27,13 +35,13 @@ object Ops {
     val toappl = Apply(y, List(f.tree)) 
     c.Expr[R](Apply(toappl, List(g.tree))) 
   }
-  
+
   def unpack[T[_], A](c: Context) = {
-      import c.universe._
-      c.prefix.tree match {
-        case Apply(Apply(TypeApply(_, _), List(x)), List(ev)) => (ev, x)
-        case t => c.abort(c.enclosingPosition, "Cannot extract subject of operation (tree = %s)" format t)
-      }
+    import c.universe._
+    c.prefix.tree match {
+      case Apply(Apply(TypeApply(_, _), List(x)), List(ev)) => (ev, x)
+      case t => c.abort(c.enclosingPosition, "Cannot extract subject of operation (tree = %s)" format t)
     }
-  
+  }
+
 }


### PR DESCRIPTION
`tapM` and `mapConst` are similar operations related to `const`. Both provide significant opportunities for optimization when overloaded, especially `tapM` for monads with no side effects (`Function0`, `Function1[C, ?]`, `Identity`), as well as being convenient.

As a side effect of this, I introduced a mechanism for syntactic aliases using phantom types with the same names as aliased methods. Open to any suggestions.