### PR TITLE
[WIP] Sketch of IList with invariant interface and covariant implementation.

### DIFF
--- a/base/shared/src/main/scala/scalaz/data/Forall.scala
+++ b/base/shared/src/main/scala/scalaz/data/Forall.scala
@@ -12,6 +12,7 @@ trait ForallModule {
 
   trait Prototype[F[_]] {
     def apply[A]: F[A]
+    final def make: ∀[F] = from(this)
   }
 
   def specialize[F[_], A](f: ∀[F]): F[A]

--- a/base/shared/src/main/scala/scalaz/data/Forall2.scala
+++ b/base/shared/src/main/scala/scalaz/data/Forall2.scala
@@ -10,6 +10,7 @@ trait Forall2Module {
 
   trait Prototype[F[_, _]] {
     def apply[A, B]: F[A, B]
+    final def make: ∀∀[F] = from(this)
   }
 
   def specialize[F[_, _], A, B](f: ∀∀[F]): F[A, B]

--- a/base/shared/src/main/scala/scalaz/data/IList.scala
+++ b/base/shared/src/main/scala/scalaz/data/IList.scala
@@ -1,0 +1,31 @@
+package scalaz
+package data
+
+import Prelude._
+import typeclass.IsCovariantClass
+import typeclass.Liskov.<~<
+
+trait IListModule {
+  type IList[A]
+
+  def uncons[A](as: IList[A]): Maybe2[A, IList[A]]
+
+  implicit def isCovariantInstance: IsCovariant[IList]
+}
+
+private[data] object IListImpl extends IListModule {
+  type IList[A] = Fix[Maybe2[A, ?]]
+
+  def uncons[A](as: IList[A]): Maybe2[A, IList[A]] =
+    Fix.unfix[Maybe2[A, ?]](as)
+
+  implicit val isCovariantInstance: IsCovariant[IList] =
+    new IsCovariantClass[IList] with IsCovariantClass.LiftLiskov[IList] {
+
+      override def liftLiskov[A, B](implicit ev: A <~< B): IList[A] <~< IList[B] = {
+        type <~~<[F[_], G[_]] = ∀.Prototype[λ[α => F[α] <~< G[α]]]
+        val ev1 = Λ[α](Maybe2.isCovariant_1[α].liftLiskov[A, B]): Maybe2[A, ?] <~~< Maybe2[B, ?]
+        Fix.liftLiskov[Maybe2[A, ?], Maybe2[B, ?]](ev1.make)(Maybe2.isCovariant_2[A])
+      }
+    }
+}

--- a/base/shared/src/main/scala/scalaz/data/Maybe2.scala
+++ b/base/shared/src/main/scala/scalaz/data/Maybe2.scala
@@ -1,0 +1,65 @@
+package scalaz
+package data
+
+import typeclass.IsCovariant
+
+sealed trait Maybe2Module {
+  /**
+   * Isomorphic to `Maybe[(A, B)]`, but avoids allocating a `Tuple2` isntance.
+   */
+  type Maybe2[A, B]
+
+  def just2 [A, B](a: A, b: B): Maybe2[A, B]
+  def empty2[A, B]            : Maybe2[A, B]
+
+  implicit def isCovariant_1[B]: IsCovariant[Maybe2[?, B]]
+  implicit def isCovariant_2[A]: IsCovariant[Maybe2[A, ?]]
+
+  object Just2 {
+    def unapply[A, B](m: Maybe2[A, B]): Just2Extractor[A, B] = new Just2Extractor(toOption2(m))
+  }
+  object Empty2 {
+    def unapply[A, B](m: Maybe2[A, B]): Boolean = toOption2(m).isEmpty
+  }
+
+  private[data] def fromOption2[A, B](o: Option2[A, B]): Maybe2[A, B]
+  private[data] def toOption2  [A, B](m: Maybe2[A, B]): Option2[A, B]
+}
+
+final class Just2Extractor[A, B] private[data] (private val value: Option2[A, B]) extends AnyVal {
+  def isEmpty: Boolean = value.isEmpty
+  def get: Just2Extractor[A, B] = this
+  def _1: A = value._1
+  def _2: B = value._2
+}
+
+private[data] object Maybe2Impl extends Maybe2Module {
+  type Maybe2[A, B] = Option2[A, B]
+
+  def just2 [A, B](a: A, b: B): Maybe2[A, B] = Some2(a, b)
+  def empty2[A, B]            : Maybe2[A, B] = None2
+
+  implicit def isCovariant_1[B]: IsCovariant[Maybe2[?, B]] = IsCovariant.scalaCovariant[Option2[+?, B]]
+  implicit def isCovariant_2[A]: IsCovariant[Maybe2[A, ?]] = IsCovariant.scalaCovariant[Option2[A, +?]]
+
+  private[data] def fromOption2[A, B](o: Option2[A, B]): Maybe2[A, B] = o
+  private[data] def toOption2  [A, B](m: Maybe2[A, B]): Option2[A, B] = m
+}
+
+/**
+ * Isomorphic to `Option[(A, B)]`, but avoids allocating a `Tuple2` instance.
+ *
+ * Covariance is intentional. For invariant version, see [[data.Maybe2]].
+ */
+private[data] sealed abstract class Option2[+A, +B] {
+  def isEmpty: Boolean = this eq None2
+  def _1: A
+  def _2: B
+}
+
+private[data] case class Some2[+A, +B](_1: A, _2: B) extends Option2[A, B]
+
+private[data] case object None2 extends Option2[Nothing, Nothing] {
+  def _1: Nothing = sys.error("unreachable code")
+  def _2: Nothing = sys.error("unreachable code")
+}

--- a/base/shared/src/main/scala/scalaz/data/package.scala
+++ b/base/shared/src/main/scala/scalaz/data/package.scala
@@ -75,4 +75,6 @@ package object data {
   val Fix: FixModule = FixImpl
   type Fix[F[_]] = Fix.Fix[F]
 
+  val Maybe2: Maybe2Module = Maybe2Impl
+  type Maybe2[A, B] = Maybe2.Maybe2[A, B]
 }

--- a/base/shared/src/main/scala/scalaz/data/package.scala
+++ b/base/shared/src/main/scala/scalaz/data/package.scala
@@ -77,4 +77,7 @@ package object data {
 
   val Maybe2: Maybe2Module = Maybe2Impl
   type Maybe2[A, B] = Maybe2.Maybe2[A, B]
+
+  val IList: IListModule = IListImpl
+  type IList[A] = IList.IList[A]
 }

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,8 @@ lazy val root = project.in(file("."))
             , metaJS
             , effectJVM
             , effectJS
+            , exampleJVM
+            , exampleJS
             , benchmarks
 ).enablePlugins(ScalaJSPlugin)
 

--- a/example/shared/src/main/scala/scalaz/example/Maybe2Usage.scala
+++ b/example/shared/src/main/scala/scalaz/example/Maybe2Usage.scala
@@ -1,0 +1,13 @@
+package scalaz.example
+
+import scalaz.data.Maybe2._
+
+object Maybe2Usage extends App {
+
+  val hi5 = just2("Hi", 5)
+
+  hi5 match {
+    case Just2(s, i) => println(s"$s $i!")
+    case Empty2()    => println("""¯\_(ツ)_/¯""")
+  }
+}


### PR DESCRIPTION
This is in the same spirit as `Maybe` in #1450.

Things to note:
 - `uncons` is just `Fix.unfix`, which is identity.
 - `IsCovariant[IList]` instance is created without (directly) using any unsafe operations (like `asInstanceOf` or `Liskov.unsafeForce`).
 - Pattern matching is available (via `uncons(as) match { ... }`; though this can't be used in nested patterns).

The major problem, as with #1450, is the lack of companion object to look up typeclass instances.

To match the memory efficiency of `scala.List`, we would have to switch to a specialized implementation of `Option2[A, B]` instead of `Option[(A, B)]` to avoid the extra `Tuple2` instance.

