### PR TITLE
Add FunctionH

### DIFF
--- a/base/src/main/scala/scalaz/Prelude.scala
+++ b/base/src/main/scala/scalaz/Prelude.scala
@@ -26,6 +26,7 @@ trait Prelude  extends data.DisjunctionFunctions
   type Profunctor[F[_,_]] = typeclass.Profunctor[F]
   type Category[=>:[_,_]] = typeclass.Category[=>:]
   type InvariantFunctor[F[_]] = typeclass.InvariantFunctor[F]
+  type ~>[F[_], G[_]] = FunctionH[F, G]
 
   def Applicative[F[_]](implicit F: Applicative[F]): Applicative[F] = F
   def Apply[F[_]](implicit F: Apply[F]): Apply[F] = F
@@ -73,7 +74,7 @@ trait Prelude  extends data.DisjunctionFunctions
 
   implicit def PstrongOps[P[_,_], A, B](pab: P[A, B])(implicit P: Strong[P]): StrongSyntax.Ops[P, A, B] =
     new StrongSyntax.Ops(pab)
-   
+
   //InvariantFunctorSyntax
   implicit def InvariantFunctorOps[F[_], A](fa: F[A])(implicit F: InvariantFunctor[F]): InvariantFunctorSyntax.Ops[F, A] =
     new InvariantFunctorSyntax.Ops(fa)

--- a/base/src/main/scala/scalaz/data/FunctionH.scala
+++ b/base/src/main/scala/scalaz/data/FunctionH.scala
@@ -1,0 +1,54 @@
+package scalaz
+package data
+
+import language.implicitConversions
+
+/** A universally quantified function, usually written as `F ~> G`,
+  * for symmetry with `A => B`.
+  *
+  * All `FunctionH[F, G]` values, with `F` and `G` functors, form functor
+  * homomorphisms (natural transformations) from `F` to `G` by a free theorem.
+  */
+trait FunctionH[-F[_], +G[_]] {
+  self =>
+  def apply[A](fa: F[A]): G[A]
+
+  def compose[E[_]](f: E ~> F): E ~> G = λ[E ~> G](
+    ea => self(f(ea))
+  )
+
+  def andThen[H[_]](f: G ~> H): F ~> H =
+    f compose self
+}
+
+trait FunctionHFunctions {
+  /** A universally quantified identity function */
+  def id[F[_]] =
+    λ[F ~> F](fa => fa)
+
+  /** Reify a `NaturalTransformation`. */
+  implicit def natToFunction[F[_], G[_], A](t: F ~> G): F[A] => G[A] = fa => t(fa)
+
+  private object MkFunctionH {
+    val unsafe: MkFunctionH = new MkFunctionH
+  }
+
+  /**
+    * Use to create a FunctionH from a quantified method:
+    * `FunctionH.mk[List, Option](_.headOption)`
+    */
+  def mk: MkFunctionH = MkFunctionH.unsafe
+}
+
+// credit to Alex Konovalov for this trick: undefined type members
+// with unstable prefixes, to encode universal quantification
+private[data] final class MkFunctionH(val dummy: Boolean = true) extends AnyVal {
+  type T
+
+  def apply[F[_], G[_]](f: F[T] => G[T]): FunctionH[F, G] = new FunctionH[F, G] {
+    def apply[A](fa: F[A]): G[A] = f(fa.asInstanceOf[F[T]]).asInstanceOf[G[A]]
+  }
+}
+
+object FunctionH extends FunctionHFunctions
+

--- a/base/src/main/scala/scalaz/package.scala
+++ b/base/src/main/scala/scalaz/package.scala
@@ -1,2 +1,8 @@
-package object scalaz extends scalaz.BaseHierarchy
+import scalaz.data.FunctionH
+
+package object scalaz extends scalaz.BaseHierarchy {
+  /** A [[scalaz.data.FunctionH]][F, G]. */
+  type ~>[-F[_], +G[_]] = FunctionH[F, G]
+
+}
 


### PR DESCRIPTION
Just a shot in the dark: I named this `FunctionH` instead of NaturalTransformation because technically speaking, not all natural transformations are `FunctionH`s, even though all `FunctionH`s are natural transformations. Bikeshedding very welcome. I also added a bit of sugar for `FunctionH` creation, courtesy of a trick @alexknvl thought of; if it's considered unnecessary by most given the `Lambda` syntax (despite that it doesn't work in Intellij) I wouldn't be averse to dropping it.