### PR TITLE
Add a "by-name" variant of Endo

### DIFF
--- a/core/src/main/scala/scalaz/Bifoldable.scala
+++ b/core/src/main/scala/scalaz/Bifoldable.scala
@@ -107,7 +107,7 @@ object Bifoldable {
    */
   trait FromBifoldMap[F[_, _]] extends Bifoldable[F] {
     override def bifoldRight[A,B,C](fa: F[A, B], z: => C)(f: (A, => C) => C)(g: (B, => C) => C) =
-      bifoldMap(fa)((a: A) => (Endo.endo(f(a, _: C))))((b: B) => (Endo.endo(g(b, _: C)))) apply z
+      bifoldMap(fa)((a: A) => Endo.endoByName[C](f(a, _)))((b: B) => Endo.endoByName[C](g(b, _))) apply z
   }
 
   /**

--- a/core/src/main/scala/scalaz/Bitraverse.scala
+++ b/core/src/main/scala/scalaz/Bitraverse.scala
@@ -104,7 +104,7 @@ trait Bitraverse[F[_, _]] extends Bifunctor[F] with Bifoldable[F] { self =>
     bifoldLShape(fa, F.zero)((m, a) => F.append(m, f(a)))((m, b) => F.append(m, g(b)))._1
 
   def bifoldRight[A,B,C](fa: F[A, B], z: => C)(f: (A, => C) => C)(g: (B, => C) => C): C =
-    bifoldMap(fa)((a: A) => (Endo.endo(f(a, _: C))))((b: B) => (Endo.endo(g(b, _: C)))) apply z
+    bifoldMap(fa)((a: A) => Endo.endoByName[C](f(a, _)))((b: B) => Endo.endoByName[C](g(b, _))) apply z
 
   /** Embed a Traverse on each side of this Bitraverse . */
   def embed[G[_],H[_]](implicit G0: Traverse[G], H0: Traverse[H]): Bitraverse[λ[(α, β) => F[G[α], H[β]]]] =

--- a/core/src/main/scala/scalaz/Endo.scala
+++ b/core/src/main/scala/scalaz/Endo.scala
@@ -15,15 +15,39 @@ final case class Endo[A](run: A => A) {
   final def andThen(other: Endo[A]): Endo[A] = other compose this
 }
 
+/** Endomorphisms using by-name evaluation.  They have special properties among functions, so
+  * are captured in this newtype.
+  *
+  * @param run The captured function.
+  */
+final case class EndoByName[A](run: (=>A) => A) {
+  final def apply(a: => A): A = run(a)
+
+  /** Do `other`, than call myself with its result. */
+  final def compose(other: => EndoByName[A]): EndoByName[A] = EndoByName(x => run(other.run(x)))
+
+  /** Call `other` with my result. */
+  final def andThen(other: EndoByName[A]): EndoByName[A] = other compose this
+}
+
 object Endo extends EndoInstances {
   /** Alias for `Endo.apply`. */
   final def endo[A](f: A => A): Endo[A] = Endo(f)
 
+  /** Alias for `EndoByName.apply`. */
+  final def endoByName[A](f: (=>A) => A): EndoByName[A] = EndoByName(f)
+
   /** Always yield `a`. */
   final def constantEndo[A](a: => A): Endo[A] = endo[A](_ => a)
 
+  /** Always yield `a`. */
+  final def constantEndoByName[A](a: => A): EndoByName[A] = EndoByName(_ => a)
+
   /** Alias for `Monoid[Endo[A]].zero`. */
   final def idEndo[A]: Endo[A] = endo[A](a => a)
+
+  /** Alias for `Monoid[EndoByName[A]].zero`. */
+  final def idEndoByName[A]: EndoByName[A] = EndoByName[A](a => a)
 
   import Isomorphism.{IsoSet, IsoFunctorTemplate}
 
@@ -37,6 +61,8 @@ object Endo extends EndoInstances {
     def from[A](ga: A => A): Endo[A] = endo(ga)
   }
 }
+
+object EndoByName extends EndoByNameInstances
 
 sealed abstract class EndoInstances {
 
@@ -58,5 +84,29 @@ sealed abstract class EndoInstances {
     // CAUTION: cheats with null
     def unzip[A, B](a: Endo[(A, B)]) =
       (Endo(x => a((x, null.asInstanceOf[B]))._1), Endo(x => a((null.asInstanceOf[A], x))._2))
+  }
+}
+
+
+sealed abstract class EndoByNameInstances {
+
+  /** Endo forms a monoid where `zero` is the identity endomorphism
+    * and `append` composes the underlying functions. */
+  implicit def endoInstance[A]: Monoid[EndoByName[A]] = new Monoid[EndoByName[A]] {
+    def append(f1: EndoByName[A], f2: => EndoByName[A]) = f1 compose f2
+    def zero = Endo.idEndoByName
+  }
+  implicit val endoInstances: Zip[EndoByName] with Unzip[EndoByName] with InvariantFunctor[EndoByName] = new Zip[EndoByName] with Unzip[EndoByName] with InvariantFunctor[EndoByName] {
+    def xmap[A, B](fa: EndoByName[A], f: A => B, g: B => A) =
+      Endo.endoByName(a => f(fa(g(a))))
+
+    def zip[A, B](a: => EndoByName[A], b: => EndoByName[B]) =
+      EndoByName {
+        case (x, y) => (a(x), b(y))
+      }
+
+    // CAUTION: cheats with null
+    def unzip[A, B](a: EndoByName[(A, B)]) =
+      (EndoByName(x => a((x, null.asInstanceOf[B]))._1), EndoByName(x => a((null.asInstanceOf[A], x))._2))
   }
 }

--- a/core/src/main/scala/scalaz/FingerTree.scala
+++ b/core/src/main/scala/scalaz/FingerTree.scala
@@ -44,7 +44,7 @@ sealed abstract class FingerTree[V, A](implicit measurer: Reducer[A, V], monoid:
       s.append(s.append(pr.foldMap(f), m.foldMap(x => x.foldMap(f))), sf.foldMap(f)))
 
   def foldRight[B](z: => B)(f: (A, => B) => B): B = {
-    foldMap((a: A) => (Endo.endo(f(a, _: B)))) apply z
+    foldMap(a => Endo.endoByName[B](f(a, _))).apply(z)
   }
 
   def foldLeft[B](b: B)(f: (B, A) => B): B = {
@@ -574,7 +574,7 @@ sealed abstract class FingerTreeInstances {
     new Foldable[Node[V, ?]] {
       def foldMap[A, M: Monoid](t: Node[V, A])(f: A => M): M = t foldMap f
       def foldRight[A, B](v: Node[V, A], z: => B)(f: (A, => B) => B): B =
-         foldMap(v)((a: A) => (Endo.endo(f.curried(a)(_: B)))) apply z
+         foldMap(v)((a: A) => Endo.endoByName[B](f(a, _))) apply z
     }
 
   implicit def fingerTreeFoldable[V]: Foldable[FingerTree[V, ?]] =

--- a/core/src/main/scala/scalaz/Foldable.scala
+++ b/core/src/main/scala/scalaz/Foldable.scala
@@ -421,17 +421,17 @@ object Foldable {
    */
   trait FromFoldMap[F[_]] extends Foldable[F] {
     override def foldRight[A, B](fa: F[A], z: => B)(f: (A, => B) => B) =
-      foldMap(fa)((a: A) => (Endo.endo(f(a, _: B)))) apply z
+      foldMap(fa)((a: A) => Endo.endoByName[B](f(a, _))) apply z
   }
 
   /**
-   * Template trait to define `Foldable` in terms of `foldr`
+   * Template trait to define `Foldable` in terms of `foldRight`
    *
    * Example:
    * {{{
    * new Foldable[Option] with Foldable.FromFoldr[Option] {
-   *   def foldr[A, B](fa: Option[A], z: B)(f: (A) => (=> B) => B) = fa match {
-   *     case Some(a) => f(a)(z)
+   *   def foldRight[A, B](fa: Option[A], z: B)(f: (A, => B) => B) = fa match {
+   *     case Some(a) => f(a, z)
    *     case None => z
    *   }
    * }
@@ -439,7 +439,7 @@ object Foldable {
    */
   trait FromFoldr[F[_]] extends Foldable[F] {
     override def foldMap[A, B](fa: F[A])(f: A => B)(implicit F: Monoid[B]) =
-        foldr[A, B](fa, F.zero)( x => y => F.append(f(x),  y))
+      foldRight[A, B](fa, F.zero)((x, y) => F.append(f(x),  y))
   }
 
   ////

--- a/core/src/main/scala/scalaz/Traverse.scala
+++ b/core/src/main/scala/scalaz/Traverse.scala
@@ -119,7 +119,7 @@ trait Traverse[F[_]] extends Functor[F] with Foldable[F] { self =>
   def foldMap[A,B](fa: F[A])(f: A => B)(implicit F: Monoid[B]): B = foldLShape(fa, F.zero)((b, a) => F.append(b, f(a)))._1
 
   override def foldRight[A, B](fa: F[A], z: => B)(f: (A, => B) => B) =
-    foldMap(fa)((a: A) => (Endo.endo(f(a, _: B)))) apply z
+    foldMap(fa)((a: A) => Endo.endoByName[B](f(a, _))) apply z
 
   def reverse[A](fa: F[A]): F[A] = {
     val (as, shape) = mapAccumL(fa, scala.List[A]())((t,h) => (h :: t,h))

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
@@ -235,6 +235,9 @@ object ScalazArbitrary extends ScalazArbitraryPlatform {
   implicit def endoArb[A](implicit A: Arbitrary[A => A]): Arbitrary[Endo[A]] =
     Functor[Arbitrary].map(A)(Endo.endo)
 
+  implicit def endoByNameArb[A](implicit A: Arbitrary[A => A]): Arbitrary[EndoByName[A]] =
+    Functor[Arbitrary].map(A)(f => Endo.endoByName(f(_)))
+
   implicit def endomorphicArbitrary[F[_, _], A](implicit F: Arbitrary[F[A, A]]): Arbitrary[Endomorphic[F, A]] =
     Functor[Arbitrary].map(F)(Endomorphic[F, A](_))
 

--- a/tests/src/test/scala/scalaz/EndoTest.scala
+++ b/tests/src/test/scala/scalaz/EndoTest.scala
@@ -10,6 +10,13 @@ object EndoTest extends SpecLite {
       Iterator.fill(20)(util.Random.nextInt).forall(n => a(n) == b(n))
     )
 
+  implicit val endoByNameIntEqual: Equal[EndoByName[Int]] =
+    Equal.equal( (a, b) =>
+      Iterator.fill(20)(util.Random.nextInt).forall(n => a(n) == b(n))
+    )
+
   checkAll(invariantFunctor.laws[Endo])
+
+  checkAll(invariantFunctor.laws[EndoByName])
 
 }


### PR DESCRIPTION
 and use it when implementing `foldRight` in term of `foldMap`, so that "by-name" evaluation semantic is preserved, potentially avoiding stack overflows.