### PR TITLE
allow OneAnd to have more laziness options

### DIFF
--- a/core/src/main/scala/scalaz/OneAnd.scala
+++ b/core/src/main/scala/scalaz/OneAnd.scala
@@ -33,6 +33,14 @@ import scalaz.Ordering.orderingInstance
 final class OneAnd[F[_], A](h: Name[A], t: Name[F[A]]) {
   def head: A    = h.value
   def tail: F[A] = t.value
+
+  // because, legacy
+  override def equals(other: Any): Boolean = other match {
+    case OneAnd(th, tt) => head == th && tail == tt
+    case _              => false
+  }
+  override def hashCode: Int = head.hashCode + 13*tail.hashCode
+  override def toString: String = s"OneAnd($head, $tail)"
 }
 
 private sealed trait OneAndFunctor[F[_]] extends Functor[OneAnd[F, ?]] {


### PR DESCRIPTION
When any typeclass is applied, it will default to eager / Value, but this at
least allows us to avoid evaluating objects like EphemeralStream and Stream
at the point of construction.

I also fixed the iso to use `IList` instead of `List`

close #1516 