### PR TITLE
Modernize meta.Ops, adapt it to new useful shapes, and use it more.

### DIFF
--- a/base/shared/src/main/scala/scalaz/Prelude.scala
+++ b/base/shared/src/main/scala/scalaz/Prelude.scala
@@ -20,9 +20,13 @@ trait Prelude  extends data.DisjunctionFunctions
   type Applicative[F[_]] = typeclass.Applicative[F]
   type Apply[F[_]] = typeclass.Apply[F]
   type Bind[M[_]] = typeclass.Bind[M]
+  type Choice[P[_,_]] = typeclass.Choice[P]
+  type Compose[P[_,_]] = typeclass.Compose[P]
   type Foldable[T[_]] = typeclass.Foldable[T]
   type Functor[F[_]] = typeclass.Functor[F]
   type Monad[M[_]] = typeclass.Monad[M]
+  type Phantom[F[_]] = typeclass.Phantom[F]
+  type Strong[F[_,_]] = typeclass.Strong[F]
   type Traversable[T[_]] = typeclass.Traversable[T]
   type Profunctor[F[_,_]] = typeclass.Profunctor[F]
   type Category[=>:[_,_]] = typeclass.Category[=>:]
@@ -38,9 +42,11 @@ trait Prelude  extends data.DisjunctionFunctions
   def Applicative[F[_]](implicit F: Applicative[F]): Applicative[F] = F
   def Apply[F[_]](implicit F: Apply[F]): Apply[F] = F
   def Bind[F[_]](implicit F: Bind[F]): Bind[F] = F
+  def Compose[P[_,_]](implicit P: Compose[P]): Compose[P] = P
   def Foldable[F[_]](implicit F: Foldable[F]): Foldable[F] = F
   def Functor[F[_]](implicit F: Functor[F]): Functor[F] = F
   def Monad[M[_]](implicit M: Monad[M]): Monad[M] = M
+  def Phantom[F[_]](implicit F: Phantom[F]): Phantom[F] = F
   def Traversable[T[_]](implicit T: Traversable[T]): Traversable[T] = T
   def Profunctor[P[_,_]](implicit P: Profunctor[P]): Profunctor[P] = P
   def Choice[P[_,_]](implicit P: Choice[P]): Choice[P] = P
@@ -66,6 +72,10 @@ trait Prelude  extends data.DisjunctionFunctions
   implicit def PbindOps[M[_], A](ma: M[A])(implicit M: Bind[M]): BindSyntax.Ops[M, A] =
     new BindSyntax.Ops(ma)
 
+  // ComposeSyntax
+  implicit def PcomposeOps[P[_, _], A, B](pab: P[A, B])(implicit P: Compose[P]): ComposeSyntax.Ops[P, A, B] =
+    new ComposeSyntax.Ops(pab)
+
   // FoldableSyntax
   implicit def PfoldableOps[F[_], A](fa: F[A])(implicit F: Foldable[F]): FoldableSyntax.Ops[F, A] =
     new FoldableSyntax.Ops(fa)
@@ -76,6 +86,10 @@ trait Prelude  extends data.DisjunctionFunctions
 
   // MaybeSyntax
   implicit class POptionAsMaybe[A](oa: Option[A]) { def asMaybe: Maybe[A] = Maybe.fromOption(oa) }
+
+  // PhantomSyntax
+  implicit def PphantomOps[F[_], A](fa: F[A])(implicit F: Phantom[F]): PhantomSyntax.Ops[F, A] =
+    new PhantomSyntax.Ops(fa)
 
   // TraversableSyntax
   implicit def PtraversableOps[T[_], A](ta: T[A])(implicit T: Traversable[T]): TraversableSyntax.Ops[T, A] =

