### PR TITLE
Estream traverse explosion

### DIFF
--- a/tests/src/test/scala/scalaz/EphemeralStreamTest.scala
+++ b/tests/src/test/scala/scalaz/EphemeralStreamTest.scala
@@ -158,6 +158,15 @@ object EphemeralStreamTest extends SpecLite {
     Foldable[EphemeralStream].foldMapRight1Opt(infiniteStream)(identity)(_ || _) must_===(Some(true))
   }
 
+  "traverse is lazy" ! {
+    import syntax.traverse._
+    import Scalaz.Id
+
+    val stream = EphemeralStream.iterate(1)(_ + 1)
+    val trav = stream.traverse[Id, Int](identity)
+    // got here without exception... that's good!
+  }
+
   "zipL" in {
     val size = 100
     val infinite = EphemeralStream.iterate(0)(_ + 1)

--- a/tests/src/test/scala/scalaz/std/StreamTest.scala
+++ b/tests/src/test/scala/scalaz/std/StreamTest.scala
@@ -33,6 +33,15 @@ object StreamTest extends SpecLite {
     evaluated must_=== false
   }
 
+  "traverse is lazy" ! {
+    import syntax.traverse._
+    import Scalaz.Id
+
+    val stream = Stream.continually(1)
+    val trav = stream.traverse[Id, Int](identity)
+    // got here without exception... that's good!
+  }
+
   "intercalate empty stream is flatten" ! forAll((a: Stream[Stream[Int]]) => a.intercalate(Stream.empty[Int]) must_===(a.flatten))
 
   "intersperse then remove odd items is identity" ! forAll {


### PR DESCRIPTION
Proof of #1515, type in `sbt`

```
testsJVM/testOnly *StreamTest
```

and you get 

```
[info] ! scalaz.EphemeralStreamTest.:traverse is lazy: Exception raised on property evaluation.
[info] > Exception: java.lang.StackOverflowError: null
```

but it passes for stdlib `Stream`. Which is a disaster.