### PR TITLE
Applicative short-circuiting

### DIFF
--- a/core/src/main/scala/scalaz/Plus.scala
+++ b/core/src/main/scala/scalaz/Plus.scala
@@ -78,5 +78,18 @@ object Plus {
 
   ////
 
+  private[scalaz] trait LiftedPlus[G[_], F[_]] extends Plus[λ[a => G[F[a]]]] {
+    implicit def G: Apply[G]
+    implicit def F: Plus[F]
+
+    def plus[A](x: G[F[A]], y: => G[F[A]]): G[F[A]] = G.apply2(x, y)(F.plus(_, _))
+  }
+
+  def liftPlus[G[_], F[_]](implicit G0: Apply[G], F0: Plus[F]): Plus[λ[a => G[F[a]]]] =
+    new LiftedPlus[G, F] {
+      def G = G0
+      def F = F0
+    }
+
   ////
 }

--- a/core/src/main/scala/scalaz/Plus.scala
+++ b/core/src/main/scala/scalaz/Plus.scala
@@ -83,6 +83,9 @@ object Plus {
     implicit def F: Plus[F]
 
     def plus[A](x: G[F[A]], y: => G[F[A]]): G[F[A]] = G.apply2(x, y)(F.plus(_, _))
+
+    override def unfoldrPsumOpt[S, A](seed: S)(f: S => Maybe[(G[F[A]], S)]): Maybe[G[F[A]]] =
+      G.unfoldrOpt(seed)(f)(Reducer.identityReducer[F[A]](F.semigroup))
   }
 
   def liftPlus[G[_], F[_]](implicit G0: Apply[G], F0: Plus[F]): Plus[λ[a => G[F[a]]]] =