--- a/base/shared/src/main/scala/scalaz/typeclass/ApplySyntax.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/ApplySyntax.scala
@@ -13,6 +13,6 @@ trait ApplySyntax {
 
 object ApplySyntax {
   class Ops[F[_] : Apply, A](@silent fa: F[A]) {
-    def ap[B](f: F[A => B]): F[B] = macro meta.Ops._f1[F[A => B], F[B]]
+    def ap[B](f: F[A => B]): F[B] = macro meta.Ops.f_1
   }
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/BindSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/BindSyntax.scala
@@ -13,7 +13,7 @@ trait BindSyntax {
 
 object BindSyntax {
   class Ops[M[_]: Bind, A](@silent ma: M[A]) {
-    def flatMap[B](f: A => M[B]): M[B] = macro meta.Ops._f1[A => M[B], M[B]]
+    def flatMap[B](f: A => M[B]): M[B] = macro meta.Ops.f_1
   }
 }
 

--- a/base/shared/src/main/scala/scalaz/typeclass/ChoiceSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/ChoiceSyntax.scala
@@ -14,9 +14,7 @@ trait ChoiceSyntax {
 
 object ChoiceSyntax {
   class Ops[P[_, _]: Choice, A, B](@silent self: P[A, B]) {
-   
-    def leftchoice[C]: P[A \/ C, B \/ C] = macro meta.Ops._f0[P[A \/ C, B \/ C]]
-
-    def rightchoice[C]: P[C \/ A, C \/ B] = macro meta.Ops._f0[P[C \/ A, C \/ B]]
+    def leftchoice[C]: P[A \/ C, B \/ C] = macro meta.Ops.f_0
+    def rightchoice[C]: P[C \/ A, C \/ B] = macro meta.Ops.f_0
   }
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/CobindSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/CobindSyntax.scala
@@ -12,6 +12,6 @@ trait CobindSyntax {
 
 object CobindSyntax {
   class Ops[F[_]: Cobind, A](@silent fa: F[A]) {
-    def cobind[B](f: F[A] => B): F[B] = macro meta.Ops._f1[F[A] => B, F[B]]
+    def cobind[B](f: F[A] => B): F[B] = macro meta.Ops.f_1
   }
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/ComonadSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/ComonadSyntax.scala
@@ -12,6 +12,6 @@ trait ComonadSyntax {
 
 object ComonadSyntax {
   class Ops[F[_]: Comonad, A](@silent self: F[A]) {
-    def copoint: A = macro meta.Ops._f0[A]
+    def copoint: A = macro meta.Ops.f_0
   }
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/ComposeSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/ComposeSyntax.scala
@@ -7,12 +7,12 @@ import scala.language.implicitConversions
 import scala.language.experimental.macros
 
 trait ComposeSyntax {
-  implicit def composeOps[=>:[_, _], A, B](fa: A =>: B)(implicit F: Compose[=>:]): ComposeSyntax.Ops[=>:, A, B] =
+  implicit def composeOps[=>:[_, _], B, C](fa: B =>: C)(implicit F: Compose[=>:]): ComposeSyntax.Ops[=>:, B, C] =
     new ComposeSyntax.Ops(fa)
 }
 
 object ComposeSyntax {
-  class Ops[=>:[_, _]: Compose, A, B](@silent self: A =>: B) {
-    def compose[C](f: B =>: C): A =>: C = macro meta.Ops._f1[B =>: C, A =>: C] 
+  class Ops[=>:[_, _]: Compose, B, C](@silent self: B =>: C) {
+    def compose[A](f: A =>: B): A =>: C = macro meta.Ops.fa_1
   }
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/FoldableSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/FoldableSyntax.scala
@@ -1,6 +1,8 @@
 package scalaz
 package typeclass
 
+import com.github.ghik.silencer.silent
+
 import scala.language.implicitConversions
 import scala.language.experimental.macros
 
@@ -10,10 +12,10 @@ trait FoldableSyntax {
 }
 
 object FoldableSyntax {
-  class Ops[F[_], A](self: F[A])(implicit F: Foldable[F]) {
-    def foldLeft[B](f: B)(g: (B, A) => B): B = F.foldLeft(self, f)(g)
-    def foldRight[B](f: => B)(g: (A, => B) => B): B = F.foldRight(self, f)(g) //TODO: macro-ize foldable syntax
-    def foldMap[B: Monoid](f: A => B): B = F.foldMap(self)(f)
-    def toList: List[A] = macro meta.Ops._f0[List[A]]
+  class Ops[F[_]: Foldable, A](@silent self: F[A]) {
+    def foldLeft[B](f: B)(g: (B, A) => B): B = macro meta.Ops.fa_1_1
+    def foldRight[B](f: => B)(g: (A, => B) => B): B = macro meta.Ops.fa_1_1
+    def foldMap[B: Monoid](f: A => B): B = macro meta.Ops.f_1_1
+    def toList: List[A] = macro meta.Ops.f_0
   }
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/FunctorSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/FunctorSyntax.scala
@@ -11,7 +11,7 @@ trait FunctorSyntax {
 
 object FunctorSyntax {
   class Ops[F[_], A](self: F[A])(implicit F: Functor[F]) {
-    def map[B](f: A => B): F[B] = macro meta.Ops._f1[A => B, F[B]]
+    def map[B](f: A => B): F[B] = macro meta.Ops.f_1
     def void: F[Unit] = F.map[A, Unit](self)(_ => ())
   }
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/InvariantFunctorSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/InvariantFunctorSyntax.scala
@@ -13,7 +13,7 @@ trait InvariantFunctorSyntax {
 
 object InvariantFunctorSyntax {
   class Ops[F[_]: InvariantFunctor, A](@silent self: F[A]) {
-    def imap[B](f: A => B)(g: B => A): F[B] = macro meta.Ops._f2[A => B, B => A, F[B]]
+    def imap[B](f: A => B)(g: B => A): F[B] = macro meta.Ops.f_1_1
   }
 }
 

--- a/base/shared/src/main/scala/scalaz/typeclass/Phantom.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/Phantom.scala
@@ -5,6 +5,6 @@ trait Phantom[F[_]] {
   def pmap[A, B](ma: F[A]): F[B]
 }
 
-object Phantom extends PhantomFunctions with PhantomSyntax {
+object Phantom extends PhantomFunctions with PhantomSyntax with PhantomInstances {
   def apply[F[_]](implicit F: Phantom[F]): Phantom[F] = F
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/PhantomSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/PhantomSyntax.scala
@@ -13,6 +13,6 @@ trait PhantomSyntax {
 
 object PhantomSyntax {
   class Ops[F[_]: Phantom, A](@silent self: F[A]) {
-    def pmap[B]: F[B] = macro meta.Ops._f0[F[B]]
+    def pmap[B]: F[B] = macro meta.Ops.f_0
   }
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/ProfunctorSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/ProfunctorSyntax.scala
@@ -15,9 +15,9 @@ object ProfunctorSyntax {
 
   //weird parameter names because of the macros 
   class Ops[F[_, _]: Profunctor, A, B](@silent self: F[A, B]) {
-    def lmap[C](f: C => A): F[C, B] = macro meta.Ops._f1[C => A, F[C, B]]
-    def rmap[C](f: B => C): F[A, C] = macro meta.Ops._f1[B => C, F[A, C]]
-    def dimap[C, D](f: C => A)(g: B => D): F[C, D] = macro meta.Ops._f2[C => A, B => D, F[C, D]]
+    def lmap[C](f: C => A): F[C, B] = macro meta.Ops.f_1
+    def rmap[C](f: B => C): F[A, C] = macro meta.Ops.f_1
+    def dimap[C, D](f: C => A)(g: B => D): F[C, D] = macro meta.Ops.f_1_1
   }
 }
 

--- a/base/shared/src/main/scala/scalaz/typeclass/SemigroupSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/SemigroupSyntax.scala
@@ -12,6 +12,6 @@ trait SemigroupSyntax {
 
 object SemigroupSyntax {
   class OpsA[A: Semigroup](@silent a: A) {
-    def append(f: => A): A = macro meta.Ops._f1[A, A]
+    def append(f: => A): A = macro meta.Ops.fa_1
   }
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/ShowSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/ShowSyntax.scala
@@ -12,6 +12,6 @@ trait ShowSyntax {
 
 object ShowSyntax {
   class Ops[A](@silent self: A)(implicit @silent A: Show[A]) {
-    def show: String = macro meta.Ops._f0[String]
+    def show: String = macro meta.Ops.f_0
   }
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/StrongSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/StrongSyntax.scala
@@ -13,7 +13,7 @@ trait StrongSyntax {
 
 object StrongSyntax {
   class Ops[F[_, _]: Strong, A, B](@silent self: F[A, B]) {
-    def first[C]: F[(A, C), (B, C)] = macro meta.Ops._f0[F[(A, C), (B, C)]]
-    def second[C]: F[(C, A), (C, B)] = macro meta.Ops._f0[F[(C, A), (C, B)]]
+    def first[C]: F[(A, C), (B, C)] = macro meta.Ops.f_0
+    def second[C]: F[(C, A), (C, B)] = macro meta.Ops.f_0
   }
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/TraversableSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/TraversableSyntax.scala
@@ -14,6 +14,6 @@ trait TraversableSyntax {
 
 object TraversableSyntax {
   class Ops[T[_]: Traversable, A](@silent self: T[A]) {
-    def traverse[F[_], B](f: A => F[B])(implicit g: Applicative[F]): F[T[B]] = macro meta.Ops._f2[A => F[B], Applicative[F], F[T[B]]]
+    def traverse[F[_], B](f: A => F[B])(implicit g: Applicative[F]): F[T[B]] = macro meta.Ops.f_1_1
   }
 }

--- a/base/shared/src/test/scala/SyntaxResolutionTest.scala
+++ b/base/shared/src/test/scala/SyntaxResolutionTest.scala
@@ -1,0 +1,51 @@
+import scalaz.Prelude._
+
+/* Tests that the various syntax macros work for the typeclasses which use them. */
+object SyntaxResolutionTest {
+
+  def _apply[F[_]: Apply, A, B](fa: F[A], f: F[A => B]): F[B] = fa.ap(f)
+
+  def _bind[F[_]: Bind, A, B](fa: F[A], f: A => F[B]): F[B] = fa.flatMap(f)
+
+  def _choice[F[_, _]: Choice, A, B, C](fab: F[A, B]) = {
+    import scalaz.data.Disjunction._
+    fab.leftchoice[C]: F[A \/ C, B \/ C]
+    fab.rightchoice[C]: F[C \/ A, C \/ B]
+  }
+
+  def _cobind[F[_]: Cobind, A, B](fa: F[A], f: F[A] => B): F[B] = fa.cobind(f)
+
+  def _comonad[F[_]: Comonad, A](fa: F[A]): A = fa.copoint
+
+  def _compose[F[_, _]: Compose, A, B, C](fab: F[A, B], fbc: F[B, C]): F[A, C] = fbc.compose(fab)
+
+  def _foldable[F[_]: Foldable, A, B, M: Monoid](fa: F[A], b: B, m: M) = {
+    fa.foldMap((a: A) => m): M
+    fa.foldLeft(b)((_, _) => b): B
+    fa.foldRight(b)((_, _) => b): B
+    fa.toList: List[A]
+  }
+
+  def _functor[F[_]: Functor, A, B](fa: F[A], f: A => B): F[B] = fa.map(f)
+
+  def _invariantFunctor[F[_]: InvariantFunctor, A, B](fa: F[A], f: A => B, g: B => A): F[B] = fa.imap(f)(g)
+
+  def _phantom[F[_]: Phantom, A, B](fa: F[A]): F[B] = fa.pmap
+
+  def _profunctor[F[_, _]: Profunctor, A, B, C, D](fab: F[A, B], ca: C => A, bd: B => D) = {
+    fab.lmap(ca) : F[C, B]
+    fab.rmap(bd) : F[A, D]
+    fab.dimap(ca)(bd): F[C, D]
+  }
+
+  def _semigroup[A: Semigroup](a1: A, a2: A): A = a1.append(a2)
+
+  def _show[A: Show](a: A): String = a.show
+
+  def _strong[F[_, _]: Strong, A, B, C](fab: F[A, B]) = {
+    fab.first[C]: F[(A, C), (B, C)]
+    fab.second[C]: F[(C, A), (C, B)]
+  }
+
+  def _traversable[F[_]: Traversable, G[_]: Applicative, A, B](fa: F[A], f: A => G[B]): G[F[B]] = fa.traverse(f)
+}

--- a/meta/shared/src/main/scala/scalaz/meta/Ops.scala
+++ b/meta/shared/src/main/scala/scalaz/meta/Ops.scala
@@ -1,35 +1,65 @@
 package scalaz
 package meta
 
-import scala.reflect.macros.whitebox.Context
+import scala.reflect.macros.blackbox
 
 // Originally inspired by http://typelevel.org/blog/2013/10/13/spires-ops-macros.html
 
-class Ops(val c: Context) {
+/** Zero-cost syntax ops macros.
+  *
+  * Inside of a syntax class, these macros can be used as the definition of
+  * extension methods to entirely eliminate the allocation of the syntax class
+  * and the implicit conversion.
+  *
+  * After defining
+  * {{{
+  * class Ops[A: Typeclass](a: A) {
+  *   def method[B](b: B): Result = macro Ops.f_1
+  * }
+  * }}}
+  *
+  * then calling `a.method(b)` (if `a`'s type has a `Typeclass` instance) will
+  * expand to `tcA.method(a)(b)` (where `tcA : Typeclass[A]` is the implicit
+  * evidence).
+  *
+  * Due to the way that scala.reflect macros work, there is no shape-polymorphic
+  * macro implementation. The methods are named according to the shape of the
+  * parameter list(s) of the typeclass method. Methods beginning with `fa_` have
+  * their first parameter list prefixed by the target of the invocation, rather
+  * than having the target in its own (first) parameter list. This is to support
+  * typeclass methods such as `Semigroup#append` and `Foldable#foldLeft`.
+  */
+class Ops(val c: blackbox.Context) {
   import c.universe._
 
-  def _f0[R]: Expr[R] = {
-    val (ev, lhs) = unpack
-    c.Expr[R](Apply(Select(ev, TermName(c.macroApplication.symbol.name.toString)), List(lhs)))
-  }
+  /* def method: R */
+  def f_0: Tree = q"$ev.$name($lhs)"
 
-  def _f1[A, R](f: Expr[A]): Expr[R] = {
-    val (ev, lhs) = unpack
-    c.Expr[R](Apply(Apply(Select(ev, TermName(c.macroApplication.symbol.name.toString)), List(lhs)), List(f.tree)))
-  }
+  /* def method(a: A): R */
+  def f_1(f: Tree): Tree = q"$ev.$name($lhs)($f)"
 
-  def _f2[A, B, R](f: Expr[A])(g: Expr[B]): Expr[R] = {
-    val (ev, lhs) = unpack
-    val y = Apply(Select(ev, TermName(c.macroApplication.symbol.name.toString)), List(lhs))
-    val toappl = Apply(y, List(f.tree))
-    c.Expr[R](Apply(toappl, List(g.tree)))
-  }
+  /* def method(f: A): R */
+  def fa_1(f: Tree): Tree = q"$ev.$name($lhs, $f)"
 
-  def unpack = {
+  /* def method(f: A)(g: B): R */
+  def f_1_1(f: Tree)(g: Tree): Tree = q"$ev.$name($lhs)($f)($g)"
+
+  /* def method(f: A)(g: B): R */
+  def fa_1_1(f: Tree)(g: Tree): Tree = q"$ev.$name($lhs, $f)($g)"
+
+  /* def method(f: A, g: B): R */
+  def f_2(f: Tree, g: Tree): Tree = q"$ev.$name($lhs)($f, $g)"
+
+  /** Destructured macro application.
+    * - `ev`: the typeclass evidence
+    * - `name`: the name of the invoked method
+    * - `lhs`: the invocation target of the call
+    */
+  private lazy val (ev, name, lhs) =
     c.prefix.tree match {
-      case Apply(Apply(TypeApply(_, _), List(x)), List(ev)) => (ev, x)
-      case t => c.abort(c.enclosingPosition, "Cannot extract subject of operation (tree = %s)" format t)
+      case Apply(Apply(TypeApply(_, _), List(x)), List(ev)) =>
+        (ev, c.macroApplication.symbol.name.toTermName, x)
+      case t => c.abort(c.enclosingPosition, s"Cannot extract subject of operation (tree = $t)")
     }
-  }
 
 }


### PR DESCRIPTION
Since 8.0.x won't support scala 2.10, there's no reason to bother using raw trees and `c.Expr`s all over the place. With this, it's possible to drop all the type parameters and write the impls in a somewhat less esoteric style (for when more shapes are inevitably needed).

The ops macros need to be blackbox, otherwise `f_0` won't fix the result type based on its type argument, and infer `Nothing`. It's not trivial to return a properly-typed tree if the return type is an arbitrary function of a cloud of types floating over the macro application, so it's easier to just accept the blackboxity and go ahead with unrestricted type inference.

Fixes #1542, so a ping to @NeQuissimus.