### PR TITLE
Type-aligned data types.

### DIFF
--- a/base/shared/src/main/scala/scalaz/data/ACatenable1.scala
+++ b/base/shared/src/main/scala/scalaz/data/ACatenable1.scala
@@ -1,0 +1,68 @@
+package scalaz
+package data
+
+import scala.annotation.tailrec
+import scalaz.typeclass.Compose
+
+/**
+ * Non-empty type-aligned sequence represented as a (non-balanced) binary tree,
+ * supporting O(1) addition to either end and O(1) concatenation.
+ */
+sealed abstract class ACatenable1[=>:[_, _], A, B] {
+  import ACatenable1._
+
+  def compose[Z](that: ACatenable1[=>:, Z, A]): ACatenable1[=>:, Z, B] =
+    Chain(that, this)
+
+  def <<<[Z](that: ACatenable1[=>:, Z, A]): ACatenable1[=>:, Z, B] =
+    this compose that
+
+  def >>>[C](that: ACatenable1[=>:, B, C]): ACatenable1[=>:, A, C] =
+    that compose this
+
+  def :+[C](f: B =>: C): ACatenable1[=>:, A, C] =
+    Chain(this, Lift(f))
+
+  def +:[Z](f: Z =>: A): ACatenable1[=>:, Z, B] =
+    Chain(Lift(f), this)
+
+  final def foldLeft[F[_]](fa: F[A])(φ: RightAction[F, =>:]): F[B] = {
+    @inline def pair[X](fx: F[X], f: ACatenable1[=>:, X, B]) = APair[F, ACatenable1[=>:, ?, B], X](fx, f)
+    @tailrec def go(step: APair[F, ACatenable1[=>:, ?, B]]): F[B] =
+      step._2 match {
+        case Chain(Chain(f, g), h) => go(pair(step._1, f >>> (g >>> h)))
+        case Chain(Lift(f), g) => go(pair(φ.apply(step._1, f), g))
+        case Lift(f) => φ.apply(step._1, f)
+      }
+    go(pair(fa, this))
+  }
+
+  def foldRight[F[_]](fb: F[B])(φ: LeftAction[F, =>:]): F[A] = {
+    @inline def pair[X](f: ACatenable1[=>:, A, X], fx: F[X]) = APair[ACatenable1[=>:, A, ?], F, X](f, fx)
+    @tailrec def go(step: APair[ACatenable1[=>:, A, ?], F]): F[A] =
+      step._1 match {
+        case Chain(f, Chain(g, h)) => go(pair((f >>> g) >>> h, step._2))
+        case Chain(f, Lift(g)) => go(pair(f, φ.apply(g, step._2)))
+        case Lift(f) => φ.apply(f, step._2)
+      }
+    go(pair(this, fb))
+  }
+
+  /**
+   * Compose the leafs in a balanced binary fashion.
+   */
+  @tailrec
+  final def fold(implicit ev: Compose[=>:]): A =>: B = this match {
+    case Chain(Chain(f, g), h) => (f >>> (g >>> h)).fold
+    case Chain(Lift(f), g) => g.foldLeft[PostComposeBalancer[=>:, A, ?]](PostComposeBalancer(f))(PostComposeBalancer.rightAction).result
+    case Lift(f) => f
+  }
+}
+
+object ACatenable1 {
+  private[ACatenable1] final case class Lift[=>:[_, _], A, B](f: A =>: B) extends ACatenable1[=>:, A, B]
+  private[ACatenable1] final case class Chain[=>:[_, _], A, B, C](f: ACatenable1[=>:, A, B], g: ACatenable1[=>:, B, C]) extends ACatenable1[=>:, A, C]
+
+  def lift[F[_, _], A, B](f: F[A, B]): ACatenable1[F, A, B] =
+    Lift(f)
+}

