### PR TITLE
Change the shape of Semigroup#append to what Ops._f1 expects.

### DIFF
--- a/base/shared/src/main/scala/scalaz/data/ConstInstances.scala
+++ b/base/shared/src/main/scala/scalaz/data/ConstInstances.scala
@@ -28,7 +28,7 @@ trait ConstInstances {
   implicit def apply[R](implicit R: Semigroup[R]): Apply[Const[R, ?]] = new Apply[Const[R, ?]] {
     def functor: Functor[Const[R, ?]] = Const.functor[R]
     def ap[A, B](fa: Const[R, A])(f: Const[R, A => B]): Const[R, B] =
-      Const(R.append(fa.getConst, f.getConst))
+      Const(R.append(fa.getConst)(f.getConst))
   }
 
   implicit def applicative[R](implicit R: Monoid[R]): Applicative[Const[R, ?]] = new Applicative[Const[R, ?]] {
@@ -37,8 +37,8 @@ trait ConstInstances {
   }
 
   implicit def semigroup[A, B](implicit A: Semigroup[A]): Semigroup[Const[A, B]] = new Semigroup[Const[A, B]] {
-    def append(a1: Const[A, B], a2: => Const[A, B]): Const[A, B] =
-      Const(A.append(a1.getConst, a2.getConst))
+    def append(a1: Const[A, B])(a2: => Const[A, B]): Const[A, B] =
+      Const(A.append(a1.getConst)(a2.getConst))
   }
 
   implicit def monoid[A, B](implicit A: Monoid[A]): Monoid[Const[A, B]] = new Monoid[Const[A, B]] {

--- a/base/shared/src/main/scala/scalaz/typeclass/FoldableClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/FoldableClass.scala
@@ -13,7 +13,8 @@ object FoldableClass {
 
   trait FoldRight[F[_]] extends Alt[FoldRight[F]] { self : Foldable[F] =>
     override def foldRight[A, B](fa: F[A], z: => B)(f: (A, => B) => B): B
-    override def foldMap[A, B: Monoid](fa: F[A])(f: A => B) = foldRight(fa, Monoid[B].empty)((a, b) => Semigroup[B].append(f(a),b))
+    override def foldMap[A, B: Monoid](fa: F[A])(f: A => B) =
+      foldRight(fa, Monoid[B].empty)((a, b) => Semigroup[B].append(f(a))(b))
   }
 
   trait Alt[D <: Alt[D]] { self: D => }

--- a/base/shared/src/main/scala/scalaz/typeclass/Semigroup.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/Semigroup.scala
@@ -2,7 +2,7 @@ package scalaz
 package typeclass
 
 trait Semigroup[A] {
-  def append(a1: A, a2: => A): A
+  def append(a1: A)(a2: => A): A
 }
 
 object Semigroup extends SemigroupSyntax {

--- a/base/shared/src/main/scala/scalaz/typeclass/SemigroupSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/SemigroupSyntax.scala
@@ -7,7 +7,7 @@ import scala.language.implicitConversions
 import scala.language.experimental.macros
 
 trait SemigroupSyntax {
-  implicit def equalOpsA[A: Semigroup](a: A): SemigroupSyntax.OpsA[A] = new SemigroupSyntax.OpsA(a)
+  implicit def semigroupOps[A: Semigroup](a: A): SemigroupSyntax.OpsA[A] = new SemigroupSyntax.OpsA(a)
 }
 
 object SemigroupSyntax {

--- a/example/src/main/tut/data/Forall.md
+++ b/example/src/main/tut/data/Forall.md
@@ -31,13 +31,13 @@ val emptyMap1: ∀∀[Map] = ∀∀.mk[∀∀[Map]].from(Map())
 import scalaz.typeclass.Semigroup
 
 def listSemigroup[A]: Semigroup[List[A]] = new Semigroup[List[A]] {
-  def append(x: List[A], y: => List[A]) = x ++ y
+  def append(x: List[A])(y: => List[A]) = x ++ y
 }
 
 type Plus[F[_]] = ∀[λ[A => Semigroup[F[A]]]]
 
 val listPlus: Plus[List] = ∀.mk[Plus[List]].from(listSemigroup)
-listPlus[Int].append(List(1, 2), List(3, 4)) == List(1, 2, 3, 4)
+listPlus[Int].append(List(1, 2))(List(3, 4)) == List(1, 2, 3, 4)
 ```
 
 ## Natural transformation


### PR DESCRIPTION
I have mixed feelings on this shape. It's consistent with other typeclasses but inconsistent with scalaz 7 and cats. The alternative is to add a shape to `Ops` to handle this kind of typeclass method. 

Fixes #1542.