### PR TITLE
Reducer: support unfolds without needing a monoid.

### DIFF
--- a/core/src/main/scala/scalaz/syntax/ReducerOps.scala
+++ b/core/src/main/scala/scalaz/syntax/ReducerOps.scala
@@ -23,7 +23,7 @@ final class ReducerOps[A](private val self: A) extends AnyVal {
     * }}}
     */
   def unfoldl[C](f: A => Maybe[(A, C)]): UnfoldTo[C] = new UnfoldTo[C] {
-    def reduceTo[M: Monoid](implicit r:  Reducer[C, M]): M = r.unfoldl(self)(f)
+    def reduceToOpt[M](implicit r: Reducer[C, M]): Maybe[M] = r.unfoldlOpt(self)(f)
   }
 
   /** Unfold to the right using this value as initial seed
@@ -34,7 +34,7 @@ final class ReducerOps[A](private val self: A) extends AnyVal {
     * }}}
     */
   def unfoldr[C](f: A => Maybe[(C, A)]): UnfoldTo[C] = new UnfoldTo[C] {
-    def reduceTo[M: Monoid](implicit r:  Reducer[C, M]): M = r.unfoldr(self)(f)
+    def reduceToOpt[M](implicit r: Reducer[C, M]): Maybe[M] = r.unfoldrOpt(self)(f)
   }
 }
 
@@ -45,8 +45,10 @@ trait ToReducerOps {
 object ReducerOps {
 
   sealed abstract class UnfoldTo[C] {
-    def reduceTo[M: Monoid](implicit r: Reducer[C, M]): M
+    def reduceToOpt[M](implicit r: Reducer[C, M]): Maybe[M]
+    def reduceTo[M: Monoid](implicit r: Reducer[C, M]): M = reduceToOpt[M] getOrElse Monoid[M].zero
 
     final def to[M[_]](implicit r: Reducer[C, M[C]], m: Monoid[M[C]]): M[C] = reduceTo[M[C]]
+    final def toOpt[M[_]](implicit r: Reducer[C, M[C]]): Maybe[M[C]] = reduceToOpt[M[C]]
   }
 }


### PR DESCRIPTION
 - Added `unfoldlOpt`, `unfoldrOpt`: unfolds that don't require monoid.
 - Removed `final` modifier from `unfoldl`.