### PR TITLE
[8.0.x] example: Add Applicative

### DIFF
--- a/example/src/main/resources/microsite/data/menu.yml
+++ b/example/src/main/resources/microsite/data/menu.yml
@@ -7,8 +7,12 @@ options:
     menu_section: typeclass
 
     nested_options:
+    - title: Applicative
+      url: typeclass/Applicative.html
+      menu_section: typeclass
     - title: Functor
       url: typeclass/Functor.html
+      menu_section: typeclass
     - title: Semigroup
       menu_section: typeclass
       url: typeclass/Semigroup.html

--- a/example/src/main/tut/typeclass/Applicative.md
+++ b/example/src/main/tut/typeclass/Applicative.md
@@ -10,7 +10,7 @@ title:  "Applicative"
 **Typical imports**
 
 ```tut:silent
-import scalaz.Prelude._
+import scalaz.Scalaz._
 ```
 
 ## Instance declaration
@@ -27,11 +27,17 @@ implicit val listap: Applicative[List] = new ApplicativeClass[List] {
 
 ## Usage
 
-```tut
+```tut:reset
+import scalaz.Scalaz._
 
 val l: List[Int] = 123.pure[List]
 
-implicit val f: Functor[List] = listap.apply.functor
-
 l.map(_ + 25)
+
+val l2 = List(17, 19, 23)
+
+val fs: List[Int => Int] = List(_ * 2, _ * 3, _ * 4, _ * 5)
+
+l2.ap(fs)
 ```
+

--- a/example/src/main/tut/typeclass/Applicative.md
+++ b/example/src/main/tut/typeclass/Applicative.md
@@ -1,0 +1,37 @@
+---
+layout: docs
+title:  "Applicative"
+---
+
+# Applicative
+
+*Whereas a [functor](./Functor.html) allows application of a pure function to a value in a context, an Applicative also allows application of a function in a context to a value in a context.*
+
+**Typical imports**
+
+```tut:silent
+import scalaz.Prelude._
+```
+
+## Instance declaration
+
+```tut
+import scalaz.typeclass.ApplicativeClass
+
+implicit val listap: Applicative[List] = new ApplicativeClass[List] {
+  def pure[A](a: A): List[A] = List(a)
+  def ap[A, B](fa: List[A])(f: List[A => B]): List[B] = fa.zip(f).map(t => t._2(t._1))
+  def map[A, B](ma: List[A])(f: A => B): List[B] = ma.map(f)
+}
+```
+
+## Usage
+
+```tut
+
+val l: List[Int] = 123.pure[List]
+
+implicit val f: Functor[List] = listap.apply.functor
+
+l.map(_ + 25)
+```

--- a/example/src/main/tut/typeclass/Functor.md
+++ b/example/src/main/tut/typeclass/Functor.md
@@ -5,11 +5,7 @@ title:  "Functor"
 
 # Functor
 
-The `Functor` type class represents a type that can be mapped over.
-
-**Category Theory**
-
-*A (mathematical) functor represents a mapping between categories.*
+*The `Functor` type class represents a type that can be mapped over.*
 
 A functor needs to satisfy the two functor laws:
 

--- a/example/src/main/tut/typeclass/Monoid.md
+++ b/example/src/main/tut/typeclass/Monoid.md
@@ -5,8 +5,6 @@ title:  "Monoid"
 
 # Monoid
 
-**Category Theory**
-
 *A monoid is a semigroup with a unique identity element.*
 
 A monoid instance must satisfy the following laws in addition to those defined by [Semigroup](Semigroup.html):


### PR DESCRIPTION
- Remove the `Category Theory` headings. We can figure out links to literature or so later
- Add `map` to the Applicative syntax
- Add an Applicative doc

I am also opening another ticket because when you look at the implementation of `ApplicativeSyntax.Ops`, it is rather strange to hop through all the "embedded" instances.