### PR TITLE
ISet faster Foldable.element, assuming typeclass coherence

### DIFF
--- a/core/src/main/scala/scalaz/ISet.scala
+++ b/core/src/main/scala/scalaz/ISet.scala
@@ -769,7 +769,7 @@ sealed abstract class ISetInstances {
     override def empty[A](fa: ISet[A]) =
       fa.isEmpty
 
-    // we're assuming typeclass coherence elsewhere...
+    // assuming typeclass coherence...
     override def element[A: Equal](fa: ISet[A], a: A): Boolean =
       Equal[A] match {
         case o: Order[_] =>

--- a/core/src/main/scala/scalaz/ISet.scala
+++ b/core/src/main/scala/scalaz/ISet.scala
@@ -769,6 +769,14 @@ sealed abstract class ISetInstances {
     override def empty[A](fa: ISet[A]) =
       fa.isEmpty
 
+    // we're assuming typeclass coherence elsewhere...
+    override def element[A: Equal](fa: ISet[A], a: A): Boolean =
+      Equal[A] match {
+        case o: Order[_] =>
+          fa.member(a)(o.asInstanceOf[Order[A]])
+        case _ => super.element(fa, a)
+      }
+
     override def any[A](fa: ISet[A])(f: A => Boolean) =
       fa match {
         case Tip() => false

--- a/tests/src/test/scala/scalaz/ISetTest.scala
+++ b/tests/src/test/scala/scalaz/ISetTest.scala
@@ -179,7 +179,7 @@ object ISetTest extends SpecLite {
     a.member(i) must_=== a.toList.contains(i)
   }
 
-  "Foldable.member" ! forAll {(a: ISet[Int], i: Int) =>
+  "Foldable.element" ! forAll {(a: ISet[Int], i: Int) =>
     import scalaz.syntax.foldable._
 
     a.element(i) must_=== a.toList.contains(i)

--- a/tests/src/test/scala/scalaz/ISetTest.scala
+++ b/tests/src/test/scala/scalaz/ISetTest.scala
@@ -179,6 +179,12 @@ object ISetTest extends SpecLite {
     a.member(i) must_=== a.toList.contains(i)
   }
 
+  "Foldable.member" ! forAll {(a: ISet[Int], i: Int) =>
+    import scalaz.syntax.foldable._
+
+    a.element(i) must_=== a.toList.contains(i)
+  }
+
   "sound delete" ! forAll {(a: ISet[Int], i: Int) =>
     val b = a.delete(i)
     structurallySound(b)


### PR DESCRIPTION
Bless me father, for I have sinned.

This is more for discussion than under the expectation of acceptance. This could start a holy war about coherence, but could be the sort of evil hack we might want in scalaz8

// @edmundnoble 