### PR TITLE
Document (very few) typeclasses

### DIFF
--- a/example/src/main/resources/microsite/data/menu.yml
+++ b/example/src/main/resources/microsite/data/menu.yml
@@ -13,9 +13,11 @@ options:
     - title: Apply
       url: typeclass/Apply.html
       menu_section: typeclass
+    - title: Debug
+      url: typeclass/Debug.html
+      menu_section: typeclass
     - title: Functor
       url: typeclass/Functor.html
-      menu_section: typeclass
       menu_section: typeclass
     - title: Monad
       url: typeclass/Monad.html
@@ -24,10 +26,7 @@ options:
       url: typeclass/Monoid.html
       menu_section: typeclass
     - title: Semigroup
-      menu_section: typeclass
       url: typeclass/Semigroup.html
-    - title: Show
-      url: typeclass/Show.html
       menu_section: typeclass
 
   - title: Data classes

--- a/example/src/main/resources/microsite/data/menu.yml
+++ b/example/src/main/resources/microsite/data/menu.yml
@@ -16,9 +16,6 @@ options:
     - title: Functor
       url: typeclass/Functor.html
       menu_section: typeclass
-    - title: Semigroup
-      menu_section: typeclass
-      url: typeclass/Semigroup.html
       menu_section: typeclass
     - title: Monad
       url: typeclass/Monad.html
@@ -26,6 +23,9 @@ options:
     - title: Monoid
       url: typeclass/Monoid.html
       menu_section: typeclass
+    - title: Semigroup
+      menu_section: typeclass
+      url: typeclass/Semigroup.html
     - title: Show
       url: typeclass/Show.html
       menu_section: typeclass

--- a/example/src/main/tut/data/Disjunction.md
+++ b/example/src/main/tut/data/Disjunction.md
@@ -6,7 +6,7 @@ title:  "Disjunction"
 # Disjunction
 
 `Disjunction` is a data type used to signal multiple possible outcomes of a computation.
-It is often used to dealing with errors, but is not tied to that case.
+It is often used when dealing with errors, but is not tied to that case.
 
 **Typical imports**
 

--- a/example/src/main/tut/typeclass/Debug.md
+++ b/example/src/main/tut/typeclass/Debug.md
@@ -11,8 +11,7 @@ By providing instances of this typeclass, a type explicitly defines that it can 
 **Typical imports**
 
 ```tut:silent
-import scalaz._
-import Scalaz._
+import scalaz.Scalaz._
 ```
 
 # Built-in instances

--- a/example/src/main/tut/typeclass/Functor.md
+++ b/example/src/main/tut/typeclass/Functor.md
@@ -15,8 +15,7 @@ A functor needs to satisfy the two functor laws:
 **Typical imports**
 
 ```tut:silent
-import scalaz._
-import Scalaz._
+import scalaz.Scalaz._
 ```
 
 ## Instance declaration

--- a/example/src/main/tut/typeclass/Monoid.md
+++ b/example/src/main/tut/typeclass/Monoid.md
@@ -14,8 +14,7 @@ A monoid instance must satisfy the following laws in addition to those defined b
 
 **Typical imports**
 ```tut:silent
-import scalaz._
-import Scalaz._
+import scalaz.Scalaz._
 ```
 
 ## Instance declaration

--- a/example/src/main/tut/typeclass/Semigroup.md
+++ b/example/src/main/tut/typeclass/Semigroup.md
@@ -13,8 +13,7 @@ A semigroup instance needs to satisfy the following law:
 
 **Typical imports**
 ```tut:silent
-import scalaz._
-import Scalaz._
+import scalaz.Scalaz._
 ```
 
 ## Instance declaration

--- a/example/src/main/tut/typeclass/index.md
+++ b/example/src/main/tut/typeclass/index.md
@@ -4,3 +4,80 @@ title:  "Type classes"
 ---
 
 # Type classes
