### PR TITLE
Maybe: Add just syntax

### DIFF
--- a/base/shared/src/main/scala/scalaz/Prelude.scala
+++ b/base/shared/src/main/scala/scalaz/Prelude.scala
@@ -1,7 +1,6 @@
 package scalaz
 
 import typeclass._
-import data._
 
 import scala.language.implicitConversions
 
@@ -43,7 +42,7 @@ trait Prelude  extends data.DisjunctionFunctions
   def Profunctor[P[_,_]](implicit P: Profunctor[P]): Profunctor[P] = P
   def Choice[P[_,_]](implicit P: Choice[P]): Choice[P] = P
   def Strong[P[_,_]](implicit P: Strong[P]): Strong[P] = P
-  def Category[=>:[_,_]](implicit P: Category[=>:]): Category[=>:] = P 
+  def Category[=>:[_,_]](implicit P: Category[=>:]): Category[=>:] = P
   def InvariantFunctor[F[_]](implicit F: InvariantFunctor[F]): InvariantFunctor[F] = F
   def Comonad[F[_]](implicit F: Comonad[F]): Comonad[F] = F
   def Cobind[F[_]](implicit F: Cobind[F]): Cobind[F] = F
@@ -69,26 +68,23 @@ trait Prelude  extends data.DisjunctionFunctions
   implicit def PfunctorOps[F[_], A](fa: F[A])(implicit F: Functor[F]): FunctorSyntax.Ops[F, A] =
     new FunctorSyntax.Ops(fa)
 
-  // MaybeSyntax
-  implicit class POptionAsMaybe[A](oa: Option[A]) { def asMaybe: Maybe[A] = Maybe.fromOption(oa) }
-
   // TraversableSyntax
   implicit def PtraversableOps[T[_], A](ta: T[A])(implicit T: Traversable[T]): TraversableSyntax.Ops[T, A] =
     new TraversableSyntax.Ops(ta)
 
-  implicit def PprofunctorOps[P[_,_], A, B](pab: P[A, B])(implicit P: Profunctor[P]): ProfunctorSyntax.Ops[P, A, B] = 
+  implicit def PprofunctorOps[P[_,_], A, B](pab: P[A, B])(implicit P: Profunctor[P]): ProfunctorSyntax.Ops[P, A, B] =
     new ProfunctorSyntax.Ops(pab)
-  
+
   implicit def PchoiceOps[P[_,_], A, B](pab: P[A, B])(implicit P: Choice[P]): ChoiceSyntax.Ops[P, A, B] =
    new ChoiceSyntax.Ops(pab)
 
   implicit def PstrongOps[P[_,_], A, B](pab: P[A, B])(implicit P: Strong[P]): StrongSyntax.Ops[P, A, B] =
     new StrongSyntax.Ops(pab)
-   
+
   //InvariantFunctorSyntax
   implicit def InvariantFunctorOps[F[_], A](fa: F[A])(implicit F: InvariantFunctor[F]): InvariantFunctorSyntax.Ops[F, A] =
     new InvariantFunctorSyntax.Ops(fa)
-  
+
   implicit def CobindOps[F[_], A](fa: F[A])(implicit F: Cobind[F]): CobindSyntax.Ops[F, A] =
     new CobindSyntax.Ops(fa)
 
@@ -98,7 +94,7 @@ trait Prelude  extends data.DisjunctionFunctions
 
   // Base Data
   // =========
-  
+
   type \/[L, R] = data.Disjunction.\/[L, R]
   type ===[A, B] = data.===[A, B]
   type Identity[A] = data.Identity[A]

--- a/base/shared/src/main/scala/scalaz/data/MaybeFunctions.scala
+++ b/base/shared/src/main/scala/scalaz/data/MaybeFunctions.scala
@@ -22,7 +22,7 @@ trait MaybeFunctions {
 }
 
 /** To be mixed into Prelude. */
-trait MaybePrelude extends MaybeFunctions {
+trait MaybePrelude extends MaybeFunctions with MaybeSyntax {
   type Maybe[A] = data.Maybe[A]
 
   override def empty[A]                     = data.Maybe.empty[A]

--- a/base/shared/src/main/scala/scalaz/data/MaybeSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/data/MaybeSyntax.scala
@@ -3,4 +3,8 @@ package data
 
 trait MaybeSyntax {
   implicit class OptionAsMaybe[A](oa: Option[A]) { def asMaybe: Maybe[A] = Maybe.fromOption(oa) }
+
+  implicit class MaybeOps[A](a: A) {
+    def just: Maybe[A] = Maybe.just(a)
+  }
 }

--- a/example/shared/src/main/scala/scalaz/example/MaybeUsage.scala
+++ b/example/shared/src/main/scala/scalaz/example/MaybeUsage.scala
@@ -15,4 +15,8 @@ object MaybeUsage extends App {
 
   // monad instance and monad ops
   x flatMap { _ => y }
+
+  // Maybe syntax
+  val five: Maybe[Int] = 5.just
+  val foo: Maybe[String] = "foo".just
 }


### PR DESCRIPTION
- Removed `POptionAsMaybe` from `Prelude`, a copy of it exists as `MaybeSyntax.OptionAsMaybe` already
- Include `MaybeSyntax` in `MaybePrelude` to restore the removed functionality
- Add `MaybeOps` that provides a generic `just`
- Add above `just` call to `Maybe` examples