### PR TITLE
~~moar~~ remove IList pattern matchers

### DIFF
--- a/core/src/main/scala/scalaz/IList.scala
+++ b/core/src/main/scala/scalaz/IList.scala
@@ -487,6 +487,9 @@ object IList extends IListInstances {
   def apply[A](as: A*): IList[A] =
     as.foldRight(empty[A])(ICons(_, _))
 
+  // warning, use of this extractor disables exhaustivity checks
+  def unapplySeq[A](ilist: IList[A]): Option[Seq[A]] = Some(ilist.toList)
+
   def single[A](a: A): IList[A] =
     ICons(a, empty)
 
@@ -520,9 +523,9 @@ object IList extends IListInstances {
     }
 
   object :: {
-    def unapply[A](xs: IList[A]): Option[(A, IList[A])] = xs match {
+    // warning, use of this extractor disables exhaustivity checks
+    def unapply[A](xs: ICons[A]): Option[(A, IList[A])] = xs match {
       case ICons(head, tail) => Some(head -> tail)
-      case INil()            => None
     }
   }
 

--- a/core/src/main/scala/scalaz/IList.scala
+++ b/core/src/main/scala/scalaz/IList.scala
@@ -487,9 +487,6 @@ object IList extends IListInstances {
   def apply[A](as: A*): IList[A] =
     as.foldRight(empty[A])(ICons(_, _))
 
-  // warning, use of this extractor disables exhaustivity checks
-  def unapplySeq[A](ilist: IList[A]): Option[Seq[A]] = Some(ilist.toList)
-
   def single[A](a: A): IList[A] =
     ICons(a, empty)
 
@@ -521,13 +518,6 @@ object IList extends IListInstances {
       def to[A](fa: List[A]) = fromList(fa)
       def from[A](fa: IList[A]) = fa.toList
     }
-
-  object :: {
-    // warning, use of this extractor disables exhaustivity checks
-    def unapply[A](xs: ICons[A]): Option[(A, IList[A])] = xs match {
-      case ICons(head, tail) => Some(head -> tail)
-    }
-  }
 
 }
 

--- a/tests/src/test/scala/scalaz/IListTest.scala
+++ b/tests/src/test/scala/scalaz/IListTest.scala
@@ -419,6 +419,14 @@ object IListTest extends SpecLite {
     }
   }
 
+  "IList() pattern match" ! forAll { (n: Int, ns: IList[Int]) =>
+    (n :: ns) match {
+      case IList(a, _) =>
+        a must_=== n
+      case _ =>
+    }
+  }
+
   checkAll(FoldableTests.anyAndAllLazy[IList])
 
   object instances {

--- a/tests/src/test/scala/scalaz/IListTest.scala
+++ b/tests/src/test/scala/scalaz/IListTest.scala
@@ -409,24 +409,6 @@ object IListTest extends SpecLite {
     ns.zipWithIndex.toList must_=== ns.toList.zipWithIndex
   }
 
-  "IList.:: pattern match" ! forAll { (n: Int, ns: IList[Int]) =>
-    import IList.::
-
-    (n :: ns) match {
-      case n1 :: ns1 =>
-        n1 must_=== n
-        ns1 must_=== ns
-    }
-  }
-
-  "IList() pattern match" ! forAll { (n: Int, ns: IList[Int]) =>
-    (n :: ns) match {
-      case IList(a, _) =>
-        a must_=== n
-      case _ =>
-    }
-  }
-
   checkAll(FoldableTests.anyAndAllLazy[IList])
 
   object instances {


### PR DESCRIPTION
~~following on from #1591 this adds an `unapplySeq`~~

This now backs out #1591... read on for the reasoning:

But I noticed that the matchers disables exhaustivity checking under https://github.com/scala/bug/issues/10660

There is precedent in `EphemeralStream` to allow this.

It's a tricky one, perhaps in combination with https://github.com/scalacenter/scalafix/issues/528 this may be allowed, but I'm starting to think that perhaps - from a fundamentalist point of view - we should remove the extractor I recently added (and reject this PR) and instead remove custom `unapply` that we have defined.

// @jdegoes may have an opinion here.