### PR TITLE
Message first, version second in @deprecation messages.

### DIFF
--- a/core/src/main/scala/scalaz/EitherT.scala
+++ b/core/src/main/scala/scalaz/EitherT.scala
@@ -244,12 +244,12 @@ object EitherT extends EitherTInstances {
   }
 
   /** Construct a left disjunction value. */
-  @deprecated("7.2.18", "prefer leftT, this method's meaning will change in scalaz 7.3")
+  @deprecated("prefer leftT; this method's meaning will change in scalaz 7.3", since = "7.2.18")
   def left[F[_], A, B](a: F[A])(implicit F: Functor[F]): EitherT[F, A, B] =
     apply(F.map(a)(\/.left))
 
   /** Construct a right disjunction value. */
-  @deprecated("7.2.18", "prefer rightT, this method's meaning will change in scalaz 7.3")
+  @deprecated("prefer rightT; this method's meaning will change in scalaz 7.3", since = "7.2.18")
   def right[F[_], A, B](b: F[B])(implicit F: Functor[F]): EitherT[F, A, B] =
     apply(F.map(b)(\/.right))
 

--- a/core/src/main/scala/scalaz/ImmutableArray.scala
+++ b/core/src/main/scala/scalaz/ImmutableArray.scala
@@ -15,9 +15,9 @@ import syntax.Ops
 sealed abstract class ImmutableArray[+A] {
   protected[this] def elemTag: ClassTag[A]
 
-  @deprecated("7.2.19", "removed in scalaz 7.3: not total")
+  @deprecated("removed in scalaz 7.3: not total", since = "7.2.19")
   def apply(index: Int): A
-  @deprecated("7.2.19", "removed in scalaz 7.3: not total")
+  @deprecated("removed in scalaz 7.3: not total", since = "7.2.19")
   def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): Unit
 
   def length: Int

--- a/core/src/main/scala/scalaz/Memo.scala
+++ b/core/src/main/scala/scalaz/Memo.scala
@@ -64,7 +64,7 @@ object Memo extends MemoInstances {
     */
   def doubleArrayMemo(n: Int, sentinel: Double = 0d): Memo[Int, Double] = new DoubleArrayMemo(n, sentinel)
 
-  @deprecated("7.2.19", "removed in scalaz 7.3: leaks mutable state, not thread safe")
+  @deprecated("removed in scalaz 7.3: leaks mutable state, not thread safe", since = "7.2.19")
   def mutableMapMemo[K, V](a: collection.mutable.Map[K, V]): Memo[K, V] =
     memo[K, V](f => k => a.getOrElseUpdate(k, f(k)))
 
@@ -72,14 +72,14 @@ object Memo extends MemoInstances {
     * Nonsensical if `K` lacks a meaningful `hashCode` and
     * `java.lang.Object.equals`.
     */
-  @deprecated("7.2.19", "removed in scalaz 7.3: not thread safe, relies on Object")
+  @deprecated("removed in scalaz 7.3: not thread safe, relies on Object", since = "7.2.19")
   def mutableHashMapMemo[K, V]: Memo[K, V] =
     mutableMapMemo(new collection.mutable.HashMap[K, V])
 
   /** As with `mutableHashMapMemo`, but forget elements according to
     * GC pressure.
     */
-  @deprecated("7.2.19", "removed in scalaz 7.3: not thread safe, relies on Object, not efficient")
+  @deprecated("removed in scalaz 7.3: not thread safe, relies on Object, not efficient", since = "7.2.19")
   def weakHashMapMemo[K, V]: Memo[K, V] =
     mutableMapMemo(new collection.mutable.WeakHashMap[K, V])
 
@@ -105,7 +105,7 @@ object Memo extends MemoInstances {
   /** Cache results in a list map.  Nonsensical unless `K` has
     * a meaningful `java.lang.Object.equals`.  $immuMapNote
     */
-  @deprecated("7.2.19", "removed in scalaz 7.3: not efficient")
+  @deprecated("removed in scalaz 7.3: not efficient", since = "7.2.19")
   def immutableListMapMemo[K, V]: Memo[K, V] = immutableMapMemo(new ListMap[K, V])
 
   /** Cache results in a tree map. $immuMapNote */


### PR DESCRIPTION
Otherwise you get messages like:

```
there was one deprecation warning (since prefer leftT; this method's meaning will change in scalaz 7.3)
```

... which I doubt was the intention.