--- a/base/shared/src/main/scala/scalaz/data/AList.scala
+++ b/base/shared/src/main/scala/scalaz/data/AList.scala
@@ -1,0 +1,174 @@
+package scalaz
+package data
+
+import Prelude._
+import scala.annotation.tailrec
+import scalaz.typeclass.{Category, Compose}
+
+/**
+ * A potentially empty type-aligned list.
+ * Example:
+ *
+ * {{{
+ * F[A, X], F[X, Y], F[Y, Z], F[Z, B]
+ * }}}
+ *
+ * The empty case witnesses type equality between `A` and `B`.
+ */
+sealed abstract class AList[F[_, _], A, B] {
+  import AList._
+
+  def ::[Z](fza: F[Z, A]): AList[F, Z, B] = ACons(fza, this)
+
+  def +:[Z](fza: F[Z, A]): AList1[F, Z, B] = ACons1(fza, this)
+
+  def :::[Z](that: AList[F, Z, A]): AList[F, Z, B] =
+    that.reverse reverse_::: this
+
+  def reverse: Composed[F, A, B] = {
+    @tailrec def go(p: APair[AList[F, ?, B], Composed[F, A, ?]]): Composed[F, A, B] = {
+      val (fs, acc) = (p._1, p._2)
+      fs match {
+        case ACons(h, t)  => go(APair.of[AList[F, ?, B], Composed[F, A, ?]](t, h :: acc))
+        case nil @ ANil() => nil.subst[Composed[F, A, ?]](acc)
+      }
+    }
+    go(APair.of[AList[F, ?, B], Composed[F, A, ?]](this, empty[λ[(α, β) => F[β, α]], A]))
+  }
+
+  def reverse_:::[Z](that: Composed[F, Z, A]): AList[F, Z, B] = {
+    @tailrec def go[G[_, _]](p: APair[AList[G, ?, Z], Composed[G, B, ?]]): Composed[G, B, Z] = {
+      val (gs, acc) = (p._1, p._2)
+      gs match {
+        case ACons(g, gs) => go(APair.of[AList[G, ?, Z], Composed[G, B, ?]](gs, g :: acc))
+        case nil @ ANil() => nil.subst[Composed[G, B, ?]](acc)
+      }
+    }
+    go[λ[(α, β) => F[β, α]]](APair.of[AList[λ[(α, β) => F[β, α]], ?, Z], Composed[λ[(α, β) => F[β, α]], B, ?]](that, this))
+  }
+
+  def foldLeft[G[_]](ga: G[A])(φ: RightAction[G, F]): G[B] = {
+    @tailrec def go(p: APair[G, AList[F, ?, B]]): G[B] = {
+      val (g, fs) = (p._1, p._2)
+      fs match {
+        case ACons(h, t)  => go(APair.of[G, AList[F, ?, B]](φ.apply(g, h), t))
+        case nil @ ANil() => nil.subst(g)
+      }
+    }
+    go(APair.of[G, AList[F, ?, B]](ga, this))
+  }
+
+  def foldRight[G[_]](gb: G[B])(φ: LeftAction[G, F]): G[A] =
+    reverse.foldLeft(gb)(RightAction.fromLeft(φ))
+
+  /**
+   * Compose the elements of this list in a balanced binary fashion.
+   */
+  def fold(implicit F: Category[F]): F[A, B] =
+    this match {
+      case ACons(h, t)  => t.foldLeft[PostComposeBalancer[F, A, ?]](PostComposeBalancer(h))(PostComposeBalancer.rightAction).result
+      case nil @ ANil() => nil.subst[F[A, ?]](F.id[A])
+    }
+
+  /**
+   * Compose the elements of this list in a balanced binary fashion.
+   */
+  def foldMaybe(implicit F: Compose[F]): AMaybe[F, A, B] =
+    this match {
+      case ACons(h, t)  => AJust(t.foldLeft[PostComposeBalancer[F, A, ?]](PostComposeBalancer(h))(PostComposeBalancer.rightAction).result)
+      case nil @ ANil() => nil.subst[AMaybe[F, A, ?]](AMaybe.empty[F, A])
+    }
+
+  /**
+   * Map and then compose the elements of this list in a balanced binary fashion.
+   */
+  def foldMap[G[_, _]](φ: F ~~> G)(implicit G: Category[G]): G[A, B] =
+    this match {
+      case ACons(h, t)  => t.foldLeft[PostComposeBalancer[G, A, ?]](PostComposeBalancer(φ.apply(h)))(PostComposeBalancer.rightAction(φ)).result
+      case nil @ ANil() => nil.subst[G[A, ?]](G.id[A])
+    }
+
+  /**
+   * Map and then compose the elements of this list in a balanced binary fashion.
+   */
+  def foldMapMaybe[G[_, _]](φ: F ~~> G)(implicit G: Compose[G]): AMaybe[G, A, B] =
+    this match {
+      case ACons(h, t)  => AJust(t.foldLeft[PostComposeBalancer[G, A, ?]](PostComposeBalancer(φ.apply(h)))(PostComposeBalancer.rightAction(φ)).result)
+      case nil @ ANil() => nil.subst[AMaybe[G, A, ?]](AMaybe.empty[G, A])
+    }
+
+  def map[G[_, _]](φ: F ~~> G): AList[G, A, B] =
+    foldRight[AList[G, ?, B]](empty[G, B])(ν[LeftAction[AList[G, ?, B], F]][α, β]((f, gs) => φ.apply(f) :: gs))
+
+  def flatMap[G[_, _]](φ: F ~~> AList[G, ?, ?]): AList[G, A, B] =
+    foldRight[AList[G, ?, B]](empty[G, B])(ν[LeftAction[AList[G, ?, B], F]][α, β]((f, gs) => φ.apply(f) ::: gs))
+
+  def size: Int = {
+    @tailrec def go(acc: Int, fs: AList[F, _, _]): Int = fs match {
+      case ACons(_, t) => go(acc + 1, t)
+      case ANil()      => acc
+    }
+    go(0, this)
+  }
+
+  override def toString: String =
+    mkString("AList(", ", ", ")")
+
+  def mkString(prefix: String, delim: String, suffix: String): String =
+    this match {
+      case ANil()      => s"$prefix$suffix"
+      case ACons(h, t) =>
+        val sb = new StringBuilder(prefix)
+        type SB[a] = StringBuilder
+        t.foldLeft[SB]( sb.append(h.toString)
+                     )( ν[RightAction[SB, F]][α, β]((buf, f) => buf.append(delim).append(f.toString))
+                     ).append(suffix).toString
+  }
+}
+
+final case class ACons[F[_, _], A, X, B](head: F[A, X], tail: AList[F, X, B]) extends AList[F, A, B] {
+  final type Pivot = X
+}
+
+sealed abstract case class ANil[F[_, _], A, B]() extends AList[F, A, B] {
+  def   subst[G[_]](ga: G[A]): G[B]
+  def unsubst[G[_]](gb: G[B]): G[A]
+  def leibniz: A === B = subst[A === ?](Leibniz.refl[A])
+}
+
+object AList {
+  /**
+   * Reversed type-aligned list is type-aligned with flipped type constructor.
+   * For example, when we reverse
+   *
+   * {{{
+   * A => B, B => C, C => D, D => E
+   * }}}
+   *
+   * we get
+   *
+   * {{{
+   * D => E, C => D, B => C, A => B
+   * }}}
+   *
+   * which is type-aligned if we flip the arrows:
+   *
+   * {{{
+   * E <= D, D <= C, C <= B, B <= A
+   * }}}
+   *
+   * The first list has type `AList[=>, A, E]`, while
+   * the reversed list has type `Composed[=>, A, E]`.
+   */
+  type Composed[F[_, _], A, B] = AList[λ[(α, β) => F[β, α]], B, A]
+
+  def apply[F[_, _], A](): AList[F, A, A] = empty
+  def apply[F[_, _], A, B](f: F[A, B]): AList[F, A, B] = f :: empty
+  def empty[F[_, _], A]: AList[F, A, A] = Nil.asInstanceOf[AList[F, A, A]]
+
+  private val Nil = nil[Nothing, Nothing]
+  private def nil[F[_, _], A]: ANil[F, A, A] = new ANil[F, A, A] {
+    def   subst[G[_]](ga: G[A]): G[A] = ga
+    def unsubst[G[_]](gb: G[A]): G[A] = gb
+  }
+}

