### PR TITLE
Add `with this.type` refinement to subclass members

### DIFF
--- a/base/shared/src/main/scala/scalaz/typeclass/ApplicativeClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/ApplicativeClass.scala
@@ -2,7 +2,7 @@ package scalaz
 package typeclass
 
 trait ApplicativeClass[F[_]] extends Applicative[F] with ApplyClass[F] {
-  final def applicative: Applicative[F] = this
+  final def applicative: Applicative[F] with this.type = this
 }
 
 object ApplicativeClass {

--- a/base/shared/src/main/scala/scalaz/typeclass/ApplyClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/ApplyClass.scala
@@ -2,5 +2,5 @@ package scalaz
 package typeclass
 
 trait ApplyClass[F[_]] extends Apply[F] with FunctorClass[F] {
-  implicit final def apply: Apply[F] = this
+  implicit final def apply: Apply[F] with this.type = this
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/Bind.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/Bind.scala
@@ -2,7 +2,7 @@ package scalaz
 package typeclass
 
 trait Bind[M[_]] {
-  def apply: Apply[M]
+  def apply: Apply[M] with this.type
   def flatMap[A, B](ma: M[A])(f: A => M[B]): M[B]
   def flatten[A](ma: M[M[A]]): M[A]
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/BindClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/BindClass.scala
@@ -2,7 +2,7 @@ package scalaz
 package typeclass
 
 trait BindClass[M[_]] extends Bind[M] with ApplyClass[M] {
-  final def bind: Bind[M] = this
+  final def bind: Bind[M] with this.type = this
 }
 
 object BindClass {

--- a/base/shared/src/main/scala/scalaz/typeclass/Category.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/Category.scala
@@ -2,6 +2,6 @@ package scalaz
 package typeclass
 
 trait Category[=>:[_,_]] {
-  def compose: Compose[=>:]
+  def compose: Compose[=>:] with this.type
   def id[A]: A =>: A
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/CategoryClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/CategoryClass.scala
@@ -2,6 +2,6 @@ package scalaz
 package typeclass
 
 trait CategoryClass[=>:[_,_]] extends Category[=>:] with Compose[=>:] {
-  def compose: Compose[=>:] = this
+  def compose: Compose[=>:] with this.type = this
   def id[A]: A =>: A
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/Choice.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/Choice.scala
@@ -2,7 +2,7 @@ package scalaz
 package typeclass
 
 trait Choice[P[_, _]] {
-  def profunctor: Profunctor[P]
+  def profunctor: Profunctor[P] with this.type
 
   def leftchoice[A, B, C](pab: P[A, B]): P[A \/ C, B \/ C]
 

--- a/base/shared/src/main/scala/scalaz/typeclass/ChoiceClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/ChoiceClass.scala
@@ -4,7 +4,7 @@ package typeclass
 import data.Disjunction.swap
 
 trait ChoiceClass[P[_, _]] extends Choice[P] with ProfunctorClass[P] {
-  final def choice: Choice[P] = this
+  final def choice: Choice[P] with this.type = this
 }
 
 object ChoiceClass {

--- a/base/shared/src/main/scala/scalaz/typeclass/Cobind.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/Cobind.scala
@@ -2,7 +2,7 @@ package scalaz
 package typeclass
 
 trait Cobind[F[_]] {
-  def functor: Functor[F]
+  def functor: Functor[F] with this.type
   def cobind[A, B](fa: F[A])(f: F[A] => B): F[B]
   def cojoin[A](fa: F[A]): F[F[A]]
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/CobindClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/CobindClass.scala
@@ -2,7 +2,7 @@ package scalaz
 package typeclass
 
 trait CobindClass[F[_]] extends Cobind[F] with FunctorClass[F] {
-  final def cobind: Cobind[F] = this
+  final def cobind: Cobind[F] with this.type = this
 }
 
 object CobindClass {

--- a/base/shared/src/main/scala/scalaz/typeclass/Comonad.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/Comonad.scala
@@ -2,7 +2,7 @@ package scalaz
 package typeclass
 
 trait Comonad[F[_]] {
-  def cobind: Cobind[F] 
+  def cobind: Cobind[F] with this.type
   def copoint[A](fa: F[A]): A
 }
 

--- a/base/shared/src/main/scala/scalaz/typeclass/ComonadClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/ComonadClass.scala
@@ -2,7 +2,7 @@ package scalaz
 package typeclass
 
 trait ComonadClass[F[_]] extends Comonad[F] with CobindClass[F] with FunctorClass[F] {
-  final def comonad: Comonad[F] = this
+  final def comonad: Comonad[F] with this.type = this
 }
 
 object ComonadClass {

--- a/base/shared/src/main/scala/scalaz/typeclass/FoldableClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/FoldableClass.scala
@@ -4,7 +4,7 @@ package typeclass
 import Prelude._
 
 trait FoldableClass[F[_]] extends Foldable[F]{
-  final def foldable: Foldable[F] = this
+  final def foldable: Foldable[F] with this.type = this
 }
 
 object FoldableClass {

--- a/base/shared/src/main/scala/scalaz/typeclass/FunctorClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/FunctorClass.scala
@@ -2,5 +2,5 @@ package scalaz
 package typeclass
 
 trait FunctorClass[F[_]] extends Functor[F]{
-  final def functor: Functor[F] = this
+  final def functor: Functor[F] with this.type = this
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/InvariantFunctorClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/InvariantFunctorClass.scala
@@ -2,5 +2,5 @@ package scalaz
 package typeclass
 
 trait InvariantFunctorClass[F[_]] extends InvariantFunctor[F]{
-  final def functor: InvariantFunctor[F] = this
+  final def functor: InvariantFunctor[F] with this.type = this
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/IsContravariantClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/IsContravariantClass.scala
@@ -4,7 +4,7 @@ package typeclass
 import data.As
 
 trait IsContravariantClass[F[_]] extends IsContravariant[F] {
-  final def isContravariant: IsContravariant[F] = this
+  final def isContravariant: IsContravariant[F] with this.type = this
 }
 
 object IsContravariantClass {

--- a/base/shared/src/main/scala/scalaz/typeclass/IsCovariantClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/IsCovariantClass.scala
@@ -4,7 +4,7 @@ package typeclass
 import data.As
 
 trait IsCovariantClass[F[_]] extends IsCovariant[F] {
-  final def isCovariant: IsCovariant[F] = this
+  final def isCovariant: IsCovariant[F] with this.type = this
 }
 
 object IsCovariantClass {

--- a/base/shared/src/main/scala/scalaz/typeclass/Monad.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/Monad.scala
@@ -2,6 +2,6 @@ package scalaz
 package typeclass
 
 trait Monad[M[_]] {
-  def applicative: Applicative[M]
-  def bind: Bind[M]
+  def applicative: Applicative[M] with this.type
+  def bind: Bind[M] with this.type
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/MonadClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/MonadClass.scala
@@ -4,7 +4,7 @@ package typeclass
 import BindClass._
 
 trait MonadClass[M[_]] extends Monad[M] with BindClass[M] with ApplicativeClass[M] {
-  final def monad: Monad[M] = this
+  final def monad: Monad[M] with this.type = this
 }
 
 object MonadClass {

--- a/base/shared/src/main/scala/scalaz/typeclass/Monoid.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/Monoid.scala
@@ -2,6 +2,6 @@ package scalaz
 package typeclass
 
 trait Monoid[A] {
-  def semigroup: Semigroup[A]
+  def semigroup: Semigroup[A] with this.type
   def empty: A
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/MonoidClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/MonoidClass.scala
@@ -2,5 +2,5 @@ package scalaz
 package typeclass
 
 trait MonoidClass[A] extends Monoid[A] with SemigroupClass[A]{
-  final def monoid: Monoid[A] = this
+  final def monoid: Monoid[A] with this.type = this
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/PhantomClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/PhantomClass.scala
@@ -2,7 +2,7 @@ package scalaz
 package typeclass
 
 trait PhantomClass[F[_]] extends Phantom[F] with Functor[F] with Contravariant[F] {
-  final def phantom: Phantom[F] = this
+  final def phantom: Phantom[F] with this.type = this
 }
 
 object PhantomClass {

--- a/base/shared/src/main/scala/scalaz/typeclass/ProfunctorClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/ProfunctorClass.scala
@@ -2,7 +2,7 @@ package scalaz
 package typeclass
 
 trait ProfunctorClass[F[_, _]] extends Profunctor[F] {
-  final def profunctor: Profunctor[F] = this
+  final def profunctor: Profunctor[F] with this.type = this
 }
 
 object ProfunctorClass {

--- a/base/shared/src/main/scala/scalaz/typeclass/SemigroupClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/SemigroupClass.scala
@@ -2,5 +2,5 @@ package scalaz
 package typeclass
 
 trait SemigroupClass[A] extends Semigroup[A]{
-  final def semigroup: Semigroup[A] = this
+  final def semigroup: Semigroup[A] with this.type = this
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/Strong.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/Strong.scala
@@ -2,7 +2,7 @@ package scalaz
 package typeclass
 
 trait Strong[P[_, _]] {
-  def profunctor: Profunctor[P]
+  def profunctor: Profunctor[P] with this.type
 
   def first[A, B, C](pab: P[A, B]): P[(A, C), (B, C)]
 

--- a/base/shared/src/main/scala/scalaz/typeclass/StrongClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/StrongClass.scala
@@ -2,7 +2,7 @@ package scalaz
 package typeclass
 
 trait StrongClass[P[_, _]] extends Strong[P] with ProfunctorClass[P] {
-  final def strong: Strong[P] = this
+  final def strong: Strong[P] with this.type = this
 }
 
 object StrongClass {

--- a/base/shared/src/main/scala/scalaz/typeclass/Traversable.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/Traversable.scala
@@ -2,8 +2,8 @@ package scalaz
 package typeclass
 
 trait Traversable[T[_]] {
-  def functor: Functor[T]
-  def foldable: Foldable[T]
+  def functor: Functor[T] with this.type
+  def foldable: Foldable[T] with this.type
 
   def traverse[F[_], A, B](ta: T[A])(f: A => F[B])(implicit F: Applicative[F]): F[T[B]]
   def sequence[F[_], A](ta: T[F[A]])(implicit F: Applicative[F]): F[T[A]]

--- a/base/shared/src/main/scala/scalaz/typeclass/TraversableClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/TraversableClass.scala
@@ -2,7 +2,7 @@ package scalaz
 package typeclass
 
 trait TraversableClass[T[_]] extends Traversable[T] with FunctorClass[T] with FoldableClass[T] {
-  final def traversable: Traversable[T] = this
+  final def traversable: Traversable[T] with this.type = this
 }
 
 object TraversableClass {

--- a/example/src/main/tut/typeclass/Monoid.md
+++ b/example/src/main/tut/typeclass/Monoid.md
@@ -21,33 +21,22 @@ import Scalaz._
 ## Instance declaration
 
 ```tut
-def ListSemigroup[A]: Semigroup[List[A]] = new Semigroup[List[A]] {
-  def append(a1: List[A], a2: => List[A]) = a1 ++ a2
-}
-
-implicit def ListMonoid[A]: Monoid[List[A]] = new Monoid[List[A]] {
-  val semigroup = ListSemigroup[A]
-  val empty = List.empty[A]
-}
-```
-
-Instances can also be defined without the intermediary `Semigroup` by using `MonoidClass`:
-
-```tut
+{
 import scalaz.typeclass.MonoidClass
 
 implicit def StringMonoid: Monoid[String] = new MonoidClass[String] {
   def append(a1: String, a2: => String) = a1 + a2
   val empty = ""
 }
+}
 ```
 
 ## Usage
 
 ```tut
-val l1 = List(1, 2, 3)
-val l2 = List(4, 5, 6)
+val s1 = "Hello"
+val s2 = " World"
 
-val l = l1.append(l2)
-l.append(ListMonoid.empty)
+val s = s1.append(s2)
+s.append(Monoid[String].empty)
 ```


### PR DESCRIPTION
Why remove subtyping from the type class hierarchy? Because it gives us ambiguous implicits.
Why keep subtyping in the type class hierarchy? Because it's efficient.

The moment someone implements `def semigroup: Semigroup[A]` in the `Monoid` class with anything but `= this`, all of Scalaz's methods accessing that method get deoptimized and the call is no longer inlined.

All instances must be *implemented* using subtyping, to keep the guarantee that our code doesn't become ridiculously slow because the JIT can't see through it. But subtyping in the *interface* is an abomination.

This PR enshrines these things in the types.