### PR TITLE
Unambiguous ops (syntax extensions) for scalaz 7.

### DIFF
--- a/core/src/main/scala/scalaz/syntax/AlignSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/AlignSyntax.scala
@@ -18,20 +18,22 @@ final class AlignOps[F[_],A] private[syntax](val self: F[A])(implicit val F: Ali
   ////
 }
 
-sealed trait ToAlignOps0 {
-  implicit def ToAlignOpsUnapply[FA](v: FA)(implicit F0: Unapply[Align, FA]) =
+sealed trait ToAlignOpsU[TC[F[_]] <: Align[F]] {
+  implicit def ToAlignOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new AlignOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToAlignOps extends ToAlignOps0 with ToFunctorOps {
-  implicit def ToAlignOps[F[_],A](v: F[A])(implicit F0: Align[F]) =
+trait ToAlignOps0[TC[F[_]] <: Align[F]] extends ToAlignOpsU[TC] {
+  implicit def ToAlignOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new AlignOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToAlignOps[TC[F[_]] <: Align[F]] extends ToAlignOps0[TC] with ToFunctorOps[TC]
 
 trait AlignSyntax[F[_]] extends FunctorSyntax[F] {
   implicit def ToAlignOps[A](v: F[A]): AlignOps[F, A] = new AlignOps[F,A](v)(AlignSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/ApplicativeBuilder.scala
+++ b/core/src/main/scala/scalaz/syntax/ApplicativeBuilder.scala
@@ -2,145 +2,102 @@ package scalaz
 package syntax
 
 /** @see [[scalaz.syntax.ApplyOps]]`#|@|` */
-private[scalaz] trait ApplicativeBuilder[M[_], A, B] {
-  val a: M[A]
-  val b: M[B]
+final class ApplicativeBuilder[M[_], A, B](a: M[A], b: M[B])(implicit ap: Apply[M]) {
+  def apply[C](f: (A, B) => C): M[C] = ap.apply2(a, b)(f)
 
-  def apply[C](f: (A, B) => C)(implicit ap: Apply[M]): M[C] = ap.apply2(a, b)(f)
+  def tupled: M[(A, B)] = apply(Tuple2.apply)
 
-  def tupled(implicit ap: Apply[M]): M[(A, B)] = apply(Tuple2.apply)
+  def ⊛[C](c: M[C]) = new ApplicativeBuilder3[C](c)
 
-  def ⊛[C](cc: M[C]) = new ApplicativeBuilder3[C] {
-    val c = cc
-  }
+  def |@|[C](c: M[C]): ApplicativeBuilder3[C] = ⊛(c)
 
-  def |@|[C](cc: M[C]): ApplicativeBuilder3[C] = ⊛(cc)
+  final class ApplicativeBuilder3[C](c: M[C]) {
+    def apply[D](f: (A, B, C) => D): M[D] = ap.apply3(a, b, c)(f)
 
-  sealed abstract class ApplicativeBuilder3[C] {
-    val c: M[C]
+    def tupled: M[(A, B, C)] = apply(Tuple3.apply)
 
-    def apply[D](f: (A, B, C) => D)(implicit ap: Apply[M]): M[D] = ap.apply3(a, b, c)(f)
+    def ⊛[D](d: M[D]) = new ApplicativeBuilder4[D](d)
 
-    def tupled(implicit ap: Apply[M]): M[(A, B, C)] = apply(Tuple3.apply)
+    def |@|[D](d: M[D]): ApplicativeBuilder4[D] = ⊛(d)
 
-    def ⊛[D](dd: M[D]) = new ApplicativeBuilder4[D] {
-      val d = dd
-    }
+    final class ApplicativeBuilder4[D](d: M[D]) {
+      def apply[E](f: (A, B, C, D) => E): M[E] = ap.apply4(a, b, c, d)(f)
 
-    def |@|[D](dd: M[D]): ApplicativeBuilder4[D] = ⊛(dd)
+      def tupled: M[(A, B, C, D)] = apply(Tuple4.apply)
 
-    sealed abstract class ApplicativeBuilder4[D] {
-      val d: M[D]
+      def ⊛[E](e: M[E]) = new ApplicativeBuilder5[E](e)
 
-      def apply[E](f: (A, B, C, D) => E)(implicit ap: Apply[M]): M[E] = ap.apply4(a, b, c, d)(f)
+      def |@|[E](e: M[E]): ApplicativeBuilder5[E] = ⊛(e)
 
-      def tupled(implicit ap: Apply[M]): M[(A, B, C, D)] = apply(Tuple4.apply)
+      final class ApplicativeBuilder5[E](e: M[E]) {
+        def apply[F](f: (A, B, C, D, E) => F): M[F] = ap.apply5(a, b, c, d, e)(f)
 
-      def ⊛[E](ee: M[E]) = new ApplicativeBuilder5[E] {
-        val e = ee
-      }
+        def tupled: M[(A, B, C, D, E)] = apply(Tuple5.apply)
 
-      def |@|[E](ee: M[E]): ApplicativeBuilder5[E] = ⊛(ee)
-
-      sealed abstract class ApplicativeBuilder5[E] {
-        val e: M[E]
-
-        def apply[F](f: (A, B, C, D, E) => F)(implicit ap: Apply[M]): M[F] = ap.apply5(a, b, c, d, e)(f)
-
-        def tupled(implicit ap: Apply[M]): M[(A, B, C, D, E)] = apply(Tuple5.apply)
-
-        def ⊛[F](f: M[F]) = new ApplicativeBuilder6[F] {
-          val ff = f
-        }
+        def ⊛[F](f: M[F]) = new ApplicativeBuilder6[F](f)
 
         def |@|[F](f: M[F]): ApplicativeBuilder6[F] = ⊛(f)
 
-        sealed abstract class ApplicativeBuilder6[F] {
-          val ff: M[F]
+        final class ApplicativeBuilder6[F](ff: M[F]) {
+          def apply[G](f: (A, B, C, D, E, F) => G): M[G] = ap.apply6(a, b, c, d, e, ff)(f)
 
-          def apply[G](f: (A, B, C, D, E, F) => G)(implicit ap: Apply[M]): M[G] = ap.apply6(a, b, c, d, e, ff)(f)
+          def tupled: M[(A, B, C, D, E, F)] = apply(Tuple6.apply)
 
-          def tupled(implicit ap: Apply[M]): M[(A, B, C, D, E, F)] = apply(Tuple6.apply)
+          def ⊛[G](g: M[G]) = new ApplicativeBuilder7[G](g)
 
-          def ⊛[G](gg: M[G]) = new ApplicativeBuilder7[G] {
-            val g = gg
-          }
+          def |@|[G](g: M[G]): ApplicativeBuilder7[G] = ⊛(g)
 
-          def |@|[G](gg: M[G]): ApplicativeBuilder7[G] = ⊛(gg)
+          final class ApplicativeBuilder7[G](g: M[G]) {
+            def apply[H](f: (A, B, C, D, E, F, G) => H): M[H] = ap.apply7(a, b, c, d, e, ff, g)(f)
 
-          sealed abstract class ApplicativeBuilder7[G] {
-            val g: M[G]
+            def tupled: M[(A, B, C, D, E, F, G)] = apply(Tuple7.apply)
 
-            def apply[H](f: (A, B, C, D, E, F, G) => H)(implicit ap: Apply[M]): M[H] = ap.apply7(a, b, c, d, e, ff, g)(f)
+            def ⊛[H](h: M[H]) = new ApplicativeBuilder8[H](h)
 
-            def tupled(implicit ap: Apply[M]): M[(A, B, C, D, E, F, G)] = apply(Tuple7.apply)
+            def |@|[H](h: M[H]): ApplicativeBuilder8[H] = ⊛(h)
 
-            def ⊛[H](hh: M[H]) = new ApplicativeBuilder8[H] {
-              val h = hh
-            }
+            final class ApplicativeBuilder8[H](h: M[H]) {
+              def apply[I](f: (A, B, C, D, E, F, G, H) => I): M[I] = ap.apply8(a, b, c, d, e, ff, g, h)(f)
 
-            def |@|[H](hh: M[H]): ApplicativeBuilder8[H] = ⊛(hh)
+              def tupled: M[(A, B, C, D, E, F, G, H)] = apply(Tuple8.apply)
 
-            sealed abstract class ApplicativeBuilder8[H] {
-              val h: M[H]
+              def ⊛[I](i: M[I]) = new ApplicativeBuilder9[I](i)
 
-              def apply[I](f: (A, B, C, D, E, F, G, H) => I)(implicit ap: Apply[M]): M[I] = ap.apply8(a, b, c, d, e, ff, g, h)(f)
+              def |@|[I](i: M[I]): ApplicativeBuilder9[I] = ⊛(i)
 
-              def tupled(implicit ap: Apply[M]): M[(A, B, C, D, E, F, G, H)] = apply(Tuple8.apply)
+              final class ApplicativeBuilder9[I](i: M[I]) {
+                def apply[J](f: (A, B, C, D, E, F, G, H, I) => J): M[J] = ap.apply9(a, b, c, d, e, ff, g, h, i)(f)
 
-              def ⊛[I](ii: M[I]) = new ApplicativeBuilder9[I] {
-                val i = ii
-              }
+                def tupled: M[(A, B, C, D, E, F, G, H, I)] = apply(Tuple9.apply)
 
-              def |@|[I](ii: M[I]): ApplicativeBuilder9[I] = ⊛(ii)
+                def ⊛[J](j: M[J]) = new ApplicativeBuilder10[J](j)
 
-              sealed abstract class ApplicativeBuilder9[I] {
-                val i: M[I]
+                def |@|[J](j: M[J]): ApplicativeBuilder10[J] = ⊛(j)
 
-                def apply[J](f: (A, B, C, D, E, F, G, H, I) => J)(implicit ap: Apply[M]): M[J] = ap.apply9(a, b, c, d, e, ff, g, h, i)(f)
+                final class ApplicativeBuilder10[J](j: M[J]) {
+                  def apply[K](f: (A, B, C, D, E, F, G, H, I, J) => K): M[K] = ap.apply10(a, b, c, d, e, ff, g, h, i, j)(f)
 
-                def tupled(implicit ap: Apply[M]): M[(A, B, C, D, E, F, G, H, I)] = apply(Tuple9.apply)
+                  def tupled: M[(A, B, C, D, E, F, G, H, I, J)] = apply(Tuple10.apply)
 
-                def ⊛[J](jj: M[J]) = new ApplicativeBuilder10[J] {
-                  val j = jj
-                }
+                  def ⊛[K](k: M[K]) = new ApplicativeBuilder11[K](k)
 
-                def |@|[J](jj: M[J]): ApplicativeBuilder10[J] = ⊛(jj)
+                  def |@|[K](k: M[K]): ApplicativeBuilder11[K] = ⊛(k)
 
-                sealed abstract class ApplicativeBuilder10[J] {
-                  val j: M[J]
-
-                  def apply[K](f: (A, B, C, D, E, F, G, H, I, J) => K)(implicit ap: Apply[M]): M[K] = ap.apply10(a, b, c, d, e, ff, g, h, i, j)(f)
-
-                  def tupled(implicit ap: Apply[M]): M[(A, B, C, D, E, F, G, H, I, J)] = apply(Tuple10.apply)
-
-                  def ⊛[K](kk: M[K]) = new ApplicativeBuilder11[K] {
-                    val k = kk
-                  }
-
-                  def |@|[K](kk: M[K]): ApplicativeBuilder11[K] = ⊛(kk)
-
-                  sealed abstract class ApplicativeBuilder11[K] {
-                    val k: M[K]
-
-                    def apply[L](f: (A, B, C, D, E, F, G, H, I, J, K) => L)(implicit ap: Apply[M]): M[L] =
+                  final class ApplicativeBuilder11[K](k: M[K]) {
+                    def apply[L](f: (A, B, C, D, E, F, G, H, I, J, K) => L): M[L] =
                       ap.apply11(a, b, c, d, e, ff, g, h, i, j, k)(f)
 
-                    def tupled(implicit ap: Apply[M]): M[(A, B, C, D, E, F, G, H, I, J, K)] = apply(Tuple11.apply)
+                    def tupled: M[(A, B, C, D, E, F, G, H, I, J, K)] = apply(Tuple11.apply)
 
-                    def ⊛[L](ll: M[L]) = new ApplicativeBuilder12[L] {
-                      val l = ll
-                    }
+                    def ⊛[L](l: M[L]) = new ApplicativeBuilder12[L](l)
 
-                    def |@|[L](ll: M[L]): ApplicativeBuilder12[L] = ⊛(ll)
+                    def |@|[L](l: M[L]): ApplicativeBuilder12[L] = ⊛(l)
 
-                    sealed abstract class ApplicativeBuilder12[L] {
-                      val l: M[L]
-
-                      def apply[MM](f: (A, B, C, D, E, F, G, H, I, J, K, L) => MM)(implicit ap: Apply[M]): M[MM] =
+                    final class ApplicativeBuilder12[L](l: M[L]) {
+                      def apply[MM](f: (A, B, C, D, E, F, G, H, I, J, K, L) => MM): M[MM] =
                         ap.apply12(a, b, c, d, e, ff, g, h, i, j, k, l)(f)
 
-                      def tupled(implicit ap: Apply[M]): M[(A, B, C, D, E, F, G, H, I, J, K, L)] = apply(Tuple12.apply)
+                      def tupled: M[(A, B, C, D, E, F, G, H, I, J, K, L)] = apply(Tuple12.apply)
                     }
 
                   }

--- a/core/src/main/scala/scalaz/syntax/ApplicativePlusSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/ApplicativePlusSyntax.scala
@@ -8,20 +8,22 @@ final class ApplicativePlusOps[F[_],A] private[syntax](val self: F[A])(implicit 
   ////
 }
 
-sealed trait ToApplicativePlusOps0 {
-  implicit def ToApplicativePlusOpsUnapply[FA](v: FA)(implicit F0: Unapply[ApplicativePlus, FA]) =
+sealed trait ToApplicativePlusOpsU[TC[F[_]] <: ApplicativePlus[F]] {
+  implicit def ToApplicativePlusOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new ApplicativePlusOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToApplicativePlusOps extends ToApplicativePlusOps0 with ToApplicativeOps with ToPlusEmptyOps {
-  implicit def ToApplicativePlusOps[F[_],A](v: F[A])(implicit F0: ApplicativePlus[F]) =
+trait ToApplicativePlusOps0[TC[F[_]] <: ApplicativePlus[F]] extends ToApplicativePlusOpsU[TC] {
+  implicit def ToApplicativePlusOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new ApplicativePlusOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToApplicativePlusOps[TC[F[_]] <: ApplicativePlus[F]] extends ToApplicativePlusOps0[TC] with ToApplicativeOps[TC] with ToPlusEmptyOps[TC]
 
 trait ApplicativePlusSyntax[F[_]] extends ApplicativeSyntax[F] with PlusEmptySyntax[F] {
   implicit def ToApplicativePlusOps[A](v: F[A]): ApplicativePlusOps[F, A] = new ApplicativePlusOps[F,A](v)(ApplicativePlusSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/ApplicativeSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/ApplicativeSyntax.scala
@@ -14,14 +14,14 @@ final class ApplicativeOps[F[_],A] private[syntax](val self: F[A])(implicit val 
   ////
 }
 
-sealed trait ToApplicativeOps0 {
-  implicit def ToApplicativeOpsUnapply[FA](v: FA)(implicit F0: Unapply[Applicative, FA]) =
+sealed trait ToApplicativeOpsU[TC[F[_]] <: Applicative[F]] {
+  implicit def ToApplicativeOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new ApplicativeOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToApplicativeOps extends ToApplicativeOps0 with ToApplyOps {
-  implicit def ToApplicativeOps[F[_],A](v: F[A])(implicit F0: Applicative[F]) =
+trait ToApplicativeOps0[TC[F[_]] <: Applicative[F]] extends ToApplicativeOpsU[TC] {
+  implicit def ToApplicativeOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new ApplicativeOps[F,A](v)
 
   ////
@@ -31,11 +31,13 @@ trait ToApplicativeOps extends ToApplicativeOps0 with ToApplyOps {
   }
 
   trait ApplicativeIdV[A] extends Ops[A] {
-    def point[F[_] : Applicative]: F[A] = Applicative[F].point(self)
-    def pure[F[_] : Applicative]: F[A] = Applicative[F].point(self)
-    def η[F[_] : Applicative]: F[A] = Applicative[F].point(self)
+    def point[F[_] : TC]: F[A] = Applicative[F].point(self)
+    def pure[F[_] : TC]: F[A] = Applicative[F].point(self)
+    def η[F[_] : TC]: F[A] = Applicative[F].point(self)
   }  ////
 }
+
+trait ToApplicativeOps[TC[F[_]] <: Applicative[F]] extends ToApplicativeOps0[TC] with ToApplyOps[TC]
 
 trait ApplicativeSyntax[F[_]] extends ApplySyntax[F] {
   implicit def ToApplicativeOps[A](v: F[A]): ApplicativeOps[F, A] = new ApplicativeOps[F,A](v)(ApplicativeSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/ApplySyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/ApplySyntax.scala
@@ -30,10 +30,8 @@ final class ApplyOps[F[_],A] private[syntax](val self: F[A])(implicit val F: App
    * Warning: each call to `|@|` leads to an allocation of wrapper object. For performance sensitive code, consider using
    *          [[scalaz.Apply]]`#applyN` directly.
    */
-  final def |@|[B](fb: F[B]) = new ApplicativeBuilder[F, A, B] {
-    val a: F[A] = self
-    val b: F[B] = fb
-  }
+  final def |@|[B](fb: F[B]) = new ApplicativeBuilder[F, A, B](self, fb)
+
   /** Alias for `|@|` */
   final def ⊛[B](fb: F[B]): ApplicativeBuilder[F, A, B] = |@|(fb)
 
@@ -46,44 +44,46 @@ final class ApplyOps[F[_],A] private[syntax](val self: F[A])(implicit val F: App
   ////
 }
 
-sealed trait ToApplyOps0 {
-  implicit def ToApplyOpsUnapply[FA](v: FA)(implicit F0: Unapply[Apply, FA]) =
+sealed trait ToApplyOpsU[TC[F[_]] <: Apply[F]] {
+  implicit def ToApplyOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new ApplyOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToApplyOps extends ToApplyOps0 with ToFunctorOps {
-  implicit def ToApplyOps[F[_],A](v: F[A])(implicit F0: Apply[F]) =
+trait ToApplyOps0[TC[F[_]] <: Apply[F]] extends ToApplyOpsU[TC] {
+  implicit def ToApplyOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new ApplyOps[F,A](v)
 
   ////
 
   def ^[F[_],A,B,C](fa: => F[A], fb: => F[B])(
-               f: (A, B) => C)(implicit F: Apply[F]): F[C] =
+               f: (A, B) => C)(implicit F: TC[F]): F[C] =
     F.apply2(fa, fb)(f)
 
   def ^^[F[_],A,B,C,D](fa: => F[A], fb: => F[B], fc: => F[C])(
-                 f: (A, B, C) => D)(implicit F: Apply[F]): F[D] =
+                 f: (A, B, C) => D)(implicit F: TC[F]): F[D] =
     F.apply3(fa, fb, fc)(f)
 
   def ^^^[F[_],A,B,C,D,E](fa: => F[A], fb: => F[B], fc: => F[C], fd: => F[D])(
-                   f: (A,B,C,D) => E)(implicit F: Apply[F]): F[E] =
+                   f: (A,B,C,D) => E)(implicit F: TC[F]): F[E] =
     F.apply4(fa, fb, fc, fd)(f)
 
   def ^^^^[F[_],A,B,C,D,E,I](fa: => F[A], fb: => F[B], fc: => F[C], fd: => F[D], fe: => F[E])(
-                     f: (A,B,C,D,E) => I)(implicit F: Apply[F]): F[I] =
+                     f: (A,B,C,D,E) => I)(implicit F: TC[F]): F[I] =
     F.apply5(fa, fb, fc, fd, fe)(f)
 
   def ^^^^^[F[_],A,B,C,D,E,I,J](fa: => F[A], fb: => F[B], fc: => F[C], fd: => F[D], fe: => F[E], fi: => F[I])(
-                       f: (A,B,C,D,E,I) => J)(implicit F: Apply[F]): F[J] =
+                       f: (A,B,C,D,E,I) => J)(implicit F: TC[F]): F[J] =
     F.apply6(fa, fb, fc, fd, fe, fi)(f)
 
   def ^^^^^^[F[_],A,B,C,D,E,I,J,K](fa: => F[A], fb: => F[B], fc: => F[C], fd: => F[D], fe: => F[E], fi: => F[I], fj: => F[J])(
-                         f: (A,B,C,D,E,I,J) => K)(implicit F: Apply[F]): F[K] =
+                         f: (A,B,C,D,E,I,J) => K)(implicit F: TC[F]): F[K] =
     F.apply7(fa, fb, fc, fd, fe, fi, fj)(f)
 
   ////
 }
+
+trait ToApplyOps[TC[F[_]] <: Apply[F]] extends ToApplyOps0[TC] with ToFunctorOps[TC]
 
 trait ApplySyntax[F[_]] extends FunctorSyntax[F] {
   implicit def ToApplyOps[A](v: F[A]): ApplyOps[F, A] = new ApplyOps[F,A](v)(ApplySyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/ArrowSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/ArrowSyntax.scala
@@ -16,25 +16,27 @@ final class ArrowOps[F[_, _],A, B] private[syntax](val self: F[A, B])(implicit v
   ////
 }
 
-sealed trait ToArrowOps0 {
-  implicit def ToArrowOpsUnapply[FA](v: FA)(implicit F0: Unapply2[Arrow, FA]) =
+sealed trait ToArrowOpsU[TC[F[_, _]] <: Arrow[F]] {
+  implicit def ToArrowOpsUnapply[FA](v: FA)(implicit F0: Unapply2[TC, FA]) =
     new ArrowOps[F0.M,F0.A,F0.B](F0(v))(F0.TC)
 
 }
 
-trait ToArrowOps extends ToArrowOps0 with ToSplitOps with ToStrongOps with ToCategoryOps {
+trait ToArrowOps0[TC[F[_, _]] <: Arrow[F]] extends ToArrowOpsU[TC] {
 
-  implicit def ToArrowOps[F[_, _],A, B](v: F[A, B])(implicit F0: Arrow[F]) =
+  implicit def ToArrowOps[F[_, _],A, B](v: F[A, B])(implicit F0: TC[F]) =
     new ArrowOps[F,A, B](v)
 
 
-  implicit def ToArrowVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: Arrow[F[G, ?, ?]]) =
+  implicit def ToArrowVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: TC[F[G, ?, ?]]) =
     new ArrowOps[F[G, ?, ?], A, B](v)(F0)
 
   ////
 
   ////
 }
+
+trait ToArrowOps[TC[F[_, _]] <: Arrow[F]] extends ToArrowOps0[TC] with ToSplitOps[TC] with ToStrongOps[TC] with ToCategoryOps[TC]
 
 trait ArrowSyntax[F[_, _]] extends SplitSyntax[F] with StrongSyntax[F] with CategorySyntax[F] {
   implicit def ToArrowOps[A, B](v: F[A, B]): ArrowOps[F, A, B] = new ArrowOps[F, A, B](v)(ArrowSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/AssociativeSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/AssociativeSyntax.scala
@@ -15,25 +15,27 @@ final class AssociativeOps[F[_, _],A, B] private[syntax](val self: F[A, B])(impl
   ////
 }
 
-sealed trait ToAssociativeOps0 {
-  implicit def ToAssociativeOpsUnapply[FA](v: FA)(implicit F0: Unapply2[Associative, FA]) =
+sealed trait ToAssociativeOpsU[TC[F[_, _]] <: Associative[F]] {
+  implicit def ToAssociativeOpsUnapply[FA](v: FA)(implicit F0: Unapply2[TC, FA]) =
     new AssociativeOps[F0.M,F0.A,F0.B](F0(v))(F0.TC)
 
 }
 
-trait ToAssociativeOps extends ToAssociativeOps0 {
+trait ToAssociativeOps0[TC[F[_, _]] <: Associative[F]] extends ToAssociativeOpsU[TC] {
 
-  implicit def ToAssociativeOps[F[_, _],A, B](v: F[A, B])(implicit F0: Associative[F]) =
+  implicit def ToAssociativeOps[F[_, _],A, B](v: F[A, B])(implicit F0: TC[F]) =
     new AssociativeOps[F,A, B](v)
 
 
-  implicit def ToAssociativeVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: Associative[F[G, ?, ?]]) =
+  implicit def ToAssociativeVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: TC[F[G, ?, ?]]) =
     new AssociativeOps[F[G, ?, ?], A, B](v)(F0)
 
   ////
 
   ////
 }
+
+trait ToAssociativeOps[TC[F[_, _]] <: Associative[F]] extends ToAssociativeOps0[TC]
 
 trait AssociativeSyntax[F[_, _]]  {
   implicit def ToAssociativeOps[A, B](v: F[A, B]): AssociativeOps[F, A, B] = new AssociativeOps[F, A, B](v)(AssociativeSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/BifoldableSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/BifoldableSyntax.scala
@@ -15,25 +15,27 @@ final class BifoldableOps[F[_, _],A, B] private[syntax](val self: F[A, B])(impli
   ////
 }
 
-sealed trait ToBifoldableOps0 {
-  implicit def ToBifoldableOpsUnapply[FA](v: FA)(implicit F0: Unapply2[Bifoldable, FA]) =
+sealed trait ToBifoldableOpsU[TC[F[_, _]] <: Bifoldable[F]] {
+  implicit def ToBifoldableOpsUnapply[FA](v: FA)(implicit F0: Unapply2[TC, FA]) =
     new BifoldableOps[F0.M,F0.A,F0.B](F0(v))(F0.TC)
 
 }
 
-trait ToBifoldableOps extends ToBifoldableOps0 {
+trait ToBifoldableOps0[TC[F[_, _]] <: Bifoldable[F]] extends ToBifoldableOpsU[TC] {
 
-  implicit def ToBifoldableOps[F[_, _],A, B](v: F[A, B])(implicit F0: Bifoldable[F]) =
+  implicit def ToBifoldableOps[F[_, _],A, B](v: F[A, B])(implicit F0: TC[F]) =
     new BifoldableOps[F,A, B](v)
 
 
-  implicit def ToBifoldableVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: Bifoldable[F[G, ?, ?]]) =
+  implicit def ToBifoldableVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: TC[F[G, ?, ?]]) =
     new BifoldableOps[F[G, ?, ?], A, B](v)(F0)
 
   ////
 
   ////
 }
+
+trait ToBifoldableOps[TC[F[_, _]] <: Bifoldable[F]] extends ToBifoldableOps0[TC]
 
 trait BifoldableSyntax[F[_, _]]  {
   implicit def ToBifoldableOps[A, B](v: F[A, B]): BifoldableOps[F, A, B] = new BifoldableOps[F, A, B](v)(BifoldableSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/BifunctorSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/BifunctorSyntax.scala
@@ -19,25 +19,27 @@ final class BifunctorOps[F[_, _],A, B] private[syntax](val self: F[A, B])(implic
   ////
 }
 
-sealed trait ToBifunctorOps0 {
-  implicit def ToBifunctorOpsUnapply[FA](v: FA)(implicit F0: Unapply2[Bifunctor, FA]) =
+sealed trait ToBifunctorOpsU[TC[F[_, _]] <: Bifunctor[F]] {
+  implicit def ToBifunctorOpsUnapply[FA](v: FA)(implicit F0: Unapply2[TC, FA]) =
     new BifunctorOps[F0.M,F0.A,F0.B](F0(v))(F0.TC)
 
 }
 
-trait ToBifunctorOps extends ToBifunctorOps0 {
+trait ToBifunctorOps0[TC[F[_, _]] <: Bifunctor[F]] extends ToBifunctorOpsU[TC] {
 
-  implicit def ToBifunctorOps[F[_, _],A, B](v: F[A, B])(implicit F0: Bifunctor[F]) =
+  implicit def ToBifunctorOps[F[_, _],A, B](v: F[A, B])(implicit F0: TC[F]) =
     new BifunctorOps[F,A, B](v)
 
 
-  implicit def ToBifunctorVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: Bifunctor[F[G, ?, ?]]) =
+  implicit def ToBifunctorVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: TC[F[G, ?, ?]]) =
     new BifunctorOps[F[G, ?, ?], A, B](v)(F0)
 
   ////
 
   ////
 }
+
+trait ToBifunctorOps[TC[F[_, _]] <: Bifunctor[F]] extends ToBifunctorOps0[TC]
 
 trait BifunctorSyntax[F[_, _]]  {
   implicit def ToBifunctorOps[A, B](v: F[A, B]): BifunctorOps[F, A, B] = new BifunctorOps[F, A, B](v)(BifunctorSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/BindRecSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/BindRecSyntax.scala
@@ -8,20 +8,22 @@ final class BindRecOps[F[_],A] private[syntax](val self: F[A])(implicit val F: B
   ////
 }
 
-sealed trait ToBindRecOps0 {
-  implicit def ToBindRecOpsUnapply[FA](v: FA)(implicit F0: Unapply[BindRec, FA]) =
+sealed trait ToBindRecOpsU[TC[F[_]] <: BindRec[F]] {
+  implicit def ToBindRecOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new BindRecOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToBindRecOps extends ToBindRecOps0 with ToBindOps {
-  implicit def ToBindRecOps[F[_],A](v: F[A])(implicit F0: BindRec[F]) =
+trait ToBindRecOps0[TC[F[_]] <: BindRec[F]] extends ToBindRecOpsU[TC] {
+  implicit def ToBindRecOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new BindRecOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToBindRecOps[TC[F[_]] <: BindRec[F]] extends ToBindRecOps0[TC] with ToBindOps[TC]
 
 trait BindRecSyntax[F[_]] extends BindSyntax[F] {
   implicit def ToBindRecOps[A](v: F[A]): BindRecOps[F, A] = new BindRecOps[F,A](v)(BindRecSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/BindSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/BindSyntax.scala
@@ -30,20 +30,22 @@ final class BindOps[F[_],A] private[syntax](val self: F[A])(implicit val F: Bind
   ////
 }
 
-sealed trait ToBindOps0 {
-  implicit def ToBindOpsUnapply[FA](v: FA)(implicit F0: Unapply[Bind, FA]) =
+sealed trait ToBindOpsU[TC[F[_]] <: Bind[F]] {
+  implicit def ToBindOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new BindOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToBindOps extends ToBindOps0 with ToApplyOps {
-  implicit def ToBindOps[F[_],A](v: F[A])(implicit F0: Bind[F]) =
+trait ToBindOps0[TC[F[_]] <: Bind[F]] extends ToBindOpsU[TC] {
+  implicit def ToBindOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new BindOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToBindOps[TC[F[_]] <: Bind[F]] extends ToBindOps0[TC] with ToApplyOps[TC]
 
 trait BindSyntax[F[_]] extends ApplySyntax[F] {
   implicit def ToBindOps[A](v: F[A]): BindOps[F, A] = new BindOps[F,A](v)(BindSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/BitraverseSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/BitraverseSyntax.scala
@@ -20,25 +20,27 @@ final class BitraverseOps[F[_, _],A, B] private[syntax](val self: F[A, B])(impli
   ////
 }
 
-sealed trait ToBitraverseOps0 {
-  implicit def ToBitraverseOpsUnapply[FA](v: FA)(implicit F0: Unapply2[Bitraverse, FA]) =
+sealed trait ToBitraverseOpsU[TC[F[_, _]] <: Bitraverse[F]] {
+  implicit def ToBitraverseOpsUnapply[FA](v: FA)(implicit F0: Unapply2[TC, FA]) =
     new BitraverseOps[F0.M,F0.A,F0.B](F0(v))(F0.TC)
 
 }
 
-trait ToBitraverseOps extends ToBitraverseOps0 with ToBifunctorOps with ToBifoldableOps {
+trait ToBitraverseOps0[TC[F[_, _]] <: Bitraverse[F]] extends ToBitraverseOpsU[TC] {
 
-  implicit def ToBitraverseOps[F[_, _],A, B](v: F[A, B])(implicit F0: Bitraverse[F]) =
+  implicit def ToBitraverseOps[F[_, _],A, B](v: F[A, B])(implicit F0: TC[F]) =
     new BitraverseOps[F,A, B](v)
 
 
-  implicit def ToBitraverseVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: Bitraverse[F[G, ?, ?]]) =
+  implicit def ToBitraverseVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: TC[F[G, ?, ?]]) =
     new BitraverseOps[F[G, ?, ?], A, B](v)(F0)
 
   ////
 
   ////
 }
+
+trait ToBitraverseOps[TC[F[_, _]] <: Bitraverse[F]] extends ToBitraverseOps0[TC] with ToBifunctorOps[TC] with ToBifoldableOps[TC]
 
 trait BitraverseSyntax[F[_, _]] extends BifunctorSyntax[F] with BifoldableSyntax[F] {
   implicit def ToBitraverseOps[A, B](v: F[A, B]): BitraverseOps[F, A, B] = new BitraverseOps[F, A, B](v)(BitraverseSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/CatchableSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/CatchableSyntax.scala
@@ -8,20 +8,22 @@ final class CatchableOps[F[_],A] private[syntax](val self: F[A])(implicit val F:
   ////
 }
 
-sealed trait ToCatchableOps0 {
-  implicit def ToCatchableOpsUnapply[FA](v: FA)(implicit F0: Unapply[Catchable, FA]) =
+sealed trait ToCatchableOpsU[TC[F[_]] <: Catchable[F]] {
+  implicit def ToCatchableOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new CatchableOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToCatchableOps extends ToCatchableOps0 {
-  implicit def ToCatchableOps[F[_],A](v: F[A])(implicit F0: Catchable[F]) =
+trait ToCatchableOps0[TC[F[_]] <: Catchable[F]] extends ToCatchableOpsU[TC] {
+  implicit def ToCatchableOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new CatchableOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToCatchableOps[TC[F[_]] <: Catchable[F]] extends ToCatchableOps0[TC]
 
 trait CatchableSyntax[F[_]]  {
   implicit def ToCatchableOps[A](v: F[A]): CatchableOps[F, A] = new CatchableOps[F,A](v)(CatchableSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/CategorySyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/CategorySyntax.scala
@@ -8,24 +8,26 @@ final class CategoryOps[F[_, _],A, B] private[syntax](val self: F[A, B])(implici
   ////
 }
 
-sealed trait ToCategoryOps0 {
-  implicit def ToCategoryOpsUnapply[FA](v: FA)(implicit F0: Unapply2[Category, FA]) =
+sealed trait ToCategoryOpsU[TC[F[_, _]] <: Category[F]] {
+  implicit def ToCategoryOpsUnapply[FA](v: FA)(implicit F0: Unapply2[TC, FA]) =
     new CategoryOps[F0.M,F0.A,F0.B](F0(v))(F0.TC)
 
 }
 
-trait ToCategoryOps extends ToCategoryOps0 with ToComposeOps {
+trait ToCategoryOps0[TC[F[_, _]] <: Category[F]] extends ToCategoryOpsU[TC] {
 
-  implicit def ToCategoryOps[F[_, _],A, B](v: F[A, B])(implicit F0: Category[F]) =
+  implicit def ToCategoryOps[F[_, _],A, B](v: F[A, B])(implicit F0: TC[F]) =
     new CategoryOps[F,A, B](v)
 
 
-  implicit def ToCategoryVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: Category[F[G, ?, ?]]) =
+  implicit def ToCategoryVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: TC[F[G, ?, ?]]) =
     new CategoryOps[F[G, ?, ?], A, B](v)(F0)
 
   ////
   ////
 }
+
+trait ToCategoryOps[TC[F[_, _]] <: Category[F]] extends ToCategoryOps0[TC] with ToComposeOps[TC]
 
 trait CategorySyntax[F[_, _]] extends ComposeSyntax[F] {
   implicit def ToCategoryOps[A, B](v: F[A, B]): CategoryOps[F, A, B] = new CategoryOps[F, A, B](v)(CategorySyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/ChoiceSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/ChoiceSyntax.scala
@@ -9,25 +9,27 @@ final class ChoiceOps[F[_, _],A, B] private[syntax](val self: F[A, B])(implicit 
   ////
 }
 
-sealed trait ToChoiceOps0 {
-  implicit def ToChoiceOpsUnapply[FA](v: FA)(implicit F0: Unapply2[Choice, FA]) =
+sealed trait ToChoiceOpsU[TC[F[_, _]] <: Choice[F]] {
+  implicit def ToChoiceOpsUnapply[FA](v: FA)(implicit F0: Unapply2[TC, FA]) =
     new ChoiceOps[F0.M,F0.A,F0.B](F0(v))(F0.TC)
 
 }
 
-trait ToChoiceOps extends ToChoiceOps0 with ToCategoryOps {
+trait ToChoiceOps0[TC[F[_, _]] <: Choice[F]] extends ToChoiceOpsU[TC] {
 
-  implicit def ToChoiceOps[F[_, _],A, B](v: F[A, B])(implicit F0: Choice[F]) =
+  implicit def ToChoiceOps[F[_, _],A, B](v: F[A, B])(implicit F0: TC[F]) =
     new ChoiceOps[F,A, B](v)
 
 
-  implicit def ToChoiceVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: Choice[F[G, ?, ?]]) =
+  implicit def ToChoiceVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: TC[F[G, ?, ?]]) =
     new ChoiceOps[F[G, ?, ?], A, B](v)(F0)
 
   ////
 
   ////
 }
+
+trait ToChoiceOps[TC[F[_, _]] <: Choice[F]] extends ToChoiceOps0[TC] with ToCategoryOps[TC]
 
 trait ChoiceSyntax[F[_, _]] extends CategorySyntax[F] {
   implicit def ToChoiceOps[A, B](v: F[A, B]): ChoiceOps[F, A, B] = new ChoiceOps[F, A, B](v)(ChoiceSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/CobindSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/CobindSyntax.scala
@@ -11,20 +11,22 @@ final class CobindOps[F[_],A] private[syntax](val self: F[A])(implicit val F: Co
   ////
 }
 
-sealed trait ToCobindOps0 {
-  implicit def ToCobindOpsUnapply[FA](v: FA)(implicit F0: Unapply[Cobind, FA]) =
+sealed trait ToCobindOpsU[TC[F[_]] <: Cobind[F]] {
+  implicit def ToCobindOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new CobindOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToCobindOps extends ToCobindOps0 with ToFunctorOps {
-  implicit def ToCobindOps[F[_],A](v: F[A])(implicit F0: Cobind[F]) =
+trait ToCobindOps0[TC[F[_]] <: Cobind[F]] extends ToCobindOpsU[TC] {
+  implicit def ToCobindOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new CobindOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToCobindOps[TC[F[_]] <: Cobind[F]] extends ToCobindOps0[TC] with ToFunctorOps[TC]
 
 trait CobindSyntax[F[_]] extends FunctorSyntax[F] {
   implicit def ToCobindOps[A](v: F[A]): CobindOps[F, A] = new CobindOps[F,A](v)(CobindSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/ComonadSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/ComonadSyntax.scala
@@ -9,20 +9,22 @@ final class ComonadOps[F[_],A] private[syntax](val self: F[A])(implicit val F: C
   ////
 }
 
-sealed trait ToComonadOps0 {
-  implicit def ToComonadOpsUnapply[FA](v: FA)(implicit F0: Unapply[Comonad, FA]) =
+sealed trait ToComonadOpsU[TC[F[_]] <: Comonad[F]] {
+  implicit def ToComonadOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new ComonadOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToComonadOps extends ToComonadOps0 with ToCobindOps {
-  implicit def ToComonadOps[F[_],A](v: F[A])(implicit F0: Comonad[F]) =
+trait ToComonadOps0[TC[F[_]] <: Comonad[F]] extends ToComonadOpsU[TC] {
+  implicit def ToComonadOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new ComonadOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToComonadOps[TC[F[_]] <: Comonad[F]] extends ToComonadOps0[TC] with ToCobindOps[TC]
 
 trait ComonadSyntax[F[_]] extends CobindSyntax[F] {
   implicit def ToComonadOps[A](v: F[A]): ComonadOps[F, A] = new ComonadOps[F,A](v)(ComonadSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/ComposeSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/ComposeSyntax.scala
@@ -18,24 +18,26 @@ final class ComposeOps[F[_, _],A, B] private[syntax](val self: F[A, B])(implicit
   ////
 }
 
-sealed trait ToComposeOps0 {
-  implicit def ToComposeOpsUnapply[FA](v: FA)(implicit F0: Unapply2[Compose, FA]) =
+sealed trait ToComposeOpsU[TC[F[_, _]] <: Compose[F]] {
+  implicit def ToComposeOpsUnapply[FA](v: FA)(implicit F0: Unapply2[TC, FA]) =
     new ComposeOps[F0.M,F0.A,F0.B](F0(v))(F0.TC)
 
 }
 
-trait ToComposeOps extends ToComposeOps0 {
+trait ToComposeOps0[TC[F[_, _]] <: Compose[F]] extends ToComposeOpsU[TC] {
 
-  implicit def ToComposeOps[F[_, _],A, B](v: F[A, B])(implicit F0: Compose[F]) =
+  implicit def ToComposeOps[F[_, _],A, B](v: F[A, B])(implicit F0: TC[F]) =
     new ComposeOps[F,A, B](v)
 
 
-  implicit def ToComposeVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: Compose[F[G, ?, ?]]) =
+  implicit def ToComposeVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: TC[F[G, ?, ?]]) =
     new ComposeOps[F[G, ?, ?], A, B](v)(F0)
 
   ////
   ////
 }
+
+trait ToComposeOps[TC[F[_, _]] <: Compose[F]] extends ToComposeOps0[TC]
 
 trait ComposeSyntax[F[_, _]]  {
   implicit def ToComposeOps[A, B](v: F[A, B]): ComposeOps[F, A, B] = new ComposeOps[F, A, B](v)(ComposeSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/ContravariantSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/ContravariantSyntax.scala
@@ -9,20 +9,22 @@ final class ContravariantOps[F[_],A] private[syntax](val self: F[A])(implicit va
   ////
 }
 
-sealed trait ToContravariantOps0 {
-  implicit def ToContravariantOpsUnapply[FA](v: FA)(implicit F0: Unapply[Contravariant, FA]) =
+sealed trait ToContravariantOpsU[TC[F[_]] <: Contravariant[F]] {
+  implicit def ToContravariantOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new ContravariantOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToContravariantOps extends ToContravariantOps0 with ToInvariantFunctorOps {
-  implicit def ToContravariantOps[F[_],A](v: F[A])(implicit F0: Contravariant[F]) =
+trait ToContravariantOps0[TC[F[_]] <: Contravariant[F]] extends ToContravariantOpsU[TC] {
+  implicit def ToContravariantOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new ContravariantOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToContravariantOps[TC[F[_]] <: Contravariant[F]] extends ToContravariantOps0[TC] with ToInvariantFunctorOps[TC]
 
 trait ContravariantSyntax[F[_]] extends InvariantFunctorSyntax[F] {
   implicit def ToContravariantOps[A](v: F[A]): ContravariantOps[F, A] = new ContravariantOps[F,A](v)(ContravariantSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/CozipSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/CozipSyntax.scala
@@ -8,20 +8,22 @@ final class CozipOps[F[_],A] private[syntax](val self: F[A])(implicit val F: Coz
   ////
 }
 
-sealed trait ToCozipOps0 {
-  implicit def ToCozipOpsUnapply[FA](v: FA)(implicit F0: Unapply[Cozip, FA]) =
+sealed trait ToCozipOpsU[TC[F[_]] <: Cozip[F]] {
+  implicit def ToCozipOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new CozipOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToCozipOps extends ToCozipOps0 {
-  implicit def ToCozipOps[F[_],A](v: F[A])(implicit F0: Cozip[F]) =
+trait ToCozipOps0[TC[F[_]] <: Cozip[F]] extends ToCozipOpsU[TC] {
+  implicit def ToCozipOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new CozipOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToCozipOps[TC[F[_]] <: Cozip[F]] extends ToCozipOps0[TC]
 
 trait CozipSyntax[F[_]]  {
   implicit def ToCozipOps[A](v: F[A]): CozipOps[F, A] = new CozipOps[F,A](v)(CozipSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/DivideSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/DivideSyntax.scala
@@ -8,20 +8,22 @@ final class DivideOps[F[_],A] private[syntax](val self: F[A])(implicit val F: Di
   ////
 }
 
-sealed trait ToDivideOps0 {
-  implicit def ToDivideOpsUnapply[FA](v: FA)(implicit F0: Unapply[Divide, FA]) =
+sealed trait ToDivideOpsU[TC[F[_]] <: Divide[F]] {
+  implicit def ToDivideOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new DivideOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToDivideOps extends ToDivideOps0 with ToContravariantOps {
-  implicit def ToDivideOps[F[_],A](v: F[A])(implicit F0: Divide[F]) =
+trait ToDivideOps0[TC[F[_]] <: Divide[F]] extends ToDivideOpsU[TC] {
+  implicit def ToDivideOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new DivideOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToDivideOps[TC[F[_]] <: Divide[F]] extends ToDivideOps0[TC] with ToContravariantOps[TC]
 
 trait DivideSyntax[F[_]] extends ContravariantSyntax[F] {
   implicit def ToDivideOps[A](v: F[A]): DivideOps[F, A] = new DivideOps[F,A](v)(DivideSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/DivisibleSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/DivisibleSyntax.scala
@@ -8,20 +8,22 @@ final class DivisibleOps[F[_],A] private[syntax](val self: F[A])(implicit val F:
   ////
 }
 
-sealed trait ToDivisibleOps0 {
-  implicit def ToDivisibleOpsUnapply[FA](v: FA)(implicit F0: Unapply[Divisible, FA]) =
+sealed trait ToDivisibleOpsU[TC[F[_]] <: Divisible[F]] {
+  implicit def ToDivisibleOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new DivisibleOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToDivisibleOps extends ToDivisibleOps0 with ToDivideOps {
-  implicit def ToDivisibleOps[F[_],A](v: F[A])(implicit F0: Divisible[F]) =
+trait ToDivisibleOps0[TC[F[_]] <: Divisible[F]] extends ToDivisibleOpsU[TC] {
+  implicit def ToDivisibleOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new DivisibleOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToDivisibleOps[TC[F[_]] <: Divisible[F]] extends ToDivisibleOps0[TC] with ToDivideOps[TC]
 
 trait DivisibleSyntax[F[_]] extends DivideSyntax[F] {
   implicit def ToDivisibleOps[A](v: F[A]): DivisibleOps[F, A] = new DivisibleOps[F,A](v)(DivisibleSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/Foldable1Syntax.scala
+++ b/core/src/main/scala/scalaz/syntax/Foldable1Syntax.scala
@@ -31,20 +31,22 @@ final class Foldable1Ops[F[_],A] private[syntax](val self: F[A])(implicit val F:
   ////
 }
 
-sealed trait ToFoldable1Ops0 {
-  implicit def ToFoldable1OpsUnapply[FA](v: FA)(implicit F0: Unapply[Foldable1, FA]) =
+sealed trait ToFoldable1OpsU[TC[F[_]] <: Foldable1[F]] {
+  implicit def ToFoldable1OpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new Foldable1Ops[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToFoldable1Ops extends ToFoldable1Ops0 with ToFoldableOps {
-  implicit def ToFoldable1Ops[F[_],A](v: F[A])(implicit F0: Foldable1[F]) =
+trait ToFoldable1Ops0[TC[F[_]] <: Foldable1[F]] extends ToFoldable1OpsU[TC] {
+  implicit def ToFoldable1Ops[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new Foldable1Ops[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToFoldable1Ops[TC[F[_]] <: Foldable1[F]] extends ToFoldable1Ops0[TC] with ToFoldableOps[TC]
 
 trait Foldable1Syntax[F[_]] extends FoldableSyntax[F] {
   implicit def ToFoldable1Ops[A](v: F[A]): Foldable1Ops[F, A] = new Foldable1Ops[F,A](v)(Foldable1Syntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/FoldableSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/FoldableSyntax.scala
@@ -86,20 +86,22 @@ final class FoldableOps[F[_],A] private[syntax](val self: F[A])(implicit val F: 
   ////
 }
 
-sealed trait ToFoldableOps0 {
-  implicit def ToFoldableOpsUnapply[FA](v: FA)(implicit F0: Unapply[Foldable, FA]) =
+sealed trait ToFoldableOpsU[TC[F[_]] <: Foldable[F]] {
+  implicit def ToFoldableOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new FoldableOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToFoldableOps extends ToFoldableOps0 {
-  implicit def ToFoldableOps[F[_],A](v: F[A])(implicit F0: Foldable[F]) =
+trait ToFoldableOps0[TC[F[_]] <: Foldable[F]] extends ToFoldableOpsU[TC] {
+  implicit def ToFoldableOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new FoldableOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToFoldableOps[TC[F[_]] <: Foldable[F]] extends ToFoldableOps0[TC]
 
 trait FoldableSyntax[F[_]]  {
   implicit def ToFoldableOps[A](v: F[A]): FoldableOps[F, A] = new FoldableOps[F,A](v)(FoldableSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/InvariantFunctorSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/InvariantFunctorSyntax.scala
@@ -14,20 +14,22 @@ final class InvariantFunctorOps[F[_],A] private[syntax](val self: F[A])(implicit
   ////
 }
 
-sealed trait ToInvariantFunctorOps0 {
-  implicit def ToInvariantFunctorOpsUnapply[FA](v: FA)(implicit F0: Unapply[InvariantFunctor, FA]) =
+sealed trait ToInvariantFunctorOpsU[TC[F[_]] <: InvariantFunctor[F]] {
+  implicit def ToInvariantFunctorOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new InvariantFunctorOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToInvariantFunctorOps extends ToInvariantFunctorOps0 {
-  implicit def ToInvariantFunctorOps[F[_],A](v: F[A])(implicit F0: InvariantFunctor[F]) =
+trait ToInvariantFunctorOps0[TC[F[_]] <: InvariantFunctor[F]] extends ToInvariantFunctorOpsU[TC] {
+  implicit def ToInvariantFunctorOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new InvariantFunctorOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToInvariantFunctorOps[TC[F[_]] <: InvariantFunctor[F]] extends ToInvariantFunctorOps0[TC]
 
 trait InvariantFunctorSyntax[F[_]]  {
   implicit def ToInvariantFunctorOps[A](v: F[A]): InvariantFunctorOps[F, A] = new InvariantFunctorOps[F,A](v)(InvariantFunctorSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/IsEmptySyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/IsEmptySyntax.scala
@@ -10,20 +10,22 @@ final class IsEmptyOps[F[_],A] private[syntax](val self: F[A])(implicit val F: I
   ////
 }
 
-sealed trait ToIsEmptyOps0 {
-  implicit def ToIsEmptyOpsUnapply[FA](v: FA)(implicit F0: Unapply[IsEmpty, FA]) =
+sealed trait ToIsEmptyOpsU[TC[F[_]] <: IsEmpty[F]] {
+  implicit def ToIsEmptyOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new IsEmptyOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToIsEmptyOps extends ToIsEmptyOps0 with ToPlusEmptyOps {
-  implicit def ToIsEmptyOps[F[_],A](v: F[A])(implicit F0: IsEmpty[F]) =
+trait ToIsEmptyOps0[TC[F[_]] <: IsEmpty[F]] extends ToIsEmptyOpsU[TC] {
+  implicit def ToIsEmptyOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new IsEmptyOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToIsEmptyOps[TC[F[_]] <: IsEmpty[F]] extends ToIsEmptyOps0[TC] with ToPlusEmptyOps[TC]
 
 trait IsEmptySyntax[F[_]] extends PlusEmptySyntax[F] {
   implicit def ToIsEmptyOps[A](v: F[A]): IsEmptyOps[F, A] = new IsEmptyOps[F,A](v)(IsEmptySyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
@@ -10,8 +10,8 @@ final class MonadErrorOps[F[_], S, A] private[syntax](self: F[A])(implicit val F
   ////
 }
 
-trait ToMonadErrorOps extends ToMonadOps {
-  implicit def ToMonadErrorOps[F[_], S, A](v: F[A])(implicit F0: MonadError[F, S]) =
+trait ToMonadErrorOps0[TC[F[_], S] <: MonadError[F, S]] {
+  implicit def ToMonadErrorOps[F[_], S, A](v: F[A])(implicit F0: TC[F, S]) =
     new MonadErrorOps[F, S, A](v)
 
   ////
@@ -21,6 +21,8 @@ trait ToMonadErrorOps extends ToMonadOps {
 
   ////
 }
+
+trait ToMonadErrorOps[TC[F[_], S] <: MonadError[F, S]] extends ToMonadErrorOps0[TC] with ToMonadOps[λ[F[_] => TC[F, S] forSome { type S }]]
 
 trait MonadErrorSyntax[F[_], S] extends MonadSyntax[F] {
   implicit def ToMonadErrorOps[A](v: F[A]): MonadErrorOps[F, S, A] =

--- a/core/src/main/scala/scalaz/syntax/MonadListenSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadListenSyntax.scala
@@ -10,10 +10,12 @@ final class MonadListenOps[F[_], W, A] private[syntax](self: F[A])(implicit ML: 
     ML.listen[A](self)
 }
 
-trait ToMonadListenOps extends ToMonadTellOps {
-  implicit def ToMonadListenOps[F[_], A, W](v: F[A])(implicit F0: MonadListen[F, W]) =
+trait ToMonadListenOps0[TC[F[_], W] <: MonadListen[F, W]] {
+  implicit def ToMonadListenOps[F[_], A, W](v: F[A])(implicit F0: TC[F, W]) =
     new MonadListenOps[F, W, A](v)(F0)
 }
+
+trait ToMonadListenOps[TC[F[_], W] <: MonadListen[F, W]] extends ToMonadListenOps0[TC] with ToMonadTellOps[TC]
 
 trait MonadListenSyntax[F[_], W] extends MonadTellSyntax[F, W] {
   implicit def ToMonadListenOps[A](v: F[A])(implicit F0: MonadListen[F, W]) =

--- a/core/src/main/scala/scalaz/syntax/MonadPlusSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadPlusSyntax.scala
@@ -31,20 +31,22 @@ final class MonadPlusOps[F[_],A] private[syntax](val self: F[A])(implicit val F:
   ////
 }
 
-sealed trait ToMonadPlusOps0 {
-  implicit def ToMonadPlusOpsUnapply[FA](v: FA)(implicit F0: Unapply[MonadPlus, FA]) =
+sealed trait ToMonadPlusOpsU[TC[F[_]] <: MonadPlus[F]] {
+  implicit def ToMonadPlusOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new MonadPlusOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToMonadPlusOps extends ToMonadPlusOps0 with ToMonadOps with ToApplicativePlusOps {
-  implicit def ToMonadPlusOps[F[_],A](v: F[A])(implicit F0: MonadPlus[F]) =
+trait ToMonadPlusOps0[TC[F[_]] <: MonadPlus[F]] extends ToMonadPlusOpsU[TC] {
+  implicit def ToMonadPlusOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new MonadPlusOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToMonadPlusOps[TC[F[_]] <: MonadPlus[F]] extends ToMonadPlusOps0[TC] with ToMonadOps[TC] with ToApplicativePlusOps[TC]
 
 trait MonadPlusSyntax[F[_]] extends MonadSyntax[F] with ApplicativePlusSyntax[F] {
   implicit def ToMonadPlusOps[A](v: F[A]): MonadPlusOps[F, A] = new MonadPlusOps[F,A](v)(MonadPlusSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/MonadSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadSyntax.scala
@@ -22,20 +22,22 @@ final class MonadOps[F[_],A] private[syntax](val self: F[A])(implicit val F: Mon
   ////
 }
 
-sealed trait ToMonadOps0 {
-  implicit def ToMonadOpsUnapply[FA](v: FA)(implicit F0: Unapply[Monad, FA]) =
+sealed trait ToMonadOpsU[TC[F[_]] <: Monad[F]] {
+  implicit def ToMonadOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new MonadOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToMonadOps extends ToMonadOps0 with ToApplicativeOps with ToBindOps {
-  implicit def ToMonadOps[F[_],A](v: F[A])(implicit F0: Monad[F]) =
+trait ToMonadOps0[TC[F[_]] <: Monad[F]] extends ToMonadOpsU[TC] {
+  implicit def ToMonadOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new MonadOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToMonadOps[TC[F[_]] <: Monad[F]] extends ToMonadOps0[TC] with ToApplicativeOps[TC] with ToBindOps[TC]
 
 trait MonadSyntax[F[_]] extends ApplicativeSyntax[F] with BindSyntax[F] {
   implicit def ToMonadOps[A](v: F[A]): MonadOps[F, A] = new MonadOps[F,A](v)(MonadSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/MonadTellSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadTellSyntax.scala
@@ -13,14 +13,16 @@ final class MonadTellOps[F[_], S, A] private[syntax](self: F[A])(implicit val F:
   ////
 }
 
-trait ToMonadTellOps extends ToMonadOps {
-  implicit def ToMonadTellOps[F[_], S, A](v: F[A])(implicit F0: MonadTell[F, S]) =
+trait ToMonadTellOps0[TC[F[_], S] <: MonadTell[F, S]] {
+  implicit def ToMonadTellOps[F[_], S, A](v: F[A])(implicit F0: TC[F, S]) =
     new MonadTellOps[F, S, A](v)
 
   ////
 
   ////
 }
+
+trait ToMonadTellOps[TC[F[_], S] <: MonadTell[F, S]] extends ToMonadTellOps0[TC] with ToMonadOps[λ[F[_] => TC[F, S] forSome { type S }]]
 
 trait MonadTellSyntax[F[_], S] extends MonadSyntax[F] {
   implicit def ToMonadTellOps[A](v: F[A]): MonadTellOps[F, S, A] =

--- a/core/src/main/scala/scalaz/syntax/NondeterminismSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/NondeterminismSyntax.scala
@@ -8,20 +8,22 @@ final class NondeterminismOps[F[_],A] private[syntax](val self: F[A])(implicit v
   ////
 }
 
-sealed trait ToNondeterminismOps0 {
-  implicit def ToNondeterminismOpsUnapply[FA](v: FA)(implicit F0: Unapply[Nondeterminism, FA]) =
+sealed trait ToNondeterminismOpsU[TC[F[_]] <: Nondeterminism[F]] {
+  implicit def ToNondeterminismOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new NondeterminismOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToNondeterminismOps extends ToNondeterminismOps0 with ToMonadOps {
-  implicit def ToNondeterminismOps[F[_],A](v: F[A])(implicit F0: Nondeterminism[F]) =
+trait ToNondeterminismOps0[TC[F[_]] <: Nondeterminism[F]] extends ToNondeterminismOpsU[TC] {
+  implicit def ToNondeterminismOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new NondeterminismOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToNondeterminismOps[TC[F[_]] <: Nondeterminism[F]] extends ToNondeterminismOps0[TC] with ToMonadOps[TC]
 
 trait NondeterminismSyntax[F[_]] extends MonadSyntax[F] {
   implicit def ToNondeterminismOps[A](v: F[A]): NondeterminismOps[F, A] = new NondeterminismOps[F,A](v)(NondeterminismSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/OptionalSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/OptionalSyntax.scala
@@ -41,20 +41,22 @@ final class OptionalOps[F[_],A] private[syntax](val self: F[A])(implicit val F: 
   ////
 }
 
-sealed trait ToOptionalOps0 {
-  implicit def ToOptionalOpsUnapply[FA](v: FA)(implicit F0: Unapply[Optional, FA]) =
+sealed trait ToOptionalOpsU[TC[F[_]] <: Optional[F]] {
+  implicit def ToOptionalOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new OptionalOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToOptionalOps extends ToOptionalOps0 {
-  implicit def ToOptionalOps[F[_],A](v: F[A])(implicit F0: Optional[F]) =
+trait ToOptionalOps0[TC[F[_]] <: Optional[F]] extends ToOptionalOpsU[TC] {
+  implicit def ToOptionalOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new OptionalOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToOptionalOps[TC[F[_]] <: Optional[F]] extends ToOptionalOps0[TC]
 
 trait OptionalSyntax[F[_]]  {
   implicit def ToOptionalOps[A](v: F[A]): OptionalOps[F, A] = new OptionalOps[F,A](v)(OptionalSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/PlusEmptySyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/PlusEmptySyntax.scala
@@ -8,14 +8,14 @@ final class PlusEmptyOps[F[_],A] private[syntax](val self: F[A])(implicit val F:
   ////
 }
 
-sealed trait ToPlusEmptyOps0 {
-  implicit def ToPlusEmptyOpsUnapply[FA](v: FA)(implicit F0: Unapply[PlusEmpty, FA]) =
+sealed trait ToPlusEmptyOpsU[TC[F[_]] <: PlusEmpty[F]] {
+  implicit def ToPlusEmptyOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new PlusEmptyOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToPlusEmptyOps extends ToPlusEmptyOps0 with ToPlusOps {
-  implicit def ToPlusEmptyOps[F[_],A](v: F[A])(implicit F0: PlusEmpty[F]) =
+trait ToPlusEmptyOps0[TC[F[_]] <: PlusEmpty[F]] extends ToPlusEmptyOpsU[TC] {
+  implicit def ToPlusEmptyOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new PlusEmptyOps[F,A](v)
 
   ////
@@ -23,6 +23,8 @@ trait ToPlusEmptyOps extends ToPlusEmptyOps0 with ToPlusOps {
   def mempty[F[_], A](implicit F: PlusEmpty[F]): F[A] = F.empty[A]
   ////
 }
+
+trait ToPlusEmptyOps[TC[F[_]] <: PlusEmpty[F]] extends ToPlusEmptyOps0[TC] with ToPlusOps[TC]
 
 trait PlusEmptySyntax[F[_]] extends PlusSyntax[F] {
   implicit def ToPlusEmptyOps[A](v: F[A]): PlusEmptyOps[F, A] = new PlusEmptyOps[F,A](v)(PlusEmptySyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/PlusSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/PlusSyntax.scala
@@ -10,20 +10,22 @@ final class PlusOps[F[_],A] private[syntax](val self: F[A])(implicit val F: Plus
   ////
 }
 
-sealed trait ToPlusOps0 {
-  implicit def ToPlusOpsUnapply[FA](v: FA)(implicit F0: Unapply[Plus, FA]) =
+sealed trait ToPlusOpsU[TC[F[_]] <: Plus[F]] {
+  implicit def ToPlusOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new PlusOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToPlusOps extends ToPlusOps0 {
-  implicit def ToPlusOps[F[_],A](v: F[A])(implicit F0: Plus[F]) =
+trait ToPlusOps0[TC[F[_]] <: Plus[F]] extends ToPlusOpsU[TC] {
+  implicit def ToPlusOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new PlusOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToPlusOps[TC[F[_]] <: Plus[F]] extends ToPlusOps0[TC]
 
 trait PlusSyntax[F[_]]  {
   implicit def ToPlusOps[A](v: F[A]): PlusOps[F, A] = new PlusOps[F,A](v)(PlusSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/ProChoiceSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/ProChoiceSyntax.scala
@@ -13,25 +13,27 @@ final class ProChoiceOps[F[_, _],A, B] private[syntax](val self: F[A, B])(implic
   ////
 }
 
-sealed trait ToProChoiceOps0 {
-  implicit def ToProChoiceOpsUnapply[FA](v: FA)(implicit F0: Unapply2[ProChoice, FA]) =
+sealed trait ToProChoiceOpsU[TC[F[_, _]] <: ProChoice[F]] {
+  implicit def ToProChoiceOpsUnapply[FA](v: FA)(implicit F0: Unapply2[TC, FA]) =
     new ProChoiceOps[F0.M,F0.A,F0.B](F0(v))(F0.TC)
 
 }
 
-trait ToProChoiceOps extends ToProChoiceOps0 with ToProfunctorOps {
+trait ToProChoiceOps0[TC[F[_, _]] <: ProChoice[F]] extends ToProChoiceOpsU[TC] {
 
-  implicit def ToProChoiceOps[F[_, _],A, B](v: F[A, B])(implicit F0: ProChoice[F]) =
+  implicit def ToProChoiceOps[F[_, _],A, B](v: F[A, B])(implicit F0: TC[F]) =
     new ProChoiceOps[F,A, B](v)
 
 
-  implicit def ToProChoiceVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: ProChoice[F[G, ?, ?]]) =
+  implicit def ToProChoiceVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: TC[F[G, ?, ?]]) =
     new ProChoiceOps[F[G, ?, ?], A, B](v)(F0)
 
   ////
 
   ////
 }
+
+trait ToProChoiceOps[TC[F[_, _]] <: ProChoice[F]] extends ToProChoiceOps0[TC] with ToProfunctorOps[TC]
 
 trait ProChoiceSyntax[F[_, _]] extends ProfunctorSyntax[F] {
   implicit def ToProChoiceOps[A, B](v: F[A, B]): ProChoiceOps[F, A, B] = new ProChoiceOps[F, A, B](v)(ProChoiceSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/ProfunctorSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/ProfunctorSyntax.scala
@@ -23,25 +23,27 @@ final class ProfunctorOps[F[_, _],A, B] private[syntax](val self: F[A, B])(impli
   ////
 }
 
-sealed trait ToProfunctorOps0 {
-  implicit def ToProfunctorOpsUnapply[FA](v: FA)(implicit F0: Unapply2[Profunctor, FA]) =
+sealed trait ToProfunctorOpsU[TC[F[_, _]] <: Profunctor[F]] {
+  implicit def ToProfunctorOpsUnapply[FA](v: FA)(implicit F0: Unapply2[TC, FA]) =
     new ProfunctorOps[F0.M,F0.A,F0.B](F0(v))(F0.TC)
 
 }
 
-trait ToProfunctorOps extends ToProfunctorOps0 {
+trait ToProfunctorOps0[TC[F[_, _]] <: Profunctor[F]] extends ToProfunctorOpsU[TC] {
 
-  implicit def ToProfunctorOps[F[_, _],A, B](v: F[A, B])(implicit F0: Profunctor[F]) =
+  implicit def ToProfunctorOps[F[_, _],A, B](v: F[A, B])(implicit F0: TC[F]) =
     new ProfunctorOps[F,A, B](v)
 
 
-  implicit def ToProfunctorVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: Profunctor[F[G, ?, ?]]) =
+  implicit def ToProfunctorVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: TC[F[G, ?, ?]]) =
     new ProfunctorOps[F[G, ?, ?], A, B](v)(F0)
 
   ////
 
   ////
 }
+
+trait ToProfunctorOps[TC[F[_, _]] <: Profunctor[F]] extends ToProfunctorOps0[TC]
 
 trait ProfunctorSyntax[F[_, _]]  {
   implicit def ToProfunctorOps[A, B](v: F[A, B]): ProfunctorOps[F, A, B] = new ProfunctorOps[F, A, B](v)(ProfunctorSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/SplitSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/SplitSyntax.scala
@@ -9,25 +9,27 @@ final class SplitOps[F[_, _],A, B] private[syntax](val self: F[A, B])(implicit v
   ////
 }
 
-sealed trait ToSplitOps0 {
-  implicit def ToSplitOpsUnapply[FA](v: FA)(implicit F0: Unapply2[Split, FA]) =
+sealed trait ToSplitOpsU[TC[F[_, _]] <: Split[F]] {
+  implicit def ToSplitOpsUnapply[FA](v: FA)(implicit F0: Unapply2[TC, FA]) =
     new SplitOps[F0.M,F0.A,F0.B](F0(v))(F0.TC)
 
 }
 
-trait ToSplitOps extends ToSplitOps0 with ToComposeOps {
+trait ToSplitOps0[TC[F[_, _]] <: Split[F]] extends ToSplitOpsU[TC] {
 
-  implicit def ToSplitOps[F[_, _],A, B](v: F[A, B])(implicit F0: Split[F]) =
+  implicit def ToSplitOps[F[_, _],A, B](v: F[A, B])(implicit F0: TC[F]) =
     new SplitOps[F,A, B](v)
 
 
-  implicit def ToSplitVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: Split[F[G, ?, ?]]) =
+  implicit def ToSplitVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: TC[F[G, ?, ?]]) =
     new SplitOps[F[G, ?, ?], A, B](v)(F0)
 
   ////
 
   ////
 }
+
+trait ToSplitOps[TC[F[_, _]] <: Split[F]] extends ToSplitOps0[TC] with ToComposeOps[TC]
 
 trait SplitSyntax[F[_, _]] extends ComposeSyntax[F] {
   implicit def ToSplitOps[A, B](v: F[A, B]): SplitOps[F, A, B] = new SplitOps[F, A, B](v)(SplitSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/StrongSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/StrongSyntax.scala
@@ -13,25 +13,27 @@ final class StrongOps[F[_, _],A, B] private[syntax](val self: F[A, B])(implicit 
   ////
 }
 
-sealed trait ToStrongOps0 {
-  implicit def ToStrongOpsUnapply[FA](v: FA)(implicit F0: Unapply2[Strong, FA]) =
+sealed trait ToStrongOpsU[TC[F[_, _]] <: Strong[F]] {
+  implicit def ToStrongOpsUnapply[FA](v: FA)(implicit F0: Unapply2[TC, FA]) =
     new StrongOps[F0.M,F0.A,F0.B](F0(v))(F0.TC)
 
 }
 
-trait ToStrongOps extends ToStrongOps0 with ToProfunctorOps {
+trait ToStrongOps0[TC[F[_, _]] <: Strong[F]] extends ToStrongOpsU[TC] {
 
-  implicit def ToStrongOps[F[_, _],A, B](v: F[A, B])(implicit F0: Strong[F]) =
+  implicit def ToStrongOps[F[_, _],A, B](v: F[A, B])(implicit F0: TC[F]) =
     new StrongOps[F,A, B](v)
 
 
-  implicit def ToStrongVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: Strong[F[G, ?, ?]]) =
+  implicit def ToStrongVFromKleisliLike[G[_], F[G[_], _, _],A, B](v: F[G, A, B])(implicit F0: TC[F[G, ?, ?]]) =
     new StrongOps[F[G, ?, ?], A, B](v)(F0)
 
   ////
 
   ////
 }
+
+trait ToStrongOps[TC[F[_, _]] <: Strong[F]] extends ToStrongOps0[TC] with ToProfunctorOps[TC]
 
 trait StrongSyntax[F[_, _]] extends ProfunctorSyntax[F] {
   implicit def ToStrongOps[A, B](v: F[A, B]): StrongOps[F, A, B] = new StrongOps[F, A, B](v)(StrongSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/Syntax.scala
+++ b/core/src/main/scala/scalaz/syntax/Syntax.scala
@@ -87,9 +87,11 @@ trait Syntaxes {
   object unzip0 extends ToUnzipOps0[Unzip]
   object unzip extends ToUnzipOps[Unzip]
 
-  object optional extends ToOptionalOps
+  object optional0 extends ToOptionalOps0[Optional]
+  object optional extends ToOptionalOps[Optional]
 
-  object catchable extends ToCatchableOps
+  object catchable0 extends ToCatchableOps0[Catchable]
+  object catchable extends ToCatchableOps[Catchable]
 
   //
   // Type classes over * * -> *
@@ -211,5 +213,5 @@ trait ToTypeClassOps
   with ToBitraverseOps0[Bitraverse] with ToComposeOps0[Compose] with ToCategoryOps0[Category]
   with ToArrowOps0[Arrow] with ToProfunctorOps0[Profunctor] with ToStrongOps0[Strong]
   with ToFoldableOps0[Foldable] with ToChoiceOps0[Choice] with ToSplitOps0[Split] with ToZipOps0[Zip] with ToUnzipOps0[Unzip] with ToMonadTellOps0[MonadTell] with ToMonadListenOps0[MonadListen] with ToMonadErrorOps0[MonadError]
-  with ToFoldable1Ops0[Foldable1] with ToTraverse1Ops0[Traverse1] with ToOptionalOps with ToCatchableOps with ToAlignOps0[Align]
+  with ToFoldable1Ops0[Foldable1] with ToTraverse1Ops0[Traverse1] with ToOptionalOps0[Optional] with ToCatchableOps0[Catchable] with ToAlignOps0[Align]
   with ToMonadTransOps

--- a/core/src/main/scala/scalaz/syntax/Syntax.scala
+++ b/core/src/main/scala/scalaz/syntax/Syntax.scala
@@ -21,49 +21,71 @@ trait Syntaxes {
 
   object enum extends ToEnumOps
 
-  object isEmpty extends ToIsEmptyOps
+  object isEmpty0 extends ToIsEmptyOps0[IsEmpty]
+  object isEmpty extends ToIsEmptyOps[IsEmpty]
 
-  object plusEmpty extends ToPlusEmptyOps
+  object plusEmpty0 extends ToPlusEmptyOps0[PlusEmpty]
+  object plusEmpty extends ToPlusEmptyOps[PlusEmpty]
 
-  object functor extends ToFunctorOps
+  object functor0 extends ToFunctorOps0[Functor]
+  object functor extends ToFunctorOps[Functor]
 
-  object invariantFunctor extends ToInvariantFunctorOps
+  object invariantFunctor0 extends ToInvariantFunctorOps0[InvariantFunctor]
+  object invariantFunctor extends ToInvariantFunctorOps[InvariantFunctor]
 
-  object contravariant extends ToContravariantOps
+  object contravariant0 extends ToContravariantOps0[Contravariant]
+  object contravariant extends ToContravariantOps[Contravariant]
 
-  object align extends ToAlignOps
+  object align0 extends ToAlignOps0[Align]
+  object align extends ToAlignOps[Align]
 
-  object apply extends ToApplyOps
+  object apply0 extends ToApplyOps0[Apply]
+  object apply extends ToApplyOps[Apply]
 
-  object applicative extends ToApplicativeOps
+  object applicative0 extends ToApplicativeOps0[Applicative]
+  object applicative extends ToApplicativeOps[Applicative]
 
-  object bind extends ToBindOps
+  object bind0 extends ToBindOps0[Bind]
+  object bind extends ToBindOps[Bind]
 
-  object monad extends ToMonadOps
+  object monad0 extends ToMonadOps0[Monad]
+  object monad extends ToMonadOps[Monad]
 
-  object cobind extends ToCobindOps
+  object cobind0 extends ToCobindOps0[Cobind]
+  object cobind extends ToCobindOps[Cobind]
 
-  object comonad extends ToComonadOps
+  object comonad0 extends ToComonadOps0[Comonad]
+  object comonad extends ToComonadOps[Comonad]
 
-  object cozip extends ToCozipOps
+  object cozip0 extends ToCozipOps0[Cozip]
+  object cozip extends ToCozipOps[Cozip]
 
-  object plus extends ToPlusOps
+  object plus0 extends ToPlusOps0[Plus]
+  object plus extends ToPlusOps[Plus]
 
-  object applicativePlus extends ToApplicativePlusOps
+  object applicativePlus0 extends ToApplicativePlusOps0[ApplicativePlus]
+  object applicativePlus extends ToApplicativePlusOps[ApplicativePlus]
 
-  object monadPlus extends ToMonadPlusOps
+  object monadPlus0 extends ToMonadPlusOps0[MonadPlus]
+  object monadPlus extends ToMonadPlusOps[MonadPlus]
 
-  object foldable extends ToFoldableOps
+  object foldable0 extends ToFoldableOps0[Foldable]
+  object foldable extends ToFoldableOps[Foldable]
 
-  object foldable1 extends ToFoldable1Ops
+  object foldable10 extends ToFoldable1Ops0[Foldable1]
+  object foldable1 extends ToFoldable1Ops[Foldable1]
 
-  object traverse extends ToTraverseOps
+  object traverse0 extends ToTraverseOps0[Traverse]
+  object traverse extends ToTraverseOps[Traverse]
 
-  object traverse1 extends ToTraverse1Ops
+  object traverse10 extends ToTraverse1Ops0[Traverse1]
+  object traverse1 extends ToTraverse1Ops[Traverse1]
 
-  object zip extends ToZipOps
+  object zip0 extends ToZipOps0[Zip]
+  object zip extends ToZipOps[Zip]
 
-  object unzip extends ToUnzipOps
+  object unzip0 extends ToUnzipOps0[Unzip]
+  object unzip extends ToUnzipOps[Unzip]
 
   object optional extends ToOptionalOps
 
@@ -73,35 +95,50 @@ trait Syntaxes {
   // Type classes over * * -> *
   //
 
-  object associative extends ToAssociativeOps
+  object associative0 extends ToAssociativeOps0[Associative]
+  object associative extends ToAssociativeOps[Associative]
 
-  object bifunctor extends ToBifunctorOps
+  object bifunctor0 extends ToBifunctorOps0[Bifunctor]
+  object bifunctor extends ToBifunctorOps[Bifunctor]
 
-  object bifoldable extends ToBifoldableOps
+  object bifoldable0 extends ToBifoldableOps0[Bifoldable]
+  object bifoldable extends ToBifoldableOps[Bifoldable]
 
-  object bitraverse extends ToBitraverseOps
+  object bitraverse0 extends ToBitraverseOps0[Bitraverse]
+  object bitraverse extends ToBitraverseOps[Bitraverse]
 
-  object compose extends ToComposeOps
+  object compose0 extends ToComposeOps0[Compose]
+  object compose extends ToComposeOps[Compose]
 
-  object profunctor extends ToProfunctorOps
+  object profunctor0 extends ToProfunctorOps0[Profunctor]
+  object profunctor extends ToProfunctorOps[Profunctor]
 
-  object strong extends ToStrongOps
+  object strong0 extends ToStrongOps0[Strong]
+  object strong extends ToStrongOps[Strong]
 
-  object proChoice extends ToProChoiceOps
+  object proChoice0 extends ToProChoiceOps0[ProChoice]
+  object proChoice extends ToProChoiceOps[ProChoice]
 
-  object category extends ToCategoryOps
+  object category0 extends ToCategoryOps0[Category]
+  object category extends ToCategoryOps[Category]
 
-  object arrow extends ToArrowOps
+  object arrow0 extends ToArrowOps0[Arrow]
+  object arrow extends ToArrowOps[Arrow]
 
-  object choice extends ToChoiceOps
+  object choice0 extends ToChoiceOps0[Choice]
+  object choice extends ToChoiceOps[Choice]
 
-  object split extends ToSplitOps
+  object split0 extends ToSplitOps0[Split]
+  object split extends ToSplitOps[Split]
 
-  object monadTell extends ToMonadTellOps
+  object monadTell0 extends ToMonadTellOps0[MonadTell]
+  object monadTell extends ToMonadTellOps[MonadTell]
 
-  object monadListen extends ToMonadListenOps
+  object monadListen0 extends ToMonadListenOps0[MonadListen]
+  object monadListen extends ToMonadListenOps[MonadListen]
 
-  object monadError extends ToMonadErrorOps
+  object monadError0 extends ToMonadErrorOps0[MonadError]
+  object monadError extends ToMonadErrorOps[MonadError]
 
   //
   // Type classes over (* -> *) -> * -> *
@@ -166,12 +203,13 @@ trait ToDataOps
 
 trait ToTypeClassOps
   extends ToSemigroupOps with ToMonoidOps with ToBandOps with ToEqualOps with ToShowOps
-  with ToOrderOps with ToEnumOps with ToPlusEmptyOps
-  with ToFunctorOps with ToContravariantOps with ToApplyOps
-  with ToApplicativeOps with ToBindOps with ToMonadOps with ToComonadOps
-  with ToBifoldableOps with ToCozipOps
-  with ToPlusOps with ToApplicativePlusOps with ToMonadPlusOps with ToTraverseOps with ToBifunctorOps with ToAssociativeOps
-  with ToBitraverseOps with ToComposeOps with ToCategoryOps
-  with ToArrowOps with ToFoldableOps with ToChoiceOps with ToSplitOps with ToZipOps with ToUnzipOps with ToMonadTellOps with ToMonadListenOps with ToMonadErrorOps
-  with ToFoldable1Ops with ToTraverse1Ops with ToOptionalOps with ToCatchableOps with ToAlignOps
+  with ToOrderOps with ToEnumOps with ToPlusEmptyOps0[PlusEmpty]
+  with ToFunctorOps0[Functor] with ToContravariantOps0[Contravariant] with ToApplyOps0[Apply]
+  with ToApplicativeOps0[Applicative] with ToBindOps0[Bind] with ToMonadOps0[Monad] with ToComonadOps0[Comonad]
+  with ToBifoldableOps0[Bifoldable] with ToCozipOps0[Cozip]
+  with ToPlusOps0[Plus] with ToApplicativePlusOps0[ApplicativePlus] with ToMonadPlusOps0[MonadPlus] with ToTraverseOps0[Traverse] with ToBifunctorOps0[Bifunctor] with ToAssociativeOps0[Associative]
+  with ToBitraverseOps0[Bitraverse] with ToComposeOps0[Compose] with ToCategoryOps0[Category]
+  with ToArrowOps0[Arrow] with ToProfunctorOps0[Profunctor] with ToStrongOps0[Strong]
+  with ToFoldableOps0[Foldable] with ToChoiceOps0[Choice] with ToSplitOps0[Split] with ToZipOps0[Zip] with ToUnzipOps0[Unzip] with ToMonadTellOps0[MonadTell] with ToMonadListenOps0[MonadListen] with ToMonadErrorOps0[MonadError]
+  with ToFoldable1Ops0[Foldable1] with ToTraverse1Ops0[Traverse1] with ToOptionalOps with ToCatchableOps with ToAlignOps0[Align]
   with ToMonadTransOps

--- a/core/src/main/scala/scalaz/syntax/Traverse1Syntax.scala
+++ b/core/src/main/scala/scalaz/syntax/Traverse1Syntax.scala
@@ -27,20 +27,22 @@ final class Traverse1Ops[F[_],A] private[syntax](val self: F[A])(implicit val F:
   ////
 }
 
-sealed trait ToTraverse1Ops0 {
-  implicit def ToTraverse1OpsUnapply[FA](v: FA)(implicit F0: Unapply[Traverse1, FA]) =
+sealed trait ToTraverse1OpsU[TC[F[_]] <: Traverse1[F]] {
+  implicit def ToTraverse1OpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new Traverse1Ops[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToTraverse1Ops extends ToTraverse1Ops0 with ToTraverseOps with ToFoldable1Ops {
-  implicit def ToTraverse1Ops[F[_],A](v: F[A])(implicit F0: Traverse1[F]) =
+trait ToTraverse1Ops0[TC[F[_]] <: Traverse1[F]] extends ToTraverse1OpsU[TC] {
+  implicit def ToTraverse1Ops[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new Traverse1Ops[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToTraverse1Ops[TC[F[_]] <: Traverse1[F]] extends ToTraverse1Ops0[TC] with ToTraverseOps[TC] with ToFoldable1Ops[TC]
 
 trait Traverse1Syntax[F[_]] extends TraverseSyntax[F] with Foldable1Syntax[F] {
   implicit def ToTraverse1Ops[A](v: F[A]): Traverse1Ops[F, A] = new Traverse1Ops[F,A](v)(Traverse1Syntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/TraverseSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/TraverseSyntax.scala
@@ -68,20 +68,22 @@ final class TraverseOps[F[_],A] private[syntax](val self: F[A])(implicit val F: 
   ////
 }
 
-sealed trait ToTraverseOps0 {
-  implicit def ToTraverseOpsUnapply[FA](v: FA)(implicit F0: Unapply[Traverse, FA]) =
+sealed trait ToTraverseOpsU[TC[F[_]] <: Traverse[F]] {
+  implicit def ToTraverseOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new TraverseOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToTraverseOps extends ToTraverseOps0 with ToFunctorOps with ToFoldableOps {
-  implicit def ToTraverseOps[F[_],A](v: F[A])(implicit F0: Traverse[F]) =
+trait ToTraverseOps0[TC[F[_]] <: Traverse[F]] extends ToTraverseOpsU[TC] {
+  implicit def ToTraverseOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new TraverseOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToTraverseOps[TC[F[_]] <: Traverse[F]] extends ToTraverseOps0[TC] with ToFunctorOps[TC] with ToFoldableOps[TC]
 
 trait TraverseSyntax[F[_]] extends FunctorSyntax[F] with FoldableSyntax[F] {
   implicit def ToTraverseOps[A](v: F[A]): TraverseOps[F, A] = new TraverseOps[F,A](v)(TraverseSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/UnzipSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/UnzipSyntax.scala
@@ -7,21 +7,21 @@ final class UnzipOps[F[_],A] private[syntax](val self: F[A])(implicit val F: Unz
   ////
 }
 
-sealed trait ToUnzipOps0 {
-  implicit def ToUnzipOpsUnapply[FA](v: FA)(implicit F0: Unapply[Unzip, FA]) =
+sealed trait ToUnzipOpsU[TC[F[_]] <: Unzip[F]] {
+  implicit def ToUnzipOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new UnzipOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToUnzipOps extends ToUnzipOps0 {
-  implicit def ToUnzipOps[F[_],A](v: F[A])(implicit F0: Unzip[F]) =
+trait ToUnzipOps0[TC[F[_]] <: Unzip[F]] extends ToUnzipOpsU[TC] {
+  implicit def ToUnzipOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new UnzipOps[F,A](v)
 
   ////
-  implicit def ToUnzipPairOps[F[_],A,B](v: F[(A, B)])(implicit F0: Unzip[F]) =
+  implicit def ToUnzipPairOps[F[_],A,B](v: F[(A, B)])(implicit F0: TC[F]) =
     new UnzipPairOps[F,A,B](v)(F0)
 
-  final class UnzipPairOps[F[_],A, B] private[syntax](self: F[(A, B)])(implicit F: Unzip[F]) {
+  final class UnzipPairOps[F[_],A, B] private[syntax](self: F[(A, B)])(implicit F: TC[F]) {
     def unfzip: (F[A], F[B]) =
       F.unzip(self)
 
@@ -34,6 +34,8 @@ trait ToUnzipOps extends ToUnzipOps0 {
 
   ////
 }
+
+trait ToUnzipOps[TC[F[_]] <: Unzip[F]] extends ToUnzipOps0[TC]
 
 trait UnzipSyntax[F[_]]  {
   implicit def ToUnzipOps[A](v: F[A]): UnzipOps[F, A] = new UnzipOps[F,A](v)(UnzipSyntax.this.F)

--- a/core/src/main/scala/scalaz/syntax/ZipSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/ZipSyntax.scala
@@ -12,20 +12,22 @@ final class ZipOps[F[_],A] private[syntax](val self: F[A])(implicit val F: Zip[F
   ////
 }
 
-sealed trait ToZipOps0 {
-  implicit def ToZipOpsUnapply[FA](v: FA)(implicit F0: Unapply[Zip, FA]) =
+sealed trait ToZipOpsU[TC[F[_]] <: Zip[F]] {
+  implicit def ToZipOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new ZipOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToZipOps extends ToZipOps0 {
-  implicit def ToZipOps[F[_],A](v: F[A])(implicit F0: Zip[F]) =
+trait ToZipOps0[TC[F[_]] <: Zip[F]] extends ToZipOpsU[TC] {
+  implicit def ToZipOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new ZipOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToZipOps[TC[F[_]] <: Zip[F]] extends ToZipOps0[TC]
 
 trait ZipSyntax[F[_]]  {
   implicit def ToZipOps[A](v: F[A]): ZipOps[F, A] = new ZipOps[F,A](v)(ZipSyntax.this.F)

--- a/effect/src/main/scala/scalaz/syntax/effect/LiftControlIOSyntax.scala
+++ b/effect/src/main/scala/scalaz/syntax/effect/LiftControlIOSyntax.scala
@@ -11,14 +11,14 @@ final class LiftControlIOOps[F[_],A] private[syntax](val self: F[A])(implicit va
   ////
 }
 
-sealed trait ToLiftControlIOOps0 {
-  implicit def ToLiftControlIOOpsUnapply[FA](v: FA)(implicit F0: Unapply[LiftControlIO, FA]) =
+sealed trait ToLiftControlIOOpsU[TC[F[_]] <: LiftControlIO[F]] {
+  implicit def ToLiftControlIOOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new LiftControlIOOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToLiftControlIOOps extends ToLiftControlIOOps0 {
-  implicit def ToLiftControlIOOps[F[_],A](v: F[A])(implicit F0: LiftControlIO[F]) =
+trait ToLiftControlIOOps[TC[F[_]] <: LiftControlIO[F]] extends ToLiftControlIOOpsU[TC] {
+  implicit def ToLiftControlIOOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new LiftControlIOOps[F,A](v)
 
   ////

--- a/effect/src/main/scala/scalaz/syntax/effect/LiftControlIOSyntax.scala
+++ b/effect/src/main/scala/scalaz/syntax/effect/LiftControlIOSyntax.scala
@@ -17,7 +17,7 @@ sealed trait ToLiftControlIOOpsU[TC[F[_]] <: LiftControlIO[F]] {
 
 }
 
-trait ToLiftControlIOOps[TC[F[_]] <: LiftControlIO[F]] extends ToLiftControlIOOpsU[TC] {
+trait ToLiftControlIOOps0[TC[F[_]] <: LiftControlIO[F]] extends ToLiftControlIOOpsU[TC] {
   implicit def ToLiftControlIOOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new LiftControlIOOps[F,A](v)
 
@@ -25,6 +25,8 @@ trait ToLiftControlIOOps[TC[F[_]] <: LiftControlIO[F]] extends ToLiftControlIOOp
 
   ////
 }
+
+trait ToLiftControlIOOps[TC[F[_]] <: LiftControlIO[F]] extends ToLiftControlIOOps0[TC]
 
 trait LiftControlIOSyntax[F[_]]  {
   implicit def ToLiftControlIOOps[A](v: F[A]): LiftControlIOOps[F, A] = new LiftControlIOOps[F,A](v)(LiftControlIOSyntax.this.F)

--- a/effect/src/main/scala/scalaz/syntax/effect/LiftIOSyntax.scala
+++ b/effect/src/main/scala/scalaz/syntax/effect/LiftIOSyntax.scala
@@ -11,14 +11,14 @@ final class LiftIOOps[F[_],A] private[syntax](val self: F[A])(implicit val F: Li
   ////
 }
 
-sealed trait ToLiftIOOps0 {
-  implicit def ToLiftIOOpsUnapply[FA](v: FA)(implicit F0: Unapply[LiftIO, FA]) =
+sealed trait ToLiftIOOpsU[TC[F[_]] <: LiftIO[F]] {
+  implicit def ToLiftIOOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new LiftIOOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToLiftIOOps extends ToLiftIOOps0 {
-  implicit def ToLiftIOOps[F[_],A](v: F[A])(implicit F0: LiftIO[F]) =
+trait ToLiftIOOps[TC[F[_]] <: LiftIO[F]] extends ToLiftIOOpsU[TC] {
+  implicit def ToLiftIOOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new LiftIOOps[F,A](v)
 
   ////

--- a/effect/src/main/scala/scalaz/syntax/effect/LiftIOSyntax.scala
+++ b/effect/src/main/scala/scalaz/syntax/effect/LiftIOSyntax.scala
@@ -17,7 +17,7 @@ sealed trait ToLiftIOOpsU[TC[F[_]] <: LiftIO[F]] {
 
 }
 
-trait ToLiftIOOps[TC[F[_]] <: LiftIO[F]] extends ToLiftIOOpsU[TC] {
+trait ToLiftIOOps0[TC[F[_]] <: LiftIO[F]] extends ToLiftIOOpsU[TC] {
   implicit def ToLiftIOOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new LiftIOOps[F,A](v)
 
@@ -25,6 +25,8 @@ trait ToLiftIOOps[TC[F[_]] <: LiftIO[F]] extends ToLiftIOOpsU[TC] {
 
   ////
 }
+
+trait ToLiftIOOps[TC[F[_]] <: LiftIO[F]] extends ToLiftIOOps0[TC]
 
 trait LiftIOSyntax[F[_]]  {
   implicit def ToLiftIOOps[A](v: F[A]): LiftIOOps[F, A] = new LiftIOOps[F,A](v)(LiftIOSyntax.this.F)

--- a/effect/src/main/scala/scalaz/syntax/effect/MonadControlIOSyntax.scala
+++ b/effect/src/main/scala/scalaz/syntax/effect/MonadControlIOSyntax.scala
@@ -11,20 +11,22 @@ final class MonadControlIOOps[F[_],A] private[syntax](val self: F[A])(implicit v
   ////
 }
 
-sealed trait ToMonadControlIOOps0 {
-  implicit def ToMonadControlIOOpsUnapply[FA](v: FA)(implicit F0: Unapply[MonadControlIO, FA]) =
+sealed trait ToMonadControlIOOpsU[TC[F[_]] <: MonadControlIO[F]] {
+  implicit def ToMonadControlIOOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new MonadControlIOOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToMonadControlIOOps extends ToMonadControlIOOps0 with ToLiftControlIOOps with ToMonadOps {
-  implicit def ToMonadControlIOOps[F[_],A](v: F[A])(implicit F0: MonadControlIO[F]) =
+trait ToMonadControlIOOps0[TC[F[_]] <: MonadControlIO[F]] extends ToMonadControlIOOpsU[TC] {
+  implicit def ToMonadControlIOOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new MonadControlIOOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToMonadControlIOOps[TC[F[_]] <: MonadControlIO[F]] extends ToMonadControlIOOps0[TC] with ToLiftControlIOOps[TC] with ToMonadOps[TC]
 
 trait MonadControlIOSyntax[F[_]] extends LiftControlIOSyntax[F] with MonadSyntax[F] {
   implicit def ToMonadControlIOOps[A](v: F[A]): MonadControlIOOps[F, A] = new MonadControlIOOps[F,A](v)(MonadControlIOSyntax.this.F)

--- a/effect/src/main/scala/scalaz/syntax/effect/MonadIOSyntax.scala
+++ b/effect/src/main/scala/scalaz/syntax/effect/MonadIOSyntax.scala
@@ -11,20 +11,22 @@ final class MonadIOOps[F[_],A] private[syntax](val self: F[A])(implicit val F: M
   ////
 }
 
-sealed trait ToMonadIOOps0 {
-  implicit def ToMonadIOOpsUnapply[FA](v: FA)(implicit F0: Unapply[MonadIO, FA]) =
+sealed trait ToMonadIOOpsU[TC[F[_]] <: MonadIO[F]] {
+  implicit def ToMonadIOOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
     new MonadIOOps[F0.M,F0.A](F0(v))(F0.TC)
 
 }
 
-trait ToMonadIOOps extends ToMonadIOOps0 with ToLiftIOOps with ToMonadOps {
-  implicit def ToMonadIOOps[F[_],A](v: F[A])(implicit F0: MonadIO[F]) =
+trait ToMonadIOOps0[TC[F[_]] <: MonadIO[F]] extends ToMonadIOOpsU[TC] {
+  implicit def ToMonadIOOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
     new MonadIOOps[F,A](v)
 
   ////
 
   ////
 }
+
+trait ToMonadIOOps[TC[F[_]] <: MonadIO[F]] extends ToMonadIOOps0[TC] with ToLiftIOOps[TC] with ToMonadOps[TC]
 
 trait MonadIOSyntax[F[_]] extends LiftIOSyntax[F] with MonadSyntax[F] {
   implicit def ToMonadIOOps[A](v: F[A]): MonadIOOps[F, A] = new MonadIOOps[F,A](v)(MonadIOSyntax.this.F)

--- a/example/src/main/scala/scalaz/example/SyntaxUsage.scala
+++ b/example/src/main/scala/scalaz/example/SyntaxUsage.scala
@@ -106,4 +106,81 @@ object SyntaxUsage extends App {
 
     List(some(0)).sequence
   }
+
+  def unambiguousFunctorSyntax(): Unit = {
+    import scalaz._
+
+    def foo[F[_]: Monad: Traverse, A, B](fa: F[A], f: A => B): F[B] = {
+      // Importing Functor syntax (import scalaz.syntax.functor._) would
+      // give ambiguous implicit values for Functor[F] when trying to use
+      // Functor syntax.
+      // Monad syntax however requires a Monad even for functor operations,
+      // and there is a unique Monad[F] in scope.
+      import scalaz.syntax.monad._
+
+      fa map f
+    }
+  }
+
+  def mixingMonadAndTraverseSyntax(): Unit = {
+    import scalaz._
+
+    def foo[F[_]: Monad: Traverse, A, B](fa: F[A], f: A => B): Unit = {
+      // Here we want to use both Monad and Traverse syntax, as well as
+      // Functor syntax. Since F is both Monad and Traverse, there are
+      // two ways to get Functor syntax for F. To avoid ambiguity,
+      // import Traverse syntax that doesn't include Functor syntax (traverse0).
+      import scalaz.syntax.monad._
+      import scalaz.syntax.traverse0._
+
+      // Functor syntax
+      fa map f
+
+      // Monad syntax
+      fa flatMap (a => f(a).point[F])
+
+      // Traverse and Applicative syntax
+      fa traverse (a => f(a).point[F])
+    }
+  }
+
+  def mixingApplicativeAndBindSyntax(): Unit = {
+    import scalaz._
+
+    def foo[F[_]: Applicative: Bind, A, B](fa: F[A], fb: F[B]): F[(A, B)] = {
+      // To avoid ambiguity, import Applicative syntax that
+      // doesn't include Apply syntax (applicative0).
+      import scalaz.syntax.bind._
+      import scalaz.syntax.applicative0._
+
+      // Bind syntax
+      fa flatMap (_ => fb)
+
+      // Applicative syntax
+      1.point[F]
+
+      // Apply syntax
+      (fa |@| fb).tupled
+    }
+  }
+
+  def mixingMonadTellAndMonadErrorSyntax(): Unit = {
+    import scalaz._
+
+    def foo[F[_], E](fa: F[Int])(implicit mt: MonadTell[F, String], me: MonadError[F, E]) = {
+      // To avoid ambiguity, import MonadError syntax that
+      // doesn't include Monad syntax (monadError0).
+      import scalaz.syntax.monadTell._
+      import scalaz.syntax.monadError0._
+
+      // Monad syntax
+      fa flatMap (_ => fa)
+
+      // MonadTell syntax
+      fa :++> "foo"
+
+      // MonadError syntax
+      fa handleError (e => fa)
+    }
+  }
 }

--- a/tests/src/test/scala/scalaz/FoldableTest.scala
+++ b/tests/src/test/scala/scalaz/FoldableTest.scala
@@ -121,7 +121,7 @@ object FoldableTest extends SpecLite {
     val gt2: (Int, => Int) => Int = (i, j) => i - j
     val strlen = (_ : String).length
 
-    import syntax.foldable1._
+    import syntax.foldable10._
     import syntax.std.list._
 
     "foldLeft1Opt" ! forAll {


### PR DESCRIPTION
The goal is to allow the user to structure imports so that ambiguous syntactic extensions are avoided.

Example:

```scala
import scalaz.syntax.monad._

def foo[F[_]: Monad: Traverse, A, B](fa: F[A], f: A => B): F[B] =
  fa map f // no ambiguous implicits, even though there are two implicit Functor instances
```

Typeclass encoding is left untouched, thus ambiguous typeclass instances are not avoided, just ambiguous ops. As such, this approach is less ambitious than scalaz8's, but maybe could be considered for scalaz7? On one hand, it can have great benefits for the client code, but on the other hand it increases the complexity of syntax extensions. I'm myself not yet 100% convinced that this is the better tradeoff.

The idea is that the import

```scala
import scalaz.syntax.traverse0._
```
imports syntax for `Traverse`, but doesn't include syntax for `Functor` or `Foldable`, whereas the (usual) import

```scala
import scalaz.syntax.traverse._
```

also brings in syntax for `Functor` and `Foldable`.
There is one change, though: for this import to provide `Functor` (or `Foldable`) syntax, there needs to be a `Traverse` instance in scope; `Functor` (or `Foldable`) instance will not suffice, even when only `Functor` (or `Foldable`) operations are performed. (This is why there is no ambiguity in the example at the top - for `Functor` ops imported via `scalaz.syntax.monad._`, a `Monad` instance is required, and there is only one.)

This allows us to import

```scala
import scalaz.syntax.monad._
import scalaz.syntax.traverse0._
```

and then use both `Monad` and `Traverse` syntax extensions without ambiguity.

For some examples, see the diff of `SyntaxUsage.scala`.

### Implementation comments

Where previously we had

```scala
trait ToTraverseOps extends ToFunctorOps with ToFoldableOps
```

we now have (to be refined shortly)

```scala
trait ToTraverseOps0

trait ToTraverseOps extends ToTraverseOps0 with ToFunctorOps with ToFoldableOps
```

That is, we provide `ToTraverseOps0` which doesn't inherit `Functor` and `Foldable` ops.

In order for `ToTraverseOps`'s inherited `ToFunctorOps` and `ToFoldableOps` to actually require a `Traverse` instance even for `Functor` or `Foldable` operations, we pass the required typeclass as a type argument. Thus we have

```scala
trait ToTraverseOps0[TC[F[_]] <: Traverse[F]]

trait ToTraverseOps[TC[F[_]] <: Traverse[F]] extends ToTraverseOps0[TC] with ToFunctorOps[TC] with ToFoldableOps[TC]
```

and then in `ToFunctorOps`, we require an instance of `TC` (e.g. `Traverse`) instead of `Functor`:

```scala
trait ToFunctorOps0[TC[F[_]] <: Functor[F]] {
  implicit def ToFunctorOps[F[_], A](v: F[A])(implicit F0: TC[F]) = ???
}
```

There is one more point worth mentioning.
Consider syntax for `MonadTell` extending syntax for `Monad`, using the above scheme:

```scala
trait ToMonadOps[TC[F[_]] <: Monad[F]]

trait ToMonadTellOps[TC[F[_], S] <: MonadTell[F, S]] extends ToMonadOps[???]
```

The kinds of type parameters of `ToMonadOps` and `ToMonadTellOps` do not match. Therefore, we cannot just pass the `TC` type parameter from `ToMonadTellOps` to `ToMonadOps`. The solution is to use an existential

```scala
trait ToMonadTellOps[TC[F[_], S] <: MonadTell[F, S]] extends ToMonadOps[λ[F[_] => TC[F, S] forSome { type S }]]
```

and, despite many problems with existentials in Scala, the compiler does consider `MonadTell[F, S] forSome { type S }` to be a subtype of `Monad[F]`.