### PR TITLE
convenient pattern matching for IList

### DIFF
--- a/core/src/main/scala/scalaz/IList.scala
+++ b/core/src/main/scala/scalaz/IList.scala
@@ -519,6 +519,14 @@ object IList extends IListInstances {
       def to[A](fa: List[A]) = fromList(fa)
       def from[A](fa: IList[A]) = fa.toList
     }
+
+  object :: {
+    def unapply[A](xs: IList[A]): Option[(A, IList[A])] = xs match {
+      case ICons(head, tail) => Some(head -> tail)
+      case INil()            => None
+    }
+  }
+
 }
 
 sealed abstract class IListInstance0 {

--- a/tests/src/test/scala/scalaz/IListTest.scala
+++ b/tests/src/test/scala/scalaz/IListTest.scala
@@ -409,6 +409,16 @@ object IListTest extends SpecLite {
     ns.zipWithIndex.toList must_=== ns.toList.zipWithIndex
   }
 
+  "IList.:: pattern match" ! forAll { (n: Int, ns: IList[Int]) =>
+    import IList.::
+
+    (n :: ns) match {
+      case n1 :: ns1 =>
+        n1 must_=== n
+        ns1 must_=== ns
+    }
+  }
+
   checkAll(FoldableTests.anyAndAllLazy[IList])
 
   object instances {


### PR DESCRIPTION
close #1591 

this looks like it might be nice to backport to 7.2