--- a/base/shared/src/main/scala/scalaz/data/AList1.scala
+++ b/base/shared/src/main/scala/scalaz/data/AList1.scala
@@ -1,0 +1,137 @@
+package scalaz
+package data
+
+import Prelude._
+import scalaz.typeclass.Compose
+
+
+/**
+ * Type-aligned list with at least 1 element.
+ * Example:
+ *
+ * {{{
+ * F[A, X], F[X, Y], F[Y, Z], F[Z, B]
+ * }}}
+ */
+sealed abstract class AList1[F[_, _], A, B] {
+  import AList1._
+
+  type Pivot
+
+  def head: F[A, Pivot]
+  def tail: AList[F, Pivot, B]
+
+  def ::[Z](fza: F[Z, A]): AList1[F, Z, B] =
+    ACons1(fza, this.toList)
+
+  def :+[C](f: F[B, C]): AList1[F, A, C] =
+    this ::: AList1(f)
+
+  def :::[Z](that: AList1[F, Z, A]): AList1[F, Z, B] =
+    that.reverse reverse_::: this
+
+  def :++[C](that: AList[F, B, C]): AList1[F, A, C] = {
+    type FXB[X] = F[X, B]
+    type FXC[X] = AList1[F, X, C]
+    foldRight1[AList1[F, ?, C]]             (
+      ∀.mk[FXB ~> FXC].from(_ +: that)     )(
+      ν[LeftAction[FXC, F]][α, β](_ :: _)  )
+  }
+
+  def reverse_:::[Z](that: Composed1[F, Z, A]): AList1[F, Z, B] =
+    that.toList reverse_::: this
+
+  def reverse: Composed1[F, A, B] = 
+    tail reverse_::: AList1[λ[(α, β) => F[β, α]], Pivot, A](head)
+
+  def :::[Z](that: AList[F, Z, A]): AList1[F, Z, B] =
+    (that ::: this.toList) match {
+      case ACons(h, t) => ACons1(h, t)
+      case ANil()      => sys.error("unreachable code")
+    }
+
+  def reverse_:::[Z](that: AList.Composed[F, Z, A]): AList1[F, Z, B] =
+    (that reverse_::: this.toList) match {
+      case ACons(h, t) => ACons1(h, t)
+      case ANil()      => sys.error("unreachable code")
+    }
+
+  def uncons: Either[F[A, B], APair[F[A, ?], AList1[F, ?, B]]] =
+    tail match {
+      case ev @ ANil() => Left(ev.subst[F[A, ?]](head))
+      case ACons(h, t) => Right(APair.of[F[A, ?], AList1[F, ?, B]](head, ACons1(h, t)))
+    }
+
+  def foldLeft[G[_]](ga: G[A])(φ: RightAction[G, F]): G[B] =
+    tail.foldLeft[G](φ.apply(ga, head))(φ)
+
+  def foldLeft1[G[_]](init: F[A, ?] ~> G)(φ: RightAction[G, F]): G[B] =
+    tail.foldLeft[G](init.apply(head))(φ)
+
+  def foldRight[G[_]](gb: G[B])(φ: LeftAction[G, F]): G[A] =
+    reverse.foldLeft(gb)(RightAction.fromLeft(φ))
+
+  def foldRight1[G[_]](init: F[?, B] ~> G)(φ: LeftAction[G, F]): G[A] =
+    reverse.foldLeft1[G](init)(RightAction.fromLeft(φ))
+
+  /**
+   * Compose the elements of this list in a balanced binary fashion.
+   */
+  def fold(implicit F: Compose[F]): F[A, B] =
+    tail.foldLeft[PostComposeBalancer[F, A, ?]](PostComposeBalancer(head))(PostComposeBalancer.rightAction).result
+
+  /**
+   * Map and then compose the elements of this list in a balanced binary fashion.
+   */
+  def foldMap[G[_, _]](φ: F ~~> G)(implicit G: Compose[G]): G[A, B] =
+    tail.foldLeft[PostComposeBalancer[G, A, ?]](PostComposeBalancer(φ.apply(head)))(PostComposeBalancer.rightAction(φ)).result
+
+  def map[G[_, _]](φ: F ~~> G): AList1[G, A, B] =
+    ACons1(φ.apply(head), tail.map(φ))
+
+  def flatMap[G[_, _]](φ: F ~~> AList1[G, ?, ?]): AList1[G, A, B] = {
+    type FXB[X] = F[X, B]
+    type GXB[X] = AList1[G, X, B]
+    foldRight1[AList1[G, ?, B]](∀.mk[FXB ~> GXB].from(φ.apply(_)))(ν[LeftAction[AList1[G, ?, B], F]][α, β]((f, gs) => φ.apply(f) ::: gs))
+  }
+
+  def size: Int = 1 + tail.size
+
+  def toList: AList[F, A, B] = head :: tail
+
+  override def toString: String = toList.mkString("AList1(", ", ", ")")
+}
+
+final case class ACons1[F[_, _], A, X, B](head: F[A, X], tail: AList[F, X, B]) extends AList1[F, A, B] {
+  type Pivot = X
+}
+
+object AList1 {
+  /**
+   * Reversed type-aligned list is type-aligned with flipped type constructor.
+   * For example, when we reverse
+   *
+   * {{{
+   * A => B, B => C, C => D, D => E
+   * }}}
+   *
+   * we get
+   *
+   * {{{
+   * D => E, C => D, B => C, A => B
+   * }}}
+   *
+   * which is type-aligned if we flip the arrows:
+   *
+   * {{{
+   * E <= D, D <= C, C <= B, B <= A
+   * }}}
+   *
+   * The first list has type `AList1[=>, A, E]`, while
+   * the reversed list has type `Composed1[=>, A, E]`.
+   */
+  type Composed1[F[_, _], A, B] = AList1[λ[(α, β) => F[β, α]], B, A]
+
+  def apply[F[_, _], A, B](f: F[A, B]): AList1[F, A, B] = ACons1(f, AList.empty)
+  def op[F[_, _], A, B](f: F[A, B]): Composed1[F, A, B] = apply[λ[(α, β) => F[β, α]], B, A](f)
+}

