### PR TITLE
some fixes for Memo

### DIFF
--- a/core/src/main/scala/scalaz/Memo.scala
+++ b/core/src/main/scala/scalaz/Memo.scala
@@ -25,7 +25,7 @@ object Memo extends MemoInstances {
   private class ArrayMemo[V >: Null : ClassTag](n: Int) extends Memo[Int, V] {
     override def apply(f: (Int) => V) = {
       val a = Need(new Array[V](n))
-      k => {
+      k => if (k < 0 || k >= n) f(k) else {
         val t = a.value(k)
         if (t == null) {
           val v = f(k)
@@ -45,9 +45,9 @@ object Memo extends MemoInstances {
           Array.fill(n)(sentinel)
         }
       }
-      k => {
+      k => if (k < 0 || k >= n) f(k) else {
         val t = a.value(k)
-        if (t == sentinel) {
+        if (t == sentinel || (sentinel.isNaN && t.isNaN)) {
           val v = f(k)
           a.value(k) = v
           v
@@ -66,20 +66,13 @@ object Memo extends MemoInstances {
 
   import collection.mutable
 
-  def mutableMapMemo[K, V](a: mutable.Map[K, V]): Memo[K, V] = memo[K, V](f => k => a.getOrElseUpdate(k, f(k)))
+  private def mutableMapMemo[K, V](a: mutable.Map[K, V]): Memo[K, V] = memo[K, V](f => k => a.getOrElseUpdate(k, f(k)))
 
   /** Cache results in a [[scala.collection.mutable.HashMap]].
     * Nonsensical if `K` lacks a meaningful `hashCode` and
     * `java.lang.Object.equals`.
     */
   def mutableHashMapMemo[K, V]: Memo[K, V] = mutableMapMemo(new mutable.HashMap[K, V])
-
-  /** As with `mutableHashMapMemo`, but forget elements according to
-    * GC pressure.
-    */
-  @deprecated("Keys are collected too quickly for weakHashMapMemo to be very useful",
-              since = "7.3.0")
-  def weakHashMapMemo[K, V]: Memo[K, V] = mutableMapMemo(new mutable.WeakHashMap[K, V])
 
   import collection.immutable
 
@@ -99,11 +92,6 @@ object Memo extends MemoInstances {
     * $immuMapNote
     */
   def immutableHashMapMemo[K, V]: Memo[K, V] = immutableMapMemo(new immutable.HashMap[K, V])
-
-  /** Cache results in a list map.  Nonsensical unless `K` has
-    * a meaningful `java.lang.Object.equals`.  $immuMapNote
-    */
-  def immutableListMapMemo[K, V]: Memo[K, V] = immutableMapMemo(new immutable.ListMap[K, V])
 
   /** Cache results in a tree map. $immuMapNote */
   def immutableTreeMapMemo[K: scala.Ordering, V]: Memo[K, V] = immutableMapMemo(new immutable.TreeMap[K, V])

--- a/tests/src/test/scala/scalaz/MemoTest.scala
+++ b/tests/src/test/scala/scalaz/MemoTest.scala
@@ -1,0 +1,52 @@
+package scalaz
+
+object MemoTest extends SpecLite {
+
+  "Memo.doubleArrayMemo should not throw exceptions" in {
+    import scalaz.std.anyVal._
+
+    var doubler_count = 0
+    def doubler(n: Int): Double = {
+      doubler_count += 1
+      n * 2.0
+    }
+
+    val memo = Memo.doubleArrayMemo(10)
+    val mdoubler = memo(doubler)
+
+    mdoubler(1) must_=== 2.0
+    doubler_count must_=== 1
+    mdoubler(1) must_=== 2.0
+    doubler_count must_=== 1
+
+    // outside the memoisation zone
+    mdoubler(20) must_=== 40.0
+    doubler_count must_=== 2
+    mdoubler(20) must_=== 40.0
+    doubler_count must_=== 3
+
+    mdoubler(-1) must_=== -2.0
+    doubler_count must_=== 4
+    mdoubler(-1) must_=== -2.0
+    doubler_count must_=== 5
+  }
+
+  "Memo.doubleArrayMemo should support Double.NaN" in {
+    import scalaz.std.anyVal._
+
+    var doubler_count = 0
+    def doubler(n: Int): Double = {
+      doubler_count += 1
+      n * 2.0
+    }
+
+    val memo = Memo.doubleArrayMemo(10, Double.NaN)
+    val mdoubler = memo(doubler)
+
+    mdoubler(0) must_=== 0.0
+    doubler_count must_=== 1
+    mdoubler(0) must_=== 0.0
+    doubler_count must_=== 1
+  }
+
+}


### PR DESCRIPTION
close #1488 

`Memo` is a wonderful idea with terrible implementations.

- hide a public method that allows mutable state to escape
- delete two implementations (weakhashmap and listmap) because neither are useful. @S11001001 has already noted the poor performance of the former, whereas `ListMap` is just generally best avoided in my experience.
- fixes several bugs in the array implementations that made `Memo` turn total functions into partial functions.
- added some tests.

Really we need to kill the current stdlib implementations and replace with versions that use the scalaz Maps / trees and/or (for performance) the java fast concurrent collections, perhaps revisiting weak keys / values again.