### PR TITLE
Add convenience constructors for <~> and <=>.

### DIFF
--- a/core/src/main/scala/scalaz/Associative.scala
+++ b/core/src/main/scala/scalaz/Associative.scala
@@ -7,17 +7,13 @@ package scalaz
 ////
 trait Associative[=>:[_, _]]  { self =>
   ////
-  import Isomorphism.<=>
+  import Isomorphism.{<=>, IsoSet}
 
   def reassociateLeft[A, B, C](f: A =>: (B =>: C)): (A =>: B) =>: C
 
   def reassociateRight[A, B, C](f: (A =>: B) =>: C): A =>: (B =>: C)
 
-  def reassociateIso[A, B, C]: ((A =>: B) =>: C) <=> (A =>: (B =>: C)) =
-    new (((A =>: B) =>: C) <=> (A =>: (B =>: C))) {
-      def from = reassociateLeft
-      def to = reassociateRight
-    }
+  def reassociateIso[A, B, C]: ((A =>: B) =>: C) <=> (A =>: (B =>: C)) = IsoSet(reassociateRight, reassociateLeft)
 
   trait AssociativeLaw {
     /** Reassociating left and then right is a no-op. */

--- a/core/src/main/scala/scalaz/Isomorphism.scala
+++ b/core/src/main/scala/scalaz/Isomorphism.scala
@@ -131,20 +131,44 @@ sealed abstract class Isomorphisms extends IsomorphismsLow0{
   /**Alias for IsoSet */
   type <=>[A, B] = IsoSet[A, B]
 
+  object IsoSet {
+    /**Convenience constructor to implement `A <=> B` from `A => B` and `B => A` */
+    def apply[A, B](to: A => B, from: B => A): A <=> B = {
+      val _to   = to
+      val _from = from
+      new Iso[Function1, A, B] {
+        override val to   = _to
+        override val from = _from
+      }
+    }
+  }
+
   /**Alias for IsoFunctor */
   type <~>[F[_], G[_]] = IsoFunctor[F, G]
 
   /**Convenience template trait to implement `<~>` */
   trait IsoFunctorTemplate[F[_], G[_]] extends IsoFunctor[F, G] {
-    final val to: NaturalTransformation[F, G] = new (F ~> G) {
+    override final val to: NaturalTransformation[F, G] = new (F ~> G) {
       def apply[A](fa: F[A]): G[A] = to[A](fa)
     }
-    final val from: NaturalTransformation[G, F] = new (G ~> F) {
+    override final val from: NaturalTransformation[G, F] = new (G ~> F) {
       def apply[A](ga: G[A]): F[A] = from[A](ga)
     }
 
     def to[A](fa: F[A]): G[A]
     def from[A](ga: G[A]): F[A]
+  }
+
+  object IsoFunctor {
+    /**Convenience constructor to implement `F <~> G` from F ~> G and G ~> F */
+    def apply[F[_], G[_]](to: F ~> G, from: G ~> F): F <~> G = {
+      val _to   = to
+      val _from = from
+      new (F <~> G) {
+        override val to = _to
+        override val from = _from
+      }
+    }
   }
 
   /**Alias for IsoBifunctor */

--- a/example/src/main/scala/scalaz/example/IsomorphismUsage.scala
+++ b/example/src/main/scala/scalaz/example/IsomorphismUsage.scala
@@ -12,7 +12,10 @@ object IsomorphismUsage extends App {
   def isoSet[A] = new IsoSet[Seq[A], List[A]] {
     def to: Seq[A] => List[A] = _.toList
     def from: List[A] => Seq[A] = _.toSeq
-  }
+  } // or simply:
+  def equivalentIsoSet[A] = IsoSet[Seq[A], List[A]](_.toList, _.toSeq)
+
+
   def isoFunctor = new IsoFunctorTemplate[Seq, List] {
     def to[A](sa: Seq[A]): List[A] = sa.toList
     def from[A](la: List[A]): Seq[A] = la.toSeq


### PR DESCRIPTION
not sure about the naming of `object`s; should `<=>` be used instead of `IsoSet`?