+
+_In computer science, a type class is a type system construct that supports ad hoc polymorphism.
+This is achieved by adding constraints to type variables in parametrically polymorphic types._ <sup>[1](#f1)</sup>
+
+Type class instances allow us to add behaviour to types without changing the types themselves.
+
+As an example, let us look at the [Show](./Show.html) type class, a safe alternative to the JVM's `Object.toString`.
+It defines that all its instances implement a method `show` with the following signature:
+
+```tut:silent
+trait Show[A] {
+  def show(a: A): String
+}
+```
+
+Now assume that we have a class which we are unable or unwilling to change in order to give it a conversion into a `String` representation.
+
+```tut:silent
+final case class BusinessObject(id: Long, value: Long)
+```
+
+Using the `Show` type class, we can easily just define such a conversion:
+
+```tut:silent
+implicit val businessObjectShow: Show[BusinessObject] = new Show[BusinessObject] {
+  def show(b: BusinessObject) = s"BO[${b.id} = ${b.value}]"
+}
+```
+
+Now, whenever we would like to turn our `BusinessObject` into a String, we can do so using our `Show` instance.
+
+```tut
+val bo = BusinessObject(1234L, 1234567L)
+
+businessObjectShow.show(bo)
+```
+
+However, this is not too convenient and very specific to our `BusinessObject`. Would it not be nicer to be able to say `bo.show`?
+
+Luckily, **Scalaz** makes all this very easy.
+
+We need something similar to the following:
+
+```tut:silent
+implicit final class ShowOps[A](self: A)(implicit s: Show[A]) {
+  def show: String = s.show(self)
+}
+```
+
+Luckily, most of this ships in Scalaz by default.
+
+```tut:reset
+import scalaz.Scalaz._
+
+final case class BusinessObject(id: Long, value: Long)
+
+implicit val businessObjectShow: Show[BusinessObject] = (b: BusinessObject) => s"BO[${b.id} = ${b.value}]"
+
+BusinessObject(1234L, 1234567L).show
+```
+
+After showing that we can add behaviour, it should now be easy to see how type classes can be used as constraints for parametrically polymorphic functions.
+
+For example, we could define a function `loudShow` as follows:
+
+```tut:silent
+def loudShow[A: Show](a: A) = a.show.toUpperCase
+```
+
+Notice that the type parameter `A` now has a constraint that requires it have an instance of `Show`.
+The above `loudShow` can be used with our original `BusinessObject` class or any type that has a `Show` instance.
+
+---
+
+Footnotes
+
+<b id="f1">1</b> <https://en.wikipedia.org/wiki/Type_class>

--- a/example/src/main/tut/typeclass/index.md
+++ b/example/src/main/tut/typeclass/index.md
@@ -5,7 +5,7 @@ title:  "Type classes"
 
 # Type classes
 
-_In computer science, a type class is a type system construct that supports ad hoc polymorphism.
+_A type class is a type system construct that supports ad hoc polymorphism.
 This is achieved by adding constraints to type variables in parametrically polymorphic types._ <sup>[1](#f1)</sup>
 
 Type class instances allow us to add behaviour to types without changing the types themselves.


### PR DESCRIPTION
Replacing #1607 with in-repo PR rather than fork. This way we can easily have other people contribute.

The goal of this PR is to document all the (currently existing) type classes into the `examples` module.

- [X] What is a type class? / index
- [ ] Applicative
- [ ] Apply
- [ ] Bind
- [ ] Category
- [ ] Choice
- [ ] Cobind
- [ ] Comonad
- [ ] Compose
- [ ] Contravariant
- [ ] Debug
- [ ] Foldable
- [X] Functor
- [ ] InvariantFunctor
- [ ] IsContravariant
- [ ] IsCovariant
- [ ] Monad
- [ ] Monoid
- [ ] Phantom
- [ ] Profunctor
- [ ] Semigroup
- [ ] Strong
- [ ] Traversable