--- a/core/src/main/scala/scalaz/PlusEmpty.scala
+++ b/core/src/main/scala/scalaz/PlusEmpty.scala
@@ -59,10 +59,10 @@ object PlusEmpty {
 
   ////
   implicit def liftPlusEmpty[M[_], N[_]](implicit M: Applicative[M], P: PlusEmpty[N]): PlusEmpty[λ[α => M[N[α]]]] =
-    new PlusEmpty[λ[α => M[N[α]]]] {
+    new Plus.LiftedPlus[M, N] with PlusEmpty[λ[α => M[N[α]]]] {
+      def G = M
+      def F = P
       def empty[A] = M.point(P.empty[A])
-      def plus[A](a: M[N[A]], b: => M[N[A]]): M[N[A]] =
-        M.apply2(a, b)(P.plus(_, _))
     }
   ////
 }

--- a/core/src/main/scala/scalaz/Reducer.scala
+++ b/core/src/main/scala/scalaz/Reducer.scala
@@ -19,7 +19,7 @@ import scalaz.Tags.Conjunction
  * Based on the Reducer Haskell library by Edward Kmett
  * (https://hackage.haskell.org/package/reducers).
  */
-sealed abstract class Reducer[C, M] {
+trait Reducer[C, M] {
   implicit def semigroup: Semigroup[M]
 
   def unit(c: C): M

--- a/core/src/main/scala/scalaz/Reducer.scala
+++ b/core/src/main/scala/scalaz/Reducer.scala
@@ -51,7 +51,10 @@ sealed abstract class Reducer[C, M] {
     }
   }
 
-  def unfoldlOpt[B](seed: B)(f: B => Maybe[(B, C)]): Maybe[M] = {
+  def unfoldlOpt[B](seed: B)(f: B => Maybe[(B, C)]): Maybe[M] =
+    defaultUnfoldlOpt(seed)(f)
+
+  @inline private def defaultUnfoldlOpt[B](seed: B)(f: B => Maybe[(B, C)]): Maybe[M] = {
     @tailrec
     def rec(seed: B, acc: M): M = f(seed) match {
       case Just((b, c)) => rec(b, cons(c, acc))
@@ -63,7 +66,10 @@ sealed abstract class Reducer[C, M] {
   def unfoldl[B](seed: B)(f: B => Maybe[(B, C)])(implicit M: Monoid[M]): M =
     unfoldlOpt(seed)(f) getOrElse M.zero
 
-  def unfoldrOpt[B](seed: B)(f: B => Maybe[(C, B)]): Maybe[M] = {
+  def unfoldrOpt[B](seed: B)(f: B => Maybe[(C, B)]): Maybe[M] =
+    defaultUnfoldrOpt(seed)(f)
+
+  @inline private def defaultUnfoldrOpt[B](seed: B)(f: B => Maybe[(C, B)]): Maybe[M] = {
     @tailrec
     def rec(acc: M, seed: B): M = f(seed) match {
       case Just((c, b)) => rec(snoc(acc, c), b)
@@ -81,6 +87,24 @@ sealed abstract class Reducer[C, M] {
 
     def snocCorrectness(m: M, c: C)(implicit E: Equal[M]): Boolean =
       E.equal(snoc(m, c), append(m, unit(c)))
+
+    def unfoldlOptConsistency[B](seed: B, f: B => Maybe[(B, C)])(implicit E: Equal[M]): Boolean = {
+      val g: ((Int, B)) => Maybe[((Int, B), C)] = { case (i, b) =>
+        if(i > 0) f(b) map { case (b, c) => ((i-1, b), c) }
+        else Maybe.empty
+      }
+      val limit = 4 // to prevent infinite unfolds
+      Equal[Maybe[M]].equal(unfoldlOpt((limit, seed))(g), defaultUnfoldlOpt((limit, seed))(g))
+    }
+
+    def unfoldrOptConsistency[B](seed: B, f: B => Maybe[(C, B)])(implicit E: Equal[M]): Boolean = {
+      val g: ((Int, B)) => Maybe[(C, (Int, B))] = { case (i, b) =>
+        if(i > 0) f(b) map { case (c, b) => (c, (i-1, b)) }
+        else Maybe.empty
+      }
+      val limit = 4 // to prevent infinite unfolds
+      Equal[Maybe[M]].equal(unfoldrOpt((limit, seed))(g), defaultUnfoldrOpt((limit, seed))(g))
+    }
   }
   def reducerLaw = new ReducerLaw {}
 }

--- a/core/src/main/scala/scalaz/Reducer.scala
+++ b/core/src/main/scala/scalaz/Reducer.scala
@@ -147,6 +147,11 @@ sealed abstract class ReducerInstances {
     unitConsReducer(_ :: Nil, _ :: _)
   }
 
+  def ReverseListReducer[C]: Reducer[C, List[C]] = {
+    import std.list._
+    reducer(_ :: Nil, (c, cs) => cs :+ c, (cs, c) => c :: cs)
+  }
+
   /** Collect `C`s into an ilist, in order. */
   implicit def IListReducer[C]: Reducer[C, IList[C]] = {
     unitConsReducer(_ :: INil(), _ :: _)

--- a/core/src/main/scala/scalaz/Semigroup.scala
+++ b/core/src/main/scala/scalaz/Semigroup.scala
@@ -186,6 +186,9 @@ object Semigroup {
     implicit def F: Apply[F]
     implicit def M: Semigroup[M]
     def append(x: F[M], y: => F[M]): F[M] = F.lift2[M, M, M]((m1, m2) => M.append(m1, m2))(x, y)
+
+    override def unfoldrSumOpt[S](seed: S)(f: S => Maybe[(F[M], S)]): Maybe[F[M]] =
+      F.unfoldrOpt(seed)(f)(Reducer.identityReducer[M])
   }
 
   /**A semigroup for sequencing Apply effects. */

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazProperties.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazProperties.scala
@@ -141,16 +141,26 @@ object ScalazProperties {
   }
 
   object reducer {
+    import ScalazArbitrary.Arbitrary_Maybe
+
     def consCorrectness[C, M](implicit R: Reducer[C, M], ac: Arbitrary[C], am: Arbitrary[M], eqm: Equal[M]): Prop =
       forAll(R.reducerLaw.consCorrectness _)
 
     def snocCorrectness[C, M](implicit R: Reducer[C, M], ac: Arbitrary[C], am: Arbitrary[M], eqm: Equal[M]): Prop =
       forAll(R.reducerLaw.snocCorrectness _)
 
+    def unfoldlOptConsistency[C, M, S](implicit R: Reducer[C, M], ac: Arbitrary[C], as: Arbitrary[S], cs: Cogen[S], eqm: Equal[M]): Prop =
+      forAll(R.reducerLaw.unfoldlOptConsistency[S] _)
+
+    def unfoldrOptConsistency[C, M, S](implicit R: Reducer[C, M], ac: Arbitrary[C], as: Arbitrary[S], cs: Cogen[S], eqm: Equal[M]): Prop =
+      forAll(R.reducerLaw.unfoldrOptConsistency[S] _)
+
     def laws[C: Arbitrary, M: Arbitrary: Equal](implicit R: Reducer[C, M]): Properties =
       newProperties("reducer") { p =>
         p.property("cons correctness") = consCorrectness[C, M]
         p.property("snoc correctness") = snocCorrectness[C, M]
+        p.property("unfoldlOpt consistency") = unfoldlOptConsistency[C, M, Int]
+        p.property("unfoldrOpt consistency") = unfoldrOptConsistency[C, M, Int]
       }
   }
 

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazProperties.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazProperties.scala
@@ -229,7 +229,10 @@ object ScalazProperties {
     def laws[F[_]](implicit F: Apply[F], af: Arbitrary[F[Int]],
                    aff: Arbitrary[F[Int => Int]], e: Equal[F[Int]]): Properties =
       newProperties("apply") { p =>
+        implicit val r: Reducer[F[Int], F[Int]] = F.liftReducer(Reducer.identityReducer[Int])
+
         p.include(functor.laws[F])
+        p.include(reducer.laws[F[Int], F[Int]])
         p.property("composition") = self.composition[F, Int, Int, Int]
       }
   }

--- a/tests/src/test/scala/scalaz/MaybeTests.scala
+++ b/tests/src/test/scala/scalaz/MaybeTests.scala
@@ -114,6 +114,44 @@ object MaybeTest extends SpecLite {
     P.unfoldrPsum(5)(f) must_=== Just("Stop")
   }
 
+  "lifted Monoid is short-circuiting" in {
+    val M: Monoid[Maybe[Int]] = Monoid.liftMonoid
+
+    val f: Int => Maybe[(Maybe[Int], Int)] = i => {
+      if (i > 0) just((just(i), i-1))
+      else if (i == 0) just((empty, i-1))
+      else sys.error("BOOM!")
+    }
+
+    M.unfoldrSum(5)(f) must_=== Empty()
+  }
+
+  "lifted PlusEmpty is short-circuiting" in {
+    import scalaz.std.list._
+
+    val P: PlusEmpty[λ[a => Maybe[List[a]]]] = PlusEmpty.liftPlusEmpty[Maybe, List]
+
+    val f: Int => Maybe[(Maybe[List[Int]], Int)] = i => {
+      if (i > 0) just((just(List.range(0, i)), i-1))
+      else if (i == 0) just((empty, i-1))
+      else sys.error("BOOM!")
+    }
+
+    P.unfoldrPsum(5)(f) must_=== Empty()
+  }
+
+  "lifted Reducer is short-circuiting" in {
+    val R: Reducer[Maybe[Int], Maybe[Int]] = Apply[Maybe].liftReducer(Reducer.identityReducer[Int])
+
+    val f: Int => Maybe[(Maybe[Int], Int)] = i => {
+      if (i > 0) just((just(i), i-1))
+      else if (i == 0) just((empty, i-1))
+      else sys.error("BOOM!")
+    }
+
+    R.unfoldrOpt(5)(f) must_=== Just(Empty())
+  }
+
   object instances {
     def equal[A: Equal] = Equal[Maybe[A]]
     def order[A: Order] = Order[Maybe[A]]

--- a/tests/src/test/scala/scalaz/TraverseTest.scala
+++ b/tests/src/test/scala/scalaz/TraverseTest.scala
@@ -40,6 +40,16 @@ object TraverseTest extends SpecLite {
       s.map(_.take(3)) must_===(some(List(0, 1, 2)))
     }
 
+    "be stack-safe and short-circuiting" in {
+      val N = 10000
+      val s: Maybe[List[Int]] = List.range(0, N) traverse { x =>
+        if(x < N-2) Maybe.just(x)
+        else if(x == N-2) Maybe.empty
+        else sys.error("BOOM!")
+      }
+      s must_=== Maybe.empty
+    }
+
     "state traverse agrees with regular traverse" in {
       val N = 10
       List.range(0,N).traverseS(x => modify((x: Int) => x+1))(0) must_=== (


### PR DESCRIPTION
Some `Applicatives` have absorbing values (such as `Option`'s `None`) that may be used to terminate early.

This PR adds a method to `Apply` that may be overridden to take advantage of such short-circuiting.

```scala
trait Apply[F[_]] {
  def unfoldrOpt[S, A, B](seed: S)(f: S => Maybe[(F[A], S)])(implicit R: Reducer[A, B]): Maybe[F[B]]
}
```

This PR then overrides this method for `Apply[Maybe]`. (This should be done for other Applicatives with absorbing elements as well.)

Finally, `List` traversal is implemented using this potentially short-circuiting method, resulting in **traversal that is both stack-safe and short-circuiting** (for short-circuiting Applicatives), resolving an old dilemma. (This should be done for other Traversables as well.)

~~(Note that the first 6 commits are from #1685.)~~