### PR TITLE
do not encourage use of Throwable

### DIFF
--- a/core/src/main/scala/scalaz/Catchable.scala
+++ b/core/src/main/scala/scalaz/Catchable.scala
@@ -16,6 +16,7 @@ package scalaz
  * total.
  */
 ////
+@deprecated("No laws, and Throwable is not referentially transparent. Prefer MonadError", "7.2.21")
 trait Catchable[F[_]]  { self =>
   ////
 

--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -368,14 +368,14 @@ object \/ extends DisjunctionInstances {
   def fromEither[A, B](e: Either[A, B]): A \/ B =
     e fold (left, right)
 
-  @deprecated("Throwable is not referentially transparent, use fromPartial", "7.2.21")
+  @deprecated("Throwable is not referentially transparent, use attempt", "7.2.21")
   def fromTryCatchThrowable[T, E <: Throwable](a: => T)(implicit nn: NotNothing[E], ex: ClassTag[E]): E \/ T = try {
     \/-(a)
   } catch {
     case e if ex.runtimeClass.isInstance(e) => -\/(e.asInstanceOf[E])
   }
 
-  @deprecated("Throwable is not referentially transparent, use fromPartial", "7.2.21")
+  @deprecated("Throwable is not referentially transparent, use attempt", "7.2.21")
   def fromTryCatchNonFatal[T](a: => T): Throwable \/ T = try {
     \/-(a)
   } catch {
@@ -396,7 +396,7 @@ object \/ extends DisjunctionInstances {
    * validating the input to their partial function and exiting early.
    *
    * If no useful information can be obtained from the `Exception`, prefer
-   * [[scalaz.Maybe#fromPartial]].
+   * [[scalaz.Maybe#attempt]].
    *
    * For interfacing with non-deterministic blocks of code that may or may not
    * throw `Throwable`, use [[scalaz.effect.IO]].
@@ -404,7 +404,7 @@ object \/ extends DisjunctionInstances {
    * For interfacing with deterministic functions that violate the type system
    * by returning `null`, use [[scalaz.Maybe#fromNullable]].
    */
-  def fromPartial[A, B](f: => B)(err: Exception => A): A \/ B =
+  def attempt[A, B](f: => B)(err: Exception => A): A \/ B =
     try \/-(f) catch {
       case e: Exception => -\/(err(e))
     }

--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -404,7 +404,7 @@ object \/ extends DisjunctionInstances {
    * For interfacing with deterministic functions that violate the type system
    * by returning `null`, use [[scalaz.Maybe#fromNullable]].
    */
-  def attempt[A, B](err: Exception => A)(f: => B): A \/ B =
+  def attempt[A, B](f: => B)(err: Exception => A): A \/ B =
     try \/-(f) catch {
       case e: Exception => -\/(err(e))
     }

--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -404,7 +404,7 @@ object \/ extends DisjunctionInstances {
    * For interfacing with deterministic functions that violate the type system
    * by returning `null`, use [[scalaz.Maybe#fromNullable]].
    */
-  def attempt[A, B](f: => B)(err: Exception => A): A \/ B =
+  def attempt[A, B](err: Exception => A)(f: => B): A \/ B =
     try \/-(f) catch {
       case e: Exception => -\/(err(e))
     }

--- a/core/src/main/scala/scalaz/EitherT.scala
+++ b/core/src/main/scala/scalaz/EitherT.scala
@@ -279,6 +279,7 @@ object EitherT extends EitherTInstances {
   def fromEither[F[_], A, B](e: F[Either[A, B]])(implicit F: Functor[F]): EitherT[F, A, B] =
     apply(F.map(e)(_ fold (\/.left, \/.right)))
 
+  @deprecated("Throwable is not referentially transparent, use \\/.fromPartial", "7.2.21")
   def fromTryCatchThrowable[F[_], A, B <: Throwable](a: => F[A])(implicit F: Applicative[F], nn: NotNothing[B], ex: ClassTag[B]): EitherT[F, B, A] =
     try {
       rightT(a)
@@ -286,6 +287,7 @@ object EitherT extends EitherTInstances {
       case e if ex.runtimeClass.isInstance(e) => leftT(F.point(e.asInstanceOf[B]))
     }
 
+  @deprecated("Throwable is not referentially transparent, use \\/.fromPartial", "7.2.21")
   def fromTryCatchNonFatal[F[_], A](a: => F[A])(implicit F: Applicative[F]): EitherT[F, Throwable, A] =
     try {
       rightT(a)

--- a/core/src/main/scala/scalaz/EitherT.scala
+++ b/core/src/main/scala/scalaz/EitherT.scala
@@ -279,7 +279,7 @@ object EitherT extends EitherTInstances {
   def fromEither[F[_], A, B](e: F[Either[A, B]])(implicit F: Functor[F]): EitherT[F, A, B] =
     apply(F.map(e)(_ fold (\/.left, \/.right)))
 
-  @deprecated("Throwable is not referentially transparent, use \\/.fromPartial", "7.2.21")
+  @deprecated("Throwable is not referentially transparent, use \\/.attempt", "7.2.21")
   def fromTryCatchThrowable[F[_], A, B <: Throwable](a: => F[A])(implicit F: Applicative[F], nn: NotNothing[B], ex: ClassTag[B]): EitherT[F, B, A] =
     try {
       rightT(a)
@@ -287,7 +287,7 @@ object EitherT extends EitherTInstances {
       case e if ex.runtimeClass.isInstance(e) => leftT(F.point(e.asInstanceOf[B]))
     }
 
-  @deprecated("Throwable is not referentially transparent, use \\/.fromPartial", "7.2.21")
+  @deprecated("Throwable is not referentially transparent, use \\/.attempt", "7.2.21")
   def fromTryCatchNonFatal[F[_], A](a: => F[A])(implicit F: Applicative[F]): EitherT[F, Throwable, A] =
     try {
       rightT(a)

--- a/core/src/main/scala/scalaz/Maybe.scala
+++ b/core/src/main/scala/scalaz/Maybe.scala
@@ -197,7 +197,7 @@ object Maybe extends MaybeInstances {
   def attempt[T](a: => T): Maybe[T] = try {
     just(a)
   } catch {
-    case e: Exception => empty
+    case NonFatal(_) => empty
   }
 
 }

--- a/core/src/main/scala/scalaz/Maybe.scala
+++ b/core/src/main/scala/scalaz/Maybe.scala
@@ -176,14 +176,14 @@ object Maybe extends MaybeInstances {
   final def fromOption[A](oa: Option[A]): Maybe[A] =
     std.option.cata(oa)(just, empty)
 
-  @deprecated("Not referentially transparent, use fromPartial", "7.2.21")
+  @deprecated("Not referentially transparent, use attempt", "7.2.21")
   def fromTryCatchThrowable[T, E <: Throwable](a: => T)(implicit nn: NotNothing[E], ex: ClassTag[E]): Maybe[T] = try {
     just(a)
   } catch {
     case e if ex.runtimeClass.isInstance(e) => empty
   }
 
-  @deprecated("NonFatal is too forgiving, use fromPartial", "7.2.21")
+  @deprecated("NonFatal is too forgiving, use attempt", "7.2.21")
   def fromTryCatchNonFatal[T](a: => T): Maybe[T] = try {
     just(a)
   } catch {
@@ -192,9 +192,9 @@ object Maybe extends MaybeInstances {
 
   /**
    * For interfacing with legacy, deterministic, partial functions. See
-   * [[\/.fromPartial]] for a further details.
+   * [[\/.attempt]] for further details.
    */
-  def fromPartial[T](a: => T): Maybe[T] = try {
+  def attempt[T](a: => T): Maybe[T] = try {
     just(a)
   } catch {
     case e: Exception => empty

--- a/core/src/main/scala/scalaz/Maybe.scala
+++ b/core/src/main/scala/scalaz/Maybe.scala
@@ -176,17 +176,30 @@ object Maybe extends MaybeInstances {
   final def fromOption[A](oa: Option[A]): Maybe[A] =
     std.option.cata(oa)(just, empty)
 
+  @deprecated("Not referentially transparent, use fromPartial", "7.2.21")
   def fromTryCatchThrowable[T, E <: Throwable](a: => T)(implicit nn: NotNothing[E], ex: ClassTag[E]): Maybe[T] = try {
     just(a)
   } catch {
     case e if ex.runtimeClass.isInstance(e) => empty
   }
 
+  @deprecated("NonFatal is too forgiving, use fromPartial", "7.2.21")
   def fromTryCatchNonFatal[T](a: => T): Maybe[T] = try {
     just(a)
   } catch {
     case NonFatal(t) => empty
   }
+
+  /**
+   * For interfacing with legacy, deterministic, partial functions. See
+   * [[\/.fromPartial]] for a further details.
+   */
+  def fromPartial[T](a: => T): Maybe[T] = try {
+    just(a)
+  } catch {
+    case e: Exception => empty
+  }
+
 }
 
 sealed abstract class MaybeInstances1 {

--- a/core/src/main/scala/scalaz/Validation.scala
+++ b/core/src/main/scala/scalaz/Validation.scala
@@ -393,14 +393,14 @@ object Validation extends ValidationInstances {
   def liftNel[E, A](a: A)(f: A => Boolean, fail: E): ValidationNel[E, A] =
     if (f(a)) Failure(NonEmptyList.nel(fail, IList.empty)) else Success(a)
 
-  @deprecated("Throwable is not referentially transparent, use \\/.fromPartial", "7.2.21")
+  @deprecated("Throwable is not referentially transparent, use \\/.attempt", "7.2.21")
   def fromTryCatchThrowable[T, E <: Throwable](a: => T)(implicit nn: NotNothing[E], ex: ClassTag[E]): Validation[E, T] = try {
     Success(a)
   } catch {
     case e if ex.runtimeClass.isInstance(e) => Failure(e.asInstanceOf[E])
   }
 
-  @deprecated("Throwable is not referentially transparent, use \\/.fromPartial", "7.2.21")
+  @deprecated("Throwable is not referentially transparent, use \\/.attempt", "7.2.21")
   def fromTryCatchNonFatal[T](a: => T): Validation[Throwable, T] = try {
     Success(a)
   } catch {

--- a/core/src/main/scala/scalaz/Validation.scala
+++ b/core/src/main/scala/scalaz/Validation.scala
@@ -393,12 +393,14 @@ object Validation extends ValidationInstances {
   def liftNel[E, A](a: A)(f: A => Boolean, fail: E): ValidationNel[E, A] =
     if (f(a)) Failure(NonEmptyList.nel(fail, IList.empty)) else Success(a)
 
+  @deprecated("Throwable is not referentially transparent, use \\/.fromPartial", "7.2.21")
   def fromTryCatchThrowable[T, E <: Throwable](a: => T)(implicit nn: NotNothing[E], ex: ClassTag[E]): Validation[E, T] = try {
     Success(a)
   } catch {
     case e if ex.runtimeClass.isInstance(e) => Failure(e.asInstanceOf[E])
   }
 
+  @deprecated("Throwable is not referentially transparent, use \\/.fromPartial", "7.2.21")
   def fromTryCatchNonFatal[T](a: => T): Validation[Throwable, T] = try {
     Success(a)
   } catch {

--- a/project/GenTypeClass.scala
+++ b/project/GenTypeClass.scala
@@ -59,7 +59,6 @@ object TypeClass {
   lazy val bifoldable = TypeClass("Bifoldable", *^*->*)
   lazy val bitraverse = TypeClass("Bitraverse", *^*->*, extendsList = Seq(bifunctor, bifoldable))
   lazy val compose = TypeClass("Compose", *^*->*)
-  lazy val catchable = TypeClass("Catchable", *->*, extendsList = Seq())
   lazy val nondeterminism = TypeClass("Nondeterminism", *->*, extendsList = Seq(monad))
   lazy val category = TypeClass("Category", *^*->*, extendsList = Seq(compose))
   lazy val choice = TypeClass("Choice", *^*->*, extendsList = Seq(category))
@@ -120,7 +119,6 @@ object TypeClass {
     bifunctor,
     bifoldable,
     bitraverse,
-    catchable,
     nondeterminism,
     compose,
     category,

--- a/tests/src/test/scala/scalaz/DisjunctionTest.scala
+++ b/tests/src/test/scala/scalaz/DisjunctionTest.scala
@@ -33,6 +33,15 @@ object DisjunctionTest extends SpecLite {
     \/.fromTryCatchThrowable[Int, Bar](throw foo).mustThrowA[Foo]
   }
 
+  "fromPartial" in {
+    // the JVM number parsers give useless error messages. Prefer .parseInt and
+    // friends from scalaz.std.syntax.string, giving hand-crafted error messages
+    // as of scalaz 7.3.0.
+    \/.fromPartial("foo".toInt)(_.getMessage) must_=== \/.left("For input string: \"foo\"")
+
+    \/.fromPartial("1".toInt)(_.getMessage) must_=== \/.right(1)
+  }
+
   "recover" in {
     sealed trait Foo
     case object Bar extends Foo

--- a/tests/src/test/scala/scalaz/DisjunctionTest.scala
+++ b/tests/src/test/scala/scalaz/DisjunctionTest.scala
@@ -33,13 +33,13 @@ object DisjunctionTest extends SpecLite {
     \/.fromTryCatchThrowable[Int, Bar](throw foo).mustThrowA[Foo]
   }
 
-  "fromPartial" in {
+  "attempt" in {
     // the JVM number parsers give useless error messages. Prefer .parseInt and
     // friends from scalaz.std.syntax.string, giving hand-crafted error messages
     // as of scalaz 7.3.0.
-    \/.fromPartial("foo".toInt)(_.getMessage) must_=== \/.left("For input string: \"foo\"")
+    \/.attempt("foo".toInt)(_.getMessage) must_=== \/.left("For input string: \"foo\"")
 
-    \/.fromPartial("1".toInt)(_.getMessage) must_=== \/.right(1)
+    \/.attempt("1".toInt)(_.getMessage) must_=== \/.right(1)
   }
 
   "recover" in {

--- a/tests/src/test/scala/scalaz/DisjunctionTest.scala
+++ b/tests/src/test/scala/scalaz/DisjunctionTest.scala
@@ -42,11 +42,11 @@ object DisjunctionTest extends SpecLite {
     {
       for {
         s <- "foo".right[String]
-        i <- \/.attempt(_.getMessage + " not an integer")(s.toInt)
+        i <- \/.attempt(s.toInt)(_.getMessage + " not an integer")
       } yield i
     } must_=== \/.left("For input string: \"foo\" not an integer")
 
-    \/.attempt(_.getMessage + " not an integer")("1".toInt) must_=== \/.right(1)
+    \/.attempt("1".toInt)(_.getMessage) must_=== \/.right(1)
   }
 
   "recover" in {

--- a/tests/src/test/scala/scalaz/DisjunctionTest.scala
+++ b/tests/src/test/scala/scalaz/DisjunctionTest.scala
@@ -34,12 +34,19 @@ object DisjunctionTest extends SpecLite {
   }
 
   "attempt" in {
+    import scalaz.syntax.either._
+
     // the JVM number parsers give useless error messages. Prefer .parseInt and
     // friends from scalaz.std.syntax.string, giving hand-crafted error messages
     // as of scalaz 7.3.0.
-    \/.attempt("foo".toInt)(_.getMessage) must_=== \/.left("For input string: \"foo\"")
+    {
+      for {
+        s <- "foo".right[String]
+        i <- \/.attempt(_.getMessage + " not an integer")(s.toInt)
+      } yield i
+    } must_=== \/.left("For input string: \"foo\" not an integer")
 
-    \/.attempt("1".toInt)(_.getMessage) must_=== \/.right(1)
+    \/.attempt(_.getMessage + " not an integer")("1".toInt) must_=== \/.right(1)
   }
 
   "recover" in {

--- a/tests/src/test/scala/scalaz/MaybeTests.scala
+++ b/tests/src/test/scala/scalaz/MaybeTests.scala
@@ -95,6 +95,12 @@ object MaybeTest extends SpecLite {
 
   "fromNullable(notNull) is just" ! forAll { (s: String) => Maybe.fromNullable(s) must_=== just(s) }
 
+  "fromPartial" in {
+    Maybe.fromPartial("foo".toInt) must_=== Maybe.empty
+
+    Maybe.fromPartial("1".toInt) must_=== Maybe.just(1)
+  }
+
   object instances {
     def equal[A: Equal] = Equal[Maybe[A]]
     def order[A: Order] = Order[Maybe[A]]

--- a/tests/src/test/scala/scalaz/MaybeTests.scala
+++ b/tests/src/test/scala/scalaz/MaybeTests.scala
@@ -95,10 +95,10 @@ object MaybeTest extends SpecLite {
 
   "fromNullable(notNull) is just" ! forAll { (s: String) => Maybe.fromNullable(s) must_=== just(s) }
 
-  "fromPartial" in {
-    Maybe.fromPartial("foo".toInt) must_=== Maybe.empty
+  "attempt" in {
+    Maybe.attempt("foo".toInt) must_=== Maybe.empty
 
-    Maybe.fromPartial("1".toInt) must_=== Maybe.just(1)
+    Maybe.attempt("1".toInt) must_=== Maybe.just(1)
   }
 
   object instances {


### PR DESCRIPTION
close #1684 

When writing my book I realised two problems:

1. scalaz encourages the use of non referentially transparent `Throwable` in many places.
2. there is no principled way to interact with a legacy **deterministic** partial function that may throw an exception.

This PR addresses both, whilst retaining backwards binary compatibility in the 7.2 line:

1. deprecation warnings have been added to the worst offenders
2. `.fromPartial` function has been added to both `Maybe` and `\/` which discourages (although cannot completely ban) the use of non-referentially transparent stacktraces. scalafix should be able to help further.

For anything more complicated than this, the user should use `IO`.
