### PR TITLE
add an `unused` annotation

### DIFF
--- a/core/src/main/scala/scalaz/unused.scala
+++ b/core/src/main/scala/scalaz/unused.scala
@@ -1,0 +1,9 @@
+package scalaz
+
+/**
+ * Mark an explicit or implicit parameter as known to be unused, as shorthand
+ * for the longer form, useful in combination with
+ * `-Ywarn-unused:explicits,implicits` compiler options.
+ */
+class unused extends deprecated("unused", "")
+


### PR DESCRIPTION
#1669 

as in https://github.com/scala/bug/issues/10790

```scalaz
class unused extends deprecated("unused", "")
```

so we can turn on unused warnings in the build, with an easy way to opt out on a per-parameter basis.

Seems like a nice lint for us to have, and very useful to have as a dependency.

I'm not sure what the binary compatibility implications are for adding annotations to parameters.