### PR TITLE
remove the EitherT syntax

### DIFF
--- a/core/src/main/scala/scalaz/syntax/EitherTOps.scala
+++ b/core/src/main/scala/scalaz/syntax/EitherTOps.scala
@@ -1,13 +1,7 @@
 package scalaz
 package syntax
 
-import Leibniz.===
-
 final class EitherTOps[V](private val self: V) extends AnyVal {
-  // to avoid a name collision with EitherOps, we suffix T to these methods
-  def eitherT[F[_]: Applicative, A, B](implicit ev: V === (A \/ B)): EitherT[F, A, B] = EitherT.either(ev(self))
-  def leftT[F[_]: Applicative, B]: EitherT[F, V, B] = EitherT.left(self)
-  def rightT[F[_]: Applicative, A]: EitherT[F, A, V] = EitherT.right(self)
 }
 
 trait ToEitherTOps {

--- a/tests/src/test/scala/scalaz/EitherTTest.scala
+++ b/tests/src/test/scala/scalaz/EitherTTest.scala
@@ -58,21 +58,6 @@ object EitherTTest extends SpecLite {
     e must_=== EitherT.either(a)
   }
 
-  "eitherT, leftT, rightT syntax" ! forAll { (a: String \/ Int) =>
-    import scalaz.syntax.eithert._
-
-    val e = EitherT.eitherT(Option(a))
-
-    e must_=== {
-      a match {
-        case -\/(v) => v.leftT
-        case \/-(v) => v.rightT
-      }
-    }
-
-    e must_=== a.eitherT
-  }
-
   "flatMapF consistent with flatMap" ! forAll { (a: EitherTList[Int, Int], f: Int => List[Int \/ String]) =>
     a.flatMap(f andThen EitherT.apply) must_=== a.flatMapF(f)
   }


### PR DESCRIPTION
I regret adding this syntax in #1593

It is very confusing to have `.eitherT` direct to `EitherT.either` etc.

I'd really like to keep the syntax, but with different names. And I can't think of anything satisfactory.

Does anybody have any suggestions for the names? Or strong feelings to keep / delete?
