### PR TITLE
Improved `Show` instance for String

### DIFF
--- a/core/src/main/scala/scalaz/std/String.scala
+++ b/core/src/main/scala/scalaz/std/String.scala
@@ -6,7 +6,7 @@ trait StringInstances {
     type SA[α] = String
     def append(f1: String, f2: => String) = f1 + f2
     def zero: String = ""
-    override def shows(f: String): String = f
+    override def shows(f: String): String = '"' + f + '"'
     def order(x: String, y: String) = Ordering.fromInt(x.compareTo(y))
     override def equal(x: String, y: String) = x == y
     override def equalIsNatural: Boolean = true

--- a/core/src/main/scala/scalaz/std/String.scala
+++ b/core/src/main/scala/scalaz/std/String.scala
@@ -6,6 +6,7 @@ trait StringInstances {
     type SA[α] = String
     def append(f1: String, f2: => String) = f1 + f2
     def zero: String = ""
+    override def show(f: String): Cord = shows(f)
     override def shows(f: String): String = '"' + f + '"'
     def order(x: String, y: String) = Ordering.fromInt(x.compareTo(y))
     override def equal(x: String, y: String) = x == y

--- a/core/src/main/scala/scalaz/std/String.scala
+++ b/core/src/main/scala/scalaz/std/String.scala
@@ -6,7 +6,7 @@ trait StringInstances {
     type SA[α] = String
     def append(f1: String, f2: => String) = f1 + f2
     def zero: String = ""
-    override def show(f: String): Cord = shows(f)
+    override def show(f: String): Cord = new Cord(FingerTree.three("\"", f, "\"")(Cord.sizer).toTree)
     override def shows(f: String): String = '"' + f + '"'
     def order(x: String, y: String) = Ordering.fromInt(x.compareTo(y))
     override def equal(x: String, y: String) = x == y

--- a/core/src/main/scala/scalaz/std/String.scala
+++ b/core/src/main/scala/scalaz/std/String.scala
@@ -6,7 +6,7 @@ trait StringInstances {
     type SA[α] = String
     def append(f1: String, f2: => String) = f1 + f2
     def zero: String = ""
-    override def show(f: String) = '"' + f + '"'
+    override def shows(f: String): String = f
     def order(x: String, y: String) = Ordering.fromInt(x.compareTo(y))
     override def equal(x: String, y: String) = x == y
     override def equalIsNatural: Boolean = true


### PR DESCRIPTION
Since there is no `Read` typeclass in Scalaz (nor should there be), `Show` becomes nearly lawless. That's okay if it's only used for debugging and never intended for serious serialization.

That said, here's an attempt at one law, which is reflected in the code change and alters the output of `.shows`:

> Law of String Identity: `String.shows == id`