### PR TITLE
[DO NOT MERGE] undeprecate impure methods

### DIFF
--- a/core/src/main/scala/scalaz/Catchable.scala
+++ b/core/src/main/scala/scalaz/Catchable.scala
@@ -16,7 +16,6 @@ package scalaz
  * total.
  */
 ////
-@deprecated("No laws, and Throwable is not referentially transparent. Prefer MonadError", "7.2.21")
 trait Catchable[F[_]]  { self =>
   ////
 

--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -368,14 +368,12 @@ object \/ extends DisjunctionInstances {
   def fromEither[A, B](e: Either[A, B]): A \/ B =
     e fold (left, right)
 
-  @deprecated("Throwable is not referentially transparent, use attempt", "7.2.21")
   def fromTryCatchThrowable[T, E <: Throwable](a: => T)(implicit nn: NotNothing[E], ex: ClassTag[E]): E \/ T = try {
     \/-(a)
   } catch {
     case e if ex.runtimeClass.isInstance(e) => -\/(e.asInstanceOf[E])
   }
 
-  @deprecated("Throwable is not referentially transparent, use attempt", "7.2.21")
   def fromTryCatchNonFatal[T](a: => T): Throwable \/ T = attempt(a)(identity)
 
   /**

--- a/core/src/main/scala/scalaz/EitherT.scala
+++ b/core/src/main/scala/scalaz/EitherT.scala
@@ -279,7 +279,6 @@ object EitherT extends EitherTInstances {
   def fromEither[F[_], A, B](e: F[Either[A, B]])(implicit F: Functor[F]): EitherT[F, A, B] =
     apply(F.map(e)(_ fold (\/.left, \/.right)))
 
-  @deprecated("Throwable is not referentially transparent, use \\/.attempt", "7.2.21")
   def fromTryCatchThrowable[F[_], A, B <: Throwable](a: => F[A])(implicit F: Applicative[F], nn: NotNothing[B], ex: ClassTag[B]): EitherT[F, B, A] =
     try {
       rightT(a)
@@ -287,7 +286,6 @@ object EitherT extends EitherTInstances {
       case e if ex.runtimeClass.isInstance(e) => leftT(F.point(e.asInstanceOf[B]))
     }
 
-  @deprecated("Throwable is not referentially transparent, use \\/.attempt", "7.2.21")
   def fromTryCatchNonFatal[F[_], A](a: => F[A])(implicit F: Applicative[F]): EitherT[F, Throwable, A] =
     try {
       rightT(a)

--- a/core/src/main/scala/scalaz/Maybe.scala
+++ b/core/src/main/scala/scalaz/Maybe.scala
@@ -176,14 +176,12 @@ object Maybe extends MaybeInstances {
   final def fromOption[A](oa: Option[A]): Maybe[A] =
     std.option.cata(oa)(just, empty)
 
-  @deprecated("Not referentially transparent, use attempt", "7.2.21")
   def fromTryCatchThrowable[T, E <: Throwable](a: => T)(implicit nn: NotNothing[E], ex: ClassTag[E]): Maybe[T] = try {
     just(a)
   } catch {
     case e if ex.runtimeClass.isInstance(e) => empty
   }
 
-  @deprecated("NonFatal is too forgiving, use attempt", "7.2.21")
   def fromTryCatchNonFatal[T](a: => T): Maybe[T] = try {
     just(a)
   } catch {

--- a/core/src/main/scala/scalaz/Validation.scala
+++ b/core/src/main/scala/scalaz/Validation.scala
@@ -393,14 +393,12 @@ object Validation extends ValidationInstances {
   def liftNel[E, A](a: A)(f: A => Boolean, fail: E): ValidationNel[E, A] =
     if (f(a)) Failure(NonEmptyList.nel(fail, IList.empty)) else Success(a)
 
-  @deprecated("Throwable is not referentially transparent, use \\/.attempt", "7.2.21")
   def fromTryCatchThrowable[T, E <: Throwable](a: => T)(implicit nn: NotNothing[E], ex: ClassTag[E]): Validation[E, T] = try {
     Success(a)
   } catch {
     case e if ex.runtimeClass.isInstance(e) => Failure(e.asInstanceOf[E])
   }
 
-  @deprecated("Throwable is not referentially transparent, use \\/.attempt", "7.2.21")
   def fromTryCatchNonFatal[T](a: => T): Validation[Throwable, T] = try {
     Success(a)
   } catch {

--- a/project/GenTypeClass.scala
+++ b/project/GenTypeClass.scala
@@ -59,6 +59,7 @@ object TypeClass {
   lazy val bifoldable = TypeClass("Bifoldable", *^*->*)
   lazy val bitraverse = TypeClass("Bitraverse", *^*->*, extendsList = Seq(bifunctor, bifoldable))
   lazy val compose = TypeClass("Compose", *^*->*)
+  lazy val catchable = TypeClass("Catchable", *->*, extendsList = Seq())
   lazy val nondeterminism = TypeClass("Nondeterminism", *->*, extendsList = Seq(monad))
   lazy val category = TypeClass("Category", *^*->*, extendsList = Seq(compose))
   lazy val choice = TypeClass("Choice", *^*->*, extendsList = Seq(category))
@@ -119,6 +120,7 @@ object TypeClass {
     bifunctor,
     bifoldable,
     bitraverse,
+    catchable,
     nondeterminism,
     compose,
     category,


### PR DESCRIPTION
Continuing the discussion from #1687 

I do not agree that this PR should be merged. I deprecated the methods in #1687 because they either

- only turn partial functions into slightly less partial functions (which is a fairly useless replacement for a `try` / `catch` block)
- or, return `Throwable` values. `Throwable` is not referentially transparent, even for deterministic failures, thanks to the stacktrace (this is actually a really big deal, I've worked in at least two places that tried to cache/intern something similar to `Throwable \/ A` and it led to a lot of pain and suffering).

Generally it is my understanding that we plan on having more principled FP in scalaz 7.3+ and that there is little room for anything that compromises purity in the API for beginner convenience. However, we should not leave users without an option... and there are several presented. I would wager that most uses of these deprecated methods would be best replaced with an IO. If the user wants the same semantics as in the deprecated methods, `Try` is in the stdlib. Or they can call `attempt` with `identity` (but it is not recommended).

We should consider introducing data structures to assist dealing with legacy throwables and nulls. For now, IO is all we have, and the new `attempt` functions I introduced are a compromise to allow the use of **deterministic** legacy blocks of code.
