### PR TITLE
Remove implicit Unapply instances that under -Ypartial-unification are covered by another case.

### DIFF
--- a/core/src/main/scala/scalaz/Unapply.scala
+++ b/core/src/main/scala/scalaz/Unapply.scala
@@ -66,21 +66,7 @@ trait Unapply[TC[_[_]], MA] {
   @inline final def apply(ma: MA): M[A] = leibniz(ma)
 }
 
-sealed abstract class Unapply_5 {
-  /**Unpack a value of type `M0[F[_], A0, B0, C0, D0, E0]` into types `[e]M0[F, A0, B0, C0, D0, e]` and `E0`, given an instance of `TC` */
-  implicit def unapplyMFABCDE5[TC[_[_]], F[_], M0[F[_], _, _, _, _, _], A0, B0, C0, D0, E0](implicit TC0: TC[M0[F, A0, B0, C0, D0, ?]]): Unapply[TC, M0[F, A0, B0, C0, D0, E0]] {
-    type M[X] = M0[F, A0, B0, C0, D0, X]
-    type A = E0
-  } =
-    new Unapply[TC, M0[F, A0, B0, C0, D0, E0]] {
-      type M[X] = M0[F, A0, B0, C0, D0, X]
-      type A = E0
-      def TC = TC0
-      def leibniz = refl
-    }
-}
-
-sealed abstract class Unapply_4 extends Unapply_5 {
+sealed abstract class Unapply_4 {
   // /** Unpack a value of type `A0` into type `[a]A0`, given a instance of `TC` */
   implicit def unapplyA[TC[_[_]], A0](implicit TC0: TC[λ[α => A0]]): Unapply[TC, A0] {
     type M[X] = A0
@@ -106,24 +92,9 @@ sealed abstract class Unapply_3 extends Unapply_4 {
       def TC = TC0
       def leibniz = refl
     }
-
-  /**Unpack a value of type `M0[F[_], A0, B0, C0]` into types `[c]M0[F, A0, B0, c]` and `C0`, given an instance of `TC` */
-  implicit def unapplyMFABC3[TC[_[_]], F[_], M0[F[_], _, _, _], A0, B0, C0](implicit TC0: TC[M0[F, A0, B0, ?]]): Unapply[TC, M0[F, A0, B0, C0]] {
-    type M[X] = M0[F, A0, B0, X]
-    type A = C0
-  } =
-    new Unapply[TC, M0[F, A0, B0, C0]] {
-      type M[X] = M0[F, A0, B0, X]
-      type A = C0
-      def TC = TC0
-      def leibniz = refl
-    }
 }
 
 sealed abstract class Unapply_2 extends Unapply_3 {
-  // Things get tricky with type State[S, A] = StateT[Id, S, A], both unapplyMAB2 and unapplyMFAB2 are applicable
-  // Without characterizing this fully, I'm using the standard implicit prioritization to avoid this.
-
   /**Unpack a value of type `M0[F[_], A0, B0]` into types `[a]M0[F, a, B0]` and `A0`, given an instance of `TC` */
   implicit def unapplyMFAB1[TC[_[_]], F[_], M0[F[_], _, _], A0, B0](implicit TC0: TC[M0[F, ?, B0]]): Unapply[TC, M0[F, A0, B0]] {
     type M[X] = M0[F, X, B0]
@@ -135,98 +106,10 @@ sealed abstract class Unapply_2 extends Unapply_3 {
       def TC = TC0
       def leibniz = refl
     }
-
-  /**Unpack a value of type `M0[F[_], A0, B0]` into types `[b]M0[F, A0, b]` and `B0`, given an instance of `TC` */
-  implicit def unapplyMFAB2[TC[_[_]], F[_], M0[F[_], _, _], A0, B0](implicit TC0: TC[M0[F, A0, ?]]): Unapply[TC, M0[F, A0, B0]] {
-    type M[X] = M0[F, A0, X]
-    type A = B0
-  } =
-    new Unapply[TC, M0[F, A0, B0]] {
-      type M[X] = M0[F, A0, X]
-      type A = B0
-      def TC = TC0
-      def leibniz = refl
-    }
 }
 
-sealed abstract class Unapply_1 extends Unapply_2 {
-  /**Unpack a value of type `M0[A0, B0, C0, D0, E0, F0, G0]` into types `[g]M0[A0, B0, C0, D0, E0, F0, g]` and `G0`, given an instance of `TC` */
-  implicit def unapplyMABCDEFG7[TC[_[_]], M0[_, _, _, _, _, _, _], A0, B0, C0, D0, E0, F0, G0](implicit TC0: TC[M0[A0, B0, C0, D0, E0, F0, ?]]): Unapply[TC, M0[A0, B0, C0, D0, E0, F0, G0]] {
-    type M[X] = M0[A0, B0, C0, D0, E0, F0, X]
-    type A = G0
-  } =
-    new Unapply[TC, M0[A0, B0, C0, D0, E0, F0, G0]] {
-      type M[X] = M0[A0, B0, C0, D0, E0, F0, X]
-      type A = G0
-      def TC = TC0
-      def leibniz = refl
-    }
-
-  /**Unpack a value of type `M0[A0, B0, C0, D0, E0, F0]` into types `[f]M0[A0, B0, C0, D0, E0, f]` and `F0`, given an instance of `TC` */
-  implicit def unapplyMABCDEF6[TC[_[_]], M0[_, _, _, _, _, _], A0, B0, C0, D0, E0, F0](implicit TC0: TC[M0[A0, B0, C0, D0, E0, ?]]): Unapply[TC, M0[A0, B0, C0, D0, E0, F0]] {
-    type M[X] = M0[A0, B0, C0, D0, E0, X]
-    type A = F0
-  } =
-    new Unapply[TC, M0[A0, B0, C0, D0, E0, F0]] {
-      type M[X] = M0[A0, B0, C0, D0, E0, X]
-      type A = F0
-      def TC = TC0
-      def leibniz = refl
-    }
-
-  /**Unpack a value of type `M0[A0, B0, C0, D0, E0]` into types `[e]M0[A0, B0, C0, D0, e]` and `E0`, given an instance of `TC` */
-  implicit def unapplyMABCDE5[TC[_[_]], M0[_, _, _, _, _], A0, B0, C0, D0, E0](implicit TC0: TC[M0[A0, B0, C0, D0, ?]]): Unapply[TC, M0[A0, B0, C0, D0, E0]] {
-    type M[X] = M0[A0, B0, C0, D0, X]
-    type A = E0
-  } =
-    new Unapply[TC, M0[A0, B0, C0, D0, E0]] {
-      type M[X] = M0[A0, B0, C0, D0, X]
-      type A = E0
-      def TC = TC0
-      def leibniz = refl
-    }
-
-  /**Unpack a value of type `M0[A0, B0, C0, D0]` into types `[d]M0[A0, B0, C0, d]` and `D0`, given an instance of `TC` */
-  implicit def unapplyMABCD4[TC[_[_]], M0[_, _, _, _], A0, B0, C0, D0](implicit TC0: TC[M0[A0, B0, C0, ?]]): Unapply[TC, M0[A0, B0, C0, D0]] {
-    type M[X] = M0[A0, B0, C0, X]
-    type A = D0
-  } =
-    new Unapply[TC, M0[A0, B0, C0, D0]] {
-      type M[X] = M0[A0, B0, C0, X]
-      type A = D0
-      def TC = TC0
-      def leibniz = refl
-    }
-
-  /**Unpack a value of type `M0[A0, B0, C0]` into types `[c]M0[A0, B0, c]` and `C0`, given an instance of `TC` */
-  implicit def unapplyMABC3[TC[_[_]], M0[_, _, _], A0, B0, C0](implicit TC0: TC[M0[A0, B0, ?]]): Unapply[TC, M0[A0, B0, C0]] {
-    type M[X] = M0[A0, B0, X]
-    type A = C0
-  } =
-    new Unapply[TC, M0[A0, B0, C0]] {
-      type M[X] = M0[A0, B0, X]
-      type A = C0
-      def TC = TC0
-      def leibniz = refl
-    }
-}
-
-sealed abstract class Unapply_0 extends Unapply_1 {
-  /** Unpack a value of type `M0[F0, A0]` where `F0: * -> *` into
-    * types `[a]M0[F0, a]` and `A`, given an instance of `TC`
-    */
-  implicit def unapplyMFA[TC[_[_]], M0[_[_], _], F0[_], A0](implicit TC0: TC[M0[F0, ?]]): Unapply[TC, M0[F0, A0]] {
-    type M[X] = M0[F0, X]
-    type A = A0
-  } =
-    new Unapply[TC, M0[F0, A0]] {
-      type M[X] = M0[F0, X]
-      type A = A0
-      def TC = TC0
-      def leibniz = refl
-    }
-
-  /**Unpack a value of type `M0[A0, B0]` into types `[a]M0[a, B0]` and `A`, given an instance of `TC` */
+sealed abstract class Unapply_0 extends Unapply_2 {
+  /**Unpack a value of type `M0[A0, B0]` into types `[a]M0[a, B0]` and `A0`, given an instance of `TC` */
   implicit def unapplyMAB1[TC[_[_]], M0[_, _], A0, B0](implicit TC0: TC[M0[?, B0]]): Unapply[TC, M0[A0, B0]] {
     type M[X] = M0[X, B0]
     type A = A0
@@ -234,18 +117,6 @@ sealed abstract class Unapply_0 extends Unapply_1 {
     new Unapply[TC, M0[A0, B0]] {
       type M[X] = M0[X, B0]
       type A = A0
-      def TC = TC0
-      def leibniz = refl
-    }
-
-  /**Unpack a value of type `M0[A0, B0]` into types `[b]M0[A0, b]` and `B`, given an instance of `TC` */
-  implicit def unapplyMAB2[TC[_[_]], M0[_, _], A0, B0](implicit TC0: TC[M0[A0, ?]]): Unapply[TC, M0[A0, B0]] {
-    type M[X] = M0[A0, X]
-    type A = B0
-  } =
-    new Unapply[TC, M0[A0, B0]] {
-      type M[X] = M0[A0, X]
-      type A = B0
       def TC = TC0
       def leibniz = refl
     }
@@ -274,17 +145,6 @@ object Unapply extends Unapply_0 {
       def leibniz = refl
     }
 
-  /** Turns a MonadTrans-like instance that has two params and turns it into an M[A] */
-  implicit def unapplyMTMAB[TC[_[_]], MT[_[_], _], MAB[_, _], A0, A1](implicit TC0: TC[MT[MAB[A0,?], ?]]):
-    Unapply[TC, MT[MAB[A0, ?], A1]] {
-      type M[X] = MT[MAB[A0, ?], X]
-      type A = A1
-    } = new Unapply[TC, MT[MAB[A0, ?], A1]] {
-      type M[X] = MT[MAB[A0, ?], X]
-      type A = A1
-      def TC = TC0
-      def leibniz = Leibniz.refl
-    }
   // TODO More!
 }
 
@@ -309,23 +169,7 @@ trait Unapply2[TC[_[_, _]], MAB] {
   @inline final def apply(ma: MAB): M[A, B] = leibniz(ma)
 }
 
-sealed abstract class Unapply2_0 {
-  /**Unpack a value of type `M0[F[_], A0, B0]` into types `[a, b]=M0[F, a, b]`, `A0`, and 'B9', given an instance of `TC` */
-  implicit def unapplyMFAB[TC[_[_, _]], F[_], M0[F[_], _, _], A0, B0](implicit TC0: TC[M0[F, ?, ?]]): Unapply2[TC, M0[F, A0, B0]] {
-    type M[X, Y] = M0[F, X, Y]
-    type A = A0
-    type B = B0
-  } =
-    new Unapply2[TC, M0[F, A0, B0]] {
-      type M[X, Y] = M0[F, X, Y]
-      type A = A0
-      type B = B0
-      def TC = TC0
-      def leibniz = refl
-    }
-}
-
-object Unapply2 extends Unapply2_0 {
+object Unapply2 {
   /** Fetch a well-typed `Unapply2` for the given typeclass and type. */
   def apply[TC[_[_, _]], MAB](implicit U: Unapply2[TC, MAB]): U.type {
     type M[X, Y] = U.M[X, Y]

--- a/tests/src/test/scala/scalaz/UnapplyTest.scala
+++ b/tests/src/test/scala/scalaz/UnapplyTest.scala
@@ -3,6 +3,9 @@ package scalaz
 import Leibniz.===
 
 object UnapplyTest extends SpecLite {
+  def teq[A[_], B[X] >: A[X] <: A[X]]: Unit = ()
+  def teq2[A[_, _], B[X, Y] >: A[X, Y] <: A[X, Y]]: Unit = ()
+
   object unapply {
     val ue = Unapply[Monad, Int \/ String]
     def mequiv[A] = implicitly[ue.M[A] === (Int \/ A)]
@@ -24,98 +27,114 @@ object UnapplyTest extends SpecLite {
 
   object unapply3 {
     implicit def functorInstance[A]: Functor[λ[α => A]] = ???
-    implicitly[Unapply[Functor, String]]
+    val u = Unapply[Functor, String]
+    teq[u.M, λ[α => String]]
   }
 
   object unapply4 {
     class M0[F[_], A0, B0, C0, D0, E0]
     implicit def functorInstance: Functor[M0[Option, Int, Int, Int, Int, ?]] = ???
-    implicitly[Unapply[Functor, M0[Option, Int, Int, Int, Int, String]]]
+    val u = Unapply[Functor, M0[Option, Int, Int, Int, Int, String]]
+    teq[u.M, M0[Option, Int, Int, Int, Int, ?]]
   }
 
   object unapply5 {
     class M0[F[_], A0, A1, B0]
     implicit def functorInstance: Functor[λ[α => M0[Option, α, α, String]]] = ???
-    implicitly[Unapply[Functor, M0[Option, Int, Int, String]]]
+    val u = Unapply[Functor, M0[Option, Int, Int, String]]
+    teq[u.M, λ[α => M0[Option, α, α, String]]]
   }
 
   object unapply6 {
     class M0[F[_], A0, B0, C0]
     implicit def functorInstance: Functor[M0[Option, Int, Int, ?]] = ???
-    implicitly[Unapply[Functor, M0[Option, Int, Int, String]]]
+    val u = Unapply[Functor, M0[Option, Int, Int, String]]
+    teq[u.M, M0[Option, Int, Int, ?]]
   }
 
   object unapply7 {
     class M0[F[_], A0, B0]
     implicit def functorInstance: Functor[M0[Option, ?, String]] = ???
-    implicitly[Unapply[Functor, M0[Option, Int, String]]]
+    val u = Unapply[Functor, M0[Option, Int, String]]
+    teq[u.M, M0[Option, ?, String]]
   }
 
   object unapply8 {
     class M0[F[_], A0, B0]
     implicit def functorInstance: Functor[M0[Option, Int, ?]] = ???
-    implicitly[Unapply[Functor, M0[Option, Int, String]]]
+    val u = Unapply[Functor, M0[Option, Int, String]]
+    teq[u.M, M0[Option, Int, ?]]
   }
 
   object unapply9 {
     class M0[F[_], A0]
     implicit def functorInstance: Functor[M0[Option, ?]] = ???
-    implicitly[Unapply[Functor, M0[Option, String]]]
+    val u = Unapply[Functor, M0[Option, String]]
+    teq[u.M, M0[Option, ?]]
   }
 
   object unapply10 {
     class M0[A0, B0, C0, D0, E0, F0, G0]
     implicit def functorInstance: Functor[M0[Int, Int, Int, Int, Int, Int, ?]] = ???
-    implicitly[Unapply[Functor, M0[Int, Int, Int, Int, Int, Int, String]]]
+    val u = Unapply[Functor, M0[Int, Int, Int, Int, Int, Int, String]]
+    teq[u.M, M0[Int, Int, Int, Int, Int, Int, ?]]
   }
 
   object unapply11 {
     class M0[A0, B0, C0, D0, E0, F0]
     implicit def functorInstance: Functor[M0[Int, Int, Int, Int, Int, ?]] = ???
-    implicitly[Unapply[Functor, M0[Int, Int, Int, Int, Int, String]]]
+    val u = Unapply[Functor, M0[Int, Int, Int, Int, Int, String]]
+    teq[u.M, M0[Int, Int, Int, Int, Int, ?]]
   }
 
   object unapply12 {
     class M0[A0, B0, C0, D0, E0]
     implicit def functorInstance: Functor[M0[Int, Int, Int, Int, ?]] = ???
-    implicitly[Unapply[Functor, M0[Int, Int, Int, Int, String]]]
+    val u = Unapply[Functor, M0[Int, Int, Int, Int, String]]
+    teq[u.M, M0[Int, Int, Int, Int, ?]]
   }
 
   object unapply13 {
     class M0[A0, B0, C0, D0]
     implicit def functorInstance: Functor[M0[Int, Int, Int, ?]] = ???
-    implicitly[Unapply[Functor, M0[Int, Int, Int, String]]]
+    val u = Unapply[Functor, M0[Int, Int, Int, String]]
+    teq[u.M, M0[Int, Int, Int, ?]]
   }
 
   object unapply14 {
     class M0[A0, B0, C0]
     implicit def functorInstance: Functor[M0[Int, Int, ?]] = ???
-    implicitly[Unapply[Functor, M0[Int, Int, String]]]
+    val u = Unapply[Functor, M0[Int, Int, String]]
+    teq[u.M, M0[Int, Int, ?]]
   }
 
   object unapply15 {
     class M0[A0, B0]
     implicit def functorInstance: Functor[M0[Int, ?]] = ???
-    implicitly[Unapply[Functor, M0[Int, String]]]
+    val u = Unapply[Functor, M0[Int, String]]
+    teq[u.M, M0[Int, ?]]
   }
 
   object unapply16 {
     class M0[A0, B0]
     implicit def functorInstance: Functor[M0[?, String]] = ???
-    implicitly[Unapply[Functor, M0[Int, String]]]
+    val u = Unapply[Functor, M0[Int, String]]
+    teq[u.M, M0[?, String]]
   }
 
   object unapply17 {
     class MT[F[_], A]
     class MAB[A, B]
     implicit def functorInstance: Functor[MT[MAB[Int, ?], ?]] = ???
-    implicitly[Unapply[Functor, MT[MAB[Int, ?], String]]]
+    val u = Unapply[Functor, MT[MAB[Int, ?], String]]
+    teq[u.M, MT[MAB[Int, ?], ?]]
   }
 
   object unapply2_0 {
     class M0[F[_], A0, B0]
     implicit def bifunctorInstance: Bifunctor[M0[Option, ?, ?]] = ???
-    implicitly[Unapply2[Bifunctor, M0[Option, Int, String]]]
+    val u = Unapply2[Bifunctor, M0[Option, Int, String]]
+    teq2[u.M, M0[Option, ?, ?]]
   }
 
   object unapplyProduct {

--- a/tests/src/test/scala/scalaz/UnapplyTest.scala
+++ b/tests/src/test/scala/scalaz/UnapplyTest.scala
@@ -22,6 +22,102 @@ object UnapplyTest extends SpecLite {
     Unapply2[Arrow, Kleisli[NonEmptyList, Int, String]].TC: Arrow[Kleisli[NonEmptyList, ?, ?]]
   }
 
+  object unapply3 {
+    implicit def functorInstance[A]: Functor[λ[α => A]] = ???
+    implicitly[Unapply[Functor, String]]
+  }
+
+  object unapply4 {
+    class M0[F[_], A0, B0, C0, D0, E0]
+    implicit def functorInstance: Functor[M0[Option, Int, Int, Int, Int, ?]] = ???
+    implicitly[Unapply[Functor, M0[Option, Int, Int, Int, Int, String]]]
+  }
+
+  object unapply5 {
+    class M0[F[_], A0, A1, B0]
+    implicit def functorInstance: Functor[λ[α => M0[Option, α, α, String]]] = ???
+    implicitly[Unapply[Functor, M0[Option, Int, Int, String]]]
+  }
+
+  object unapply6 {
+    class M0[F[_], A0, B0, C0]
+    implicit def functorInstance: Functor[M0[Option, Int, Int, ?]] = ???
+    implicitly[Unapply[Functor, M0[Option, Int, Int, String]]]
+  }
+
+  object unapply7 {
+    class M0[F[_], A0, B0]
+    implicit def functorInstance: Functor[M0[Option, ?, String]] = ???
+    implicitly[Unapply[Functor, M0[Option, Int, String]]]
+  }
+
+  object unapply8 {
+    class M0[F[_], A0, B0]
+    implicit def functorInstance: Functor[M0[Option, Int, ?]] = ???
+    implicitly[Unapply[Functor, M0[Option, Int, String]]]
+  }
+
+  object unapply9 {
+    class M0[F[_], A0]
+    implicit def functorInstance: Functor[M0[Option, ?]] = ???
+    implicitly[Unapply[Functor, M0[Option, String]]]
+  }
+
+  object unapply10 {
+    class M0[A0, B0, C0, D0, E0, F0, G0]
+    implicit def functorInstance: Functor[M0[Int, Int, Int, Int, Int, Int, ?]] = ???
+    implicitly[Unapply[Functor, M0[Int, Int, Int, Int, Int, Int, String]]]
+  }
+
+  object unapply11 {
+    class M0[A0, B0, C0, D0, E0, F0]
+    implicit def functorInstance: Functor[M0[Int, Int, Int, Int, Int, ?]] = ???
+    implicitly[Unapply[Functor, M0[Int, Int, Int, Int, Int, String]]]
+  }
+
+  object unapply12 {
+    class M0[A0, B0, C0, D0, E0]
+    implicit def functorInstance: Functor[M0[Int, Int, Int, Int, ?]] = ???
+    implicitly[Unapply[Functor, M0[Int, Int, Int, Int, String]]]
+  }
+
+  object unapply13 {
+    class M0[A0, B0, C0, D0]
+    implicit def functorInstance: Functor[M0[Int, Int, Int, ?]] = ???
+    implicitly[Unapply[Functor, M0[Int, Int, Int, String]]]
+  }
+
+  object unapply14 {
+    class M0[A0, B0, C0]
+    implicit def functorInstance: Functor[M0[Int, Int, ?]] = ???
+    implicitly[Unapply[Functor, M0[Int, Int, String]]]
+  }
+
+  object unapply15 {
+    class M0[A0, B0]
+    implicit def functorInstance: Functor[M0[Int, ?]] = ???
+    implicitly[Unapply[Functor, M0[Int, String]]]
+  }
+
+  object unapply16 {
+    class M0[A0, B0]
+    implicit def functorInstance: Functor[M0[?, String]] = ???
+    implicitly[Unapply[Functor, M0[Int, String]]]
+  }
+
+  object unapply17 {
+    class MT[F[_], A]
+    class MAB[A, B]
+    implicit def functorInstance: Functor[MT[MAB[Int, ?], ?]] = ???
+    implicitly[Unapply[Functor, MT[MAB[Int, ?], String]]]
+  }
+
+  object unapply2_0 {
+    class M0[F[_], A0, B0]
+    implicit def bifunctorInstance: Bifunctor[M0[Option, ?, ?]] = ???
+    implicitly[Unapply2[Bifunctor, M0[Option, Int, String]]]
+  }
+
   object unapplyProduct {
     val ue = UnapplyProduct[Applicative, Writer[IList[String], Int], Writer[IList[String], Char]]
     def mequiv[A] = implicitly[ue.M[A] === Writer[IList[String], A]]


### PR DESCRIPTION
Remove implicit `Unapply` instances that under `-Ypartial-unification` are covered by another case.

Add tests that the cases covered by the removed instances are still covered.

Where the clients previously depended on an instance that is now removed, they will be required to enable `-Ypartial-unification`.