--- a/base/shared/src/main/scala/scalaz/data/AMaybe.scala
+++ b/base/shared/src/main/scala/scalaz/data/AMaybe.scala
@@ -1,0 +1,29 @@
+package scalaz
+package data
+
+/** Similar to `Option[F[A, B]]`, except that
+  * the empty case witnesses type equality between `A` and `B`.
+  */
+sealed abstract class AMaybe[F[_, _], A, B]
+
+case class AJust[F[_, _], A, B](value: F[A, B]) extends AMaybe[F, A, B]
+
+/**
+  * The empty case contains evidence of type equality
+  * to overcome the limitations of pattern-matching on GADTs.
+  */
+sealed abstract case class AEmpty[F[_, _], A, B]() extends AMaybe[F, A, B] {
+  def   subst[G[_]](ga: G[A]): G[B]
+  def unsubst[G[_]](gb: G[B]): G[A]
+  def leibniz: A === B = subst[A === ?](Leibniz.refl)
+}
+
+object AMaybe {
+  def empty[F[_, _], A]: AMaybe[F, A, A] = None.asInstanceOf[AMaybe[F, A, A]]
+
+  private val None = none[Nothing, Nothing]
+  private def none[F[_, _], A]: AMaybe[F, A, A] = new AEmpty[F, A, A] {
+    def   subst[G[_]](ga: G[A]): G[A] = ga
+    def unsubst[G[_]](gb: G[A]): G[A] = gb
+  }
+}

