### PR TITLE
Fix data type

### DIFF
--- a/base/shared/src/main/scala/scalaz/data/Fix.scala
+++ b/base/shared/src/main/scala/scalaz/data/Fix.scala
@@ -1,0 +1,27 @@
+package scalaz
+package data
+
+import Prelude._
+import typeclass.Liskov
+import typeclass.Liskov.<~<
+
+trait FixModule {
+  type Fix[F[_]]
+
+  /* functions */
+
+  def   fix[F[_]](f: F[Fix[F]]):   Fix[F]
+  def unfix[F[_]](f:   Fix[F] ): F[Fix[F]]
+
+  def liftLiskov[F[_], G[_]](ev: ∀[λ[α => F[α] <~< G[α]]])(implicit F: IsCovariant[F]): Fix[F] <~< Fix[G]
+}
+
+private[data] trait FixImpl extends FixModule {
+  type Fix[F[_]] = F[Any]
+
+  def   fix[F[_]](f: F[Fix[F]]):   Fix[F]  = f.asInstanceOf[F[Any]]
+  def unfix[F[_]](f:   Fix[F] ): F[Fix[F]] = f.asInstanceOf[F[Fix[F]]]
+
+  def liftLiskov[F[_], G[_]](ev: ∀[λ[α => F[α] <~< G[α]]])(implicit F: IsCovariant[F]): Fix[F] <~< Fix[G] =
+    Liskov.unsafeForce
+}

--- a/base/shared/src/main/scala/scalaz/data/Fix.scala
+++ b/base/shared/src/main/scala/scalaz/data/Fix.scala
@@ -10,17 +10,21 @@ trait FixModule {
 
   /* functions */
 
-  def   fix[F[_]](f: F[Fix[F]]):   Fix[F]
-  def unfix[F[_]](f:   Fix[F] ): F[Fix[F]]
+  def   fix[F[_]](f: F[data.Fix[F]]):   Fix[F]
+  def unfix[F[_]](f:   Fix[F] ): F[data.Fix[F]]
+
+  def subst[G[_[_[_]]]](g: G[λ[α[_] => α[data.Fix[α]]]]): G[Fix]
 
   def liftLiskov[F[_], G[_]](ev: ∀[λ[α => F[α] <~< G[α]]])(implicit F: IsCovariant[F]): Fix[F] <~< Fix[G]
 }
 
-private[data] trait FixImpl extends FixModule {
-  type Fix[F[_]] = F[Any]
+private[data] object FixImpl extends FixModule {
+  type Fix[F[_]] = F[data.Fix[F]]
 
-  def   fix[F[_]](f: F[Fix[F]]):   Fix[F]  = f.asInstanceOf[F[Any]]
-  def unfix[F[_]](f:   Fix[F] ): F[Fix[F]] = f.asInstanceOf[F[Fix[F]]]
+  def   fix[F[_]](f: F[data.Fix[F]]):   Fix[F]  = f
+  def unfix[F[_]](f:   Fix[F] ): F[data.Fix[F]] = f
+
+  def subst[G[_[_[_]]]](g: G[λ[α[_] => α[data.Fix[α]]]]): G[Fix] = g
 
   def liftLiskov[F[_], G[_]](ev: ∀[λ[α => F[α] <~< G[α]]])(implicit F: IsCovariant[F]): Fix[F] <~< Fix[G] =
     Liskov.unsafeForce

--- a/base/shared/src/main/scala/scalaz/data/package.scala
+++ b/base/shared/src/main/scala/scalaz/data/package.scala
@@ -71,4 +71,8 @@ package object data {
       def apply[A, B](f: F[A, B], g: G[B]): G[A] = action.apply(f, g)
     }
   }
+
+  object Fix extends FixModule with FixImpl
+  type Fix[F[_]] = Fix.Fix[F]
+
 }

--- a/base/shared/src/main/scala/scalaz/data/package.scala
+++ b/base/shared/src/main/scala/scalaz/data/package.scala
@@ -72,7 +72,7 @@ package object data {
     }
   }
 
-  object Fix extends FixModule with FixImpl
+  val Fix: FixModule = FixImpl
   type Fix[F[_]] = Fix.Fix[F]
 
 }


### PR DESCRIPTION
Non-boxing implementation of `Fix`.

This is the part of #1455 (`IList` via `Fix`) which is independent of `IList` and useful on its own.