### PR TITLE
Add Store monad and State comonad

### DIFF
--- a/core/src/main/scala/scalaz/StateT.scala
+++ b/core/src/main/scala/scalaz/StateT.scala
@@ -228,6 +228,23 @@ sealed abstract class StateTInstances1 extends StateTInstances2 {
 sealed abstract class StateTInstances0 extends StateTInstances1 {
   implicit def StateMonadTrans[S]: Hoist[λ[(g[_], a) => StateT[g, S, a]]] =
     new StateTHoist[S] {}
+
+  implicit def stateComonad[S](implicit S: Monoid[S]): Comonad[State[S, ?]] =
+    new Comonad[State[S, ?]] {
+      override def copoint[A](fa: State[S, A]): A =
+        fa.eval(S.zero)
+
+      override def cojoin[A](fa: State[S, A]): State[S, State[S, A]] =
+        State[S, State[S, A]](s => (
+          fa.exec(S.zero),
+          State((t: S) => fa.run(S.append(s, t)))))
+
+      override def map[A, B](fa: State[S, A])(f: A => B): State[S, B] =
+        fa map f
+
+      override def cobind[A, B](fa: State[S, A])(f: State[S, A] => B): State[S, B] =
+        cojoin(fa).map(f)
+    }
 }
 
 abstract class StateTInstances extends StateTInstances0 {

--- a/core/src/main/scala/scalaz/StateT.scala
+++ b/core/src/main/scala/scalaz/StateT.scala
@@ -236,7 +236,7 @@ sealed abstract class StateTInstances0 extends StateTInstances1 {
 
       override def cojoin[A](fa: State[S, A]): State[S, State[S, A]] =
         State[S, State[S, A]](s => (
-          fa.exec(S.zero),
+          fa.exec(s),
           State((t: S) => fa.run(S.append(s, t)))))
 
       override def map[A, B](fa: State[S, A])(f: A => B): State[S, B] =

--- a/tests/src/test/scala/scalaz/StoreTTest.scala
+++ b/tests/src/test/scala/scalaz/StoreTTest.scala
@@ -1,18 +1,34 @@
 package scalaz
 
+import org.scalacheck.Arbitrary
 import std.AllInstances._
 import scalaz.scalacheck.ScalazProperties._
 import scalaz.scalacheck.ScalazArbitrary._
 
 object StoreTTest extends SpecLite {
 
-  implicit def storeTuple1IntEqual = new Equal[StoreT[Tuple1, Int, Int]] {
-    def equal(a1: StoreT[Tuple1, Int, Int], a2: StoreT[Tuple1, Int, Int]) = (a1.run, a2.run) match {
-      case ((tf1, x1), (tf2, x2)) => Equal[Int].equal(x1, x2) && Equal[Int].equal(tf1._1(0), tf2._1(0))
+  private[this] val storeTestInts = (-10 to 10).toList
+
+  implicit def storeTIntEqual[F[_]: Comonad]: Equal[StoreT[F, Int, Int]] =
+    new Equal[StoreT[F, Int, Int]] {
+      def equal(a1: StoreT[F, Int, Int], a2: StoreT[F, Int, Int]) =
+        (a1.run, a2.run) match {
+          case ((tf1, x1), (tf2, x2)) =>
+            Equal[Int].equal(x1, x2) && storeTestInts.forall(i =>
+              Equal[Int].equal(Comonad[F].copoint(tf1)(i), Comonad[F].copoint(tf2)(i)))
+        }
     }
-  }
 
   checkAll(comonad.laws[StoreT[Tuple1, Int, ?]])
+
+  checkAll {
+    // Not sure why this is needed explicitly
+    val am: Arbitrary[Store[Int, Int]]        = implicitly
+    val af: Arbitrary[Int => Store[Int, Int]] = implicitly
+    val ag: Arbitrary[Store[Int, Int => Int]] = implicitly
+    val eq: Equal[Store[Int, Int]]            = implicitly
+    monad.laws[Store[Int, ?]](implicitly, am, af, ag, eq)
+  }
 
   object instances {
     type A = Int


### PR DESCRIPTION
I read http://comonad.com/reader/2018/the-state-comonad/ and decided to quickly bang this out.

I also tried generising for `{State,Store}T` but they'd both need typeclasses over `F[_]` on both sides of the dual line. Specifically, for a `Monad[StoreT[F, S, ?]]`, `peek` needs a `Comonad[F]` where as `Monad#point` needs `Point[F]`. And similarly, a `Comonad[StateT[F, S, ?]]` needs both `Bind[F]` and `copoint`.
  