### PR TITLE
Make several data types invariant

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Future.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Future.scala
@@ -51,7 +51,7 @@ import scala.concurrent.duration._
  * `Future[Throwable \/ A]` with a number of additional
  * convenience functions.
  */
-sealed abstract class Future[+A] {
+sealed abstract class Future[A] {
   import Future._
 
   def flatMap[B](f: A => Future[B]): Future[B] = this match {
@@ -233,9 +233,9 @@ sealed abstract class Future[+A] {
 }
 
 object Future {
-  case class Now[+A](a: A) extends Future[A]
-  case class Async[+A](onFinish: (A => Trampoline[Unit]) => Unit) extends Future[A]
-  case class Suspend[+A](thunk: () => Future[A]) extends Future[A]
+  case class Now[A](a: A) extends Future[A]
+  case class Async[A](onFinish: (A => Trampoline[Unit]) => Unit) extends Future[A]
+  case class Suspend[A](thunk: () => Future[A]) extends Future[A]
   case class BindSuspend[A,B](thunk: () => Future[A], f: A => Future[B]) extends Future[B]
   case class BindAsync[A,B](onFinish: (A => Trampoline[Unit]) => Unit,
                             f: A => Future[B]) extends Future[B]

--- a/core/src/main/scala/scalaz/Bifoldable.scala
+++ b/core/src/main/scala/scalaz/Bifoldable.scala
@@ -82,6 +82,7 @@ trait Bifoldable[F[_, _]]  { self =>
 
   trait BifoldableLaw {
     import std.vector._
+    import syntax.either._
 
     def leftFMConsistent[A: Equal, B: Equal](fa: F[A, B]): Boolean =
       Equal[Vector[B \/ A]].equal(bifoldMap[A, B, Vector[B \/ A]](fa)(a => Vector(\/-(a)))(b => Vector(-\/(b))),
@@ -89,7 +90,7 @@ trait Bifoldable[F[_, _]]  { self =>
 
     def rightFMConsistent[A: Equal, B: Equal](fa: F[A, B]): Boolean =
       Equal[Vector[B \/ A]].equal(bifoldMap[A, B, Vector[B \/ A]](fa)(a => Vector(\/-(a)))(b => Vector(-\/(b))),
-                                  bifoldRight(fa, Vector.empty[B \/ A])(\/-(_) +: _)(-\/(_) +: _))
+                                  bifoldRight(fa, Vector.empty[B \/ A])(_.right[B] +: _)(_.left[A] +: _))
   }
 
   def bifoldableLaw = new BifoldableLaw {}

--- a/core/src/main/scala/scalaz/Cofree.scala
+++ b/core/src/main/scala/scalaz/Cofree.scala
@@ -279,7 +279,7 @@ private trait CofreeTraverse[F[_]] extends Traverse1[Cofree[F, ?]] with CofreeFo
     G.apply2(f(fa.head), F.traverse(fa.tail)(traverse(_)(f)))(Cofree(_, _))
 
   override def traverse1Impl[G[_], A, B](fa: Cofree[F,A])(f: A => G[B])(implicit G: Apply[G]): G[Cofree[F,B]] =
-    G.applyApplicative.traverse(fa.tail)(a => -\/(traverse1(a)(f)))
+    G.applyApplicative.traverse[Cofree[F, A], F, Cofree[F, B]](fa.tail)(a => -\/(traverse1(a)(f)))
       .fold(ftl => G.apply2(f(fa.head), ftl)(Cofree(_, _)),
          tl => G.map(f(fa.head))(Cofree.apply(_, tl)))
 }

--- a/core/src/main/scala/scalaz/Either3.scala
+++ b/core/src/main/scala/scalaz/Either3.scala
@@ -3,7 +3,7 @@ package scalaz
 import scalaz.syntax.equal._
 import scalaz.syntax.show._
 
-sealed abstract class Either3[+A, +B, +C] extends Product with Serializable {
+sealed abstract class Either3[A, B, C] extends Product with Serializable {
   def fold[Z](left: A => Z, middle: B => Z, right: C => Z): Z = this match {
     case Left3(a)   => left(a)
     case Middle3(b) => middle(b)
@@ -27,9 +27,9 @@ sealed abstract class Either3[+A, +B, +C] extends Product with Serializable {
   def rightOr[Z](z: => Z)(f: C => Z): Z = fold(_ => z, _ => z, f)
 }
 
-final case class Left3[+A, +B, +C](a: A) extends Either3[A, B, C]
-final case class Middle3[+A, +B, +C](b: B) extends Either3[A, B, C]
-final case class Right3[+A, +B, +C](c: C) extends Either3[A, B, C]
+final case class Left3[A, B, C](a: A) extends Either3[A, B, C]
+final case class Middle3[A, B, C](b: B) extends Either3[A, B, C]
+final case class Right3[A, B, C](c: C) extends Either3[A, B, C]
 
 object Either3 {
   def left3[A, B, C](a: A):   Either3[A, B, C] = Left3(a)

--- a/core/src/main/scala/scalaz/Free.scala
+++ b/core/src/main/scala/scalaz/Free.scala
@@ -192,7 +192,7 @@ sealed abstract class Free[S[_], A] {
   final def runRecM[M[_]](f: S[Free[S, A]] => M[Free[S, A]])(implicit S: Functor[S], M: Applicative[M], B: BindRec[M]): M[A] = {
     B.tailrecM(this)(_.resume match {
       case -\/(sf) => M.map(f(sf))(\/.left)
-      case a @ \/-(_) => M.point(a)
+      case a @ \/-(_) => M.point(a.coerceLeft)
     })
   }
 

--- a/core/src/main/scala/scalaz/Kleisli.scala
+++ b/core/src/main/scala/scalaz/Kleisli.scala
@@ -392,12 +392,12 @@ private trait KleisliProChoice[F[_]] extends ProChoice[Kleisli[F, ?, ?]] with Kl
   def left[A, B, C](fa: Kleisli[F, A, B]): Kleisli[F, A \/ C, B \/ C] =
     Kleisli {
       case -\/(a) => F.map(fa run a)(\/.left)
-      case b @ \/-(_) => F.point(b)
+      case b @ \/-(_) => F.point(b.coerceLeft)
     }
 
   def right[A, B, C](fa: Kleisli[F, A, B]): Kleisli[F, C \/ A, C \/ B] =
     Kleisli {
-      case b @ -\/(_) => F.point(b)
+      case b @ -\/(_) => F.point(b.coerceRight)
       case \/-(a) => F.map(fa run a)(\/.right)
     }
 }

--- a/core/src/main/scala/scalaz/LazyOption.scala
+++ b/core/src/main/scala/scalaz/LazyOption.scala
@@ -1,7 +1,7 @@
 package scalaz
 
 /** [[scala.Option]], but with a value by name. */
-sealed abstract class LazyOption[+A] extends Product with Serializable {
+sealed abstract class LazyOption[A] extends Product with Serializable {
 
   import LazyOption._
   import LazyEither._
@@ -10,7 +10,7 @@ sealed abstract class LazyOption[+A] extends Product with Serializable {
   def fold[X](some: (=> A) => X, none: => X): X =
     this match {
       case LazySome(z) => some(z())
-      case LazyNone    => none
+      case LazyNone()  => none
     }
 
   def ?[X](some: => X, none: => X): X =
@@ -52,7 +52,7 @@ sealed abstract class LazyOption[+A] extends Product with Serializable {
   def toList: List[A] =
     fold(_ :: Nil, Nil)
 
-  def orElse[AA >: A](a: => LazyOption[AA]): LazyOption[AA] =
+  def orElse(a: => LazyOption[A]): LazyOption[A] =
     fold(_ => this, a)
 
 /* TODO
@@ -103,7 +103,7 @@ sealed abstract class LazyOption[+A] extends Product with Serializable {
 
 private final case class LazySome[A](a: () => A) extends LazyOption[A]
 
-private case object LazyNone extends LazyOption[Nothing]
+private final case class LazyNone[A] private() extends LazyOption[A]
 
 sealed abstract class LazyOptionInstances {
   import LazyOption._
@@ -112,7 +112,7 @@ sealed abstract class LazyOptionInstances {
     new Traverse[LazyOption] with MonadPlus[LazyOption] with BindRec[LazyOption] with Cozip[LazyOption] with Zip[LazyOption] with Unzip[LazyOption] with Align[LazyOption] with Cobind[LazyOption] with Optional[LazyOption] with IsEmpty[LazyOption] {
       def cobind[A, B](fa: LazyOption[A])(f: LazyOption[A] => B): LazyOption[B] = map(cojoin(fa))(f)
       override def cojoin[A](a: LazyOption[A]) = a match {
-        case LazyNone => LazyNone
+        case LazyNone() => lazyNone
         case o @ LazySome(_) => LazySome(() => o)
       }
       def traverseImpl[G[_]: Applicative, A, B](fa: LazyOption[A])(f: A => G[B]): G[LazyOption[B]] = fa traverse (a => f(a))
@@ -143,7 +143,7 @@ sealed abstract class LazyOptionInstances {
       @scala.annotation.tailrec
       def tailrecM[A, B](a: A)(f: A => LazyOption[A \/ B]): LazyOption[B] =
         f(a) match {
-          case LazyNone => LazyNone
+          case LazyNone() => lazyNone
           case LazySome(t) => t() match {
             case \/-(b) => lazySome(b)
             case -\/(a0) => tailrecM(a0)(f)
@@ -158,13 +158,13 @@ sealed abstract class LazyOptionInstances {
 
   implicit def lazyOptionMonoid[A: Semigroup]: Monoid[LazyOption[A]] =
     new Monoid[LazyOption[A]] {
-      def zero = LazyNone
+      def zero = lazyNone
 
       def append(a: LazyOption[A], b: => LazyOption[A]) = (a, b) match {
         case (LazySome(a1), LazySome(b1))     => LazySome(() => Semigroup[A].append(a1(), b1()))
-        case (LazySome(_) , LazyNone)         => a
-        case (LazyNone    , b1 @ LazySome(_)) => b1
-        case (LazyNone    , LazyNone)         => LazyNone
+        case (LazySome(_) , LazyNone())       => a
+        case (LazyNone()  , b1 @ LazySome(_)) => b1
+        case (LazyNone()  , LazyNone())       => lazyNone
       }
     }
 
@@ -177,11 +177,13 @@ implicit def LazyOptionOrder[A: Order]: Order[LazyOption[A]] =
 }
 
 object LazyOption extends LazyOptionInstances {
+  private val none = LazyNone[Any]
+
   def lazySome[A](a: => A): LazyOption[A] =
     LazySome(() => a)
 
   def lazyNone[A]: LazyOption[A] =
-    LazyNone
+    none.asInstanceOf[LazyOption[A]]
 
   def fromOption[A](oa: Option[A]): LazyOption[A] = oa match {
     case Some(x) => lazySome(x)

--- a/core/src/main/scala/scalaz/LazyOptionT.scala
+++ b/core/src/main/scala/scalaz/LazyOptionT.scala
@@ -48,7 +48,7 @@ final case class LazyOptionT[F[_], A](run: F[LazyOption[A]]) {
 
   def orElse(a: => LazyOptionT[F, A])(implicit F: Monad[F]): LazyOptionT[F, A] =
     LazyOptionT(F.bind(run) {
-      case LazyNone => a.run
+      case LazyNone() => a.run
       case x@LazySome(_) => F.point(x)
     })
 

--- a/core/src/main/scala/scalaz/NullArgument.scala
+++ b/core/src/main/scala/scalaz/NullArgument.scala
@@ -42,14 +42,14 @@ final class NullArgument[A, B] private(_apply: Option[A] => B) {
     NullArgument {
       case None => -\/(apply(None))
       case Some(-\/(a)) => -\/(apply(Some(a)))
-      case Some(c @ \/-(_)) => c
+      case Some(c @ \/-(_)) => c.coerceLeft
     }
 
   def right[C]: (C \/ A) ?=> (C \/ B) =
     NullArgument {
       case None => \/-(apply(None))
       case Some(\/-(a)) => \/-(apply(Some(a)))
-      case Some(c @ -\/(_)) => c
+      case Some(c @ -\/(_)) => c.coerceRight
     }
 
   def compose[C](f: C ?=> A): C ?=> B =

--- a/core/src/main/scala/scalaz/NullResult.scala
+++ b/core/src/main/scala/scalaz/NullResult.scala
@@ -54,12 +54,12 @@ final class NullResult[A, B] private(_apply: A => Option[B]) {
   def left[C]: (A \/ C) =>? (B \/ C) =
     NullResult {
       case -\/(a) => apply(a) map (\/.left)
-      case c @ \/-(_) => Some(c)
+      case c @ \/-(_) => Some(c.coerceLeft)
     }
 
   def right[C]: (C \/ A) =>? (C \/ B) =
     NullResult {
-      case c @ -\/(_) => Some(c)
+      case c @ -\/(_) => Some(c.coerceRight)
       case \/-(a) => apply(a) map (\/.right)
     }
 

--- a/core/src/main/scala/scalaz/OneAnd.scala
+++ b/core/src/main/scala/scalaz/OneAnd.scala
@@ -175,7 +175,7 @@ private sealed trait OneAndTraverse[F[_]] extends Traverse1[OneAnd[F, ?]] with O
   def F: Traverse[F]
 
   def traverse1Impl[G[_],A,B](fa: OneAnd[F, A])(f: A => G[B])(implicit G: Apply[G]) =
-    G.applyApplicative.traverse(fa.tail)(f andThen \/.left)(F)
+    G.applyApplicative.traverse(fa.tail)(f andThen \/.left[G[B], B])(F)
      .fold(ftl => G.apply2(f(fa.head), ftl)(OneAnd.apply),
            tl => G.map(f(fa.head))(OneAnd(_, tl)))
 

--- a/core/src/main/scala/scalaz/Product.scala
+++ b/core/src/main/scala/scalaz/Product.scala
@@ -154,7 +154,7 @@ private trait ProductTraverse1L[F[_], G[_]] extends Traverse1[λ[α => (F[α], G
 
   def traverse1Impl[X[_], A, B](a: (F[A], G[A]))(f: A => X[B])(implicit X0: Apply[X]): X[(F[B], G[B])] = {
     def resume = F.traverse1(a._1)(f)
-    X0.applyApplicative.traverse(a._2)(f andThen \/.left)(G)
+    X0.applyApplicative.traverse(a._2)(f andThen \/.left[X[B], B])(G)
       .fold(X0.tuple2(resume, _),
             pr => X0.map(resume)((_, pr)))
   }
@@ -168,7 +168,7 @@ private trait ProductTraverse1R[F[_], G[_]] extends Traverse1[λ[α => (F[α], G
 
   def traverse1Impl[X[_], A, B](a: (F[A], G[A]))(f: A => X[B])(implicit X0: Apply[X]): X[(F[B], G[B])] = {
     def resume = G.traverse1(a._2)(f)
-    X0.applyApplicative.traverse(a._1)(f andThen \/.left)(F)
+    X0.applyApplicative.traverse(a._1)(f andThen \/.left[X[B], B])(F)
       .fold(X0.tuple2(_, resume),
             pr => X0.map(resume)((pr, _)))
   }

--- a/core/src/main/scala/scalaz/Validation.scala
+++ b/core/src/main/scala/scalaz/Validation.scala
@@ -31,7 +31,7 @@ import scala.reflect.ClassTag
  * @tparam E The type of the `Failure`
  * @tparam A The type of the `Success`
  */
-sealed abstract class Validation[+E, +A] extends Product with Serializable {
+sealed abstract class Validation[E, A] extends Product with Serializable {
 
   final class SwitchingValidation[X](s: => X){
     def <<?:(fail: X): X =
@@ -71,11 +71,11 @@ sealed abstract class Validation[+E, +A] extends Product with Serializable {
   }
 
   /** Spin in tail-position on the success value of this validation. */
-  def loopSuccess[EE >: E, AA >: A, X](success: AA => X \/ Validation[EE, AA], failure: EE => X): X =
+  def loopSuccess[X](success: A => X \/ Validation[E, A], failure: E => X): X =
     Validation.loopSuccess(this, success, failure)
 
   /** Spin in tail-position on the failure value of this validation. */
-  def loopFailure[EE >: E, AA >: A, X](success: AA => X, failure: EE => X \/ Validation[EE, AA]): X =
+  def loopFailure[X](success: A => X, failure: E => X \/ Validation[E, A]): X =
     Validation.loopFailure(this, success, failure)
 
   /** Flip the failure/success values in this validation. Alias for `swap` */
@@ -108,7 +108,7 @@ sealed abstract class Validation[+E, +A] extends Product with Serializable {
   /** Run the given function on the left value. */
   def leftMap[C](f: E => C): Validation[C, A] =
     this match {
-      case a @ Success(_) => a
+      case a @ Success(_) => a.coerceFailure
       case Failure(e) => Failure(f(e))
     }
 
@@ -121,13 +121,13 @@ sealed abstract class Validation[+E, +A] extends Product with Serializable {
   /** Map on the success of this validation. */
   def map[B](f: A => B): Validation[E, B] = this match {
     case Success(a) => Success(f(a))
-    case e @ Failure(_) => e
+    case e @ Failure(_) => e.coerceSuccess
   }
 
   /** Traverse on the success of this validation. */
-  def traverse[G[_] : Applicative, EE >: E, B](f: A => G[B]): G[Validation[EE, B]] = this match {
+  def traverse[G[_] : Applicative, B](f: A => G[B]): G[Validation[E, B]] = this match {
     case Success(a) => Applicative[G].map(f(a))(Validation.success)
-    case e @ Failure(_) => Applicative[G].point(e)
+    case e @ Failure(_) => Applicative[G].point(e.coerceSuccess)
   }
 
   /** Run the side-effect on the success of this validation. */
@@ -137,10 +137,10 @@ sealed abstract class Validation[+E, +A] extends Product with Serializable {
   }
 
   /** Apply a function in the environment of the success of this validation, accumulating errors. */
-  def ap[EE >: E, B](x: => Validation[EE, A => B])(implicit E: Semigroup[EE]): Validation[EE, B] = (this, x) match {
+  def ap[B](x: => Validation[E, A => B])(implicit E: Semigroup[E]): Validation[E, B] = (this, x) match {
     case (Success(a), Success(f))   => Success(f(a))
-    case (e @ Failure(_), Success(_)) => e
-    case (Success(_), e @ Failure(_)) => e
+    case (e @ Failure(_), Success(_)) => e.coerceSuccess
+    case (Success(_), e @ Failure(_)) => e.coerceSuccess
     case (Failure(e1), Failure(e2)) => Failure(E.append(e2, e1))
   }
 
@@ -151,7 +151,7 @@ sealed abstract class Validation[+E, +A] extends Product with Serializable {
   }
 
   /** Filter on the success of this validation. */
-  def filter[EE >: E](p: A => Boolean)(implicit M: Monoid[EE]): Validation[EE, A] =
+  def filter(p: A => Boolean)(implicit M: Monoid[E]): Validation[E, A] =
     this match {
       case Failure(_) => this
       case Success(e) => if(p(e)) this else Failure(M.zero)
@@ -230,14 +230,14 @@ sealed abstract class Validation[+E, +A] extends Product with Serializable {
     }
 
   /** Return this if it is a success, otherwise, return the given value. Alias for `|||` */
-  def orElse[EE >: E, AA >: A](x: => Validation[EE, AA]): Validation[EE, AA] =
+  def orElse(x: => Validation[E, A]): Validation[E, A] =
     this match {
       case Failure(_) => x
       case Success(_) => this
     }
 
   /** Return this if it is a success, otherwise, return the given value. Alias for `orElse` */
-  def |||[EE >: E, AA >: A](x: => Validation[EE, AA]): Validation[EE, AA] =
+  def |||(x: => Validation[E, A]): Validation[E, A] =
     orElse(x)
 
   /**
@@ -249,7 +249,7 @@ sealed abstract class Validation[+E, +A] extends Product with Serializable {
    * failure(v1) +++ failure(v2) → failure(v1 + v2)
    * }}}
    */
-  def +++[EE >: E, AA >: A](x: => Validation[EE, AA])(implicit M1: Semigroup[AA], M2: Semigroup[EE]): Validation[EE, AA] =
+  def +++(x: => Validation[E, A])(implicit M1: Semigroup[A], M2: Semigroup[E]): Validation[E, A] =
     this match {
       case Failure(a1) => x match {
         case Failure(a2) => Failure(M2.append(a1, a2))
@@ -262,44 +262,44 @@ sealed abstract class Validation[+E, +A] extends Product with Serializable {
     }
 
   /** Ensures that the success value of this validation satisfies the given predicate, or fails with the given value. */
-  def ensure[EE >: E](onFailure: => EE)(f: A => Boolean): Validation[EE, A] =
+  def ensure(onFailure: => E)(f: A => Boolean): Validation[E, A] =
     excepting({ case a if !f(a) => onFailure})
 
   /** Compare two validations values for equality. */
-  def ===[EE >: E, AA >: A](x: Validation[EE, AA])(implicit EE: Equal[EE], EA: Equal[AA]): Boolean =
+  def ===(x: Validation[E, A])(implicit EE: Equal[E], EA: Equal[A]): Boolean =
     this match {
       case Failure(e1) => x match {
-        case Failure(e2) => Equal[EE].equal(e1, e2)
+        case Failure(e2) => EE.equal(e1, e2)
         case Success(_) => false
       }
       case Success(a1) => x match {
-        case Success(a2) => Equal[AA].equal(a1, a2)
+        case Success(a2) => EA.equal(a1, a2)
         case Failure(_) => false
       }
     }
 
   /** Compare two validations values for ordering. */
-  def compare[EE >: E, AA >: A](x: Validation[EE, AA])(implicit EE: Order[EE], EA: Order[AA]): Ordering =
+  def compare(x: Validation[E, A])(implicit OE: Order[E], OA: Order[A]): Ordering =
     this match {
       case Failure(e1) => x match {
-        case Failure(e2) => Order[EE].apply(e1, e2)
+        case Failure(e2) => OE.apply(e1, e2)
         case Success(_) => Ordering.LT
       }
       case Success(a1) => x match {
-        case Success(a2) => Order[AA].apply(a1, a2)
+        case Success(a2) => OA.apply(a1, a2)
         case Failure(_) => Ordering.GT
       }
     }
 
   /** Show for a validation value. */
-  def show[EE >: E, AA >: A](implicit SE: Show[EE], SA: Show[AA]): Cord =
+  def show(implicit SE: Show[E], SA: Show[A]): Cord =
     this match {
-      case Failure(e) => ("Failure(": Cord) ++ Show[EE].show(e) :- ')'
-      case Success(a) => ("Success(": Cord) ++ Show[AA].show(a) :- ')'
+      case Failure(e) => ("Failure(": Cord) ++ SE.show(e) :- ')'
+      case Success(a) => ("Success(": Cord) ++ SA.show(a) :- ')'
     }
 
   /** If `this` and `that` are both success, or both a failure, combine them with the provided `Semigroup` for each. Otherwise, return the success. Alias for `+|+` */
-  def append[EE >: E, AA >: A](that: Validation[EE, AA])(implicit es: Semigroup[EE], as: Semigroup[AA]): Validation[EE, AA] = (this, that) match {
+  def append(that: Validation[E, A])(implicit es: Semigroup[E], as: Semigroup[A]): Validation[E, A] = (this, that) match {
     case (Success(a1), Success(a2))   => Success(as.append(a1, a2))
     case (Success(_), Failure(_)) => this
     case (Failure(_), Success(_)) => that
@@ -307,10 +307,10 @@ sealed abstract class Validation[+E, +A] extends Product with Serializable {
   }
 
   /** If `this` and `that` are both success, or both a failure, combine them with the provided `Semigroup` for each. Otherwise, return the success. Alias for `append` */
-  def +|+[EE >: E, AA >: A](x: Validation[EE, AA])(implicit es: Semigroup[EE], as: Semigroup[AA]): Validation[EE, AA] = append(x)
+  def +|+(x: Validation[E, A])(implicit es: Semigroup[E], as: Semigroup[A]): Validation[E, A] = append(x)
 
   /** If `this` is a success, return it; otherwise, if `that` is a success, return it; otherwise, combine the failures with the specified semigroup. */
-  def findSuccess[EE >: E, AA >: A](that: => Validation[EE, AA])(implicit es: Semigroup[EE]): Validation[EE, AA] = this match {
+  def findSuccess(that: => Validation[E, A])(implicit es: Semigroup[E]): Validation[E, A] = this match {
     case Failure(e) => that match {
       case Failure(e0) => Failure(es.append(e, e0))
       case success => success
@@ -320,9 +320,9 @@ sealed abstract class Validation[+E, +A] extends Product with Serializable {
   }
 
   /** Wraps the failure value in a [[scalaz.NonEmptyList]] */
-  def toValidationNel[EE >: E, AA >: A]: ValidationNel[EE, AA] =
+  def toValidationNel: ValidationNel[E, A] =
     this match {
-      case a @ Success(_) => a
+      case a @ Success(_) => a.coerceFailure
       case Failure(e) => Failure(NonEmptyList(e))
     }
 
@@ -349,7 +349,7 @@ sealed abstract class Validation[+E, +A] extends Product with Serializable {
    * }}}
    * @since 7.0.2
    */
-  def excepting[EE >: E](pf: PartialFunction[A, EE]): Validation[EE, A] = {
+  def excepting(pf: PartialFunction[A, E]): Validation[E, A] = {
     import syntax.std.option._
     this match {
       case Success(s) => pf.lift(s) toFailure s
@@ -359,8 +359,12 @@ sealed abstract class Validation[+E, +A] extends Product with Serializable {
 
 }
 
-final case class Success[A](a: A) extends Validation[Nothing, A]
-final case class Failure[E](e: E) extends Validation[E, Nothing]
+final case class Success[E, A](a: A) extends Validation[E, A] {
+  def coerceFailure[F]: Validation[F, A] = this.asInstanceOf[Validation[F, A]]
+}
+final case class Failure[E, A](e: E) extends Validation[E, A] {
+  def coerceSuccess[B]: Validation[E, B] = this.asInstanceOf[Validation[E, B]]
+}
 
 object Validation extends ValidationInstances {
 
@@ -429,7 +433,7 @@ object Validation extends ValidationInstances {
 
 
 sealed abstract class ValidationInstances extends ValidationInstances0 {
-  type \?/[+E, +A] =
+  type \?/[E, A] =
   Validation[E, A]
 }
 
@@ -474,10 +478,10 @@ sealed abstract class ValidationInstances0 extends ValidationInstances1 {
 
 final class ValidationFlatMap[E, A] private[scalaz](private val self: Validation[E, A]) extends AnyVal {
   /** Bind through the success of this validation. */
-  def flatMap[EE >: E, B](f: A => Validation[EE, B]): Validation[EE, B] =
+  def flatMap[B](f: A => Validation[E, B]): Validation[E, B] =
     self match {
       case Success(a) => f(a)
-      case e @ Failure(_) => e
+      case e @ Failure(_) => e.coerceSuccess
     }
 }
 
@@ -513,7 +517,7 @@ sealed abstract class ValidationInstances2 extends ValidationInstances3 {
 
       def cozip[A, B](x: Validation[L, A \/ B]) =
         x match {
-          case l @ Failure(_) => -\/(l)
+          case l @ Failure(_) => -\/(l.coerceSuccess)
           case Success(e) => e match {
             case -\/(a) => -\/(Success(a))
             case \/-(b) => \/-(Success(b))

--- a/core/src/main/scala/scalaz/package.scala
+++ b/core/src/main/scala/scalaz/package.scala
@@ -224,7 +224,7 @@ package object scalaz {
     *
     * Useful for accumulating errors through the corresponding [[scalaz.Applicative]] instance.
     */
-  type ValidationNel[E, +X] = Validation[NonEmptyList[E], X]
+  type ValidationNel[E, X] = Validation[NonEmptyList[E], X]
 
   type FirstOf[A] = A @@ Tags.FirstVal
   type LastOf[A] = A @@ Tags.LastVal
@@ -346,15 +346,13 @@ package object scalaz {
   type IMap[A, B] = ==>>[A, B]
   val IMap = ==>>
 
-  type GlorifiedTuple[+A, +B] = A \/ B
-
-  type Disjunction[+A, +B] = \/[A, B]
+  type Disjunction[A, B] = \/[A, B]
   val Disjunction = \/
 
-  type DLeft[+A] = -\/[A]
+  type DLeft[A, B] = -\/[A, B]
   val DLeft = -\/
 
-  type DRight[+B] = \/-[B]
+  type DRight[A, B] = \/-[A, B]
   val DRight = \/-
 
   type DisjunctionT[F[_], A, B] = EitherT[F, A, B]

--- a/core/src/main/scala/scalaz/std/Future.scala
+++ b/core/src/main/scala/scalaz/std/Future.scala
@@ -57,7 +57,7 @@ private class FutureInstance(implicit ec: ExecutionContext) extends Nondetermini
     fab zip fa map { case (fa, a) => fa(a) }
 
   def attempt[A](f: Future[A]): Future[Throwable \/ A] =
-    f.map(\/.right).recover { case e => -\/(e) }
+    f.map(\/.right[Throwable, A]).recover { case e => -\/(e) }
 
   def fail[A](e: Throwable): Future[A] =
     Future.failed(e)

--- a/core/src/main/scala/scalaz/std/Option.scala
+++ b/core/src/main/scala/scalaz/std/Option.scala
@@ -79,7 +79,10 @@ trait OptionInstances extends OptionInstances0 {
         a map (Some(_))
 
       def pextract[B, A](fa: Option[A]): Option[B] \/ A =
-        fa map \/.right getOrElse -\/(None)
+        fa match {
+          case Some(a) => \/-(a)
+          case None    => -\/(None)
+        }
       override def isDefined[A](fa: Option[A]): Boolean = fa.isDefined
       override def toOption[A](fa: Option[A]): Option[A] = fa
       override def getOrElse[A](o: Option[A])(d: => A) = o getOrElse d

--- a/example/src/main/scala/scalaz/example/BifunctorUsage.scala
+++ b/example/src/main/scala/scalaz/example/BifunctorUsage.scala
@@ -40,8 +40,8 @@ object BifunctorUsage extends App {
   assert(Bifunctor[Validation].bimap("asdf".failure[Int])(_.toUpperCase, _+1) === "ASDF".failure)
   assert(Bifunctor[Validation].bimap(1.success[String])(_.toUpperCase, _+1) === 2.success)
 
-  assert(Bifunctor[\/].bimap("asdf".left[Int])(_.toUpperCase, _+1) === "ASDF".left)
-  assert(Bifunctor[\/].bimap(1.right[String])(_.toUpperCase, _+1) === 2.right)
+  assert(Bifunctor[\/].bimap("asdf".left[Int])(_.toUpperCase, _+1) === "ASDF".left[Int])
+  assert(Bifunctor[\/].bimap(1.right[String])(_.toUpperCase, _+1) === 2.right[String])
 
   // There is syntax for bimap:
   assert(("asdf",1).bimap(_.length, _+1) === (4 -> 2))
@@ -83,7 +83,7 @@ object BifunctorUsage extends App {
   // bifunctor, we can get a bimap that operates on every item in the
   // list.
   val bff = Functor[List] bicompose Bifunctor[\/]
-  val bfres = bff.bimap(List("asdf".left, 2.right, "qwer".left, 4.right))(_.toUpperCase, _+1)
+  val bfres = bff.bimap[String, Int, String, Int](List("asdf".left, 2.right, "qwer".left, 4.right))(_.toUpperCase, _+1)
   assert(bfres === List("ASDF".left, 3.right, "QWER".left, 5.right))
 
   //
@@ -92,12 +92,12 @@ object BifunctorUsage extends App {
 
   // We can get at the either the left or right underlying functors.
   val leftF = Bifunctor[\/].leftFunctor[String]
-  assert(leftF.map("asdf".right[Int])(_ + 1) === "asdf".right)
-  assert(leftF.map(1.left)(_ + 1) === 2.left)
+  assert(leftF.map("asdf".right[Int])(_ + 1) === "asdf".right[Int])
+  assert(leftF.map(1.left)(_ + 1) === 2.left[String])
 
   val rightF = Bifunctor[\/].rightFunctor[String]
-  assert(rightF.map("asdf".left[Int])(_ + 1) === "asdf".left)
-  assert(rightF.map(1.right)(_ + 1) === 2.right)
+  assert(rightF.map("asdf".left[Int])(_ + 1) === "asdf".left[Int])
+  assert(rightF.map(1.right)(_ + 1) === 2.right[String])
 
   //
   // Ufunctor

--- a/example/src/main/scala/scalaz/example/UnapplyInference.scala
+++ b/example/src/main/scala/scalaz/example/UnapplyInference.scala
@@ -55,8 +55,12 @@ object UnapplyInference extends App {
 
   def kleisliU(): Unit = {
     import scalaz._
+    import scalaz.syntax.either._
     val k: Kleisli[NumberFormatException \/ ?, String, Int] =
-      Kleisli.kleisliU{s: String => try \/-(s.toInt) catch{ case e: NumberFormatException => -\/(e) }}
+      Kleisli.kleisliU { s: String =>
+        try s.toInt.right[NumberFormatException]
+        catch { case e: NumberFormatException => e.left[Int] }
+      }
   }
 
   def functorSyntaxChaining(): Unit = {

--- a/example/src/main/scala/scalaz/example/transformers/typecheck/TypeCheckerWithExplicitTypes_MonadTransformers.scala
+++ b/example/src/main/scala/scalaz/example/transformers/typecheck/TypeCheckerWithExplicitTypes_MonadTransformers.scala
@@ -18,7 +18,7 @@ object TypeCheckerWithExplicitTypes_MonadTransformers {
   def compare(t1: Type, t2: Type, resultType: Type, errorMsg: String): String \/ Type =
     if (t1 == t2) success(resultType) else typeError(errorMsg)
 
-  type V[+T] = String \/ T
+  type V[T] = String \/ T
 
   def liftK[T, U](e: String \/ U): ReaderT[V, T, U] = kleisli[V, T, U]((env: T) => e)
 

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
@@ -222,8 +222,8 @@ object ScalazArbitrary extends ScalazArbitraryPlatform {
   implicit def theseArb[A: Arbitrary, B: Arbitrary]: Arbitrary[A \&/ B] =
     Arbitrary(Gen.oneOf(
       ^(arbitrary[A], arbitrary[B])(\&/.Both(_, _)),
-      arbitrary[A].map(\&/.This(_)),
-      arbitrary[B].map(\&/.That(_))
+      arbitrary[A].map(\&/.This[A, B](_)),
+      arbitrary[B].map(\&/.That[A, B](_))
     ))
 
   implicit def endoArb[A](implicit A: Arbitrary[A => A]): Arbitrary[Endo[A]] =

--- a/tests/jvm/src/test/scala/scalaz/concurrent/TaskTest.scala
+++ b/tests/jvm/src/test/scala/scalaz/concurrent/TaskTest.scala
@@ -122,7 +122,7 @@ object TaskTest extends SpecLite {
   }
 
   "catches exceptions thrown in handleWith" ! {
-    Task { Thread.sleep(10); throw FailWhale; 42 }.handleWith { case FailWhale => Task.delay(throw SadTrombone) }.unsafePerformSyncAttempt ==
+    Task { Thread.sleep(10); throw FailWhale; 42 }.handleWith { case FailWhale => Task.delay[Int](throw SadTrombone) }.unsafePerformSyncAttempt ==
       -\/(SadTrombone)
   }
 
@@ -179,7 +179,7 @@ object TaskTest extends SpecLite {
 
       // NB: Task can only be interrupted in between steps (before the `map`)
       val t1 = fork { sleep(1000); now(()) }.map { _ => t1v.set(1) }
-      val t2 = fork { now(throw ex) }
+      val t2 = fork { now[Unit](throw ex) }
       val t3 = fork { sleep(1000); now(()) }.map { _ => t3v.set(3) }
 
       val t = fork(Task.gatherUnordered(Seq(t1,t2,t3), exceptionCancels = true))(es3)
@@ -203,7 +203,7 @@ object TaskTest extends SpecLite {
 
       // NB: Task can only be interrupted in between steps (before the `map`)
       val t1 = fork { sleep(1000); now(()) }.map { _ => t1v.set(1) }
-      val t2 = fork { sleep(100); now(throw ex) }
+      val t2 = fork { sleep(100); now[Unit](throw ex) }
       val t3 = fork { sleep(1000); now(()) }.map { _ => t3v.set(3) }
 
       val t = fork(Task.gatherUnordered(Seq(t1,t2,t3), exceptionCancels = true))(es3)

--- a/tests/jvm/src/test/scala/scalaz/concurrent/TimerTest.scala
+++ b/tests/jvm/src/test/scala/scalaz/concurrent/TimerTest.scala
@@ -35,7 +35,7 @@ object TimerTest extends SpecLite {
       withTimer{timer =>
         val future = timer.withTimeout(Future{Thread.sleep(500); "Test"}, 100)
         withTimeout(5000){
-          future.unsafePerformSync must_== Timeout.left
+          future.unsafePerformSync must_== Timeout().left
         }
       }
     }

--- a/tests/jvm/src/test/scala/scalaz/std/FutureTest.scala
+++ b/tests/jvm/src/test/scala/scalaz/std/FutureTest.scala
@@ -10,6 +10,7 @@ import org.scalacheck.Prop.forAll
 import scalaz.scalacheck.ScalazProperties._
 import scalaz.scalacheck.ScalazArbitrary._
 import scalaz.std.AllInstances._
+import scalaz.syntax.all._
 import scalaz.Tags._
 
 import scala.concurrent._
@@ -28,13 +29,13 @@ class FutureTest extends SpecLite {
   import scala.concurrent.ExecutionContext.Implicits.global
 
   implicit def futureEqual[A : Equal] = Equal[Throwable \/ A] contramap { future: Future[A] =>
-    val futureWithError = future.map(\/-(_)).recover { case e => -\/(e) }
+    val futureWithError = future.map(_.right[Throwable]).recover { case e => e.left[A] }
     Await.result(futureWithError, duration)
   }
 
   implicit def futureShow[A: Show]: Show[Future[A]] = Contravariant[Show].contramap(Show[String \/ A]){
     future: Future[A] =>
-      val futureWithError = future.map(\/-(_)).recover { case e => -\/(e.toString) }
+      val futureWithError = future.map(_.right[String]).recover { case e => e.toString.left[A] }
       Await.result(futureWithError, duration)
   }
 

--- a/tests/src/test/scala/scalaz/DisjunctionTest.scala
+++ b/tests/src/test/scala/scalaz/DisjunctionTest.scala
@@ -41,8 +41,8 @@ object DisjunctionTest extends SpecLite {
     implicit val equalFoo = Equal.equalA[Foo]
     implicit val showFoo = Show.showA[Foo]
 
-    -\/[Foo](Bar).recover({ case Bar => 1 }) must_=== \/-(1)
-    -\/[Foo](Bar).recover({ case Baz => 1 }) must_=== -\/(Bar)
+    -\/[Foo, Int](Bar).recover({ case Bar => 1 }) must_=== \/-(1)
+    -\/[Foo, Int](Bar).recover({ case Baz => 1 }) must_=== -\/(Bar)
     \/.right[Foo, Int](1).recover({ case Bar => 4 }) must_=== \/-(1)
   }
 
@@ -62,8 +62,8 @@ object DisjunctionTest extends SpecLite {
       case Baz => \/-(1)
     }
 
-    -\/[Foo](Bar).recoverWith(barToBaz) must_=== -\/(Baz)
-    -\/[Foo](Bar).recoverWith(bazToInt) must_=== -\/(Bar)
+    -\/[Foo, Int](Bar).recoverWith(barToBaz) must_=== -\/(Baz)
+    -\/[Foo, Int](Bar).recoverWith(bazToInt) must_=== -\/(Bar)
     \/.right[Foo, Int](1).recoverWith(barToBaz) must_=== \/-(1)
   }
 

--- a/tests/src/test/scala/scalaz/InjectTest.scala
+++ b/tests/src/test/scala/scalaz/InjectTest.scala
@@ -107,12 +107,12 @@ object InjectTest extends SpecLite {
 
   "apply in left" in {
     val fa = Test1(Seq("a"), Free.pure[Test1Algebra, Int](_))
-    (Inject[Test1Algebra, C0].inj(fa) == Coproduct(-\/(fa))) must_===(true)
+    (Inject[Test1Algebra, C0].inj(fa).run == -\/(fa)) must_===(true)
   }
 
   "apply in right" in {
     val fa = Test2(Seq("a"), Free.pure[Test2Algebra, Int](_))
-    (Inject[Test2Algebra, C0].inj(fa) == Coproduct(\/-(fa))) must_===(true)
+    (Inject[Test2Algebra, C0].inj(fa).run == \/-(fa)) must_===(true)
   }
 
   "unapply from left" in {

--- a/tests/src/test/scala/scalaz/LazyEitherTest.scala
+++ b/tests/src/test/scala/scalaz/LazyEitherTest.scala
@@ -3,6 +3,7 @@ package scalaz
 import scalaz.scalacheck.ScalazProperties._
 import scalaz.scalacheck.ScalazArbitrary._
 import std.AllInstances._
+import syntax.either._
 
 object LazyEitherTest extends SpecLite {
   implicit def LazyEitherEqual[A: Equal, B: Equal]: Equal[LazyEither[A, B]] = new Equal[LazyEither[A, B]] {
@@ -24,7 +25,7 @@ object LazyEitherTest extends SpecLite {
 
     val result =
       BindRec[LazyEither[Int, ?]].tailrecM(0) {
-        i => LazyEither.lazyRight(if (i < 10000) \/.left(i + 1) else \/.right(i))
+        i => LazyEither.lazyRight(if (i < 10000) (i + 1).left[Int] else i.right[Int])
       }
     result.getOrElse(0) must_=== times
   }

--- a/tests/src/test/scala/scalaz/LazyOptionTest.scala
+++ b/tests/src/test/scala/scalaz/LazyOptionTest.scala
@@ -25,7 +25,7 @@ object LazyOptionTest extends SpecLite {
 
     val result =
       BindRec[LazyOption].tailrecM(0) {
-        i => LazyOption.lazySome(if (i < 10000) \/.left(i + 1) else \/.right(i))
+        i => LazyOption.lazySome[Int \/ Int](if (i < 10000) \/.left(i + 1) else \/.right(i))
       }
     result.getOrElse(0) must_=== times
   }

--- a/tests/src/test/scala/scalaz/MapTest.scala
+++ b/tests/src/test/scala/scalaz/MapTest.scala
@@ -746,19 +746,19 @@ object MapTest extends SpecLite {
     }
 
     "mapEither" in {
-      val f = (a: String) => if (a < "c") \/.left(a) else \/.right(a)
+      val f: String => (String \/ String) = a => if (a < "c") \/.left(a) else \/.right(a)
       val lst = fromList(List(5 -> "a", 3 -> "b", 1 -> "x", 7 -> "z"))
 
       lst.mapEither(f) must_===((fromList(List(3 -> "b", 5 -> "a")), fromList(List(1 -> "x", 7 -> "z"))))
-      lst.mapEither((a: String) => \/.right(a)) must_===((empty[Int, String], lst))
+      lst.mapEither((a: String) => \/-[String, String](a)) must_===((empty[Int, String], lst))
     }
 
     "mapEitherWithKey" in {
-      val f = (k: Int, a: String) => if (k < 5) \/.left(k * 2) else \/.right(a + a)
+      val f: (Int, String) => (Int \/ String) = (k, a) => if (k < 5) \/.left(k * 2) else \/.right(a + a)
       val lst = fromList(List(5 -> "a", 3 -> "b", 1 -> "x", 7 -> "z"))
 
       lst.mapEitherWithKey(f) must_===(fromList(List(1 -> 2, 3 -> 6)) -> fromList(List(5 -> "aa", 7 -> "zz")))
-      lst.mapEitherWithKey((_: Int, a: String) => \/.right(a)) must_===(empty[Int, String] -> lst)
+      lst.mapEitherWithKey((_: Int, a: String) => \/-[String, String](a)) must_===(empty[Int, String] -> lst)
     }
   }
 

--- a/tests/src/test/scala/scalaz/MonadPlusTest.scala
+++ b/tests/src/test/scala/scalaz/MonadPlusTest.scala
@@ -10,46 +10,46 @@ object MonadPlusTest extends SpecLite {
   }
 
   "uniteU" in {
-    MonadPlus[List].uniteU(List(\/.right(1), \/.left("a"), \/.right(2))) must_===(List(1, 2))
+    MonadPlus[List].uniteU(List[String \/ Int](\/.right(1), \/.left("a"), \/.right(2))) must_===(List(1, 2))
   }
 
   "lefts" in {
     import \&/._
     import syntax.monadPlus._
 
-    List(\/.right(1), \/.left("a"), \/.right(2)).lefts must_===(List("a"))
+    List[String \/ Int](\/.right(1), \/.left("a"), \/.right(2)).lefts must_===(List("a"))
 
     List(1 -> "a", 2 -> "b").lefts must_===(List(1, 2))
 
     Vector[Int \&/ String](This(1), Both(3, "a"), That("b")).lefts must_===(Vector(1, 3))
 
-    Stream(Success(1), Failure("a"), Success(2)).lefts must_===(Stream("a"))
+    Stream[Validation[String, Int]](Success(1), Failure("a"), Success(2)).lefts must_===(Stream("a"))
   }
 
   "rights" in {
     import \&/._
     import syntax.monadPlus._
 
-    List(\/.right(1), \/.left("a"), \/.right(2)).rights must_===(List(1, 2))
+    List[String \/ Int](\/.right(1), \/.left("a"), \/.right(2)).rights must_===(List(1, 2))
 
     List(1 -> "a", 2 -> "b").rights must_===(List("a", "b"))
 
     Vector[Int \&/ String](This(1), Both(3, "a"), That("b")).rights must_===(Vector("a", "b"))
 
-    Stream(Success(1), Failure("a"), Success(2)).rights must_===(Stream(1, 2))
+    Stream[Validation[String, Int]](Success(1), Failure("a"), Success(2)).rights must_===(Stream(1, 2))
   }
 
   "separate" in {
     import \&/._
     import syntax.monadPlus._
 
-    List(\/.right(1), \/.left("a"), \/.right(2)).separate must_===(List("a") -> List(1, 2))
+    List[String \/ Int](\/.right(1), \/.left("a"), \/.right(2)).separate must_===(List("a") -> List(1, 2))
 
     List(1 -> "a", 2 -> "b").separate must_===(List(1, 2) -> List("a", "b"))
 
     Vector[Int \&/ String](This(1), Both(3, "a"), That("b")).separate must_===(Vector(1, 3) -> Vector("a", "b"))
 
-    Stream(Success(1), Failure("a"), Success(2)).separate must_===(Stream("a") -> Stream(1, 2))
+    Stream[Validation[String, Int]](Success(1), Failure("a"), Success(2)).separate must_===(Stream("a") -> Stream(1, 2))
   }
 
   "filter" in {

--- a/tests/src/test/scala/scalaz/ValidationTest.scala
+++ b/tests/src/test/scala/scalaz/ValidationTest.scala
@@ -48,8 +48,8 @@ object ValidationTest extends SpecLite {
   "ap2" should {
     "accumulate failures in order" in {
       import syntax.show._
-      val fail1 = Failure("1").toValidationNel
-      val fail2 = Failure("2").toValidationNel
+      val fail1 = Failure[String, Int]("1").toValidationNel
+      val fail2 = Failure[String, Int]("2").toValidationNel
       val f = (_:Int) + (_:Int)
       Apply[ValidationNel[String, ?]].ap2(fail1, fail2)(Success(f)).shows must_===("""Failure(["1","2"])""")
     }
@@ -90,12 +90,6 @@ object ValidationTest extends SpecLite {
     (List("1", "2", "3") map (_.parseInt.leftMap(_.toString) excepting { case i if i < 0 => errmsg(i) })) must_===(List(1.success[String], 2.success[String], 3.success[String]))
 
     (List("1", "-2", "3") map (_.parseInt.leftMap(_.toString) excepting { case i if i < 0 => errmsg(i) })) must_===(List(1.success[String], errmsg(-2).failure[Int], 3.success[String]))
-
-    implicit val ShowAny: Show[Any] = Show.showA; implicit val EqualAny: Equal[Any] = Equal.equalA
-    def errmsgA(i: Int): Any = errmsg(i)
-    (List("1", "2", "3") map (_.parseInt.leftMap(_.toString) excepting { case i if i < 0 => errmsgA(i) })) must_===(List(1.success[Any], 2.success[Any], 3.success[Any]))
-
-    (List("1", "-2", "3") map (_.parseInt.leftMap(_.toString) excepting { case i if i < 0 => errmsgA(i) })) must_===(List(1.success[Any], errmsgA(-2).failure[Int], 3.success[Any]))
   }
 
   "ensure" in {


### PR DESCRIPTION
 * `\/`
 * `Either3`
 * `LazyEither`
 * `MonoidCoproduct` (`:+:`)
 * `These` (`\&/`)
 * `Validation`
 * `Future`
 * `Task`

Resolves #1469.

Note that I added coercion methods like

```scala
-\/[A, B](a).coerceRight[C] : (A \/ C)
```

so that `A -\/ B` can be coerced to `A \/ C` at zero allocation cost.

I could remove these methods, at the cost of introducing some new allocations.