### PR TITLE
Redefine scalaz.meta.Ops as a macro bundle

### DIFF
--- a/meta/shared/src/main/scala/scalaz/meta/Ops.scala
+++ b/meta/shared/src/main/scala/scalaz/meta/Ops.scala
@@ -5,35 +5,31 @@ import scala.reflect.macros.whitebox.Context
 
 // Originally inspired by http://typelevel.org/blog/2013/10/13/spires-ops-macros.html
 
-object Ops {
-  
-  
-  def _f0[R](c: Context): c.Expr[R] = {
-    import c.universe._
-    val (ev, lhs) = unpack(c)
+class Ops(val c: Context) {
+  import c.universe._
+
+  def _f0[R]: Expr[R] = {
+    val (ev, lhs) = unpack
     c.Expr[R](Apply(Select(ev, TermName(c.macroApplication.symbol.name.toString)), List(lhs)))
   }
-  
-  def _f1[A, R](c: Context)(f: c.Expr[A]): c.Expr[R] = {
-    import c.universe._
-    val (ev, lhs) = unpack(c)
+
+  def _f1[A, R](f: Expr[A]): Expr[R] = {
+    val (ev, lhs) = unpack
     c.Expr[R](Apply(Apply(Select(ev, TermName(c.macroApplication.symbol.name.toString)), List(lhs)), List(f.tree)))
   }
 
-  def _f2[A, B, R](c: Context)(f: c.Expr[A])(g: c.Expr[B]): c.Expr[R] = {
-    import c.universe._
-    val (ev, lhs) = unpack(c)
+  def _f2[A, B, R](f: Expr[A])(g: Expr[B]): Expr[R] = {
+    val (ev, lhs) = unpack
     val y = Apply(Select(ev, TermName(c.macroApplication.symbol.name.toString)), List(lhs))
-    val toappl = Apply(y, List(f.tree)) 
-    c.Expr[R](Apply(toappl, List(g.tree))) 
+    val toappl = Apply(y, List(f.tree))
+    c.Expr[R](Apply(toappl, List(g.tree)))
   }
-  
-  def unpack[T[_], A](c: Context) = {
-      import c.universe._
-      c.prefix.tree match {
-        case Apply(Apply(TypeApply(_, _), List(x)), List(ev)) => (ev, x)
-        case t => c.abort(c.enclosingPosition, "Cannot extract subject of operation (tree = %s)" format t)
-      }
+
+  def unpack = {
+    c.prefix.tree match {
+      case Apply(Apply(TypeApply(_, _), List(x)), List(ev)) => (ev, x)
+      case t => c.abort(c.enclosingPosition, "Cannot extract subject of operation (tree = %s)" format t)
     }
-  
+  }
+
 }


### PR DESCRIPTION
Removes some boilerplate.

See http://docs.scala-lang.org/overviews/macros/bundles.html

Also upgrades some versions and drops the deprecated sbt.Build trait.

Feedback always welcome.