### PR TITLE
Unfolds and early termination

### DIFF
--- a/core/src/main/scala/scalaz/Maybe.scala
+++ b/core/src/main/scala/scalaz/Maybe.scala
@@ -323,6 +323,21 @@ sealed abstract class MaybeInstances extends MaybeInstances0 {
 
       def plus[A](a: Maybe[A], b: => Maybe[A]) = a orElse b
 
+      override def unfoldrPsumOpt[S, A](seed: S)(f: S => Maybe[(Maybe[A], S)]): Maybe[Maybe[A]] = {
+        @scala.annotation.tailrec
+        def go(s: S): Maybe[A] = f(s) match {
+          case Just((ma, s)) => ma match {
+            case a @ Just(_) => a
+            case _ => go(s)
+          }
+          case Empty() => Empty()
+        }
+        f(seed) map { case (ma, s) => ma match {
+          case a @ Just(_) => a
+          case Empty() => go(s)
+        }}
+      }
+
       override def foldRight[A, B](fa: Maybe[A], z: => B)(f: (A, => B) => B) =
         fa.cata(f(_, z), z)
 

--- a/core/src/main/scala/scalaz/Monoid.scala
+++ b/core/src/main/scala/scalaz/Monoid.scala
@@ -44,6 +44,12 @@ trait Monoid[F] extends Semigroup[F] { self =>
   final def onEmpty[A,B](a: F)(v: => B)(implicit eq: Equal[F], mb: Monoid[B]): B =
     ifEmpty(a)(v)(mb.zero)
 
+  def unfoldlSum[S](seed: S)(f: S => Maybe[(S, F)]): F =
+    unfoldlSumOpt(seed)(f) getOrElse zero
+
+  def unfoldrSum[S](seed: S)(f: S => Maybe[(F, S)]): F =
+    unfoldrSumOpt(seed)(f) getOrElse zero
+
   /** Every `Monoid` gives rise to a [[scalaz.Category]], for which
     * the type parameters are phantoms.
     *

--- a/core/src/main/scala/scalaz/Plus.scala
+++ b/core/src/main/scala/scalaz/Plus.scala
@@ -1,12 +1,44 @@
 package scalaz
 
 ////
+import scala.annotation.tailrec
+import scalaz.Maybe.Just
+
 /**
  * Universally quantified [[scalaz.Semigroup]].
  */
 ////
 trait Plus[F[_]]  { self =>
   ////
+
+  def plus[A](a: F[A], b: => F[A]): F[A]
+
+  /**
+   * Unfold `seed` to the left and sum using [[#plus]].
+   * `Plus` instances with right absorbing elements may override this method
+   * to not unfold more than is necessary to determine the result.
+   */
+  def unfoldlPsumOpt[S, A](seed: S)(f: S => Maybe[(S, F[A])]): Maybe[F[A]] = {
+    @tailrec def go(s: S, acc: F[A]): F[A] = f(s) match {
+      case Just((s, fa)) => go(s, plus(fa, acc))
+      case _ => acc
+    }
+    f(seed) map { case (s, a) => go(s, a) }
+  }
+
+  /**
+   * Unfold `seed` to the right and sum using [[#plus]].
+   * `Plus` instances with left absorbing elements may override this method
+   * to not unfold more than is necessary to determine the result.
+   */
+  def unfoldrPsumOpt[S, A](seed: S)(f: S => Maybe[(F[A], S)]): Maybe[F[A]] = {
+    @tailrec def go(acc: F[A], s: S): F[A] = f(s) match {
+      case Just((fa, s)) => go(plus(acc, fa), s)
+      case _ => acc
+    }
+    f(seed) map { case (a, s) => go(a, s) }
+  }
+
 
   /**The composition of Plus `F` and `G`, `[x]F[G[x]]`, is a Plus */
   def compose[G[_]]: Plus[λ[α => F[G[α]]]] =
@@ -21,10 +53,14 @@ trait Plus[F[_]]  { self =>
       implicit def G = G0
     }
 
-  def plus[A](a: F[A], b: => F[A]): F[A]
-
   def semigroup[A]: Semigroup[F[A]] = new Semigroup[F[A]] {
     def append(f1: F[A], f2: => F[A]): F[A] = plus(f1, f2)
+
+    override def unfoldlSumOpt[S](seed: S)(f: S => Maybe[(S, F[A])]): Maybe[F[A]] =
+      unfoldlPsumOpt(seed)(f)
+
+    override def unfoldrSumOpt[S](seed: S)(f: S => Maybe[(F[A], S)]): Maybe[F[A]] =
+      unfoldrPsumOpt(seed)(f)
   }
 
   trait PlusLaw {

--- a/core/src/main/scala/scalaz/PlusEmpty.scala
+++ b/core/src/main/scala/scalaz/PlusEmpty.scala
@@ -9,6 +9,12 @@ trait PlusEmpty[F[_]] extends Plus[F] { self =>
   ////
   def empty[A]: F[A]
 
+  def unfoldlPsum[S, A](seed: S)(f: S => Maybe[(S, F[A])]): F[A] =
+    unfoldlPsumOpt(seed)(f) getOrElse empty
+
+  def unfoldrPsum[S, A](seed: S)(f: S => Maybe[(F[A], S)]): F[A] =
+    unfoldrPsumOpt(seed)(f) getOrElse empty
+
   /**The composition of PlusEmpty `F` and `G`, `[x]F[G[x]]`, is a PlusEmpty */
   override def compose[G[_]]: PlusEmpty[λ[α => F[G[α]]]] =
     new CompositionPlusEmpty[F, G] {
@@ -28,6 +34,9 @@ trait PlusEmpty[F[_]] extends Plus[F] { self =>
     new Monoid[F[A]] {
       def append(f1: F[A], f2: => F[A]): F[A] = plus(f1, f2)
       def zero: F[A] = empty[A]
+
+      override def unfoldlSum[S](seed: S)(f: S => Maybe[(S, F[A])]): F[A] = unfoldlPsum(seed)(f)
+      override def unfoldrSum[S](seed: S)(f: S => Maybe[(F[A], S)]): F[A] = unfoldrPsum(seed)(f)
     }
 
   trait EmptyLaw extends PlusLaw {

--- a/core/src/main/scala/scalaz/std/AnyVal.scala
+++ b/core/src/main/scala/scalaz/std/AnyVal.scala
@@ -305,7 +305,7 @@ trait AnyValInstances {
 
     def order(a1: Int @@ Multiplication, a2: Int @@ Multiplication) = Order[Int].order(Tag.unwrap(a1), Tag.unwrap(a2))
 
-    override def unfoldlSum[S](s: S)(f: S => Maybe[(S, Int @@ Multiplication)]) = {
+    override def unfoldlSumOpt[S](s: S)(f: S => Maybe[(S, Int @@ Multiplication)]) = {
       val f0 = Multiplication.unsubst[λ[x => S => Maybe[(S, x)]], Int](f)
 
       @tailrec def go(s: S, acc: Int): Int =
@@ -315,11 +315,11 @@ trait AnyValInstances {
           case _ => acc
         }
 
-      Multiplication(f0(s) map { case (s, i) => go(s, i) } getOrElse 1)
+      f0(s) map { case (s, i) => Multiplication(go(s, i)) }
     }
 
-    override def unfoldrSum[S](s: S)(f: S => Maybe[(Int @@ Multiplication, S)]) =
-      unfoldlSum[S](s)(f(_) map (_.swap))
+    override def unfoldrSumOpt[S](s: S)(f: S => Maybe[(Int @@ Multiplication, S)]) =
+      unfoldlSumOpt[S](s)(f(_) map (_.swap))
   }
 
   implicit val longInstance: Monoid[Long] with Enum[Long] with Show[Long] = new Monoid[Long] with Enum[Long] with Show[Long] {

--- a/core/src/main/scala/scalaz/std/Stream.scala
+++ b/core/src/main/scala/scalaz/std/Stream.scala
@@ -38,7 +38,10 @@ trait StreamInstances {
     }
 
     override def foldMap[A, B](fa: Stream[A])(f: A => B)(implicit M: Monoid[B]) =
-      this.foldRight(fa, M.zero)((a, b) => M.append(f(a), b))
+      M.unfoldrSum(fa)(as => as.headOption match {
+        case Some(a) => Maybe.just((f(a), as.tail))
+        case None => Maybe.empty
+      })
 
     override def foldMap1Opt[A, B](fa: Stream[A])(f: A => B)(implicit B: Semigroup[B]) =
       foldMapRight1Opt(fa)(f)((l, r) => B.append(f(l), r))

--- a/core/src/main/scala/scalaz/syntax/FoldableSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/FoldableSyntax.scala
@@ -81,11 +81,14 @@ final class FoldableOps[F[_],A] private[syntax](val self: F[A])(implicit val F: 
   final def sequence_[G[_], B](implicit ev: A === G[B], G: Applicative[G]): G[Unit] = F.sequence_(ev.subst[F](self))(G)
   final def sequenceS_[S, B](implicit ev: A === State[S,B]): State[S,Unit] = F.sequenceS_(ev.subst[F](self))
   def sequenceF_[M[_],B](implicit ev: F[A] <~< F[Free[M,B]]): Free[M, Unit] = F.sequenceF_(ev(self))
-  final def msuml[G[_], B](implicit ev: A === G[B], G: PlusEmpty[G]): G[B] = F.msuml(ev.subst[F](self))
-  final def msumlU(implicit G: Unapply[PlusEmpty, A]): G.M[G.A] = F.msumlU(self)
   final def asum[G[_], B](implicit ev: A === G[B], G: PlusEmpty[G]): G[B] = F.asum(ev.subst[F](self))(G)
   final def psum[G[_], B](implicit ev: A === G[B], G: PlusEmpty[G]): G[B] = F.psum(ev.subst[F](self))(G)
   final def psumMap[G[_], B](f: A => G[B])(implicit G: PlusEmpty[G]): G[B] = F.psumMap(self)(f)(G)
+
+  @deprecated("use psum", "7.3.0")
+  final def msuml[G[_], B](implicit ev: A === G[B], G: PlusEmpty[G]): G[B] = F.msuml(ev.subst[F](self))
+  @deprecated("use psum", "7.3.0")
+  final def msumlU(implicit G: Unapply[PlusEmpty, A]): G.M[G.A] = F.msumlU(self)
   ////
 }
 

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazProperties.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazProperties.scala
@@ -88,11 +88,21 @@ object ScalazProperties {
   }
 
   object semigroup {
+    import ScalazArbitrary.Arbitrary_Maybe
+
     def associative[A](implicit A: Semigroup[A], eqa: Equal[A], arb: Arbitrary[A]): Prop = forAll(A.semigroupLaw.associative _)
+
+    def unfoldlSumOptConsistency[A, S](implicit A: Semigroup[A], eqa: Equal[A], aa: Arbitrary[A], as: Arbitrary[S], cs: Cogen[S]): Prop =
+      forAll(A.semigroupLaw.unfoldlSumOptConsistency[S] _)
+
+    def unfoldrSumOptConsistency[A, S](implicit A: Semigroup[A], eqa: Equal[A], aa: Arbitrary[A], as: Arbitrary[S], cs: Cogen[S]): Prop =
+      forAll(A.semigroupLaw.unfoldrSumOptConsistency[S] _)
 
     def laws[A](implicit A: Semigroup[A], eqa: Equal[A], arb: Arbitrary[A]): Properties =
       newProperties("semigroup") { p =>
         p.property("associative") = associative[A]
+        p.property("unfoldlSumOpt consistency") = unfoldlSumOptConsistency[A, Int]
+        p.property("unfoldrSumOpt consistency") = unfoldrSumOptConsistency[A, Int]
       }
   }
 

--- a/tests/src/test/scala/scalaz/MaybeTests.scala
+++ b/tests/src/test/scala/scalaz/MaybeTests.scala
@@ -102,6 +102,18 @@ object MaybeTest extends SpecLite {
 
   "fromNullable(notNull) is just" ! forAll { (s: String) => Maybe.fromNullable(s) must_=== just(s) }
 
+  "Maybe addition should terminate when encountering the first Just" in {
+    val P = PlusEmpty[Maybe]
+
+    val f: Int => Maybe[(Maybe[String], Int)] = i => {
+      if (i > 0) just((Maybe.empty, i-1))
+      else if (i == 0) just((just("Stop"), i-1))
+      else sys.error("BOOM!")
+    }
+
+    P.unfoldrPsum(5)(f) must_=== Just("Stop")
+  }
+
   object instances {
     def equal[A: Equal] = Equal[Maybe[A]]
     def order[A: Order] = Order[Maybe[A]]

--- a/tests/src/test/scala/scalaz/ReducerTest.scala
+++ b/tests/src/test/scala/scalaz/ReducerTest.scala
@@ -2,6 +2,7 @@ package scalaz
 
 import scalaz.Tags._
 import scalaz.std.AllInstances._
+import scalaz.syntax.contravariant._
 import scalaz.scalacheck.ScalazArbitrary._
 import scalaz.scalacheck.ScalazProperties.reducer
 
@@ -26,4 +27,35 @@ object ReducerTest extends SpecLite {
   checkAll(reducer.laws[Option[Int], Option[Int] @@ First])
   checkAll(reducer.laws[Int, Option[Int] @@ Last])
   checkAll(reducer.laws[Option[Int], Option[Int] @@ Last])
+
+
+  "Int multiplication should terminate when encountering 0" in {
+    val R = implicitly[Reducer[Int, Int @@ Multiplication]]
+    implicit val S: Show[Int @@ Multiplication] = Show[Int].contramap(Tag.unwrap)
+
+    val f: Int => Maybe[(Int, Int)] = i => {
+      if(i >= 0) Maybe.just((i-1, i))
+      else sys.error("BOOM!")
+    }
+    val g = (i: Int) => f(i) map (_.swap)
+
+    R.unfoldl(5)(f) must_=== Multiplication(0)
+    R.unfoldr(5)(g) must_=== Multiplication(0)
+  }
+
+  "conjunction should terminate when encountering false" in {
+    val R = implicitly[Reducer[Boolean, Boolean @@ Conjunction]]
+    implicit val S: Show[Boolean @@ Conjunction] = Show[Boolean].contramap(Tag.unwrap)
+
+    val f: Int => Maybe[(Int, Boolean)] = i => {
+      if(i > 0) Maybe.just((i-1, true))
+      else if(i == 0) Maybe.just((i-1, false))
+      else sys.error("BOOM!")
+    }
+    val g = (i: Int) => f(i) map (_.swap)
+
+    R.unfoldl(5)(f) must_=== Conjunction(false)
+    R.unfoldr(5)(g) must_=== Conjunction(false)
+  }
+
 }

--- a/tests/src/test/scala/scalaz/std/AnyValTest.scala
+++ b/tests/src/test/scala/scalaz/std/AnyValTest.scala
@@ -38,6 +38,11 @@ object AnyValTest extends SpecLite {
     checkAll("Boolean", monoid.laws[Boolean])
   }
 
+  {
+    implicit val B = std.anyVal.booleanInstance.disjunction
+    checkAll("Boolean", monoid.laws[Boolean])
+  }
+
   checkAll("Int @@ Multiplication", monoid.laws[Int @@ Multiplication])
   checkAll("Short @@ Multiplication", monoid.laws[Short @@ Multiplication])
   checkAll("Byte", monoid.laws[Byte])
@@ -76,5 +81,33 @@ object AnyValTest extends SpecLite {
 
     M.unfoldlSum(5)(f) must_=== Tag(0)
     M.unfoldrSum(5)(g) must_=== Tag(0)
+  }
+
+  "conjunction should terminate when encountering false" in {
+    val M = booleanInstance.conjunction
+
+    val f: Int => Maybe[(Int, Boolean)] = i => {
+      if(i > 0) Maybe.just((i-1, true))
+      else if(i == 0) Maybe.just((i-1, false))
+      else sys.error("BOOM!")
+    }
+    val g = (i: Int) => f(i) map (_.swap)
+
+    M.unfoldlSum(5)(f) must_=== false
+    M.unfoldrSum(5)(g) must_=== false
+  }
+
+  "disjunction should terminate when encountering true" in {
+    val M = booleanInstance.disjunction
+
+    val f: Int => Maybe[(Int, Boolean)] = i => {
+      if(i > 0) Maybe.just((i-1, false))
+      else if(i == 0) Maybe.just((i-1, true))
+      else sys.error("BOOM!")
+    }
+    val g = (i: Int) => f(i) map (_.swap)
+
+    M.unfoldlSum(5)(f) must_=== true
+    M.unfoldrSum(5)(g) must_=== true
   }
 }


### PR DESCRIPTION
Iterated multiplication may terminate when 0 is encountered.

This PR adds methods to `Semigroup`, `Monoid`, `Plus`, `PlusEmpty` that may take advantage of this fact.

It is demonstrated on a few cases:
 - `Int` multiplication
 - `Boolean` conjunction and disjunction
 - `Maybe` "addition" (`Plus`)

Finally, these potentially short-circuiting methods can be used to implement `foldMap` (and `fold`, `psum`, `psumMap`) on many data structures. As a demonstration, it is done for `Stream`. As a result, we get **`foldMap` that is both stack-safe _and_ short-circuiting.**

Consequently, we may deprecate `msuml`, since there's no more need for it (`psum` used to be short-circuiting and `msuml` stack-safe, but now `psum` is both).