### PR TITLE
Monad Plus and Traverse instances for Dequeue

### DIFF
--- a/core/src/main/scala/scalaz/Dequeue.scala
+++ b/core/src/main/scala/scalaz/Dequeue.scala
@@ -237,8 +237,8 @@ sealed abstract class DequeueInstances {
     def append(a: Dequeue[A], b: => Dequeue[A]): Dequeue[A] = a ++ b
   }
 
-  implicit val dequeueInstances: Foldable[Dequeue] with IsEmpty[Dequeue] with MonadPlus[Dequeue] =
-    new Foldable[Dequeue] with IsEmpty[Dequeue] with MonadPlus[Dequeue] {
+  implicit val dequeueInstances: Traverse[Dequeue] with IsEmpty[Dequeue] with MonadPlus[Dequeue] =
+    new Traverse[Dequeue] with IsEmpty[Dequeue] with MonadPlus[Dequeue] {
       override def foldRight[A,B](fa: Dequeue[A], b: => B)(f: (A, => B) =>B): B = fa.foldRight(b)((a,b) => f(a,b))
       override def foldLeft[A,B](fa: Dequeue[A], b: B)(f: (B,A)=>B): B = fa.foldLeft(b)(f)
       override def foldMap[A,B](fa: Dequeue[A])(f: A => B)(implicit F: Monoid[B]): B = fa.foldLeft(F.zero)((b,a) => F.append(b, f(a)))
@@ -249,6 +249,9 @@ sealed abstract class DequeueInstances {
       override def map[A,B](fa: Dequeue[A])(f: A => B): Dequeue[B] = fa map f
       override def point[A](a: => A): Dequeue[A] = Dequeue(a)
       override def bind[A, B](fa: Dequeue[A])(f: A => Dequeue[B]): Dequeue[B] = foldMap(fa)(f)
+      override def traverseImpl[F[_], A, B](fa: Dequeue[A])(f: A => F[B])(implicit F: scalaz.Applicative[F]): F[Dequeue[B]] =
+        fa.foldRight(F.point(Dequeue.empty[B]))((a, fbs) => F.apply2(f(a), fbs)(_ +: _))
+
     }
 }
 

--- a/core/src/main/scala/scalaz/Dequeue.scala
+++ b/core/src/main/scala/scalaz/Dequeue.scala
@@ -249,7 +249,7 @@ sealed abstract class DequeueInstances {
       override def map[A,B](fa: Dequeue[A])(f: A => B): Dequeue[B] = fa map f
       override def point[A](a: => A): Dequeue[A] = Dequeue(a)
       override def bind[A, B](fa: Dequeue[A])(f: A => Dequeue[B]): Dequeue[B] = foldMap(fa)(f)
-      override def traverseImpl[F[_], A, B](fa: Dequeue[A])(f: A => F[B])(implicit F: scalaz.Applicative[F]): F[Dequeue[B]] =
+      override def traverseImpl[F[_], A, B](fa: Dequeue[A])(f: A => F[B])(implicit F: Applicative[F]): F[Dequeue[B]] =
         fa.foldRight(F.point(Dequeue.empty[B]))((a, fbs) => F.apply2(f(a), fbs)(_ +: _))
 
     }

--- a/core/src/main/scala/scalaz/Dequeue.scala
+++ b/core/src/main/scala/scalaz/Dequeue.scala
@@ -237,16 +237,19 @@ sealed abstract class DequeueInstances {
     def append(a: Dequeue[A], b: => Dequeue[A]): Dequeue[A] = a ++ b
   }
 
-  implicit val dequeueInstances: Foldable[Dequeue] with IsEmpty[Dequeue] with Functor[Dequeue] = new Foldable[Dequeue] with IsEmpty[Dequeue] with Functor[Dequeue] {
-    override def foldRight[A,B](fa: Dequeue[A], b: => B)(f: (A, => B) =>B): B = fa.foldRight(b)((a,b) => f(a,b))
-    override def foldLeft[A,B](fa: Dequeue[A], b: B)(f: (B,A)=>B): B = fa.foldLeft(b)(f)
-    override def foldMap[A,B](fa: Dequeue[A])(f: A => B)(implicit F: Monoid[B]): B = fa.foldLeft(F.zero)((b,a) => F.append(b, f(a)))
-    override def empty[A]: Dequeue[A] = Dequeue.empty
-    override def plus[A](a: Dequeue[A], b: => Dequeue[A]): Dequeue[A] = a ++ b
-    override def isEmpty[A](fa: Dequeue[A]) = fa.isEmpty
-    override def length[A](fa: Dequeue[A]) = fa.size
-    override def map[A,B](fa: Dequeue[A])(f: A => B): Dequeue[B] = fa map f
-  }
+  implicit val dequeueInstances: Foldable[Dequeue] with IsEmpty[Dequeue] with MonadPlus[Dequeue] =
+    new Foldable[Dequeue] with IsEmpty[Dequeue] with MonadPlus[Dequeue] {
+      override def foldRight[A,B](fa: Dequeue[A], b: => B)(f: (A, => B) =>B): B = fa.foldRight(b)((a,b) => f(a,b))
+      override def foldLeft[A,B](fa: Dequeue[A], b: B)(f: (B,A)=>B): B = fa.foldLeft(b)(f)
+      override def foldMap[A,B](fa: Dequeue[A])(f: A => B)(implicit F: Monoid[B]): B = fa.foldLeft(F.zero)((b,a) => F.append(b, f(a)))
+      override def empty[A]: Dequeue[A] = Dequeue.empty
+      override def plus[A](a: Dequeue[A], b: => Dequeue[A]): Dequeue[A] = a ++ b
+      override def isEmpty[A](fa: Dequeue[A]) = fa.isEmpty
+      override def length[A](fa: Dequeue[A]) = fa.size
+      override def map[A,B](fa: Dequeue[A])(f: A => B): Dequeue[B] = fa map f
+      override def point[A](a: => A): Dequeue[A] = Dequeue(a)
+      override def bind[A, B](fa: Dequeue[A])(f: A => Dequeue[B]): Dequeue[B] = foldMap(fa)(f)
+    }
 }
 
 private[scalaz] trait DequeueEqual[A] extends Equal[Dequeue[A]] {

--- a/tests/src/test/scala/scalaz/DequeueTest.scala
+++ b/tests/src/test/scala/scalaz/DequeueTest.scala
@@ -10,7 +10,7 @@ object DequeueTest extends SpecLite {
   checkAll(isEmpty.laws[Dequeue])
   checkAll(foldable.laws[Dequeue])
   checkAll(plusEmpty.laws[Dequeue])
-  checkAll(functor.laws[Dequeue])
+  checkAll(monadPlus.laws[Dequeue])
 
   "fromList works" ! forAll{ (l: List[Int]) ⇒
     Dequeue.fromFoldable(l).toStream must_===(l.toStream)

--- a/tests/src/test/scala/scalaz/DequeueTest.scala
+++ b/tests/src/test/scala/scalaz/DequeueTest.scala
@@ -8,7 +8,7 @@ import org.scalacheck.Prop.forAll
 object DequeueTest extends SpecLite {
   checkAll(monoid.laws[Dequeue[Int]])
   checkAll(isEmpty.laws[Dequeue])
-  checkAll(foldable.laws[Dequeue])
+  checkAll(traverse.laws[Dequeue])
   checkAll(plusEmpty.laws[Dequeue])
   checkAll(monadPlus.laws[Dequeue])
 


### PR DESCRIPTION
There might be a reason these didn't exist before, but I didn't see any old issues about it.  If this gets approved, I'll backport to 7.2.x.