### PR TITLE
add MonadError.emap

### DIFF
--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -490,6 +490,8 @@ sealed abstract class DisjunctionInstances1 extends DisjunctionInstances2 {
       def bind[A, B](fa: L \/ A)(f: A => L \/ B) =
         fa flatMap f
 
+      override def emap[A, B](fa: L \/ A)(f: A => L \/ B) = bind(fa)(f)
+
       def point[A](a: => A) =
         \/-(a)
 

--- a/core/src/main/scala/scalaz/MonadError.scala
+++ b/core/src/main/scala/scalaz/MonadError.scala
@@ -11,6 +11,9 @@ trait MonadError[F[_], S] extends Monad[F] { self =>
   def raiseError[A](e: S): F[A]
   def handleError[A](fa: F[A])(f: S => F[A]): F[A]
 
+  def emap[A, B](fa: F[A])(f: A => S \/ B): F[B] =
+    bind(fa)(a => f(a).fold(raiseError(_), pure(_)))
+
   trait MonadErrorLaw {
     def raisedErrorsHandled[A](e: S, f: S => F[A])(implicit FEA: Equal[F[A]]): Boolean =
       FEA.equal(handleError(raiseError(e))(f), f(e))

--- a/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
@@ -8,7 +8,7 @@ final class MonadErrorOps[F[_], S, A] private[syntax](self: F[A])(implicit val F
     F.handleError(self)(f)
 
   final def emap[B](f: A => S \/ B): F[B] =
-    F.bind(self)(a => f(a).fold(F.raiseError(_), F.pure(_)))
+    F.emap(self)(f)
 
   ////
 }


### PR DESCRIPTION
I wanted to do this in #1661 but couldn't because of bincompat.

The main motivation is that `emap` can be optimised efficiently by many typeclasses, e.g. decoders.