### PR TITLE
avoid object allocations from Maybe.Empty()

### DIFF
--- a/core/src/main/scala/scalaz/Maybe.scala
+++ b/core/src/main/scala/scalaz/Maybe.scala
@@ -152,6 +152,11 @@ sealed abstract class Maybe[A] {
 object Maybe extends MaybeInstances {
 
   final case class Empty[A]() extends Maybe[A]
+  object Empty {
+    private[this] val shared: Empty[Nothing] = new Empty()
+    def apply[A](): Empty[A] = shared.asInstanceOf[Empty[A]]
+    def unapply[A](e: Empty[A]): Boolean = true
+  }
 
   final case class Just[A](a: A) extends Maybe[A]
 

--- a/core/src/main/scala/scalaz/Maybe.scala
+++ b/core/src/main/scala/scalaz/Maybe.scala
@@ -151,11 +151,9 @@ sealed abstract class Maybe[A] {
 
 object Maybe extends MaybeInstances {
 
-  final case class Empty[A]() extends Maybe[A]
-  object Empty {
-    private[this] val shared: Empty[Nothing] = new Empty()
-    def apply[A](): Empty[A] = shared.asInstanceOf[Empty[A]]
-    def unapply[A](e: Empty[A]): Boolean = true
+  final case object Empty extends Maybe[Nothing] {
+    def apply[A](): Maybe[A] = this.asInstanceOf[Maybe[A]]
+    def unapply[A](e: Maybe[A]): Boolean = this == e
   }
 
   final case class Just[A](a: A) extends Maybe[A]

--- a/tests/src/test/scala/scalaz/MaybeTests.scala
+++ b/tests/src/test/scala/scalaz/MaybeTests.scala
@@ -82,6 +82,13 @@ object MaybeTest extends SpecLite {
 
   "empty isn't just" ! check(!empty.isJust)
 
+  "empty pattern matches" ! check {
+    empty match {
+      case Empty() => true
+      case _       => false
+    }
+  }
+
   "just to option is some" ! forAll { x: Int => just(x).toOption.isDefined }
 
   "empty to option is none" ! check(empty.toOption.isEmpty)


### PR DESCRIPTION
It's horrible, I hate it, but scala makes us do this if we want to avoid object allocations.

I'd quite like a compiler plugin (or a stock compiler optimisation) that does this automatically for zero parameter case classes.

close #1498 