--- a/base/shared/src/main/scala/scalaz/data/APair.scala
+++ b/base/shared/src/main/scala/scalaz/data/APair.scala
@@ -1,0 +1,33 @@
+package scalaz
+package data
+
+/**
+ * Type-aligned pair with upper-bounded type parameter. Isomorphic to
+ *
+ * {{{
+ * (F[A], G[A]) forSome { type A <: U }
+ * }}}
+ *
+ * but more robust with respect to type inference.
+ */
+sealed abstract class BoundedAPair[U, F[_ <: U], G[_ <: U]] {
+  type Pivot <: U
+  val _1: F[Pivot]
+  val _2: G[Pivot]
+}
+
+object BoundedAPair {
+  def apply[U, F[_ <: U], G[_ <: U], A <: U](fa: F[A], ga: G[A]): BoundedAPair[U, F, G] =
+    new BoundedAPair[U, F, G] { type Pivot = A; val _1 = fa; val _2 = ga }
+
+  def unapply[U, F[_ <: U], G[_ <: U]](p: BoundedAPair[U, F, G]): Option[(F[p.Pivot], G[p.Pivot])] =
+    Some((p._1, p._2))
+
+  /** Defer specifying `A`, so that it could possibly be inferred. */
+  def of[U, F[_ <: U], G[_ <: U]]: Builder[U, F, G] = new Builder[U, F, G]
+
+  class Builder[U, F[_ <: U], G[_ <: U]] {
+    def apply[A <: U](fa: F[A], ga: G[A]): BoundedAPair[U, F, G] =
+      BoundedAPair[U, F, G, A](fa, ga)
+  }
+}

