### PR TITLE
 Migrate Reducer in sync with reducer haskell lib

### DIFF
--- a/core/src/main/scala/scalaz/Cord.scala
+++ b/core/src/main/scala/scalaz/Cord.scala
@@ -137,7 +137,7 @@ object Cord {
 
   def apply(as: Cord*): Cord = as.foldLeft(cord(FingerTree.empty))(_ ++ _)
 
-  def fromStrings[A](as: Seq[String]): Cord = cord(as.foldLeft(FingerTree.empty[Int, String](sizer))((x, y) => x :+ y))
+  def fromStrings[A](as: Seq[String]): Cord = cord(as.foldLeft(FingerTree.empty[Int, String])((x, y) => x :+ y))
 
   implicit val sizer: Reducer[String, Int] = UnitReducer((a: String) => a.length)
 

--- a/core/src/main/scala/scalaz/Reducer.scala
+++ b/core/src/main/scala/scalaz/Reducer.scala
@@ -7,19 +7,19 @@ import scalaz.Tags.Conjunction
 
 
 /**
- * A `Reducer[C,M]` is a [[scalaz.Monoid]]`[M]` that maps
+ * A `Reducer[C,M]` is a [[scalaz.Semigroup]]`[M]` that maps
  * values of type `C` through `unit` to values of type `M`. A `C-Reducer` may also
- * supply operations which tack on another `C` to an existing `Monoid` `M` on the left
+ * supply operations which tack on another `C` to an existing `Semigroup` `M` on the left
  * or right. These specialized reductions may be more efficient in some scenarios
  * and are used when appropriate by a [[scalaz.Generator]]. The names `cons` and `snoc` work
- * by analogy to the synonymous operations in the list monoid.
+ * by analogy to the synonymous operations in the list semigroup.
  *
  * Minimal definition: `unit` or `snoc`
  *
- * Based on a Haskell library by Edward Kmett
+ * Based on the Reducer Haskell library by Edward Kmett
  */
 sealed abstract class Reducer[C, M] {
-  implicit def monoid: Monoid[M]
+  implicit def semigroup: Semigroup[M]
 
   def unit(c: C): M
 
@@ -29,21 +29,18 @@ sealed abstract class Reducer[C, M] {
   /** Faster `append(unit(c), m)`. */
   def cons(c: C, m: M): M
 
-  def zero: M =
-    monoid.zero
-
   def append(a1: M, a2: => M): M =
-    monoid.append(a1, a2)
+    semigroup.append(a1, a2)
 
   /** Distribute `C`s to `M` and `N`. */
   def compose[N](r: Reducer[C, N]): Reducer[C, (M, N)] = {
-    implicit val m = Reducer.this.monoid
-    implicit val n = r.monoid
+    implicit val m = Reducer.this.semigroup
+    implicit val n = r.semigroup
     new Reducer[C, (M, N)] {
 
       import std.tuple._
 
-      val monoid = Monoid[(M, N)]
+      val semigroup = Semigroup[(M, N)]
 
       override def unit(x: C) = (Reducer.this.unit(x), r.unit(x))
 
@@ -53,37 +50,37 @@ sealed abstract class Reducer[C, M] {
     }
   }
 
-  final def unfoldl[B](seed: B)(f: B => Maybe[(B, C)]): M = {
+  final def unfoldl[B](seed: B)(f: B => Maybe[(B, C)])(implicit M: Monoid[M]): M = {
     @tailrec
     def rec(seed: B, acc: M): M = f(seed) match {
       case Just((b, c)) => rec(b, cons(c, acc))
       case _ => acc
     }
-    rec(seed, zero)
+    rec(seed, M.zero)
   }
 
-  def unfoldr[B](seed: B)(f: B => Maybe[(C, B)]): M = {
+  def unfoldr[B](seed: B)(f: B => Maybe[(C, B)])(implicit M: Monoid[M]): M = {
     @tailrec
     def rec(seed: B, acc: M): M = f(seed) match {
       case Just((c, b)) => rec(b, snoc(acc, c))
       case _ => acc
     }
-    rec(seed, zero)
+    rec(seed, M.zero)
   }
 }
 sealed abstract class UnitReducer[C, M] extends Reducer[C, M] {
-  implicit def monoid: Monoid[M]
+  implicit def semigroup: Semigroup[M]
   def unit(c: C): M
 
-  def snoc(m: M, c: C): M = monoid.append(m, unit(c))
+  def snoc(m: M, c: C): M = semigroup.append(m, unit(c))
 
-  def cons(c: C, m: M): M = monoid.append(unit(c), m)
+  def cons(c: C, m: M): M = semigroup.append(unit(c), m)
 }
 
 object UnitReducer {
-  /** Minimal `Reducer` derived from a monoid and `unit`. */
-  def apply[C, M](u: C => M)(implicit mm: Monoid[M]): Reducer[C, M] = new UnitReducer[C, M] {
-    val monoid = mm
+  /** Minimal `Reducer` derived from a semigroup and `unit`. */
+  def apply[C, M](u: C => M)(implicit M: Semigroup[M]): Reducer[C, M] = new UnitReducer[C, M] {
+    val semigroup = M
     def unit(c: C) = u(c)
   }
 }
@@ -92,7 +89,7 @@ object Reducer extends ReducerInstances {
   /** Reducer derived from `unit`, `cons`, and `snoc`.  Permits more
     * sharing than `UnitReducer.apply`.
     */
-  def apply[C, M](u: C => M, cs: (C, M) => M, sc: (M, C) => M)(implicit mm: Monoid[M]): Reducer[C, M] =
+  def apply[C, M](u: C => M, cs: (C, M) => M, sc: (M, C) => M)(implicit M: Semigroup[M]): Reducer[C, M] =
     reducer(u, cs, sc)
 }
 
@@ -124,13 +121,13 @@ sealed abstract class ReducerInstances {
 
   /** Collect `C`s into a vector, in order. */
   implicit def VectorReducer[C]: Reducer[C, Vector[C]] = new Reducer[C, Vector[C]]{
-    val monoid: Monoid[Vector[C]] = std.vector.vectorMonoid[C]
+    val semigroup: Semigroup[Vector[C]] = std.vector.vectorMonoid[C]
     def cons(c: C, m: Vector[C]) = c +: m
     def snoc(m: Vector[C], c: C) = m :+ c
     def unit(c: C) = Vector(c)
   }
 
-  /** The "or" monoid. */
+  /** The "or" semigroup. */
   implicit val AnyReducer: Reducer[Boolean, Boolean] = {
     implicit val B = std.anyVal.booleanInstance.disjunction
     unitReducer(x => x)
@@ -138,13 +135,13 @@ sealed abstract class ReducerInstances {
 
   import std.anyVal._
 
-  /** The "and" monoid. */
+  /** The "and" semigroup. */
   implicit val AllReducer: Reducer[Boolean, Boolean @@ Conjunction] = unitReducer(b => Tag[Boolean, Conjunction](b))
 
   /** Accumulate endomorphisms. */
   implicit def EndoReducer[A]: Reducer[A => A, Endo[A]] = unitReducer(Endo(_))
 
-  implicit def DualReducer[A: Monoid]: Reducer[A, A @@ Tags.Dual] = unitReducer(Tags.Dual(_: A))(Dual.dualMonoid[A])
+  implicit def DualReducer[A: Semigroup]: Reducer[A, A @@ Tags.Dual] = unitReducer(Tags.Dual(_: A))(Dual.dualSemigroup[A])
 
   import Tags.{Multiplication, First, Last}
 
@@ -175,9 +172,9 @@ sealed abstract class ReducerInstances {
   implicit def LastOptionReducer[A]: Reducer[Option[A], Option[A] @@ Last] = unitReducer(o => Tag[Option[A], Last](o))
 
   /** Alias for [[scalaz.Reducer]]`.apply`. */
-  def reducer[C, M](u: C => M, cs: (C, M) => M, sc: (M, C) => M)(implicit mm: Monoid[M]): Reducer[C, M] =
+  def reducer[C, M](u: C => M, cs: (C, M) => M, sc: (M, C) => M)(implicit sm: Semigroup[M]): Reducer[C, M] =
     new Reducer[C, M] {
-      val monoid = mm
+      val semigroup = sm
 
       def unit(c: C) = u(c)
 
@@ -186,55 +183,55 @@ sealed abstract class ReducerInstances {
       def cons(c: C, m: M): M = cs(c, m)
     }
 
-  def foldReduce[F[_], A, B](a: F[A])(implicit f: Foldable[F], r: Reducer[A, B]): B =
-    f.foldMap(a)(r.unit)(r.monoid)
+  def foldReduce[F[_], A, B: Monoid](a: F[A])(implicit f: Foldable[F], r: Reducer[A, B]): B =
+    f.foldMap(a)(r.unit)
 
   /** Alias for [[scalaz.UnitReducer]]`.apply`. */
-  def unitReducer[C, M](u: C => M)(implicit mm: Monoid[M]): Reducer[C, M] =
+  def unitReducer[C, M](u: C => M)(implicit mm: Semigroup[M]): Reducer[C, M] =
     new UnitReducer[C, M] {
-      val monoid = mm
+      val semigroup = mm
       def unit(c: C) = u(c)
     }
 
-  def unitConsReducer[C, M](u: C => M, cs: (C, M) => M)(implicit mm: Monoid[M]): Reducer[C, M] = new Reducer[C, M] {
-    val monoid = mm
+  def unitConsReducer[C, M](u: C => M, cs: (C, M) => M)(implicit sm: Semigroup[M]): Reducer[C, M] = new Reducer[C, M] {
+    val semigroup = sm
 
     def unit(c: C) = u(c)
 
-    def snoc(m: M, c: C): M = mm.append(m, u(c))
+    def snoc(m: M, c: C): M = sm.append(m, u(c))
 
     def cons(c: C, m: M): M = cs(c, m)
 
-    override def unfoldr[B](seed: B)(f: B => Maybe[(C, B)]): M = {
+    override def unfoldr[B](seed: B)(f: B => Maybe[(C, B)])(implicit M: Monoid[M]): M = {
       import  std.function._
       def go(s: B, f: B => Maybe[(C, B)]): Trampoline[M] = f(s) match {
         case Just((c, b)) => suspend(go(b, f)) map (m => cs(c, m))
-        case _ => return_[Function0, M](zero)
+        case _ => return_[Function0, M](M.zero)
       }
       go(seed, f).run
     }
   }
 
-  def unitLazyConsReducer[C, M](u: C => M, cs: (C, => M) => M)(implicit mm: Monoid[M]): Reducer[C, M] = new Reducer[C, M] {
-    val monoid = mm
+  def unitLazyConsReducer[C, M](u: C => M, cs: (C, => M) => M)(implicit sm: Semigroup[M]): Reducer[C, M] = new Reducer[C, M] {
+    val semigroup = sm
 
     def unit(c: C) = u(c)
 
-    def snoc(m: M, c: C): M = mm.append(m, u(c))
+    def snoc(m: M, c: C): M = sm.append(m, u(c))
 
     def cons(c: C, m: M): M = cs(c, m)
 
-    override def unfoldr[B](seed: B)(f: B => Maybe[(C, B)]): M = {
+    override def unfoldr[B](seed: B)(f: B => Maybe[(C, B)])(implicit M: Monoid[M]): M = {
       def unfold(s: B): M = f(s) match {
         case Just((a, r)) => cs(a, unfold(r))
-        case _ => zero
+        case _ => M.zero
       }
       unfold(seed)
     }
   }
 
-  /** The reducer derived from any monoid.  Not implicit because it is
+  /** The reducer derived from any semigroup.  Not implicit because it is
     * suboptimal for most reducer applications.
     */
-  def identityReducer[M](implicit mm: Monoid[M]): Reducer[M, M] = unitReducer(x => x)
+  def identityReducer[M](implicit mm: Semigroup[M]): Reducer[M, M] = unitReducer(x => x)
 }

--- a/core/src/main/scala/scalaz/Reducer.scala
+++ b/core/src/main/scala/scalaz/Reducer.scala
@@ -106,6 +106,11 @@ sealed abstract class ReducerInstances {
     unitConsReducer(_ :: INil(), _ :: _)
   }
 
+  /** Collect `C`s into an NonEmptyList, in order. */
+  implicit def NonEmptyListReducer[C]: Reducer[C, NonEmptyList[C]] = {
+    unitConsReducer(NonEmptyList.nel(_, INil()),  _ <:: _)
+  }
+
   /** Collect `C`s into a stream, in order. */
   implicit def StreamReducer[C]: Reducer[C, Stream[C]] = {
     import std.stream._

--- a/core/src/main/scala/scalaz/std/String.scala
+++ b/core/src/main/scala/scalaz/std/String.scala
@@ -11,7 +11,9 @@ trait StringInstances {
     type SA[α] = String
     def append(f1: String, f2: => String) = f1 + f2
     def zero: String = ""
-    override def show(f: String): Cord = new Cord(FingerTree.three("\"", f, "\"")(Cord.sizer).toTree)
+    import std.anyVal.intInstance
+    import Cord.sizer
+    override def show(f: String): Cord = new Cord(FingerTree.three[Int, String]("\"", f, "\"").toTree)
     override def shows(f: String): String = '"' + f + '"'
     def order(x: String, y: String) = Ordering.fromInt(x.compareTo(y))
     override def equal(x: String, y: String) = x == y

--- a/core/src/main/scala/scalaz/syntax/ReducerOps.scala
+++ b/core/src/main/scala/scalaz/syntax/ReducerOps.scala
@@ -23,7 +23,7 @@ final class ReducerOps[A](private val self: A) extends AnyVal {
     * }}}
     */
   def unfoldl[C](f: A => Maybe[(A, C)]): UnfoldTo[C] = new UnfoldTo[C] {
-    def reduceTo[M](implicit r: Reducer[C, M]): M = r.unfoldl(self)(f)
+    def reduceTo[M: Monoid](implicit r:  Reducer[C, M]): M = r.unfoldl(self)(f)
   }
 
   /** Unfold to the right using this value as initial seed
@@ -34,7 +34,7 @@ final class ReducerOps[A](private val self: A) extends AnyVal {
     * }}}
     */
   def unfoldr[C](f: A => Maybe[(C, A)]): UnfoldTo[C] = new UnfoldTo[C] {
-    def reduceTo[M](implicit r: Reducer[C, M]): M = r.unfoldr(self)(f)
+    def reduceTo[M: Monoid](implicit r:  Reducer[C, M]): M = r.unfoldr(self)(f)
   }
 }
 
@@ -45,8 +45,8 @@ trait ToReducerOps {
 object ReducerOps {
 
   sealed abstract class UnfoldTo[C] {
-    def reduceTo[M](implicit r: Reducer[C, M]): M
+    def reduceTo[M: Monoid](implicit r: Reducer[C, M]): M
 
-    final def to[M[_]](implicit r: Reducer[C, M[C]]): M[C] = reduceTo[M[C]]
+    final def to[M[_]](implicit r: Reducer[C, M[C]], m: Monoid[M[C]]): M[C] = reduceTo[M[C]]
   }
 }

--- a/example/src/main/scala/scalaz/example/FingerTreeUsage.scala
+++ b/example/src/main/scala/scalaz/example/FingerTreeUsage.scala
@@ -8,7 +8,7 @@ object FingerTreeUsage extends App{
   import FingerTree._
   import std.anyVal._
 
-  def streamToTree[A](stream: Stream[A]): FingerTree[Int, A] = stream.foldLeft(empty(SizeReducer[A])) {
+  def streamToTree[A](stream: Stream[A]): FingerTree[Int, A] = stream.foldLeft(empty[Int, A]) {
     case (t, x) => (t :+ x)
   }
 
@@ -16,7 +16,7 @@ object FingerTreeUsage extends App{
 
   implicit def SizeReducer[A]: Reducer[A, Int] = UnitReducer(x => 1)
 
-  val emptyTree = empty[Int, Int](SizeReducer[Int])
+  val emptyTree = empty[Int, Int]
 
   assert(emptyTree.isEmpty)
 

--- a/iteratee/src/main/scala/scalaz/iteratee/Iteratee.scala
+++ b/iteratee/src/main/scala/scalaz/iteratee/Iteratee.scala
@@ -40,8 +40,8 @@ trait IterateeFunctions {
    *
    * This iteratee is useful for F[_] with efficient cons, i.e. List.
    */
-  def reversed[A, F[_]](implicit r: Reducer[A, F[A]]): Iteratee[A, F[A]] = {
-    fold[A, Id, F[A]](r.monoid.zero)((acc, e) => r.cons(e, acc))
+  def reversed[A, F[_]](implicit r: Reducer[A, F[A]], m: Monoid[F[A]]): Iteratee[A, F[A]] = {
+    fold[A, Id, F[A]](m.zero)((acc, e) => r.cons(e, acc))
   }
 
   /**

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
@@ -458,19 +458,19 @@ object ScalazArbitrary extends ScalazArbitraryPlatform {
 
   import FingerTree._
 
-  implicit def FingerArbitrary[V, A](implicit a: Arbitrary[A], measure: Reducer[A, V]): Arbitrary[Finger[V, A]] = Arbitrary(oneOf(
+  implicit def FingerArbitrary[V: Monoid, A](implicit a: Arbitrary[A], measure: Reducer[A, V]): Arbitrary[Finger[V, A]] = Arbitrary(oneOf(
     arbitrary[A].map(one(_): Finger[V, A]),
     ^(arbitrary[A], arbitrary[A])(two(_, _): Finger[V, A]),
     ^^(arbitrary[A], arbitrary[A], arbitrary[A])(three(_, _, _): Finger[V, A]),
     ^^^(arbitrary[A], arbitrary[A], arbitrary[A], arbitrary[A])(four(_, _, _, _): Finger[V, A])
   ))
 
-  implicit def NodeArbitrary[V, A](implicit a: Arbitrary[A], measure: Reducer[A, V]): Arbitrary[Node[V, A]] = Arbitrary(oneOf(
+  implicit def NodeArbitrary[V: Monoid, A](implicit a: Arbitrary[A], measure: Reducer[A, V]): Arbitrary[Node[V, A]] = Arbitrary(oneOf(
     ^(arbitrary[A], arbitrary[A])(node2[V, A](_, _)),
     ^^(arbitrary[A], arbitrary[A], arbitrary[A])(node3[V, A](_, _, _))
   ))
 
-  implicit def FingerTreeArbitrary[V, A](implicit a: Arbitrary[A], measure: Reducer[A, V]): Arbitrary[FingerTree[V, A]] = Arbitrary {
+  implicit def FingerTreeArbitrary[V: Monoid, A](implicit a: Arbitrary[A], measure: Reducer[A, V]): Arbitrary[FingerTree[V, A]] = Arbitrary {
     def fingerTree[A](n: Int)(implicit a1: Arbitrary[A], measure1: Reducer[A, V]): Gen[FingerTree[V, A]] = n match {
       case 0 => empty[V, A]
       case 1 => arbitrary[A].map(single[V, A](_))

--- a/tests/jvm/src/test/scala/scalaz/concurrent/FutureTest.scala
+++ b/tests/jvm/src/test/scala/scalaz/concurrent/FutureTest.scala
@@ -47,14 +47,14 @@ object FutureTest extends SpecLite {
   "Nondeterminism[Future]" should {
     import scalaz.concurrent.Future._
     implicit val es = Executors.newFixedThreadPool(1)
-    val intSetReducer = Reducer.unitReducer[Int, Set[Int]](Set(_))
+    implicit val intSetReducer = Reducer.unitReducer[Int, Set[Int]](Set(_))
 
     "correctly process reduceUnordered for >1 futures in non-blocking way" in {
       val f1 = fork(now(1))(es)
       val f2 = delay(7).flatMap(_=>fork(now(2))(es))
       val f3 = fork(now(3))(es)
 
-      val f = fork(Future.reduceUnordered(Seq(f1,f2,f3))(intSetReducer))(es)
+      val f = fork(Future.reduceUnordered(Seq(f1,f2,f3)))(es)
 
       f.unsafePerformSync must_== Set(1,2,3)
     }
@@ -63,13 +63,13 @@ object FutureTest extends SpecLite {
     "correctly process reduceUnordered for 1 future in non-blocking way" in {
       val f1 = fork(now(1))(es)
 
-      val f = fork(Future.reduceUnordered(Seq(f1))(intSetReducer))(es)
+      val f = fork(Future.reduceUnordered(Seq(f1)))(es)
 
       f.unsafePerformSync must_== Set(1)
     }
 
     "correctly process reduceUnordered for empty seq of futures in non-blocking way" in {
-      val f = fork(Future.reduceUnordered(Seq())(intSetReducer))(es)
+      val f = fork(Future.reduceUnordered(Seq()))(es)
 
       f.unsafePerformSync must_== Set()
     }

--- a/tests/jvm/src/test/scala/scalaz/concurrent/TaskTest.scala
+++ b/tests/jvm/src/test/scala/scalaz/concurrent/TaskTest.scala
@@ -142,13 +142,13 @@ object TaskTest extends SpecLite {
   "Nondeterminism[Task]" should {
     import scalaz.concurrent.Task._
     val es = Executors.newFixedThreadPool(1)
-    val intSetReducer = Reducer.unitReducer[Int, Set[Int]](Set(_))
+    implicit val intSetReducer = Reducer.unitReducer[Int, Set[Int]](Set(_))
 
     "correctly process reduceUnordered for >1 tasks in non-blocking way" in {
       val t1 = fork(now(1))(es)
       val t2 = delay(7).flatMap(_=>fork(now(2))(es))
       val t3 = fork(now(3))(es)
-      val t = fork(Task.reduceUnordered(Seq(t1,t2,t3))(intSetReducer))(es)
+      val t = fork(Task.reduceUnordered(Seq(t1,t2,t3)))(es)
 
       t.unsafePerformSync must_== Set(1,2,3)
     }
@@ -157,13 +157,13 @@ object TaskTest extends SpecLite {
     "correctly process reduceUnordered for 1 task in non-blocking way" in {
       val t1 = fork(now(1))(es)
 
-      val t = fork(Task.reduceUnordered(Seq(t1))(intSetReducer))(es)
+      val t = fork(Task.reduceUnordered(Seq(t1)))(es)
 
       t.unsafePerformSync must_== Set(1)
     }
 
     "correctly process reduceUnordered for empty seq of tasks in non-blocking way" in {
-      val t = fork(Task.reduceUnordered(Seq())(intSetReducer))(es)
+      val t = fork(Task.reduceUnordered(Seq()))(es)
 
       t.unsafePerformSync must_== Set()
     }

--- a/tests/src/test/scala/scalaz/FingerTreeTest.scala
+++ b/tests/src/test/scala/scalaz/FingerTreeTest.scala
@@ -30,7 +30,7 @@ object FingerTreeTest extends SpecLite {
 
   val intStream = Stream.from(1)
 
-  def streamToTree[A](stream: Stream[A]): SequenceTree[A] = stream.foldLeft(FingerTree.empty(SizeReducer[A])) {
+  def streamToTree[A](stream: Stream[A]): SequenceTree[A] = stream.foldLeft(FingerTree.empty[Int, A]) {
     case (t, x) => (t :+ x)
   }
 
@@ -73,10 +73,10 @@ object FingerTreeTest extends SpecLite {
   }
 
   "foldLeft snoc is identity" ! forAll {
-    (tree: SequenceTree[Int]) => tree.foldLeft(FingerTree.empty(SizeReducer[Int]))(_ :+ _).toStream must_==(tree.toStream)
+    (tree: SequenceTree[Int]) => tree.foldLeft(FingerTree.empty[Int, Int])(_ :+ _).toStream must_==(tree.toStream)
   }
 
-  "foldLeft cons is reverse" ! forAll {(tree: SequenceTree[Int]) => tree.foldLeft(FingerTree.empty(SizeReducer[Int]))((x, y) => y +: x).toStream must_==(tree.toStream.reverse)}
+  "foldLeft cons is reverse" ! forAll {(tree: SequenceTree[Int]) => tree.foldLeft(FingerTree.empty[Int, Int])((x, y) => y +: x).toStream must_==(tree.toStream.reverse)}
 
   "Fingertree" should {
 


### PR DESCRIPTION
(https://hackage.haskell.org/package/reducers)
Essentially lower the constraint on Reducer from Monoid to Semigroup.
Previous API was based on the now deprecated `monoids` package.

**Question 1**: should `Reducer` `snoc`/`cons` be lazy on their second argument, to match `semigroup` laziness behavior?
**Question 2**: should `Generator` be a type class, as in haskell? (ie. should we add implicit instances?)

**Question 3**: should we remove the unnecessary `Monoid` constraint on `mapTo`? IUC, this would mean that `mapTo` become the only primitive operation of `Generator` and that `mapFrom` is removed entirely.

this is  preliminary work to have a clean solution to  #1513 (`FromFoldable1`)
  
Above questions can be discussed here, but are probably better addressed (if needed) on separate PRs.