### PR TITLE
Unboxed Forall

### DIFF
--- a/base/shared/src/main/scala/scalaz/Prelude.scala
+++ b/base/shared/src/main/scala/scalaz/Prelude.scala
@@ -6,6 +6,7 @@ import data._
 import scala.language.implicitConversions
 
 trait Prelude  extends data.DisjunctionFunctions
+                  with data.ForallSyntax
                   with data.IdentityTypes
                   with data.MaybeFunctions
                   with typeclass.BindFunctions
@@ -97,6 +98,11 @@ trait Prelude  extends data.DisjunctionFunctions
   type Identity[A] = data.Identity[A]
   type Maybe[A] = data.Maybe[A]
   type Forget[A, B, C] = data.Forget[A, B, C]
+
+  val forall = data.forall
+  type Forall[F[_]] = forall.Forall[F]
+  type ∀[F[_]] = Forall[F]
+
 }
 
 object Prelude extends Prelude

--- a/base/shared/src/main/scala/scalaz/Prelude.scala
+++ b/base/shared/src/main/scala/scalaz/Prelude.scala
@@ -7,6 +7,7 @@ import scala.language.implicitConversions
 
 trait Prelude  extends data.DisjunctionFunctions
                   with data.ForallSyntax
+                  with data.Forall2Syntax
                   with data.IdentityTypes
                   with data.MaybeFunctions
                   with typeclass.BindFunctions
@@ -99,9 +100,15 @@ trait Prelude  extends data.DisjunctionFunctions
   type Maybe[A] = data.Maybe[A]
   type Forget[A, B, C] = data.Forget[A, B, C]
 
-  val forall = data.forall
-  type Forall[F[_]] = forall.Forall[F]
-  type ∀[F[_]] = Forall[F]
+  val Forall : data.Forall.type = data.Forall
+  val ∀      : data.Forall.type = data.Forall
+  type Forall[F[_]]             = Forall.Forall[F]
+  type ∀[F[_]]                  = Forall.Forall[F]
+
+  val Forall2 : data.Forall2.type = data.Forall2
+  val ∀∀      : data.Forall2.type = data.Forall2
+  type Forall2[F[_, _]]           = Forall2.Forall2[F]
+  type ∀∀[F[_, _]]                = Forall2.Forall2[F]
 
 }
 