--- a/base/shared/src/main/scala/scalaz/data/balanced.scala
+++ b/base/shared/src/main/scala/scalaz/data/balanced.scala
@@ -1,0 +1,80 @@
+package scalaz
+package data
+
+import Prelude._
+import scalaz.typeclass.Compose
+
+/**
+ * Binary counter-like accumulator for type-aligned binary type constructors,
+ * with the most significant bit on the right and addition of new elements (i.e. "increment") from the left.
+ */
+final class PreComposeBalancer[F[_, _], A, B] private(count: Int, stack: AList1[F, A, B]) {
+
+  /** Pre-compose an element. */
+  def +:[Z](f: F[Z, A])(implicit F: Compose[F]): PreComposeBalancer[F, Z, B] =
+    add(f, stack, 1, count)
+
+  def result(implicit F: Compose[F]): F[A, B] =
+    stack.tail.foldLeft(stack.head)(RightAction.compose(F))
+
+  private def add[X, Y](h: F[X, Y], t: AList1[F, Y, B], hcount: Int, tfactor: Int)(implicit F: Compose[F]): PreComposeBalancer[F, X, B] = {
+    // hcount: number of elemnts composed in the head (`h`)
+    // tfactor: how many times more elements are there in tail (`t`) than in head (tcount = hcount * tfactor)
+    if(tfactor % 2 == 0) new PreComposeBalancer(hcount * (tfactor + 1), h :: t)
+    else {
+      val h1 = F.compose(t.head, h)
+      val h1count = hcount * 2
+      t.tail match {
+        case nil @ ANil() => assert(tfactor == 1); new PreComposeBalancer(h1count, h1 +: nil)
+        case ACons(f, fs) => add(h1, f +: fs, h1count, tfactor / 2)
+      }
+    }
+  }
+}
+
+object PreComposeBalancer {
+
+  def apply[F[_, _], A, B](f: F[A, B]): PreComposeBalancer[F, A, B] =
+    new PreComposeBalancer(1, AList1(f))
+
+  def leftAction[F[_, _], Z](implicit F: Compose[F]): LeftAction[PreComposeBalancer[F, ?, Z], F] =
+    ν[LeftAction[PreComposeBalancer[F, ?, Z], F]][X, Y]((f, acc) => f +: acc)
+
+  def leftAction[G[_, _], F[_, _], Z](φ: F ~~> G)(implicit G: Compose[G]): LeftAction[PreComposeBalancer[G, ?, Z], F] =
+    ν[LeftAction[PreComposeBalancer[G, ?, Z], F]][X, Y]((f, acc) => φ.apply(f) +: acc)
+}
+
+/**
+ * Binary counter-like accumulator for type-aligned binary type constructors,
+ * with the most significant bit on the left and addition of new elements (i.e. "increment") from the right.
+ */
+final class PostComposeBalancer[F[_, _], A, B](private val repr: PreComposeBalancer[λ[(α, β) => F[β, α]], B, A]) extends AnyVal {
+  import PostComposeBalancer._
+
+  /** Post-compose an element. */
+  def :+[C](f: F[B, C])(implicit F: Compose[F]): PostComposeBalancer[F, A, C] =
+    wrap((f +: repr)(flip(F)))
+
+  def result(implicit F: Compose[F]): F[A, B] =
+    repr.result(flip(F))
+}
+
+object PostComposeBalancer {
+  def apply[F[_, _], A, B](f: F[A, B]): PostComposeBalancer[F, A, B] =
+    wrap(PreComposeBalancer[λ[(α, β) => F[β, α]], B, A](f))
+
+  def wrap[F[_, _], A, B](pre: PreComposeBalancer[λ[(α, β) => F[β, α]], B, A]): PostComposeBalancer[F, A, B] =
+    new PostComposeBalancer[F, A, B](pre)
+
+  def rightAction[F[_, _], A](implicit F: Compose[F]): RightAction[PostComposeBalancer[F, A, ?], F] =
+    ν[RightAction[PostComposeBalancer[F, A, ?], F]][B, C]((acc, f) => acc :+ f)
+
+  def rightAction[G[_, _], F[_, _], A](φ: F ~~> G)(implicit G: Compose[G]): RightAction[PostComposeBalancer[G, A, ?], F] =
+    ν[RightAction[PostComposeBalancer[G, A, ?], F]][B, C]((acc, f) => acc :+ φ.apply(f))
+
+  private def flip[F[_, _]](F: Compose[F]): Compose[λ[(α, β) => F[β, α]]] =
+    new Compose[λ[(α, β) => F[β, α]]] {
+      def compose[A, B, C](f: F[C, B], g: F[B, A]): F[C, A] =
+        F.compose(g, f)
+    }
+}

