### PR TITLE
Disjunction.fromTryCatchNonFatal

### DIFF
--- a/base/shared/src/main/scala/scalaz/data/DisjunctionFunctions.scala
+++ b/base/shared/src/main/scala/scalaz/data/DisjunctionFunctions.scala
@@ -1,6 +1,8 @@
 package scalaz
 package data
 
+import scala.util.control.NonFatal
+
 import Disjunction.{\/, \/-, -\/}
 
 trait DisjunctionFunctions {
@@ -8,7 +10,13 @@ trait DisjunctionFunctions {
   @inline def right[L, R](value: R): Disjunction[L, R] = \/-(value)
 
   def either[A, B, C](ac: A => C)(bc: B => C): A \/ B => C = _ match {
-    case -\/(l)  => ac(l)
+    case -\/(l) => ac(l)
     case \/-(r) => bc(r)
+  }
+
+  def fromTryCatchNonFatal[A](block: => A): Throwable \/ A = try {
+    \/-(block)
+  } catch {
+    case NonFatal(t) => -\/(t)
   }
 }

--- a/example/shared/src/main/scala/scalaz/example/DisjunctionUsage.scala
+++ b/example/shared/src/main/scala/scalaz/example/DisjunctionUsage.scala
@@ -1,0 +1,24 @@
+package scalaz.example
+
+import scalaz.data.Disjunction
+import Disjunction._
+
+object DisjunctionUsage extends App {
+  val left: String \/ Int = -\/("Foo")
+  val right: String \/ Int = \/-(42)
+  val disj: String \/ Int = Disjunction.fromEither(Left("Foo"))
+
+  // Pattern match
+  left match {
+    case -\/(str) => println(str)
+    case \/-(i) => println(i)
+  }
+
+  // Fold
+  val folded: String = disj.fold(_ + "Bar")(_.toString)
+
+  // try/catch
+  val caught: Throwable \/ String = Disjunction.fromTryCatchNonFatal {
+    null.toString
+  }
+}


### PR DESCRIPTION
`\/.fromTryCatchNonFatal` is a life-saver when integrating with Java libraries.
This is adding it to `DisjunctionFunctions` in Scalaz 8

I am also adding example usages for `Disjunction`, I assume these are going to be turned into/serve as documentation in the future.