### PR TITLE
Equal may be Order aware

### DIFF
--- a/core/src/main/scala/scalaz/Equal.scala
+++ b/core/src/main/scala/scalaz/Equal.scala
@@ -20,6 +20,9 @@ trait Equal[F]  { self =>
 
   // derived functions
 
+  /** A coherent / consistent instance of Order, should one exist. */
+  def toOrder: Maybe[Order[F]] = Maybe.empty
+
   trait EqualLaw {
     import std.boolean.conditional
     def commutative(f1: F, f2: F): Boolean = equal(f1, f2) == equal(f2, f1)

--- a/core/src/main/scala/scalaz/ISet.scala
+++ b/core/src/main/scala/scalaz/ISet.scala
@@ -769,6 +769,9 @@ sealed abstract class ISetInstances {
     override def empty[A](fa: ISet[A]) =
       fa.isEmpty
 
+    override def element[A: Equal](fa: ISet[A], a: A): Boolean =
+      Equal[A].toOrder.cata(fa.member(a)(_), super.element(fa, a))
+
     override def any[A](fa: ISet[A])(f: A => Boolean) =
       fa match {
         case Tip() => false

--- a/core/src/main/scala/scalaz/Order.scala
+++ b/core/src/main/scala/scalaz/Order.scala
@@ -35,6 +35,8 @@ trait Order[F] extends Equal[F] { self =>
     override def equal(b1: B, b2: B) = self.equal(f(b1), f(b2))
   }
 
+  override def toOrder: Maybe[Order[F]] = Maybe.just(this)
+
   /** @note `Order.fromScalaOrdering(toScalaOrdering).order(x, y)`
             = `this.order(x, y)` */
   def toScalaOrdering: SOrdering[F] = new SOrdering[F] {

--- a/tests/src/test/scala/scalaz/ISetTest.scala
+++ b/tests/src/test/scala/scalaz/ISetTest.scala
@@ -179,6 +179,12 @@ object ISetTest extends SpecLite {
     a.member(i) must_=== a.toList.contains(i)
   }
 
+  "Foldable.element" ! forAll {(a: ISet[Int], i: Int) =>
+    import scalaz.syntax.foldable._
+
+    a.element(i) must_=== a.toList.contains(i)
+  }
+
   "sound delete" ! forAll {(a: ISet[Int], i: Int) =>
     val b = a.delete(i)
     structurallySound(b)


### PR DESCRIPTION
allowing for more efficient binary search when implementing Foldable methods.

As discussed in https://github.com/scalaz/scalaz/pull/1575, this approach proposed by @aaronvargo