### PR TITLE
Add macro shape for OpsA-style syntax.

### DIFF
--- a/base/shared/src/main/scala/scalaz/typeclass/ApplicativeSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/ApplicativeSyntax.scala
@@ -1,14 +1,17 @@
 package scalaz
 package typeclass
 
-import scala.language.implicitConversions
+import com.github.ghik.silencer.silent
+
+import language.implicitConversions
+import language.experimental.macros
 
 trait ApplicativeSyntax {
   implicit def applicativeOpsA[A](a: A): ApplicativeSyntax.OpsA[A] = new ApplicativeSyntax.OpsA(a)
 }
 
 object ApplicativeSyntax {
-  class OpsA[A](a: A) {
-    def pure[F[_]](implicit F: Applicative[F]): F[A] = F.pure(a)
+  class OpsA[A](@silent a: A) {
+    def pure[F[_]: Applicative]: F[A] = macro meta.IdOps.id_1
   }
 }

--- a/base/shared/src/test/scala/SyntaxResolutionTest.scala
+++ b/base/shared/src/test/scala/SyntaxResolutionTest.scala
@@ -3,6 +3,8 @@ import scalaz.Prelude._
 /* Tests that the various syntax macros work for the typeclasses which use them. */
 object SyntaxResolutionTest {
 
+  def _applicative[F[_]: Applicative, A](a: A): F[A] = a.pure[F]
+
   def _apply[F[_]: Apply, A, B](fa: F[A], f: F[A => B]): F[B] = fa.ap(f)
 
   def _bind[F[_]: Bind, A, B](fa: F[A], f: A => F[B]): F[B] = fa.flatMap(f)

--- a/meta/shared/src/main/scala/scalaz/meta/Ops.scala
+++ b/meta/shared/src/main/scala/scalaz/meta/Ops.scala
@@ -61,5 +61,23 @@ class Ops(val c: blackbox.Context) {
         (ev, c.macroApplication.symbol.name.toTermName, x)
       case t => c.abort(c.enclosingPosition, s"Cannot extract subject of operation (tree = $t)")
     }
+}
 
+/** Versions of the zero-cost macros for when the receiver is not an instance
+  * of the typeclass in question.
+  */
+class IdOps(val c: blackbox.Context) {
+  import c.universe._
+
+  /* def method(x: A): R */
+  def id_1(x: Tree): Tree = q"$x.$name($lhs)"
+
+  private lazy val lhs =
+    c.prefix.tree match {
+      case Apply(TypeApply(_, _), List(lhs)) => lhs
+      case t => c.abort(c.enclosingPosition, s"Cannot extract subject of operation (tree = $t)")
+    }
+
+  private lazy val name =
+    c.macroApplication.symbol.name.toTermName
 }


### PR DESCRIPTION
This allows for such syntax as `f.pure[F]` and (eventually) `err.raiseError[M]`.

After this I'll leave the macros alone for a while.