### PR TITLE
Factor stdlib collections' instances

### DIFF
--- a/core/src/main/scala/scalaz/Foldable.scala
+++ b/core/src/main/scala/scalaz/Foldable.scala
@@ -156,9 +156,9 @@ trait Foldable[F[_]]  { self =>
   def indexOr[A](fa: F[A], default: => A, i: Int): A =
     index(fa, i) getOrElse default
 
-  def toList[A](fa: F[A]): List[A] = foldLeft(fa, scala.List[A]())((t, h) => h :: t).reverse
-  def toVector[A](fa: F[A]): Vector[A] = foldLeft(fa, Vector[A]())(_ :+ _)
-  def toSet[A](fa: F[A]): Set[A] = foldLeft(fa, Set[A]())(_ + _)
+  def toList[A](fa: F[A]): List[A] = to[A, List](fa)
+  def toVector[A](fa: F[A]): Vector[A] = to[A, Vector](fa)
+  def toSet[A](fa: F[A]): Set[A] = to[A, Set](fa)
   def toStream[A](fa: F[A]): Stream[A] = foldRight[A, Stream[A]](fa, Stream.empty)(Stream.cons(_, _))
   def to[A, G[_]](fa: F[A])(implicit c: CanBuildFrom[Nothing, A, G[A]]): G[A] =
     foldLeft(fa, c())(_ += _).result

--- a/core/src/main/scala/scalaz/IList.scala
+++ b/core/src/main/scala/scalaz/IList.scala
@@ -411,7 +411,7 @@ sealed abstract class IList[A] extends Product with Serializable {
     uncons(EphemeralStream(), (h, t) => EphemeralStream.cons(h, t.toEphemeralStream))
 
   def toList: List[A] =
-    foldRight(Nil : List[A])(_ :: _)
+    Foldable[IList].toList(this)
 
   def toNel: Option[NonEmptyList[A]] =
     uncons(None, (h, t) => Some(NonEmptyList.nel(h, t)))
@@ -426,7 +426,7 @@ sealed abstract class IList[A] extends Product with Serializable {
     IList.show(Show.showA).shows(this) // lame, but helpful for debugging
 
   def toVector: Vector[A] =
-    foldRight(Vector[A]())(_ +: _)
+    Foldable[IList].toVector(this)
 
   def toZipper: Option[Zipper[A]] =
     sToZipper(toStream)
@@ -594,6 +594,8 @@ sealed abstract class IListInstances extends IListInstance0 {
       }
 
       override def toIList[A](fa: IList[A]) = fa
+
+      override def toStream[A](fa: IList[A]) = fa.toStream
 
       override def foldLeft[A, B](fa: IList[A], z: B)(f: (B, A) => B) =
         fa.foldLeft(z)(f)

--- a/core/src/main/scala/scalaz/NonEmptyList.scala
+++ b/core/src/main/scala/scalaz/NonEmptyList.scala
@@ -24,7 +24,10 @@ final class NonEmptyList[A] private[scalaz](val head: A, val tail: IList[A]) {
   /** @since 7.0.3 */
   def foreach(f: A => Unit): Unit = {
     f(head)
-    tail.toList.foreach(f)
+    tail.foldLeft(()){(_, a) =>
+      f(a)
+      ()
+    }
   }
 
   def flatMap[B](f: A => NonEmptyList[B]): NonEmptyList[B] = {

--- a/core/src/main/scala/scalaz/std/Iterable.scala
+++ b/core/src/main/scala/scalaz/std/Iterable.scala
@@ -80,10 +80,10 @@ private[std] trait IterableSubtypeFoldable[I[X] <: Iterable[X]] extends Foldable
   override final def empty[A](fa: I[A]) = fa.isEmpty
 
   override final def any[A](fa: I[A])(p: A => Boolean): Boolean =
-    fa.exists(p)
+    fa exists p
 
   override final def all[A](fa: I[A])(p: A => Boolean): Boolean =
-    fa.forall(p)
+    fa forall p
 }
 
 object iterable extends IterableInstances

--- a/core/src/main/scala/scalaz/std/Iterable.scala
+++ b/core/src/main/scala/scalaz/std/Iterable.scala
@@ -98,7 +98,6 @@ private[std] trait StrictOrLazySeqSubtypeCovariant[F[+X] <: Seq[X] with GenericT
 
   protected[this] implicit def canBuildFrom[A]: CanBuildFrom[F[_], A, F[A]]
 
-  override final def index[A](fa: F[A], i: Int) = fa.lift.apply(i)
   override final def length[A](fa: F[A]) = fa.length
   override final def point[A](a: => A) = Factory(a)
   override final def bind[A, B](fa: F[A])(f: A => F[B]) = fa flatMap f
@@ -128,6 +127,7 @@ private[std] trait StrictOrLazySeqSubtypeCovariant[F[+X] <: Seq[X] with GenericT
 private[std] trait StrictSeqSubtypeCovariant[F[+X] <: Seq[X] with GenericTraversableTemplate[X, F] with SeqLike[X, F[X]]]
     extends StrictOrLazySeqSubtypeCovariant[F] {
   override final def plus[A](a: F[A], b: => F[A]) = a ++ b
+  override final def index[A](fa: F[A], i: Int) = fa.lift.apply(i)
 
   override final def tailrecM[A, B](a: A)(f: A => F[A \/ B]): F[B] = {
     val bs = canBuildFrom[B].apply()

--- a/core/src/main/scala/scalaz/std/Iterable.scala
+++ b/core/src/main/scala/scalaz/std/Iterable.scala
@@ -90,7 +90,7 @@ private[std] trait IterableSubtypeFoldable[I[X] <: Iterable[X]] extends Foldable
     fa forall p
 }
 
-private[std] trait SeqSubtypeCovariant[F[+X] <: Seq[X] with GenericTraversableTemplate[X, F] with SeqLike[X, F[X]]]
+private[std] trait StrictOrLazySeqSubtypeCovariant[F[+X] <: Seq[X] with GenericTraversableTemplate[X, F] with SeqLike[X, F[X]]]
     extends Traverse[F] with MonadPlus[F] with BindRec[F] with Zip[F] with Unzip[F] with IsEmpty[F] {
   import Liskov.<~<
 
@@ -103,7 +103,6 @@ private[std] trait SeqSubtypeCovariant[F[+X] <: Seq[X] with GenericTraversableTe
   override final def point[A](a: => A) = Factory(a)
   override final def bind[A, B](fa: F[A])(f: A => F[B]) = fa flatMap f
   override final def empty[A] = Factory.empty
-  override final def plus[A](a: F[A], b: => F[A]) = a ++ b
   override final def isEmpty[A](fa: F[A]) = fa.isEmpty
   override final def map[A, B](l: F[A])(f: A => B) = l map f
   override final def widen[A, B](l: F[A])(implicit ev: A <~< B) = Liskov.co(ev)(l)
@@ -124,6 +123,11 @@ private[std] trait SeqSubtypeCovariant[F[+X] <: Seq[X] with GenericTraversableTe
       (cur, buf.result)
     }
   }
+}
+
+private[std] trait StrictSeqSubtypeCovariant[F[+X] <: Seq[X] with GenericTraversableTemplate[X, F] with SeqLike[X, F[X]]]
+    extends StrictOrLazySeqSubtypeCovariant[F] {
+  override final def plus[A](a: F[A], b: => F[A]) = a ++ b
 
   override final def tailrecM[A, B](a: A)(f: A => F[A \/ B]): F[B] = {
     val bs = canBuildFrom[B].apply()
@@ -132,7 +136,7 @@ private[std] trait SeqSubtypeCovariant[F[+X] <: Seq[X] with GenericTraversableTe
       xs match {
         case (\/-(b) +: tail) :: rest =>
           bs += b
-          go(tail.toVector :: rest)
+          go(tail :: rest)
         case (-\/(a0) +: tail) :: rest =>
           go(f(a0) :: tail :: rest)
         case _ :: rest =>

--- a/core/src/main/scala/scalaz/std/Iterable.scala
+++ b/core/src/main/scala/scalaz/std/Iterable.scala
@@ -102,7 +102,7 @@ private[std] trait StrictOrLazySeqSubtypeCovariant[F[+X] <: Seq[X] with GenericT
   override final def length[A](fa: F[A]) = fa.length
   override final def point[A](a: => A) = Factory(a)
   override final def bind[A, B](fa: F[A])(f: A => F[B]) = fa flatMap f
-  override final def empty[A] = Factory.empty
+  override final def empty[A] = Factory.empty[A]
   override final def isEmpty[A](fa: F[A]) = fa.isEmpty
   override final def map[A, B](l: F[A])(f: A => B) = l map f
   override final def widen[A, B](l: F[A])(implicit ev: A <~< B) = Liskov.co(ev)(l)

--- a/core/src/main/scala/scalaz/std/Iterable.scala
+++ b/core/src/main/scala/scalaz/std/Iterable.scala
@@ -1,6 +1,10 @@
 package scalaz
 package std
 
+import collection.SeqLike
+import collection.generic.{CanBuildFrom, SeqFactory, GenericTraversableTemplate}
+import collection.immutable.Seq
+
 trait IterableInstances {
 
   implicit def iterableShow[CC[X] <: Iterable[X], A: Show]: Show[CC[A]] = new Show[CC[A]] {
@@ -84,6 +88,60 @@ private[std] trait IterableSubtypeFoldable[I[X] <: Iterable[X]] extends Foldable
 
   override final def all[A](fa: I[A])(p: A => Boolean): Boolean =
     fa forall p
+}
+
+private[std] trait SeqSubtypeCovariant[F[+X] <: Seq[X] with GenericTraversableTemplate[X, F] with SeqLike[X, F[X]]]
+    extends Traverse[F] with MonadPlus[F] with BindRec[F] with Zip[F] with Unzip[F] with IsEmpty[F] {
+  import Liskov.<~<
+
+  protected[this] val Factory: SeqFactory[F]
+
+  protected[this] implicit def canBuildFrom[A]: CanBuildFrom[F[_], A, F[A]]
+
+  override final def index[A](fa: F[A], i: Int) = fa.lift.apply(i)
+  override final def length[A](fa: F[A]) = fa.length
+  override final def point[A](a: => A) = Factory(a)
+  override final def bind[A, B](fa: F[A])(f: A => F[B]) = fa flatMap f
+  override final def empty[A] = Factory.empty
+  override final def plus[A](a: F[A], b: => F[A]) = a ++ b
+  override final def isEmpty[A](fa: F[A]) = fa.isEmpty
+  override final def map[A, B](l: F[A])(f: A => B) = l map f
+  override final def widen[A, B](l: F[A])(implicit ev: A <~< B) = Liskov.co(ev)(l)
+  override final def filter[A](fa: F[A])(p: A => Boolean): F[A] = fa filter p
+
+  override final def zip[A, B](a: => F[A], b: => F[B]) = {
+    val _a = a
+    if(_a.isEmpty) empty
+    else _a zip b
+  }
+  override final def unzip[A, B](a: F[(A, B)]) = a.unzip
+
+  override final def traverseS[S,A,B](l: F[A])(f: A => State[S,B]): State[S, F[B]] = {
+    State{s: S =>
+      val buf = canBuildFrom[B].apply(l)
+      var cur = s
+      l.foreach { a => val bs = f(a)(cur); buf += bs._2; cur = bs._1 }
+      (cur, buf.result)
+    }
+  }
+
+  override final def tailrecM[A, B](a: A)(f: A => F[A \/ B]): F[B] = {
+    val bs = canBuildFrom[B].apply()
+    @scala.annotation.tailrec
+    def go(xs: List[Seq[A \/ B]]): Unit =
+      xs match {
+        case (\/-(b) +: tail) :: rest =>
+          bs += b
+          go(tail.toVector :: rest)
+        case (-\/(a0) +: tail) :: rest =>
+          go(f(a0) :: tail :: rest)
+        case _ :: rest =>
+          go(rest)
+        case Nil =>
+      }
+    go(List(f(a)))
+    bs.result
+  }
 }
 
 object iterable extends IterableInstances

--- a/core/src/main/scala/scalaz/std/List.scala
+++ b/core/src/main/scala/scalaz/std/List.scala
@@ -12,8 +12,6 @@ trait ListInstances0 {
 trait ListInstances extends ListInstances0 {
   implicit val listInstance: Traverse[List] with MonadPlus[List] with BindRec[List] with Zip[List] with Unzip[List] with Align[List] with IsEmpty[List] with Cobind[List] =
     new Traverse[List] with MonadPlus[List] with BindRec[List] with Zip[List] with Unzip[List] with Align[List] with IsEmpty[List] with Cobind[List] with IterableSubtypeFoldable[List] with StrictSeqSubtypeCovariant[List] {
-      import Liskov.<~<
-
       protected[this] override val Factory = List
       protected[this] override def canBuildFrom[A] = List.canBuildFrom
 

--- a/core/src/main/scala/scalaz/std/List.scala
+++ b/core/src/main/scala/scalaz/std/List.scala
@@ -79,10 +79,7 @@ trait ListInstances extends ListInstances0 {
         }
     }
 
-  implicit def listMonoid[A]: Monoid[List[A]] = new Monoid[List[A]] {
-    def append(f1: List[A], f2: => List[A]) = f1 ::: f2
-    def zero: List[A] = Nil
-  }
+  implicit def listMonoid[A]: Monoid[List[A]] = listInstance.monoid[A]
 
   implicit def listShow[A: Show]: Show[List[A]] = new Show[List[A]] {
     override def show(as: List[A]) = {

--- a/core/src/main/scala/scalaz/std/List.scala
+++ b/core/src/main/scala/scalaz/std/List.scala
@@ -11,7 +11,7 @@ trait ListInstances0 {
 
 trait ListInstances extends ListInstances0 {
   implicit val listInstance: Traverse[List] with MonadPlus[List] with BindRec[List] with Zip[List] with Unzip[List] with Align[List] with IsEmpty[List] with Cobind[List] =
-    new Traverse[List] with MonadPlus[List] with BindRec[List] with Zip[List] with Unzip[List] with Align[List] with IsEmpty[List] with Cobind[List] {
+    new Traverse[List] with MonadPlus[List] with BindRec[List] with Zip[List] with Unzip[List] with Align[List] with IsEmpty[List] with Cobind[List] with IterableSubtypeFoldable[List] {
       import Liskov.<~<
 
       override def findLeft[A](fa: List[A])(f: A => Boolean) = fa.find(f)
@@ -76,8 +76,6 @@ trait ListInstances extends ListInstances0 {
         })
       }
 
-      override def foldLeft[A, B](fa: List[A], z: B)(f: (B, A) => B): B = fa.foldLeft(z)(f)
-
       override def foldRight[A, B](fa: List[A], z: => B)(f: (A, => B) => B) = {
         import scala.collection.mutable.ArrayStack
         val s = new ArrayStack[A]
@@ -90,8 +88,6 @@ trait ListInstances extends ListInstances0 {
         }
         r
       }
-
-      override def toList[A](fa: List[A]) = fa
 
       def isEmpty[A](fa: List[A]) = fa.isEmpty
 
@@ -106,12 +102,6 @@ trait ListInstances extends ListInstances0 {
           case Nil => Nil
           case _::t => a :: cojoin(t)
         }
-
-      override def any[A](fa: List[A])(p: A => Boolean): Boolean =
-        fa.exists(p)
-
-      override def all[A](fa: List[A])(p: A => Boolean): Boolean =
-        fa.forall(p)
 
       def tailrecM[A, B](a: A)(f: A => List[A \/ B]): List[B] = {
         val bs = List.newBuilder[B]

--- a/core/src/main/scala/scalaz/std/Set.scala
+++ b/core/src/main/scala/scalaz/std/Set.scala
@@ -2,15 +2,13 @@ package scalaz
 package std
 
 trait SetInstances {
-  implicit val setInstance: Foldable[Set] with IsEmpty[Set] = new Foldable[Set] with IsEmpty[Set] with Foldable.FromFoldr[Set] {
+  implicit val setInstance: Foldable[Set] with IsEmpty[Set] = new Foldable[Set] with IsEmpty[Set] with Foldable.FromFoldr[Set] with IterableSubtypeFoldable[Set] {
     override def length[A](fa: Set[A]) = fa.size
     def empty[A] = Set()
     def plus[A](a: Set[A], b: => Set[A]) = a ++ b
     def isEmpty[A](fa: Set[A]) = fa.isEmpty
 
-    override def toSet[A](fa: Set[A]) = fa
-
-    def foldRight[A, B](fa: Set[A], z: => B)(f: (A, => B) => B) = {
+    override def foldRight[A, B](fa: Set[A], z: => B)(f: (A, => B) => B) = {
       import scala.collection.mutable.ArrayStack
       val s = new ArrayStack[A]
       fa.foreach(a => s += a)
@@ -22,10 +20,6 @@ trait SetInstances {
       }
       r
     }
-    override def all[A](fa: Set[A])(f: A => Boolean) =
-      fa forall f
-    override def any[A](fa: Set[A])(f: A => Boolean) =
-      fa exists f
   }
 
   import Ordering._

--- a/core/src/main/scala/scalaz/std/Stream.scala
+++ b/core/src/main/scala/scalaz/std/Stream.scala
@@ -115,10 +115,7 @@ trait StreamInstances {
       }
     }
 
-  implicit def streamMonoid[A]: Monoid[Stream[A]] = new Monoid[Stream[A]] {
-    def append(f1: Stream[A], f2: => Stream[A]) = f1 #::: f2
-    def zero: Stream[A] = scala.Stream.empty
-  }
+  implicit def streamMonoid[A]: Monoid[Stream[A]] = streamInstance.monoid[A]
 
   implicit def streamEqual[A](implicit A0: Equal[A]): Equal[Stream[A]] =
     new StreamEqual[A] { def A = A0 }

--- a/core/src/main/scala/scalaz/std/Vector.scala
+++ b/core/src/main/scala/scalaz/std/Vector.scala
@@ -12,7 +12,7 @@ sealed trait VectorInstances0 {
 }
 
 trait VectorInstances extends VectorInstances0 {
-  implicit val vectorInstance: Traverse[Vector] with MonadPlus[Vector] with BindRec[Vector] with Zip[Vector] with Unzip[Vector] with IsEmpty[Vector] with Align[Vector] = new Traverse[Vector] with MonadPlus[Vector] with BindRec[Vector] with Zip[Vector] with Unzip[Vector] with IsEmpty[Vector] with Align[Vector] {
+  implicit val vectorInstance: Traverse[Vector] with MonadPlus[Vector] with BindRec[Vector] with Zip[Vector] with Unzip[Vector] with IsEmpty[Vector] with Align[Vector] = new Traverse[Vector] with MonadPlus[Vector] with BindRec[Vector] with Zip[Vector] with Unzip[Vector] with IsEmpty[Vector] with Align[Vector] with IterableSubtypeFoldable[Vector] {
     override def index[A](fa: Vector[A], i: Int) = fa.lift.apply(i)
     override def length[A](fa: Vector[A]) = fa.length
     def point[A](a: => A) = empty :+ a
@@ -43,8 +43,6 @@ trait VectorInstances extends VectorInstances0 {
           val bs = f(a)(acc._1)
           (bs._1, acc._2 :+ bs._2)
         }))
-
-    override def toVector[A](fa: Vector[A]) = fa
 
     override def foldRight[A, B](fa: Vector[A], z: => B)(f: (A, => B) => B) = {
       var i = fa.length
@@ -86,12 +84,6 @@ trait VectorInstances extends VectorInstances0 {
           bs.drop(sizeA).map(b => f(\&/.That(b)))
       }
     }
-
-    override def all[A](fa: Vector[A])(f: A => Boolean) =
-      fa forall f
-
-    override def any[A](fa: Vector[A])(f: A => Boolean) =
-      fa exists f
   }
 
   implicit def vectorMonoid[A]: Monoid[Vector[A]] = new Monoid[Vector[A]] {

--- a/core/src/main/scala/scalaz/std/Vector.scala
+++ b/core/src/main/scala/scalaz/std/Vector.scala
@@ -46,16 +46,10 @@ trait VectorInstances extends VectorInstances0 {
     }
   }
 
-  implicit def vectorMonoid[A]: Monoid[Vector[A]] = new Monoid[Vector[A]] {
-    // Vector concat is O(n^2) in Scala 2.10 - it's actually faster to do repeated appends
-    // https://issues.scala-lang.org/browse/SI-7725
-    //
-    // It was reduced to O(n) in Scala 2.11 - ideally it would be O(log n)
-    // https://issues.scala-lang.org/browse/SI-4442
-    def append(f1: Vector[A], f2: => Vector[A]) = f2.foldLeft(f1)(_ :+ _)
-    def zero: Vector[A] = Vector.empty
-  }
-
+  // Vector concat was reduced to O(n) in Scala 2.11 - ideally it would be O(log n)
+  // https://issues.scala-lang.org/browse/SI-4442
+  implicit def vectorMonoid[A]: Monoid[Vector[A]] = vectorInstance.monoid[A]
+ 
   implicit def vectorShow[A: Show]: Show[Vector[A]] = new Show[Vector[A]] {
     import Cord._
     override def show(as: Vector[A]) =


### PR DESCRIPTION
Just a lot of factoring to make the `scalaz.std` code less boring to read, not to mention get much better method specialization coverage.

Also includes related "to is almost always better than toList/toVector/toSet; use it"; if you like nothing else from this PR you should like this. bba9442

There's probably more to do here.