--- a/base/shared/src/main/scala/scalaz/data/package.scala
+++ b/base/shared/src/main/scala/scalaz/data/package.scala
@@ -1,5 +1,7 @@
 package scalaz
 
+import typeclass.Compose
+
 package object data {
   val Forall: ForallModule with ForallSyntax = ForallImpl
   val ∀ : Forall.type = Forall
@@ -12,4 +14,61 @@ package object data {
 
   type Forall2[F[_, _]] = Forall2.Forall2[F]
   type ∀∀[F[_, _]] = Forall2[F]
+
+  type ~>[F[_], G[_]] = ∀[λ[α => F[α] => G[α]]]
+  type ~~>[F[_, _], G[_, _]] = ∀∀[λ[(α, β) => F[α, β] => G[α, β]]]
+
+  /**
+   * Type-aligned pair. Isomorphic to
+   *
+   * {{{
+   * (F[A], G[A]) forSome { type A }
+   * }}}
+   *
+   * but more robust with respect to type inference.
+   */
+  type APair[F[_], G[_]] = BoundedAPair[Any, F, G]
+
+  object APair {
+    def apply[F[_], G[_], A](fa: F[A], ga: G[A]): APair[F, G] =
+      BoundedAPair[Any, F, G, A](fa, ga)
+
+    def unapply[F[_], G[_]](p: APair[F, G]): Option[(F[p.Pivot], G[p.Pivot])] =
+      Some((p._1, p._2))
+
+    /** Defer specifying `A`, so that it could possibly be inferred. */
+    def of[F[_], G[_]] = BoundedAPair.of[Any, F, G]
+  }
+
+  /** Type-aligned right action of `F` on `G`. */
+  type RightAction[G[_], F[_, _]] = Forall2.Prototype[λ[(α, β) => (G[α], F[α, β]) => G[β]]]
+
+  object RightAction {
+
+    def fromLeft[G[_], F[_, _]](act: LeftAction[G, F]): RightAction[G, λ[(α, β) => F[β, α]]] =
+      ν[RightAction[G, λ[(α, β) => F[β, α]]]][α, β]((g, f) => act.apply(f, g))
+
+    def compose[F[_, _], A](implicit F: Compose[F]): RightAction[F[A, ?], F] =
+      ν[RightAction[F[A, ?], F]][α, β]((fa, f) => F.compose(f, fa))
+
+    implicit class Ops[G[_], F[_, _]](val action: RightAction[G, F]) extends AnyVal {
+      def apply[A, B](g: G[A], f: F[A, B]): G[B] = action.apply(g, f)
+    }
+  }
+
+  /** Type-aligned left action of `F` on `G`. */
+  type LeftAction[G[_], F[_, _]] = Forall2.Prototype[λ[(α, β) => (F[α, β], G[β]) => G[α]]]
+
+  object LeftAction {
+
+    def fromRight[G[_], F[_, _]](act: RightAction[G, F]): LeftAction[G, λ[(α, β) => F[β, α]]] =
+      ν[LeftAction[G, λ[(α, β) => F[β, α]]]][α, β]((f, g) => act.apply(g, f))
+
+    def compose[F[_, _], Z](implicit F: Compose[F]): LeftAction[F[?, Z], F] =
+      ν[LeftAction[F[?, Z], F]][α, β]((f, fy) => F.compose(fy, f))
+
+    implicit class Ops[G[_], F[_, _]](val action: LeftAction[G, F]) extends AnyVal {
+      def apply[A, B](f: F[A, B], g: G[B]): G[A] = action.apply(f, g)
+    }
+  }
 }

--- a/project/ScalazBuild.scala
+++ b/project/ScalazBuild.scala
@@ -42,6 +42,7 @@ object Scalaz {
       ),
     libraryDependencies ++= compileOnlyDeps ++ testDeps ++ Seq(
       compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.4"),
+      compilerPlugin("com.github.tomasmikula" %% "pascal" % "0.1"),
       compilerPlugin("com.github.ghik" %% "silencer-plugin" % "0.5")
     ),
     incOptions ~= (_.withLogRecompileOnMacro(false))


### PR DESCRIPTION
 - **`AMaybe[F[_, _], A, B]`:** Similar to `Maybe[F[A, B]]`, but the empty case witnesses type equality between `A` and `B`.
 - **`APair[F[_], G[_]]`:** Isomorphic to `(F[A], G[A]) forSome { type A }`, but more robust with respect to type inference.
 - **`AList[F[_, _], A, B]`:** Type-aligned list. Empty list witnesses type equality between `A` and `B`.
 - **`AList1[F[_, _], A, B]`:** Non-empty type-aligned list.
 - **`ACatenable1[F[_, _], A, B]`:** Non-empty type-aligned sequence with _O(1)_ `cons`, `snoc` and concatenation.

All sequence data types (`AList`, `AList1`, `ACatenable1`) are folded in balanced binary fashion (analogous to what @S11001001 did in #1022).

The [P∀scal compiler plugin](https://github.com/TomasMikula/pascal) was added to help with creation of some polymorphic values.