### PR TITLE
Make \/.left/right methods (instead of functions).

### DIFF
--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -370,12 +370,12 @@ final case class \/-[A, B](b: B) extends (A \/ B) {
 object \/ extends DisjunctionInstances {
 
   /** Construct a left disjunction value. */
-  def left[A, B]: A => A \/ B =
-    -\/(_)
+  def left[A, B](a: A): A \/ B =
+    -\/(a)
 
   /** Construct a right disjunction value. */
-  def right[A, B]: B => A \/ B =
-    \/-(_)
+  def right[A, B](b: B): A \/ B =
+    \/-(b)
 
   /** Construct a disjunction value from a standard `scala.Either`. */
   def fromEither[A, B](e: Either[A, B]): A \/ B =


### PR DESCRIPTION
To avoid allocating an extra function object.

Resolves #1611.