### PR TITLE
derivation of MonadError for isomorphic things

### DIFF
--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -495,9 +495,6 @@ sealed abstract class DisjunctionInstances1 extends DisjunctionInstances2 {
         case -\/(e) => f(e)
         case r => r
       }
-
-      override def emap[A, B](fa: L \/ A)(f: A => L \/ B): L \/ B =
-        bind(fa)(f)
     }
 }
 

--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -495,6 +495,9 @@ sealed abstract class DisjunctionInstances1 extends DisjunctionInstances2 {
         case -\/(e) => f(e)
         case r => r
       }
+
+      override def emap[A](fa: L \/ A)(f: A => L \/ A): L \/ A =
+        bind(fa)(f)
     }
 }
 

--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -496,7 +496,7 @@ sealed abstract class DisjunctionInstances1 extends DisjunctionInstances2 {
         case r => r
       }
 
-      override def emap[A](fa: L \/ A)(f: A => L \/ A): L \/ A =
+      override def emap[A, B](fa: L \/ A)(f: A => L \/ B): L \/ B =
         bind(fa)(f)
     }
 }

--- a/core/src/main/scala/scalaz/MonadError.scala
+++ b/core/src/main/scala/scalaz/MonadError.scala
@@ -11,7 +11,7 @@ trait MonadError[F[_], S] extends Monad[F] { self =>
   def raiseError[A](e: S): F[A]
   def handleError[A](fa: F[A])(f: S => F[A]): F[A]
 
-  def emap[A](fa: F[A])(f: A => S \/ A): F[A] =
+  def emap[A, B](fa: F[A])(f: A => S \/ B): F[B] =
     bind(fa)(a => f(a).fold(raiseError(_), pure(_)))
 
   trait MonadErrorLaw {

--- a/core/src/main/scala/scalaz/MonadError.scala
+++ b/core/src/main/scala/scalaz/MonadError.scala
@@ -11,6 +11,9 @@ trait MonadError[F[_], S] extends Monad[F] { self =>
   def raiseError[A](e: S): F[A]
   def handleError[A](fa: F[A])(f: S => F[A]): F[A]
 
+  def emap[A](fa: F[A])(f: A => S \/ A): F[A] =
+    bind(fa)(a => f(a).fold(raiseError(_), pure(_)))
+
   trait MonadErrorLaw {
     def raisedErrorsHandled[A](e: S, f: S => F[A])(implicit FEA: Equal[F[A]]): Boolean =
       FEA.equal(handleError(raiseError(e))(f), f(e))

--- a/core/src/main/scala/scalaz/MonadError.scala
+++ b/core/src/main/scala/scalaz/MonadError.scala
@@ -31,23 +31,11 @@ object MonadError {
   ////
   import Isomorphism.<~>
 
-  /**
-   * Derives a MonadError for something isomorphic to a thing with a MonadError.
-   */
-  def fromIsoWithMonadError[F[_], G[_], E](
-    D: F <~> G
-  )(
-    implicit ME: MonadError[G, E]
-  ): MonadError[F, E] = new MonadError[F, E] {
-    override def point[A](a: => A): F[A] =
-      D.from(ME.point(a))
-    override def raiseError[A](e: E): F[A] =
-      D.from(ME.raiseError(e))
-    override def bind[A, B](fa: F[A])(f: A => F[B]): F[B] =
-      D.from(ME.bind(D.to(fa))(a => D.to(f(a))))
-    override def handleError[A](fa: F[A])(f: E => F[A]): F[A] =
-      D.from(ME.handleError(D.to(fa))(a => D.to(f(a))))
-  }
+  def fromIso[F[_], G[_], E](D: F <~> G)(implicit ME: MonadError[G, E]): MonadError[F, E] =
+    new IsomorphismMonadError[F, G, E] {
+      override implicit def G: MonadError[G, E] = ME
+      override def iso: F <~> G = D
+    }
 
   ////
 }

--- a/core/src/main/scala/scalaz/MonadError.scala
+++ b/core/src/main/scala/scalaz/MonadError.scala
@@ -33,15 +33,15 @@ object MonadError {
   ////
 
   /**
-   * Derives a MonadError for something isomorphic to ReaderT, having an
-   * underlying MonadError. Useful for typeclasses with a covariant SAM, where
-   * In is the contravariant parameter and Out is the covariant parameter,
-   * errors as E. e.g. decoders from In to String \/ A.
+   * Derives a MonadError for something isomorphic to a thing with a MonadError.
+   * Useful for typeclasses with a covariant SAM, where In is the contravariant
+   * parameter and Out is the covariant parameter, errors as E. e.g. decoders
+   * from In to String \/ A.
    */
-  def fromIsoWithMonadError[F[_], In, Out[_], E](
-    D: F <~> ReaderT[Out, In, ?]
+  def fromIsoWithMonadError[F[_], G[_], E](
+    D: F <~> G
   )(
-    implicit ME: MonadError[ReaderT[Out, In, ?], E]
+    implicit ME: MonadError[G, E]
   ): MonadError[F, E] = new MonadError[F, E] {
     override def point[A](a: => A): F[A] =
       D.from(ME.point(a))

--- a/core/src/main/scala/scalaz/MonadError.scala
+++ b/core/src/main/scala/scalaz/MonadError.scala
@@ -34,9 +34,6 @@ object MonadError {
 
   /**
    * Derives a MonadError for something isomorphic to a thing with a MonadError.
-   * Useful for typeclasses with a covariant SAM, where In is the contravariant
-   * parameter and Out is the covariant parameter, errors as E. e.g. decoders
-   * from In to String \/ A.
    */
   def fromIsoWithMonadError[F[_], G[_], E](
     D: F <~> G

--- a/core/src/main/scala/scalaz/MonadError.scala
+++ b/core/src/main/scala/scalaz/MonadError.scala
@@ -11,9 +11,6 @@ trait MonadError[F[_], S] extends Monad[F] { self =>
   def raiseError[A](e: S): F[A]
   def handleError[A](fa: F[A])(f: S => F[A]): F[A]
 
-  def emap[A, B](fa: F[A])(f: A => S \/ B): F[B] =
-    bind(fa)(a => f(a).fold(raiseError(_), pure(_)))
-
   trait MonadErrorLaw {
     def raisedErrorsHandled[A](e: S, f: S => F[A])(implicit FEA: Equal[F[A]]): Boolean =
       FEA.equal(handleError(raiseError(e))(f), f(e))

--- a/core/src/main/scala/scalaz/MonadError.scala
+++ b/core/src/main/scala/scalaz/MonadError.scala
@@ -39,9 +39,9 @@ object MonadError {
    * errors as E. e.g. decoders from In to String \/ A.
    */
   def fromIsoWithMonadError[F[_], In, Out[_], E](
-      implicit
-      D: F <~> ReaderT[Out, In, ?],
-      ME: MonadError[ReaderT[Out, In, ?], E]
+    D: F <~> ReaderT[Out, In, ?]
+  )(
+    implicit ME: MonadError[ReaderT[Out, In, ?], E]
   ): MonadError[F, E] = new MonadError[F, E] {
     override def point[A](a: => A): F[A] =
       D.from(ME.point(a))

--- a/core/src/main/scala/scalaz/MonadError.scala
+++ b/core/src/main/scala/scalaz/MonadError.scala
@@ -1,5 +1,7 @@
 package scalaz
 
+import Isomorphism.<~>
+
 ////
 /**
  *
@@ -29,6 +31,27 @@ object MonadError {
   @inline def apply[F[_], S](implicit F: MonadError[F, S]): MonadError[F, S] = F
 
   ////
+
+  /**
+   * Derives a MonadError for something isomorphic to ReaderT, having an
+   * underlying MonadError. Useful for typeclasses with a covariant SAM, where
+   * In is the contravariant parameter and Out is the covariant parameter,
+   * errors as E. e.g. decoders from In to String \/ A.
+   */
+  def fromIsoWithMonadError[F[_], In, Out[_], E](
+      implicit
+      D: F <~> ReaderT[Out, In, ?],
+      ME: MonadError[ReaderT[Out, In, ?], E]
+  ): MonadError[F, E] = new MonadError[F, E] {
+    override def point[A](a: => A): F[A] =
+      D.from(ME.point(a))
+    override def raiseError[A](e: E): F[A] =
+      D.from(ME.raiseError(e))
+    override def bind[A, B](fa: F[A])(f: A => F[B]): F[B] =
+      D.from(ME.bind(D.to(fa))(a => D.to(f(a))))
+    override def handleError[A](fa: F[A])(f: E => F[A]): F[A] =
+      D.from(ME.handleError(D.to(fa))(a => D.to(f(a))))
+  }
 
   ////
 }

--- a/core/src/main/scala/scalaz/MonadError.scala
+++ b/core/src/main/scala/scalaz/MonadError.scala
@@ -1,7 +1,5 @@
 package scalaz
 
-import Isomorphism.<~>
-
 ////
 /**
  *
@@ -31,6 +29,7 @@ object MonadError {
   @inline def apply[F[_], S](implicit F: MonadError[F, S]): MonadError[F, S] = F
 
   ////
+  import Isomorphism.<~>
 
   /**
    * Derives a MonadError for something isomorphic to a thing with a MonadError.

--- a/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
@@ -8,7 +8,7 @@ final class MonadErrorOps[F[_], S, A] private[syntax](self: F[A])(implicit val F
     F.handleError(self)(f)
 
   final def emap(f: A => S \/ A): F[A] =
-    F.bind(self)(a => f(a).fold(F.raiseError(_), F.pure(_)))
+    F.emap(self)(f)
 
   ////
 }

--- a/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
@@ -7,6 +7,9 @@ final class MonadErrorOps[F[_], S, A] private[syntax](self: F[A])(implicit val F
   final def handleError(f: S => F[A]): F[A] =
     F.handleError(self)(f)
 
+  final def emap(f: A => S \/ A): F[A] =
+    F.bind(self)(a => f(a).fold(F.raiseError(_), F.pure(_)))
+
   ////
 }
 

--- a/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
@@ -7,7 +7,7 @@ final class MonadErrorOps[F[_], S, A] private[syntax](self: F[A])(implicit val F
   final def handleError(f: S => F[A]): F[A] =
     F.handleError(self)(f)
 
-  final def emap(f: A => S \/ A): F[A] =
+  final def emap[B](f: A => S \/ B): F[B] =
     F.emap(self)(f)
 
   ////

--- a/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
@@ -8,7 +8,7 @@ final class MonadErrorOps[F[_], S, A] private[syntax](self: F[A])(implicit val F
     F.handleError(self)(f)
 
   final def emap[B](f: A => S \/ B): F[B] =
-    F.emap(self)(f)
+    F.bind(self)(a => f(a).fold(F.raiseError(_), F.pure(_)))
 
   ////
 }

--- a/project/build.scala
+++ b/project/build.scala
@@ -306,9 +306,7 @@ object build {
       mimaBinaryIssueFilters ++= {
         import com.typesafe.tools.mima.core._
         import com.typesafe.tools.mima.core.ProblemFilters._
-        Seq(
-          exclude[ReversedMissingMethodProblem]("scalaz.MonadError.emap")
-        )
+        Nil
       },
       name := "scalaz-core",
       sourceGenerators in Compile += (sourceManaged in Compile).map{

--- a/project/build.scala
+++ b/project/build.scala
@@ -19,7 +19,7 @@ import com.typesafe.sbt.osgi.SbtOsgi._
 import sbtbuildinfo.BuildInfoPlugin.autoImport._
 
 import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
-import com.typesafe.tools.mima.plugin.MimaKeys.mimaPreviousArtifacts
+import com.typesafe.tools.mima.plugin.MimaKeys.{mimaPreviousArtifacts, mimaBinaryIssueFilters}
 
 import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 import scalanative.sbtplugin.ScalaNativePlugin.autoImport._
@@ -303,6 +303,13 @@ object build {
   lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform).crossType(ScalazCrossType)
     .settings(standardSettings)
     .settings(
+      mimaBinaryIssueFilters ++= {
+        import com.typesafe.tools.mima.core._
+        import com.typesafe.tools.mima.core.ProblemFilters._
+        Seq(
+          exclude[ReversedMissingMethodProblem]("scalaz.MonadError.emap")
+        )
+      },
       name := "scalaz-core",
       sourceGenerators in Compile += (sourceManaged in Compile).map{
         dir => Seq(GenerateTupleW(dir), TupleNInstances(dir))

--- a/tests/src/test/scala/scalaz/MonadErrorTest.scala
+++ b/tests/src/test/scala/scalaz/MonadErrorTest.scala
@@ -35,11 +35,12 @@ object MonadErrorTest extends SpecLite {
   }
 
   "emap syntax" in {
-    def f(s: String): String \/ String =
-      if (s.startsWith("h")) "fail".left else s.right
+    def f(s: String): String \/ Char =
+      if (s.length == 1) s(0).right
+      else s"not a char: $s".left
 
-    Decoder[String].emap(f).decode("hello") must_=== "fail".left
-    Decoder[String].emap(f).decode("goodbye") must_=== "goodbye".right
+    Decoder[String].emap(f).decode("hello") must_=== "not a char: hello".left
+    Decoder[String].emap(f).decode("g") must_=== 'g'.right
   }
 
 }

--- a/tests/src/test/scala/scalaz/MonadErrorTest.scala
+++ b/tests/src/test/scala/scalaz/MonadErrorTest.scala
@@ -2,7 +2,7 @@ package scalaz
 
 import std.AllInstances._
 import syntax.either._
-import syntax.functor._
+import syntax.monadError._
 import Isomorphism.{ <~>, IsoFunctorTemplate }
 
 object MonadErrorTest extends SpecLite {
@@ -33,6 +33,14 @@ object MonadErrorTest extends SpecLite {
 
   "fromIsoWithMonadError" in {
     Decoder[String].map(_.toUpperCase).decode("hello") must_=== "HELLO".right
+  }
+
+  "emap syntax" in {
+    def f(s: String): String \/ String =
+      if (s.startsWith("h")) "fail".left else s.right
+
+    Decoder[String].emap(f).decode("hello") must_=== "fail".left
+    Decoder[String].emap(f).decode("goodbye") must_=== "goodbye".right
   }
 
 }

--- a/tests/src/test/scala/scalaz/MonadErrorTest.scala
+++ b/tests/src/test/scala/scalaz/MonadErrorTest.scala
@@ -27,8 +27,7 @@ object MonadErrorTest extends SpecLite {
         def to[A](fa: Decoder[A]) = ReaderT[Out, String, A](fa.decode)
       }
 
-    implicit val monad: MonadError[Decoder, String] =
-      MonadError.fromIsoWithMonadError(isoReaderT)
+    implicit val monad: MonadError[Decoder, String] = MonadError.fromIso(isoReaderT)
   }
 
   "fromIsoWithMonadError" in {

--- a/tests/src/test/scala/scalaz/MonadErrorTest.scala
+++ b/tests/src/test/scala/scalaz/MonadErrorTest.scala
@@ -1,0 +1,37 @@
+package scalaz
+
+import std.AllInstances._
+import syntax.either._
+import syntax.functor._
+import Isomorphism.{ <~>, IsoFunctorTemplate }
+
+object MonadErrorTest extends SpecLite {
+
+  trait Decoder[A] {
+    def decode(s: String): String \/ A
+  }
+  object Decoder {
+    type Out[a] = String \/ a
+
+    @inline def apply[A](implicit A: Decoder[A]): Decoder[A] = A
+    @inline def instance[A](f: String => String \/ A): Decoder[A] = new Decoder[A] {
+      override def decode(s: String): String \/ A = f(s)
+    }
+
+    implicit val string: Decoder[String] = instance(_.right)
+
+    implicit val isoReaderT: Decoder <~> ReaderT[Out, String, ?] =
+      new IsoFunctorTemplate[Decoder, ReaderT[Out, String, ?]] {
+        def from[A](fa: ReaderT[Out, String, A]) = instance(fa.run(_))
+        def to[A](fa: Decoder[A]) = ReaderT[Out, String, A](fa.decode)
+      }
+
+    implicit val monad: MonadError[Decoder, String] =
+      MonadError.fromIsoWithMonadError[Decoder, String, Out, String]
+  }
+
+  "fromIsoWithMonadError" in {
+    Decoder[String].map(_.toUpperCase).decode("hello") must_=== "HELLO".right
+  }
+
+}

--- a/tests/src/test/scala/scalaz/MonadErrorTest.scala
+++ b/tests/src/test/scala/scalaz/MonadErrorTest.scala
@@ -27,7 +27,7 @@ object MonadErrorTest extends SpecLite {
       }
 
     implicit val monad: MonadError[Decoder, String] =
-      MonadError.fromIsoWithMonadError[Decoder, String, Out, String]
+      MonadError.fromIsoWithMonadError[Decoder, String, Out, String](isoReaderT)
   }
 
   "fromIsoWithMonadError" in {


### PR DESCRIPTION
and some nice extra syntax

motivated by https://github.com/fthomas/refined/pull/447

can be used to provide a `MonadError` for typeclasses that only have type parameters in covariant position, giving us `.map`, `.emap` and more for free.

I'd like to test the MonadError laws on this derived instance... could somebody please help me do that?