### PR TITLE
Void and denial inequality.

### DIFF
--- a/base/shared/src/main/scala/scalaz/Prelude.scala
+++ b/base/shared/src/main/scala/scalaz/Prelude.scala
@@ -77,8 +77,11 @@ trait BaseData {
 }
 
 trait BaseDataAliases { self: BaseData =>
+  type Void = data.Void.Void
+
   type \/[L, R]    = data.Disjunction.\/[L, R]
   type ===[A, B]   = data.Is[A, B]
+  type =!=[A, B]   = data.NotIs[A, B]
   type <~<[-A, +B] = data.As[A, B]
   type >~>[+B, -A] = data.As[A, B]
 
@@ -95,7 +98,8 @@ trait BaseDataAliases { self: BaseData =>
 }
 
 trait AllFunctions
-    extends data.DisjunctionFunctions
+    extends data.VoidFunctions
+    with data.DisjunctionFunctions
     with data.MaybeFunctions
     with typeclass.InvariantFunctorFunctions
     with typeclass.PhantomFunctions

--- a/base/shared/src/main/scala/scalaz/data/NotIs.scala
+++ b/base/shared/src/main/scala/scalaz/data/NotIs.scala
@@ -2,42 +2,42 @@ package scalaz
 package data
 
 /**
-  * The denial inequality is a symmetric irreflexive binary relation with
-  * the additional condition that if two elements are apart, then any other
-  * element is apart from at least one of them (this last property is often
-  * called co-transitivity or comparison). Co-transitivity for denial
-  * inequality is *not* constructive.
-  *
-  * @see [[https://en.wikipedia.org/wiki/Apartness_relation
-  *        Apartness relation]]
-  */
+ * The denial inequality is a symmetric irreflexive binary relation with
+ * the additional condition that if two elements are apart, then any other
+ * element is apart from at least one of them (this last property is often
+ * called co-transitivity or comparison). Co-transitivity for denial
+ * inequality is *not* constructive.
+ *
+ * @see [[https://en.wikipedia.org/wiki/Apartness_relation
+ *        Apartness relation]]
+ */
 final case class NotIs[A, B](run: (A === B) => Void) { self =>
   import NotIs._
 
   /**
-    * Having `A === B` and `A =!= B` at the same time leads to a contradiction.
-    */
+   * Having `A === B` and `A =!= B` at the same time leads to a contradiction.
+   */
   def apply(ab: A === B): Void = run(ab)
 
   /**
-    * If `F[A] =!= F[B]`, then `A =!= B`. This is a contrapositive to 
-    * `(A === B) => (F[A] === F[B])`.
-    */
+   * If `F[A] =!= F[B]`, then `A =!= B`. This is a contrapositive to
+   * `(A === B) => (F[A] === F[B])`.
+   */
   def lower[F[_]]: PartialLower[F, A, B] =
     new PartialLower[F, A, B](this)
 
   /**
-    * Inequality is symmetric relation and therefore can be flipped around.
-    * Flipping is its own inverse, so `x.flip.flip == x`.
-    */
+   * Inequality is symmetric relation and therefore can be flipped around.
+   * Flipping is its own inverse, so `x.flip.flip == x`.
+   */
   def flip: B =!= A = NotIs.witness[B, A](ba => self(ba.flip))
 }
 object NotIs {
   def apply[A, B](implicit ev: NotIs[A, B]): NotIs[A, B] = ev
 
   /**
-    * Inequality is an irreflexive relation.
-    */
+   * Inequality is an irreflexive relation.
+   */
   def irreflexive[A](ev: A NotIs A): Void =
     ev.apply(Is.refl[A])
 

--- a/base/shared/src/main/scala/scalaz/data/NotIs.scala
+++ b/base/shared/src/main/scala/scalaz/data/NotIs.scala
@@ -1,0 +1,51 @@
+package scalaz
+package data
+
+/**
+  * The denial inequality is a symmetric irreflexive binary relation with
+  * the additional condition that if two elements are apart, then any other
+  * element is apart from at least one of them (this last property is often
+  * called co-transitivity or comparison). Co-transitivity for denial
+  * inequality is *not* constructive.
+  *
+  * @see [[https://en.wikipedia.org/wiki/Apartness_relation
+  *        Apartness relation]]
+  */
+final case class NotIs[A, B](run: (A === B) => Void) { self =>
+  import NotIs._
+
+  /**
+    * Having `A === B` and `A =!= B` at the same time leads to a contradiction.
+    */
+  def apply(ab: A === B): Void = run(ab)
+
+  /**
+    * If `F[A] =!= F[B]`, then `A =!= B`. This is a contrapositive to 
+    * `(A === B) => (F[A] === F[B])`.
+    */
+  def lower[F[_]]: PartialLower[F, A, B] =
+    new PartialLower[F, A, B](this)
+
+  /**
+    * Inequality is symmetric relation and therefore can be flipped around.
+    * Flipping is its own inverse, so `x.flip.flip == x`.
+    */
+  def flip: B =!= A = NotIs.witness[B, A](ba => self(ba.flip))
+}
+object NotIs {
+  def apply[A, B](implicit ev: NotIs[A, B]): NotIs[A, B] = ev
+
+  /**
+    * Inequality is an irreflexive relation.
+    */
+  def irreflexive[A](ev: A NotIs A): Void =
+    ev.apply(Is.refl[A])
+
+  def witness[A, B](f: (A === B) => Void): NotIs[A, B] =
+    new NotIs[A, B](f)
+
+  private[NotIs] final class PartialLower[F[_], A, B](val ab: NotIs[A, B]) extends AnyVal {
+    def apply[X, Y](implicit A: A === F[X], B: B === F[Y]): X =!= Y =
+      NotIs(xy => ab(A andThen xy.lift[F] andThen B.flip))
+  }
+}

--- a/base/shared/src/main/scala/scalaz/data/Void.scala
+++ b/base/shared/src/main/scala/scalaz/data/Void.scala
@@ -1,0 +1,13 @@
+package scalaz
+package data
+
+trait VoidFunctions {
+  def unsafeVoid: Void = throw new Void.Absurd
+}
+
+object Void extends VoidFunctions {
+  private[data] trait Tag
+  type Void <: Nothing with Tag
+
+  private[data] final class Absurd extends RuntimeException
+}


### PR DESCRIPTION
The api is currently rather impoverished since the majority of the methods I have in `leibniz` require additional data types to be defined first. `NotIs` could be implemented as a newtype over `(A === B) => Void`, but I would like to first add a `@newtype` macro / compiler plugin to scalaz so that I don't pollute the code with unnecessary details of newtype encoding.