--- a/base/shared/src/main/scala/scalaz/data/Forall.scala
+++ b/base/shared/src/main/scala/scalaz/data/Forall.scala
@@ -53,7 +53,7 @@ trait ForallSyntax {
 
 object ForallSyntax {
   final class Ops[F[_]](val a: ∀[F]) extends AnyVal {
-    def of[A]: F[A] = forall.specialize(a)
+    def of[A]: F[A] = Forall.specialize(a)
     def apply[A]: F[A] = of[A]
   }
 }

--- a/base/shared/src/main/scala/scalaz/data/Forall.scala
+++ b/base/shared/src/main/scala/scalaz/data/Forall.scala
@@ -1,0 +1,74 @@
+package scalaz
+package data
+
+import scala.language.implicitConversions
+
+trait ForallModule {
+  type Forall[F[_]]
+
+  type ∀[F[_]] = Forall[F]
+
+  trait Prototype[F[_]] {
+    def apply[A]: F[A]
+  }
+
+  def specialize[F[_], A](f: ∀[F]): F[A]
+
+  def from[F[_]](p: Prototype[F]): ∀[F]
+
+  def of[F[_]]: MkForall[F]
+
+  def mk[X](implicit u: Unapply[X]): MkForall[u.F] = of[u.F]
+
+  sealed trait MkForall[F[_]] extends Any {
+    type T
+    def from(ft: F[T]): ∀[F]
+    def apply(ft: F[T]): ∀[F] = from(ft)
+  }
+
+  trait Unapply[X] {
+    type F[_]
+  }
+
+  object Unapply {
+    implicit def unapply[G[_]]: Unapply[∀[G]] { type F[A] = G[A] } =
+      new Unapply[∀[G]] { type F[A] = G[A] }
+
+    implicit def unapply1[G[_], H[_]]: Unapply[∀[λ[α => G[H[α]]]]] { type F[A] = G[H[A]] } =
+      new Unapply[∀[λ[α => G[H[α]]]]] { type F[A] = G[H[A]] }
+
+    implicit def unapply2[P[_, _], G[_], H[_]]: Unapply[∀[λ[α => P[G[α], H[α]]]]] { type F[A] = P[G[A], H[A]] } =
+      new Unapply[∀[λ[α => P[G[α], H[α]]]]] { type F[A] = P[G[A], H[A]] }
+  }
+}
+
+trait ForallSyntax {
+  import ForallSyntax._
+
+  implicit def toForallOps[F[_]](a: ∀[F]): Ops[F] = new Ops[F](a)
+  implicit def toForallOps1[F[_], G[_]](a: ∀[λ[α => F[G[α]]]]): Ops[λ[α => F[G[α]]]] = new Ops[λ[α => F[G[α]]]](a)
+  implicit def toForallOps2[F[_, _], G[_], H[_]](a: ∀[λ[α => F[G[α], H[α]]]]): Ops[λ[α => F[G[α], H[α]]]] = new Ops[λ[α => F[G[α], H[α]]]](a)
+  // add other shapes here as needed
+}
+
+object ForallSyntax {
+  final class Ops[F[_]](val a: ∀[F]) extends AnyVal {
+    def of[A]: F[A] = forall.specialize(a)
+    def apply[A]: F[A] = of[A]
+  }
+}
+
+private[data] object ForallImpl extends ForallModule with ForallSyntax {
+  type Forall[F[_]] = F[Any]
+
+  def from[F[_]](p: Prototype[F]): ∀[F] = p[Any]
+
+  def specialize[F[_], A](f: ∀[F]): F[A] = f.asInstanceOf[F[A]]
+
+  def of[F[_]]: MkForall[F] = new MkForallImpl[F]
+}
+
+private[data] final class MkForallImpl[F[_]](val dummy: Boolean = false) extends AnyVal with ForallImpl.MkForall[F] {
+  type T = Any
+  def from(ft: F[T]): ForallImpl.∀[F] = ft
+}

--- a/base/shared/src/main/scala/scalaz/data/Forall2.scala
+++ b/base/shared/src/main/scala/scalaz/data/Forall2.scala
@@ -1,0 +1,81 @@
+package scalaz
+package data
+
+import scala.language.implicitConversions
+
+trait Forall2Module {
+  type Forall2[F[_, _]]
+
+  type ∀∀[F[_, _]] = Forall2[F]
+
+  trait Prototype[F[_, _]] {
+    def apply[A, B]: F[A, B]
+  }
+
+  def specialize[F[_, _], A, B](f: ∀∀[F]): F[A, B]
+
+  def from[F[_, _]](p: Prototype[F]): ∀∀[F]
+
+  def of[F[_, _]]: MkForall2[F]
+
+  def mk[X](implicit u: Unapply[X]): MkForall2[u.F] = of[u.F]
+
+  sealed trait MkForall2[F[_, _]] extends Any {
+    type T
+    type U
+    def from(ft: F[T, U]): ∀∀[F]
+    def apply(ft: F[T, U]): ∀∀[F] = from(ft)
+  }
+
+  trait Unapply[X] {
+    type F[_, _]
+  }
+
+  object Unapply {
+    implicit def unapply[G[_, _]]: Unapply[∀∀[G]] { type F[A, B] = G[A, B] } =
+      new Unapply[∀∀[G]] { type F[A, B] = G[A, B] }
+
+    implicit def unapply1[G[_], H[_, _]]: Unapply[∀∀[λ[(α, β) => G[H[α, β]]]]] { type F[A, B] = G[H[A, B]] } =
+      new Unapply[∀∀[λ[(α, β) => G[H[α, β]]]]] { type F[A, B] = G[H[A, B]] }
+
+    implicit def unapply2[P[_, _], G[_], H[_]]: Unapply[∀∀[λ[(α, β) => P[G[α], H[β]]]]] { type F[A, B] = P[G[A], H[B]] } =
+      new Unapply[∀∀[λ[(α, β) => P[G[α], H[β]]]]] { type F[A, B] = P[G[A], H[B]] }
+
+    implicit def unapply3[P[_, _], G[_, _], H[_, _]]: Unapply[∀∀[λ[(α, β) => P[G[α, β], H[α, β]]]]] { type F[A, B] = P[G[A, B], H[A, B]] } =
+      new Unapply[∀∀[λ[(α, β) => P[G[α, β], H[α, β]]]]] { type F[A, B] = P[G[A, B], H[A, B]] }
+  }
+}
+
+trait Forall2Syntax {
+  import Forall2Syntax._
+
+  implicit def toForall2Ops[F[_, _]](a: ∀∀[F]): Ops[F] = new Ops[F](a)
+  implicit def toForall2Ops1[F[_], G[_, _]](a: ∀∀[λ[(α, β) => F[G[α, β]]]]): Ops[λ[(α, β) => F[G[α, β]]]] = new Ops[λ[(α, β) => F[G[α, β]]]](a)
+  implicit def toForall2Ops2[F[_, _], G[_], H[_]](a: ∀∀[λ[(α, β) => F[G[α], H[β]]]]): Ops[λ[(α, β) => F[G[α], H[β]]]] = new Ops[λ[(α, β) => F[G[α], H[β]]]](a)
+  implicit def toForall2Ops3[F[_, _], G[_, _], H[_, _]](a: ∀∀[λ[(α, β) => F[G[α, β], H[α, β]]]]): Ops[λ[(α, β) => F[G[α, β], H[α, β]]]] = new Ops[λ[(α, β) => F[G[α, β], H[α, β]]]](a)
+  // add other shapes here as needed
+}
+
+object Forall2Syntax {
+  final class Ops[F[_, _]](val a: ∀∀[F]) extends AnyVal {
+    def of[A, B]: F[A, B] = Forall2.specialize(a)
+    def apply[A, B]: F[A, B] = of[A, B]
+  }
+}
+
+private[data] object Forall2Impl extends Forall2Module with Forall2Syntax {
+  type Forall2[F[_, _]] = F[Any, Any]
+
+  def from[F[_, _]](p: Prototype[F]): ∀∀[F] = p[Any, Any]
+
+  def specialize[F[_, _], A, B](f: ∀∀[F]): F[A, B] = f.asInstanceOf[F[A, B]]
+
+  def of[F[_, _]]: MkForall2[F] = new MkForall2Impl[F]
+}
+
+private[data] final class MkForall2Impl[F[_, _]](val dummy: Boolean = false) extends AnyVal with Forall2Impl.MkForall2[F] {
+  type T = Any
+  type U = Any
+  def from(ft: F[T, U]): Forall2Impl.∀∀[F] = ft
+}
+

--- a/base/shared/src/main/scala/scalaz/data/package.scala
+++ b/base/shared/src/main/scala/scalaz/data/package.scala
@@ -1,0 +1,9 @@
+package scalaz
+
+package object data {
+  val forall: ForallModule with ForallSyntax = ForallImpl
+  val ∀ : forall.type = forall
+
+  type Forall[F[_]] = forall.Forall[F]
+  type ∀[F[_]] = Forall[F]
+}

--- a/base/shared/src/main/scala/scalaz/data/package.scala
+++ b/base/shared/src/main/scala/scalaz/data/package.scala
@@ -1,9 +1,15 @@
 package scalaz
 
 package object data {
-  val forall: ForallModule with ForallSyntax = ForallImpl
-  val ∀ : forall.type = forall
+  val Forall: ForallModule with ForallSyntax = ForallImpl
+  val ∀ : Forall.type = Forall
 
-  type Forall[F[_]] = forall.Forall[F]
+  type Forall[F[_]] = Forall.Forall[F]
   type ∀[F[_]] = Forall[F]
+
+  val Forall2: Forall2Module with Forall2Syntax = Forall2Impl
+  val ∀∀ : Forall2.type = Forall2
+
+  type Forall2[F[_, _]] = Forall2.Forall2[F]
+  type ∀∀[F[_, _]] = Forall2[F]
 }

--- a/build.sbt
+++ b/build.sbt
@@ -47,3 +47,10 @@ lazy val meta         = crossProject.module
 lazy val metaJVM      = meta.jvm
 
 lazy val metaJS       = meta.js
+
+lazy val example      = crossProject.module
+  .dependsOn( base )
+
+lazy val exampleJVM   = example.jvm
+
+lazy val exampleJS    = example.js

--- a/example/shared/src/main/scala/scalaz/example/ForallUsage.scala
+++ b/example/shared/src/main/scala/scalaz/example/ForallUsage.scala
@@ -1,0 +1,49 @@
+package scalaz
+package example
+
+import scalaz.data.∀
+import scalaz.data.forall._
+
+object ForallUsage extends App {
+  import scalaz.typeclass.Semigroup
+
+  def listSemigroup[A]: Semigroup[List[A]] = new Semigroup[List[A]] {
+    def append(x: List[A], y: => List[A]) = x ++ y
+  }
+
+  // isntances can be created using ∀.of syntax
+  val nil: ∀[List] = ∀.of[List](Nil)
+
+  // or ∀.mk syntax
+  val nil1: ∀[List] = ∀.mk[∀[List]].from(Nil)
+
+
+  /* universally quantified semigroup */
+
+  type Plus[F[_]] = ∀[λ[A => Semigroup[F[A]]]]
+
+  // create an instance
+  val listPlus: Plus[List] =
+    ∀.mk[Plus[List]].from(listSemigroup)
+
+  // use the instance
+  assert( listPlus[Int].append(List(1, 2), List(3, 4)) == List(1, 2, 3, 4) )
+
+
+  /* natural transformation */
+
+  type ~>[F[_], G[_]] = ∀[λ[A => F[A] => G[A]]]
+
+  // create an instance
+  val headOption: List ~> Option = ∀.mk[List ~> Option].from(_.headOption)
+
+  // use the instance
+  assert( headOption[Int](List(1, 2, 3)) == Some(1) )
+
+  // extra syntax for applying a natural transformation to universally quantified value
+  implicit class NaturalTransformationOps[F[_], G[_]](trans: F ~> G) {
+    def $(f: ∀[F]): ∀[G] = ∀.of[G](trans.apply.apply(f.apply))
+  }
+
+  val none: ∀[Option] = headOption $ nil
+}

--- a/example/shared/src/main/scala/scalaz/example/ForallUsage.scala
+++ b/example/shared/src/main/scala/scalaz/example/ForallUsage.scala
@@ -1,8 +1,7 @@
 package scalaz
 package example
 
-import scalaz.data.∀
-import scalaz.data.forall._
+import Prelude._
 
 object ForallUsage extends App {
   import scalaz.typeclass.Semigroup
@@ -11,11 +10,13 @@ object ForallUsage extends App {
     def append(x: List[A], y: => List[A]) = x ++ y
   }
 
-  // isntances can be created using ∀.of syntax
+  // isntances can be created using `of` syntax
   val nil: ∀[List] = ∀.of[List](Nil)
+  val emptyMap: ∀∀[Map] = ∀∀.of[Map](Map())
 
-  // or ∀.mk syntax
+  // or `mk` syntax
   val nil1: ∀[List] = ∀.mk[∀[List]].from(Nil)
+  val emptyMap1: ∀∀[Map] = ∀∀.mk[∀∀[Map]].from(Map())
 
 
   /* universally quantified semigroup */
@@ -45,5 +46,27 @@ object ForallUsage extends App {
     def $(f: ∀[F]): ∀[G] = ∀.of[G](trans.apply.apply(f.apply))
   }
 
+  // applying a universally quantified function to a universally quantified value
+  // yields a universally quantified value
   val none: ∀[Option] = headOption $ nil
+
+
+  /* binatural transformation */
+  type ~~>[F[_, _], G[_, _]] = ∀∀[λ[(α, β) => F[α, β] => G[α, β]]]
+
+  // create an instance
+  type Option2[A, B] = Option[(A, B)]
+  val pick: Map ~~> Option2 = ∀∀.mk[Map ~~> Option2].from(_.headOption)
+
+  // use the instance
+  assert( pick[String, Int](Map("hi" -> 5)) == Some("hi" -> 5) )
+
+  // extra syntax for applying a binatural transformation to univarsally quantified value
+  implicit class BinaturalTransformationOps[F[_, _], G[_, _]](trans: F ~~> G) {
+    def $(f: ∀∀[F]): ∀∀[G] = ∀∀.of[G](trans.apply.apply(f.apply))
+  }
+
+  // applying a universally quantified function to a universally quantified value
+  // yields a universally quantified value
+  val none2: ∀∀[Option2] = pick $ emptyMap
 }


### PR DESCRIPTION
Define `Forall[F[_]]` as an abstract type, privately implemented as

```scala
type Forall[F[_]] = F[Any]
```

A type alias is provided

```scala
type ∀[F[_]] = Forall[F]
```

### Creating instances

Since `Forall[F]` is represented as `F[Any]`, care needs to be taken so that only truly parametric instances can be created. Two ways to create instances are provided:

 1. From a "prototype", which is a Scalaz7-style universally quantified value:

    ```scala
    def from[F[_]](p: Prototype[F]): Forall[F]

    trait Prototype[F[_]] {
      def apply[A]: F[A]
    }
    ```

    Prospectively, there could be convenient syntax for creating `Prototype`s via non/kind-projector#54.

    Note that creation via a prototype requires an allocation of a short-lived object (the prototype), but the resulting `Forall[F]` value is unboxed. (Perhaps that one allocation could be eliminated by the optimizer?)

 2. Via the same trick (due to @alexknvl) as in #1416:

    ```scala
    val l1: Forall[List] = Forall.of[List](Nil)

    // or

    val l2: Forall[List] = Forall.mk[Forall[List]].from(Nil)
    ```

    The seemingly longer `mk[...].from(...)` syntax becomes more succinct in some cases:

    ```scala
    def listSemigroup[A]: Semigroup[List[A]] = ???

    type Plus[F[_]] = Forall[λ[A => Semigroup[F[A]]]]

    val listPlus: Plus[List] = Forall.of[λ[A => Semigroup[F[A]]]](listSemigroup)

    // vs

    val listPlus: Plus[List] = Forall.mk[Plus[List]].from(listSemigroup)
    ```

### Using instances

From user's perspective `Forall[F]` is completely abstract, but values are enriched with `apply[A]` method:

```scala
class ForallOps[F[_]](val a: Forall[F]) extends AnyVal {
  def apply[A]: F[A] = ???
}
```

One then uses this method to get an instance specialized for a specific type:

```scala
listPlus[Int].append(List(1, 2), List(3, 4)) // List(1, 2, 3, 4)
```

---

See also `ForallUsage.scala` on how `Forall` can be used to represent `NaturalTransformation`.