### PR TITLE
Show `Show` some love.

### DIFF
--- a/base/shared/src/main/scala/scalaz/Prelude.scala
+++ b/base/shared/src/main/scala/scalaz/Prelude.scala
@@ -31,6 +31,7 @@ trait Prelude  extends data.DisjunctionFunctions
   type Cobind[F[_]] = typeclass.Cobind[F]
   type IsCovariant[F[_]] = typeclass.IsCovariant[F]
   type IsContravariant[F[_]] = typeclass.IsContravariant[F]
+  type Show[A] = typeclass.Show[A]
 
   def Applicative[F[_]](implicit F: Applicative[F]): Applicative[F] = F
   def Apply[F[_]](implicit F: Apply[F]): Apply[F] = F
@@ -48,6 +49,7 @@ trait Prelude  extends data.DisjunctionFunctions
   def Cobind[F[_]](implicit F: Cobind[F]): Cobind[F] = F
   def IsCovariant[F[_]](implicit F: IsCovariant[F]): IsCovariant[F] = F
   def IsContravariant[F[_]](implicit F: IsContravariant[F]): IsContravariant[F] = F
+  def Show[A](implicit A: Show[A]): Show[A] = A
 
   // ApplicativeSyntax
   implicit def PapplicativeOpsA[A](a: A): ApplicativeSyntax.OpsA[A] = new ApplicativeSyntax.OpsA(a)
@@ -93,6 +95,9 @@ trait Prelude  extends data.DisjunctionFunctions
 
   implicit def ComonadOps[F[_], A](fa: F[A])(implicit F: Comonad[F]): ComonadSyntax.Ops[F, A] =
     new ComonadSyntax.Ops(fa)
+
+  implicit def ShowOps[A](a: A)(implicit A: Show[A]): ShowSyntax.Ops[A] =
+    new ShowSyntax.Ops[A](a)(A)
 
 
   // Base Data

--- a/base/shared/src/main/scala/scalaz/data/AMaybe.scala
+++ b/base/shared/src/main/scala/scalaz/data/AMaybe.scala
@@ -8,7 +8,7 @@ import Prelude.===
   */
 sealed abstract class AMaybe[F[_, _], A, B]
 
