### PR TITLE
adding Magma and Group

### DIFF
--- a/base/shared/src/main/scala/scalaz/data/ConstInstances.scala
+++ b/base/shared/src/main/scala/scalaz/data/ConstInstances.scala
@@ -28,7 +28,7 @@ trait ConstInstances {
   implicit def apply[R](implicit R: Semigroup[R]): Apply[Const[R, ?]] = new Apply[Const[R, ?]] {
     def functor: Functor[Const[R, ?]] = Const.functor[R]
     def ap[A, B](fa: Const[R, A])(f: Const[R, A => B]): Const[R, B] =
-      Const(R.append(fa.getConst, f.getConst))
+      Const(R.magma.append(fa.getConst, f.getConst))
   }
 
   implicit def applicative[R](implicit R: Monoid[R]): Applicative[Const[R, ?]] = new Applicative[Const[R, ?]] {
@@ -36,9 +36,9 @@ trait ConstInstances {
     def pure[A](a: A): Const[R, A] = Const(R.empty)
   }
 
-  implicit def semigroup[A, B](implicit A: Semigroup[A]): Semigroup[Const[A, B]] = new Semigroup[Const[A, B]] {
+  implicit def semigroup[A, B](implicit A: Semigroup[A]): Semigroup[Const[A, B]] = new SemigroupClass[Const[A, B]] {
     def append(a1: Const[A, B], a2: => Const[A, B]): Const[A, B] =
-      Const(A.append(a1.getConst, a2.getConst))
+      Const(A.magma.append(a1.getConst, a2.getConst))
   }
 
   implicit def monoid[A, B](implicit A: Monoid[A]): Monoid[Const[A, B]] = new Monoid[Const[A, B]] {

--- a/base/shared/src/main/scala/scalaz/data/These.scala
+++ b/base/shared/src/main/scala/scalaz/data/These.scala
@@ -64,9 +64,9 @@ sealed abstract class These[L, R] {
       case Both(left1, right1) => Both(left1, right1(right))
     }
     case Both(left, right) => f match {
-      case This(left1)         => This(L.append(left, left1))
+      case This(left1)         => This(L.magma.append(left, left1))
       case That(right1)        => Both(left, right1(right))
-      case Both(left1, right1) => Both(L.append(left, left1), right1(right))
+      case Both(left1, right1) => Both(L.magma.append(left, left1), right1(right))
     }
   }
 
@@ -75,9 +75,9 @@ sealed abstract class These[L, R] {
     case thiz @ This(_)    => thiz.pmap[D]
     case That(right)       => f(right)
     case Both(left, right) => f(right) match {
-      case This(left1)         => This(L.append(left, left1))
+      case This(left1)         => This(L.magma.append(left, left1))
       case That(right1)        => Both(left, right1)
-      case Both(left1, right1) => Both(L.append(left, left1), right1)
+      case Both(left1, right1) => Both(L.magma.append(left, left1), right1)
     }
   }
 
@@ -112,15 +112,15 @@ sealed abstract class These[L, R] {
   }
 
   final def lappend(other: L)(implicit L: Semigroup[L]): These[L, R] = this match {
-    case This(left)        => This(L.append(left, other))
+    case This(left)        => This(L.magma.append(left, other))
     case That(right)       => Both(other, right)
-    case Both(left, right) => Both(L.append(left, other), right)
+    case Both(left, right) => Both(L.magma.append(left, other), right)
   }
 
   final def rappend(other: R)(implicit R: Semigroup[R]): These[L, R] = this match {
     case This(left)        => Both(left, other)
-    case That(right)       => That(R.append(right, other))
-    case Both(left, right) => Both(left, R.append(right, other))
+    case That(right)       => That(R.magma.append(right, other))
+    case Both(left, right) => Both(left, R.magma.append(right, other))
   }
 
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/FoldableClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/FoldableClass.scala
@@ -13,7 +13,7 @@ object FoldableClass {
 
   trait FoldRight[F[_]] extends Alt[FoldRight[F]] { self : Foldable[F] =>
     override def foldRight[A, B](fa: F[A], z: => B)(f: (A, => B) => B): B
-    override def foldMap[A, B: Monoid](fa: F[A])(f: A => B) = foldRight(fa, Monoid[B].empty)((a, b) => Semigroup[B].append(f(a),b))
+    override def foldMap[A, B: Monoid](fa: F[A])(f: A => B) = foldRight(fa, Monoid[B].empty)((a, b) => Semigroup[B].magma.append(f(a),b))
   }
 
   trait Alt[D <: Alt[D]] { self: D => }

--- a/base/shared/src/main/scala/scalaz/typeclass/Group.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/Group.scala
@@ -1,0 +1,16 @@
+package scalaz
+package typeclass
+
+/* A Group is a Monoid with negation and inverse, such that
+ * a |+| inverse(a)  = monoid.empty
+ * inverse(a) |+| a  = monoid.empty
+ *  
+ * */
+trait Group[A] {
+  def monoid: Monoid[A]
+  def inverse(a: A): A
+}
+
+object Group extends GroupInstances {
+  def apply[A](implicit A: Group[A]): Group[A] = A
+}

--- a/base/shared/src/main/scala/scalaz/typeclass/GroupClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/GroupClass.scala
@@ -1,0 +1,6 @@
+package scalaz
+package typeclass
+
+trait GroupClass[A] extends Group[A] with MonoidClass[A]{
+  final def group: Group[A] = this
+}

--- a/base/shared/src/main/scala/scalaz/typeclass/GroupInstances.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/GroupInstances.scala
@@ -1,0 +1,12 @@
+package scalaz
+package typeclass
+
+trait GroupInstances {
+
+  implicit val int: Group[Int] = new GroupClass[Int] {
+    def append(a1: Int, a2: => Int) = a1 + a2
+    def empty = 0
+    def inverse(a:Int) = a * -1
+  }
+
+}

--- a/base/shared/src/main/scala/scalaz/typeclass/Magma.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/Magma.scala
@@ -1,0 +1,12 @@
+package scalaz
+package typeclass
+
+/* A Magma is a Set with a binary operation that returns a member of the same Set
+ * */
+trait Magma[A] {
+  def append(a1: A, a2: => A): A
+}
+
+object Magma extends MagmaInstances {
+  def apply[A](implicit A: Magma[A]): Magma[A] = A
+}

--- a/base/shared/src/main/scala/scalaz/typeclass/MagmaClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/MagmaClass.scala
@@ -1,0 +1,6 @@
+package scalaz
+package typeclass
+
+trait MagmaClass[A] extends Magma[A]{
+  final def magma: Magma[A] = this
+}

--- a/base/shared/src/main/scala/scalaz/typeclass/MagmaInstances.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/MagmaInstances.scala
@@ -1,0 +1,6 @@
+package scalaz
+package typeclass
+
+trait MagmaInstances {
+
+}

--- a/base/shared/src/main/scala/scalaz/typeclass/Semigroup.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/Semigroup.scala
@@ -1,8 +1,11 @@
 package scalaz
 package typeclass
 
+/**
+ * A Semigroup is a Magma with associativity
+ */
 trait Semigroup[A] {
-  def append(a1: A, a2: => A): A
+  def magma:Magma[A]
 }
 
 object Semigroup extends SemigroupSyntax {

--- a/base/shared/src/main/scala/scalaz/typeclass/SemigroupClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/SemigroupClass.scala
@@ -1,6 +1,6 @@
 package scalaz
 package typeclass
 
-trait SemigroupClass[A] extends Semigroup[A]{
+trait SemigroupClass[A] extends Semigroup[A] with MagmaClass[A]{
   final def semigroup: Semigroup[A] = this
 }


### PR DESCRIPTION
First stab at expanding the Algebra hierarchy.
Adding:
- Magma
- Group
Made `Semigroup` to be composed of Magma, which implied that now `Semigroup` does not have a "native" `append`. This seems awkward, since now some parts of the code must do:
```
Semigroup[A].magma.append
```
On the other hand, the above could be solved using syntax sugar. It wasn't very clear how Semigroup syntax should work, so I didn't use it on the first commit.
