### PR TITLE
avoid deprecated PartialFunction.apply method

### DIFF
--- a/core/src/main/scala/scalaz/std/Future.scala
+++ b/core/src/main/scala/scalaz/std/Future.scala
@@ -66,7 +66,7 @@ private class FutureInstance(implicit ec: ExecutionContext) extends Nondetermini
     fail(e)
 
   def handleError[A](fa: Future[A])(f: Throwable => Future[A]): Future[A] =
-    fa.recoverWith(PartialFunction(f))
+    fa.recoverWith{case t => f(t)}
 }
 
 object scalaFuture extends FutureInstances


### PR DESCRIPTION
this was deprecated some time ago and will no longer exist
in Scala 2.13.0-M4

this came up over at https://github.com/scala/scala/pull/6319