-case class AJust[F[_, _], A, B](value: F[A, B]) extends AMaybe[F, A, B]
+final case class AJust[F[_, _], A, B](value: F[A, B]) extends AMaybe[F, A, B]
 
 /**
   * The empty case contains evidence of type equality
@@ -20,7 +20,7 @@ sealed abstract case class AEmpty[F[_, _], A, B]() extends AMaybe[F, A, B] {
   def leibniz: A Is B = subst[A === ?](Is.refl)
 }
 
-object AMaybe {
+object AMaybe extends AMaybeInstances {
   def empty[F[_, _], A]: AMaybe[F, A, A] = None.asInstanceOf[AMaybe[F, A, A]]
 
   private val None = none[Nothing, Nothing]

--- a/base/shared/src/main/scala/scalaz/data/AMaybeInstances.scala
+++ b/base/shared/src/main/scala/scalaz/data/AMaybeInstances.scala
@@ -1,0 +1,13 @@
+package scalaz
+package data
+
+import typeclass._
+
+trait AMaybeInstances {
+
+  implicit final def show[F[_, _], A, B](implicit FAB: Show[F[A, B]]): Show[AMaybe[F, A, B]] = {
+    case AJust(value) => s"AMaybe(${FAB.show(value)})"
+    case AEmpty()     =>  "AEmpty()"
+  }
+
+}

--- a/base/shared/src/main/scala/scalaz/data/ConstInstances.scala
+++ b/base/shared/src/main/scala/scalaz/data/ConstInstances.scala
@@ -45,4 +45,7 @@ trait ConstInstances {
     def semigroup: Semigroup[Const[A, B]] = implicitly
     def empty: Const[A, B] = Const(A.empty)
   }
+
+  implicit def show[A, B](implicit A: Show[A]): Show[Const[A, B]] =
+    a => A.show(a.getConst)
 }

--- a/base/shared/src/main/scala/scalaz/data/DisjunctionInstances.scala
+++ b/base/shared/src/main/scala/scalaz/data/DisjunctionInstances.scala
@@ -19,4 +19,9 @@ trait DisjunctionInstances {
     override def flatMap[A, B](oa: L \/ A)(f: A => L \/ B): L \/ B =
       oa.fold[L \/ B](l => -\/(l))(a => f(a))
   }
+
+  implicit def show[L, R](implicit L: Show[L], R: Show[R]): Show[L \/ R] = {
+    case -\/(left)  => s"""-\/(${L.show(left)})"""
+    case \/-(right) => s"""\/-(${R.show(right)})"""
+  }
 }

--- a/base/shared/src/main/scala/scalaz/data/Maybe.scala
+++ b/base/shared/src/main/scala/scalaz/data/Maybe.scala
@@ -2,7 +2,7 @@ package scalaz
 package data
 
 import Prelude._
-import typeclass.{MonadClass, TraversableClass}
+import typeclass.{MonadClass, TraversableClass, Show}
 import typeclass.FoldableClass._
 
 sealed trait MaybeModule extends MaybeFunctions {
@@ -16,12 +16,14 @@ sealed trait MaybeModule extends MaybeFunctions {
   def isCovariant: IsCovariant[Maybe]
   def monad: Monad[Maybe]
   def traversable: Traversable[Maybe]
+  def show[A: Show]: Show[Maybe[A]]
 }
 
 object MaybeModule extends MaybeSyntax {
   implicit def monadMaybe: Monad[Maybe] = Maybe.monad
   implicit def traversableMaybe: Traversable[Maybe] = Maybe.traversable
   implicit def isCovariantMaybe: IsCovariant[Maybe] = Maybe.isCovariant
+  implicit def showMaybe[A: Show]: Show[Maybe[A]] = Maybe.show[A]
 }
 
 private[data] object MaybeImpl extends MaybeModule {
@@ -39,6 +41,11 @@ private[data] object MaybeImpl extends MaybeModule {
   def isCovariant: IsCovariant[Maybe] = typeclass.IsCovariant.scalaCovariant[Option]
   def monad: Monad[Maybe] = instance
   def traversable: Traversable[Maybe] = instance
+
+  def show[A](implicit A: Show[A]): Show[Maybe[A]] = {
+    case Some(a) => s"Just(${A.show(a)})"
+    case None    =>  "Empty"
+  }
 
   private val instance =
     new MonadClass.Template[Maybe] with TraversableClass[Maybe] with FoldRight[Maybe] {

--- a/base/shared/src/main/scala/scalaz/data/Maybe2.scala
+++ b/base/shared/src/main/scala/scalaz/data/Maybe2.scala
@@ -1,7 +1,7 @@
 package scalaz
 package data
 
-import typeclass.IsCovariant
+import typeclass.{IsCovariant, Show}
 
 sealed trait Maybe2Module {
   /**
@@ -14,6 +14,7 @@ sealed trait Maybe2Module {
 
   implicit def isCovariant_1[B]: IsCovariant[Maybe2[?, B]]
   implicit def isCovariant_2[A]: IsCovariant[Maybe2[A, ?]]
+  implicit def show[A: Show, B: Show]: Show[Maybe2[A, B]]
 
   object Just2 {
     def unapply[A, B](m: Maybe2[A, B]): Just2Extractor[A, B] = new Just2Extractor(toOption2(m))
@@ -41,6 +42,11 @@ private[data] object Maybe2Impl extends Maybe2Module {
 
   implicit def isCovariant_1[B]: IsCovariant[Maybe2[?, B]] = IsCovariant.scalaCovariant[Option2[+?, B]]
   implicit def isCovariant_2[A]: IsCovariant[Maybe2[A, ?]] = IsCovariant.scalaCovariant[Option2[A, +?]]
+
+  implicit def show[A, B](implicit A: Show[A], B: Show[B]): Show[Maybe2[A, B]] = {
+    case Some2(_1, _2) => s"Just2(${A.show(_1)}, ${B.show(_2)})"
+    case None2         =>  "Empty2"
+  }
 
   private[data] def fromOption2[A, B](o: Option2[A, B]): Maybe2[A, B] = o
   private[data] def toOption2  [A, B](m: Maybe2[A, B]): Option2[A, B] = m

--- a/base/shared/src/main/scala/scalaz/typeclass/Show.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/Show.scala
@@ -1,5 +1,21 @@
 package scalaz
+package typeclass
 
-abstract class Show[A] {
+/** A typeclass describing types which can be meaningfully represented as a `String`.
+  */
+trait Show[A] {
+  /** Produce a `String` representation of `a`.
+    */
+  /* todo: when we have a `Cord`, change this to return that instead,
+   * todo: and add a `def shows(a: A): String = show(a).toString`
+   */
   def show(a: A): String
+}
+
+object Show extends ShowInstances with ShowSyntax {
+  @inline def apply[A](implicit A: Show[A]): Show[A] = A
+
+  /** A factory for `Show` instances which delegates to Scala's `.toString` method.
+    */
+  def fromToString[A]: Show[A] = _.toString()
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/ShowInstances.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/ShowInstances.scala
@@ -1,0 +1,14 @@
+package scalaz
+package typeclass
+
+trait ShowInstances {
+
+  implicit final def string: Show[String] = s => s
+
+
+  implicit final def contravariant: Contravariant[Show] =
+    new Contravariant[Show] {
+      def contramap[A, B](r: Show[A])(f: B => A): Show[B] =
+        b => r.show(f(b))
+    }
+}

--- a/base/shared/src/main/scala/scalaz/typeclass/ShowSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/ShowSyntax.scala
@@ -1,0 +1,17 @@
+package scalaz
+package typeclass
+
+import com.github.ghik.silencer.silent
+
+import language.implicitConversions
+import language.experimental.macros
+
+trait ShowSyntax {
+  implicit def showOps[A](self: A)(implicit A: Show[A]) = new ShowSyntax.Ops[A](self)(A)
+}
+
+object ShowSyntax {
+  class Ops[A](@silent self: A)(implicit @silent A: Show[A]) {
+    def show: String = macro meta.Ops._f0[String]
+  }
+}

--- a/example/shared/src/main/scala/scalaz/example/ShowUsage.scala
+++ b/example/shared/src/main/scala/scalaz/example/ShowUsage.scala
@@ -1,0 +1,19 @@
+package scalaz
+package example
+
+import data._, typeclass._
+
+object ShowUsage extends App {
+  import Show._
+
+  assert("asdf".show == "asdf")
+
+  case class Foo(a: Int)
+  implicit val fooShow: Show[Foo] = (f: Foo) => s"Foo! ${f.a}"
+
+  assert(Foo(1).toString == "Foo(1)")
+  assert(Foo(1).show == "Foo! 1")
+
+  assert(Maybe.just(Foo(1)).show == "Just(Foo! 1)")
+
+}


### PR DESCRIPTION
It's a very useful typeclass if you have an `Any#toString`-shaped hole in your cornea. Someone seems to have made a file for it and then never done anything with it. This resurrects it as a typical typeclass, with syntax, instances, usage examples, &c.