### PR TITLE
Polymorphic singletons

### DIFF
--- a/base/shared/src/main/scala/scalaz/data/Forall.scala
+++ b/base/shared/src/main/scala/scalaz/data/Forall.scala
@@ -37,7 +37,10 @@ trait ForallModule {
     implicit def unapply1[G[_], H[_]]: Unapply[∀[λ[α => G[H[α]]]]] { type F[A] = G[H[A]] } =
       new Unapply[∀[λ[α => G[H[α]]]]] { type F[A] = G[H[A]] }
 
-    implicit def unapply2[P[_, _], G[_], H[_]]: Unapply[∀[λ[α => P[G[α], H[α]]]]] { type F[A] = P[G[A], H[A]] } =
+    implicit def unapply2[P[_, _]]: Unapply[∀[λ[α => P[α, α]]]] { type F[A] = P[A, A] } =
+      new Unapply[∀[λ[α => P[α, α]]]] { type F[A] = P[A, A] }
+
+    implicit def unapply3[P[_, _], G[_], H[_]]: Unapply[∀[λ[α => P[G[α], H[α]]]]] { type F[A] = P[G[A], H[A]] } =
       new Unapply[∀[λ[α => P[G[α], H[α]]]]] { type F[A] = P[G[A], H[A]] }
   }
 }
@@ -47,7 +50,8 @@ trait ForallSyntax {
 
   implicit def toForallOps[F[_]](a: ∀[F]): Ops[F] = new Ops[F](a)
   implicit def toForallOps1[F[_], G[_]](a: ∀[λ[α => F[G[α]]]]): Ops[λ[α => F[G[α]]]] = new Ops[λ[α => F[G[α]]]](a)
-  implicit def toForallOps2[F[_, _], G[_], H[_]](a: ∀[λ[α => F[G[α], H[α]]]]): Ops[λ[α => F[G[α], H[α]]]] = new Ops[λ[α => F[G[α], H[α]]]](a)
+  implicit def toForallOps2[F[_, _]](a: ∀[λ[α => F[α, α]]]): Ops[λ[α => F[α, α]]] = new Ops[λ[α => F[α, α]]](a)
+  implicit def toForallOps3[F[_, _], G[_], H[_]](a: ∀[λ[α => F[G[α], H[α]]]]): Ops[λ[α => F[G[α], H[α]]]] = new Ops[λ[α => F[G[α], H[α]]]](a)
   // add other shapes here as needed
 }
 

--- a/base/shared/src/main/scala/scalaz/data/Leibniz.scala
+++ b/base/shared/src/main/scala/scalaz/data/Leibniz.scala
@@ -1,16 +1,21 @@
 package scalaz
 package data
 
+import Prelude._
 import Identity.Id
 
-trait ===[A, B] {
+sealed trait ===[A, B] {
   def apply(a: A): B = subst[Id](a)
   def subst[F[_]](fa: F[A]): F[B]
   def onF[X](fa: X => A): X => B = subst[X => ?](fa)
 }
 
 object Leibniz {
-  def refl[A]: A === A = new (A === A) {
+  private def refl_[A]: A === A = new (A === A) {
     def subst[F[_]](fa: F[A]): F[A] = fa
   }
+
+  private val Refl = ∀.of[λ[α => α === α]].from(refl_)
+
+  def refl[A]: A === A = Refl[A]
 }

--- a/base/shared/src/main/scala/scalaz/data/Maybe.scala
+++ b/base/shared/src/main/scala/scalaz/data/Maybe.scala
@@ -9,6 +9,7 @@ sealed abstract class Maybe[A] {
 }
 
 object Maybe extends MaybeFunctions with MaybeInstances with MaybeSyntax {
-  final private[data] case object Empty extends Maybe[Nothing]
+  final private[data] class Empty[A] private[Maybe]() extends Maybe[A]
+  private[data] val Empty = ∀.of[Empty].from(new Empty)
   final case class Just[A](a: A) extends Maybe[A]
 }

--- a/base/shared/src/main/scala/scalaz/data/MaybeFunctions.scala
+++ b/base/shared/src/main/scala/scalaz/data/MaybeFunctions.scala
@@ -1,18 +1,16 @@
 package scalaz
 package data
 
-import typeclass.IsCovariant
-import typeclass.Liskov._
-
+import Prelude._
 import Maybe.{Empty, Just}
 
 trait MaybeFunctions {
-  def empty[A]: Maybe[A] = IsCovariant[Maybe].widen(Empty)
+  def empty[A]: Maybe[A] = Empty[A]
   def just[A](a: A): Maybe[A] = Just(a)
 
   def maybe[A, B](n: B)(f: A => B): Maybe[A] => B = _ match {
-    case Empty    => n
-    case Just(x)  => f(x)
+    case Just(x) => f(x)
+    case _       => n
   }
 
   def fromOption[A](oa: Option[A]): Maybe[A] = oa.fold[Maybe[A]](empty[A])(Just(_))

--- a/base/shared/src/main/scala/scalaz/typeclass/Liskov.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/Liskov.scala
@@ -1,6 +1,8 @@
 package scalaz
 package typeclass
 
+import Prelude._
+
 sealed abstract class Liskov[-A, +B] {
   def subst[F[-_]](p: F[B]): F[A]
 
@@ -16,8 +18,12 @@ sealed abstract class Liskov[-A, +B] {
 }
 
 object Liskov extends LiskovTypes with LiskovInstances with LiskovFunctions {
-  /**Subtyping is reflexive */
-  implicit def refl[A]: (A <~< A) = new (A <~< A) {
+  private def refl_[A]: (A <~< A) = new (A <~< A) {
     def subst[F[-_]](p: F[A]): F[A] = p
   }
+
+  private val Refl = ∀.of[λ[α => α <~< α]].from(refl_)
+
+  /**Subtyping is reflexive */
+  implicit def refl[A]: (A <~< A) = Refl[A]
 }


### PR DESCRIPTION
Use polymorphic singleton values in order to avoid either of
 - allocating a new instance for each type argument; or
 - using `asInstanceOf` to cast the singleton object to the desired type.

## Example: `Maybe`

### Approach A

```scala
case class Empty[A]() extends Maybe[A]
```

👎  Allocates a new `Empty[T]` instance for each type `T`.

### Approach B

```scala
case object Empty extends Maybe[Nothing]
```

👎  Use `Empty.asInstanceOf[Maybe[T]]` to get an empty instance of `Maybe[T]`. (Note that `Maybe` is assumed to be invariant.)

### Approach C (this PR)

```scala
class Empty[A] private[Maybe]() extends Maybe[A]
val Empty: ∀[Empty] = ∀.of[Empty].from(new Empty)
```

To get an empty instance of `Maybe[T]`, use

```scala
Empty[T]
```

which doesn't allocate any new objects (assuming zero-cost syntax that adds the `.apply[T]` method to `∀[Empty]`).

👍  Avoids both downsides of approaches A and B.