### PR TITLE
Use sbt-travisci. Fixes #1438

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,6 @@
 lazy val root = Project(
   id = "root",
   base = file(".")
-).settings(
-  scalaVersion := "2.12.2"
 ).aggregate ( bazeJVM
             , bazeJS
             , metaJVM

--- a/project/ScalazBuild.scala
+++ b/project/ScalazBuild.scala
@@ -6,7 +6,7 @@ object Scalaz extends Build {
 
   def stdSettings(prjName: String) = Seq(
     name := s"scalaz-$prjName",
-    scalaVersion := "2.12.2",
+    // scalaVersion is defined in .travis.yml, via sbt-travisci
     scalacOptions ++= Seq("-feature","-deprecation", "-Xlint", "-language:higherKinds",
                           "-Ydelambdafy:method", "-Ypartial-unification", "-target:jvm-1.8", "-opt:l:project",
                           "-opt-warnings"),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.24")
-
+addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.1.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.17")


### PR DESCRIPTION
Before:

    > show scalaVersion
    [info] metaJVM/*:scalaVersion
    [info] 	2.12.2
    [info] metaJS/*:scalaVersion
    [info] 	2.12.2
    [info] benchmarks/*:scalaVersion
    [info] 	2.12.2
    [info] bazeJS/*:scalaVersion
    [info] 	2.12.2
    [info] effectJS/*:scalaVersion
    [info] 	2.12.2
    [info] effectJVM/*:scalaVersion
    [info] 	2.12.2
    [info] bazeJVM/*:scalaVersion
    [info] 	2.12.2
    [info] root/*:scalaVersion
    [info] 	2.12.2

After:

    > reload
    ...
    >
    > show scalaVersion
    [info] metaJVM/*:scalaVersion
    [info] 	2.12.2
    [info] metaJS/*:scalaVersion
    [info] 	2.12.2
    [info] benchmarks/*:scalaVersion
    [info] 	2.12.2
    [info] bazeJS/*:scalaVersion
    [info] 	2.12.2
    [info] effectJS/*:scalaVersion
    [info] 	2.12.2
    [info] effectJVM/*:scalaVersion
    [info] 	2.12.2
    [info] bazeJVM/*:scalaVersion
    [info] 	2.12.2
    [info] {.}/*:scalaVersion
    [info] 	2.12.2

They are the same, which is what we want: scalaVersion (technically
"scalaVersion in ThisBuild") is being defined by the value in
.travis.yml.