### PR TITLE
Maybe.orError and \/.orRaiseError

### DIFF
--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -349,6 +349,11 @@ sealed abstract class \/[A, B] extends Product with Serializable {
       b => \&/.That(b)
     )
 
+  def orRaiseError[F[_]](implicit F: MonadError[F, A]): F[B] =
+    fold(
+      a => F.raiseError(a),
+      b => F.point(b)
+    )
 }
 
 /** A left disjunction

--- a/core/src/main/scala/scalaz/Maybe.scala
+++ b/core/src/main/scala/scalaz/Maybe.scala
@@ -147,6 +147,10 @@ sealed abstract class Maybe[A] {
    * empty value for type `F` */
   final def orEmpty[F[_]](implicit F: ApplicativePlus[F]): F[A] =
     cata(F.point(_), F.empty)
+
+  final def orError[F[_], E](e: E)(implicit F: MonadError[F, E]): F[A] =
+    cata(F.point(_), F.raiseError(e))
+
 }
 
 object Maybe extends MaybeInstances {


### PR DESCRIPTION
Maybe.orError, which is useful when wanting to flatten F[Maybe[A]] to an F[A] when operating inside a MonadError