### PR TITLE
sbt build improvements for JVM contributors

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,4 +1,3 @@
 -Xms3784m
 -Xmx3784m
--XX:MaxMetaspaceSize=1g
 -Xss2m

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,4 @@
+-Xms3784m
+-Xmx3784m
+-XX:MaxMetaspaceSize=1g
+-Xss2m

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,17 @@ import com.typesafe.tools.mima.plugin.MimaKeys.mimaPreviousArtifacts
 import org.scalajs.sbtplugin.cross._
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
+/*
+ * NOTICE if you are a contributor who only cares about the JVM, create a file
+ * `local.sbt` containing
+ *
+ *   onLoad in Global := { s => "project rootJVM" :: s }
+ *
+ * and regular commands such as "compile" / "test" will skip over all the
+ * scalajs / scala-native stuff.
+ */
+
+
 lazy val jsProjects = Seq[ProjectReference](
   coreJS, effectJS, iterateeJS, scalacheckBindingJS_1_12, scalacheckBindingJS_1_13, testsJS
 )


### PR DESCRIPTION
All the scalajs / scala-native stuff keeps getting in my way when I'm wanting to contribute, this should help most contributors.

The `sbt` script should read the `.jvmopts` file so contributors don't have to manually set up a memory limit. Without this, about 2 compile cycles is enough to OOM.