### PR TITLE
Consistent use of case objects for invariant "empty" ADTs

### DIFF
--- a/core/src/main/scala/scalaz/Dequeue.scala
+++ b/core/src/main/scala/scalaz/Dequeue.scala
@@ -223,7 +223,7 @@ private[scalaz] final case object EmptyDequeue extends Dequeue[Nothing] {
   override val backMaybe = Maybe.empty
 
   def apply[A]() = this.asInstanceOf[Dequeue[A]]
-  def unapply[A](q: Dequeue[A]) = q.isEmpty
+  def unapply[A](q: Dequeue[A]) = this eq q
 }
 
 sealed abstract class DequeueInstances {

--- a/core/src/main/scala/scalaz/IList.scala
+++ b/core/src/main/scala/scalaz/IList.scala
@@ -477,7 +477,7 @@ sealed abstract class IList[A] extends Product with Serializable {
 
 final case object INil extends IList[Nothing] {
   def apply[A](): IList[A] = this.asInstanceOf[IList[A]]
-  def unapply[A](e: IList[A]): Boolean = this == e
+  def unapply[A](e: IList[A]): Boolean = this eq e
 }
 final case class ICons[A](head: A, tail: IList[A]) extends IList[A]
 

--- a/core/src/main/scala/scalaz/IList.scala
+++ b/core/src/main/scala/scalaz/IList.scala
@@ -475,9 +475,10 @@ sealed abstract class IList[A] extends Product with Serializable {
 
 }
 
-// In order to get exhaustiveness checking and a sane unapply in both 2.9 and 2.10 it seems
-// that we need to use bare case classes. Sorry. Suggestions welcome.
-final case class INil[A]() extends IList[A]
+final case object INil extends IList[Nothing] {
+  def apply[A](): IList[A] = this.asInstanceOf[IList[A]]
+  def unapply[A](e: IList[A]): Boolean = this == e
+}
 final case class ICons[A](head: A, tail: IList[A]) extends IList[A]
 
 object IList extends IListInstances {
@@ -714,8 +715,8 @@ private trait IListEqual[A] extends Equal[IList[A]] {
             equal(ac.tail, bc.tail)
           case _ => false
         }
-        case _: INil[A] => b match {
-          case _ : INil[A] => true
+        case INil() => b match {
+          case INil() => true
           case _ => false
         }
       }

--- a/core/src/main/scala/scalaz/ISet.scala
+++ b/core/src/main/scala/scalaz/ISet.scala
@@ -874,11 +874,10 @@ object ISet extends ISetInstances {
         }
     }
 
-  private[scalaz] abstract case class Tip[A] private() extends ISet[A] {
+  private[scalaz] final case object Tip extends ISet[Nothing] {
     val size = 0
-  }
-  private[scalaz] object Tip extends Tip[Nothing] {
     def apply[A](): ISet[A] = this.asInstanceOf[ISet[A]]
+    def unapply[A](i: ISet[A]): Boolean = this eq i
   }
 
   private[scalaz] final case class Bin[A](a: A, l: ISet[A], r: ISet[A]) extends ISet[A] {

--- a/core/src/main/scala/scalaz/Map.scala
+++ b/core/src/main/scala/scalaz/Map.scala
@@ -1218,12 +1218,10 @@ private[scalaz] sealed trait MapEqual[A, B] extends Equal[A ==>> B] {
 }
 
 object ==>> extends MapInstances {
-  private[scalaz] case object Tip extends (Nothing ==>> Nothing) {
+  private[scalaz] final case object Tip extends (Nothing ==>> Nothing) {
     val size = 0
-
-    def unapply[A, B](a: A ==>> B): Boolean = a eq this
-
     def apply[A, B](): A ==>> B = this.asInstanceOf[A ==>> B]
+    def unapply[A, B](a: A ==>> B): Boolean = this eq a
   }
 
   private[scalaz] final case class Bin[A, B](k: A, v: B, l: A ==>> B, r: A ==>> B) extends ==>>[A, B] {

--- a/core/src/main/scala/scalaz/Maybe.scala
+++ b/core/src/main/scala/scalaz/Maybe.scala
@@ -153,7 +153,7 @@ object Maybe extends MaybeInstances {
 
   final case object Empty extends Maybe[Nothing] {
     def apply[A](): Maybe[A] = this.asInstanceOf[Maybe[A]]
-    def unapply[A](e: Maybe[A]): Boolean = this == e
+    def unapply[A](e: Maybe[A]): Boolean = this eq e
   }
 
   final case class Just[A](a: A) extends Maybe[A]


### PR DESCRIPTION
same deal as #1579 ... just as ugly but the runtime benefits are worth it.