### PR TITLE
Add `Bifunctor`.

### DIFF
--- a/base/shared/src/main/scala/scalaz/Prelude.scala
+++ b/base/shared/src/main/scala/scalaz/Prelude.scala
@@ -10,12 +10,14 @@ trait BaseTypeclasses {
 
   type Applicative[F[_]]      = InstanceOf[ApplicativeClass[F]]
   type Apply[F[_]]            = InstanceOf[ApplyClass[F]]
+  type Bifunctor[F[_, _]]     = InstanceOf[BifunctorClass[F]]
   type Bind[M[_]]             = InstanceOf[BindClass[M]]
   type Category[=>:[_, _]]    = InstanceOf[CategoryClass[=>:]]
   type Choice[P[_, _]]        = InstanceOf[ChoiceClass[P]]
   type Cobind[F[_]]           = InstanceOf[CobindClass[F]]
   type Comonad[F[_]]          = InstanceOf[ComonadClass[F]]
   type Compose[P[_, _]]       = InstanceOf[ComposeClass[P]]
+  type Debug[A]               = InstanceOf[DebugClass[A]]
   type Foldable[T[_]]         = InstanceOf[FoldableClass[T]]
   type Functor[F[_]]          = InstanceOf[FunctorClass[F]]
   type InvariantFunctor[F[_]] = InstanceOf[InvariantFunctorClass[F]]
@@ -27,12 +29,12 @@ trait BaseTypeclasses {
   type Phantom[F[_]]          = InstanceOf[PhantomClass[F]]
   type Profunctor[F[_, _]]    = InstanceOf[ProfunctorClass[F]]
   type Semigroup[T]           = InstanceOf[SemigroupClass[T]]
-  type Debug[A]               = InstanceOf[DebugClass[A]]
   type Strong[F[_, _]]        = InstanceOf[StrongClass[F]]
   type Traversable[T[_]]      = InstanceOf[TraversableClass[T]]
 
   final def Applicative[F[_]](implicit F: Applicative[F]): Applicative[F]                = F
   final def Apply[F[_]](implicit F: Apply[F]): Apply[F]                                  = F
+  final def Bifunctor[F[_, _]](implicit F: Bifunctor[F]): Bifunctor[F]                   = F
   final def Bind[F[_]](implicit F: Bind[F]): Bind[F]                                     = F
   final def Category[=>:[_, _]](implicit P: Category[=>:]): Category[=>:]                = P
   final def Choice[P[_, _]](implicit P: Choice[P]): Choice[P]                            = P
@@ -115,6 +117,7 @@ trait AllInstances
     with data.IdentityInstances
     with data.TheseInstances
     with data.UpStarInstances
+    with typeclass.BifunctorInstances
     with typeclass.BindInstances
     with typeclass.ChoiceInstances
     with typeclass.CobindInstances
@@ -140,6 +143,7 @@ trait AllSyntax
     with data.Maybe2Syntax
     with typeclass.ApplicativeSyntax
     with typeclass.ApplySyntax
+    with typeclass.BifunctorSyntax
     with typeclass.BindSyntax
     with typeclass.ChoiceSyntax
     with typeclass.CobindSyntax

--- a/base/shared/src/main/scala/scalaz/data/DisjunctionInstances.scala
+++ b/base/shared/src/main/scala/scalaz/data/DisjunctionInstances.scala
@@ -1,7 +1,7 @@
 package scalaz
 package data
 
-import scalaz.typeclass.{BifunctorClass, BindClass, DebugClass, MonadClass}
+import scalaz.typeclass.{ BifunctorClass, BindClass, DebugClass, MonadClass }
 
 trait DisjunctionInstances {
   implicit def disjunctionMonad[L]: Monad[L \/ ?] =

--- a/base/shared/src/main/scala/scalaz/data/DisjunctionInstances.scala
+++ b/base/shared/src/main/scala/scalaz/data/DisjunctionInstances.scala
@@ -1,7 +1,7 @@
 package scalaz
 package data
 
-import scalaz.typeclass.{ BindClass, DebugClass, MonadClass }
+import scalaz.typeclass.{BifunctorClass, BindClass, DebugClass, MonadClass}
 
 trait DisjunctionInstances {
   implicit def disjunctionMonad[L]: Monad[L \/ ?] =
@@ -25,4 +25,12 @@ trait DisjunctionInstances {
       case -\/(left)  => s"""-\/(${L.debug(left)})"""
       case \/-(right) => s"""\/-(${R.debug(right)})"""
     }
+
+  implicit val disjunctionBifunctor: Bifunctor[Disjunction] =
+    instanceOf(new BifunctorClass[Disjunction] with BifunctorClass.DeriveLmapRmap[Disjunction] {
+      def bimap[A, B, S, T](fab: A \/ B)(as: A => S, bt: B => T): S \/ T = fab match {
+        case -\/(a) => -\/(as(a))
+        case \/-(b) => \/-(bt(b))
+      }
+    })
 }

--- a/base/shared/src/main/scala/scalaz/data/Maybe2.scala
+++ b/base/shared/src/main/scala/scalaz/data/Maybe2.scala
@@ -1,7 +1,7 @@
 package scalaz
 package data
 
-import scalaz.typeclass.DebugClass
+import scalaz.typeclass.{BifunctorClass, DebugClass}
 
 sealed trait Maybe2Module {
 
@@ -16,6 +16,7 @@ sealed trait Maybe2Module {
   implicit def isCovariant_1[B]: IsCovariant[Maybe2[?, B]]
   implicit def isCovariant_2[A]: IsCovariant[Maybe2[A, ?]]
   implicit def debug[A: Debug, B: Debug]: Debug[Maybe2[A, B]]
+  implicit def bifunctor: Bifunctor[Maybe2]
 
   object Just2 {
     def unapply[A, B](m: Maybe2[A, B]): Just2Extractor[A, B] = new Just2Extractor(toOption2(m))
@@ -49,6 +50,15 @@ private[data] object Maybe2Impl extends Maybe2Module {
       case Some2(_1, _2) => s"Just2(${A.debug(_1)}, ${B.debug(_2)})"
       case _             => "Empty2"
     }
+
+  implicit def bifunctor: scalaz.Bifunctor[Maybe2] =
+    instanceOf(new BifunctorClass[Maybe2] with BifunctorClass.DeriveLmapRmap[Maybe2] {
+      def bimap[A, B, S, T](fab: Maybe2[A, B])(as: A => S, bt: B => T): Maybe2[S, T] =
+        fab match {
+          case Some2(_1, _2) => Some2(as(_1), bt(_2))
+          case None2         => None2
+        }
+    })
 
   private[data] def fromOption2[A, B](o: Option2[A, B]): Maybe2[A, B] = o
   private[data] def toOption2[A, B](m: Maybe2[A, B]): Option2[A, B]   = m

--- a/base/shared/src/main/scala/scalaz/data/Maybe2.scala
+++ b/base/shared/src/main/scala/scalaz/data/Maybe2.scala
@@ -1,7 +1,7 @@
 package scalaz
 package data
 
-import scalaz.typeclass.{BifunctorClass, DebugClass}
+import scalaz.typeclass.{ BifunctorClass, DebugClass }
 
 sealed trait Maybe2Module {
 

--- a/base/shared/src/main/scala/scalaz/data/TheseInstances.scala
+++ b/base/shared/src/main/scala/scalaz/data/TheseInstances.scala
@@ -4,7 +4,13 @@ package data
 import scalaz.typeclass._
 
 trait TheseInstances {
-  // implicit def bifunctor: Bifunctor[These] = ...
+  implicit def bifunctor: Bifunctor[These] =
+    instanceOf(new BifunctorClass[These] {
+      def bimap[A, B, S, T](fab: These[A, B])(as: A => S, bt: B => T) = fab.bimap(as)(bt)
+
+      def lmap[A, B, S](fab: These[A, B])(as: A => S) = fab.lmap(as)
+      def rmap[A, B, T](fab: These[A, B])(bt: B => T) = fab.rmap(bt)
+    })
 
   implicit final def theseMonad[L: Semigroup]: Monad[These[L, ?]] =
     instanceOf(

--- a/base/shared/src/main/scala/scalaz/data/package.scala
+++ b/base/shared/src/main/scala/scalaz/data/package.scala
@@ -70,11 +70,17 @@ package object data {
     }
   }
 
+  val AFix: AFixModule = AFixImpl
+  type AFix[F[_[_, _], _, _], A, B] = AFix.AFix[F, A, B]
+
+  val AList: AListModule = AListImpl
+  type AList[F[_, _], A, B] = AList.AList[F, A, B]
+
   val Fix: FixModule = FixImpl
   type Fix[F[_]] = Fix.Fix[F]
 
-  val AFix: AFixModule = AFixImpl
-  type AFix[F[_[_, _], _, _], A, B] = AFix.AFix[F, A, B]
+  val IList: IListModule = IListImpl
+  type IList[A] = IList.IList[A]
 
   val Maybe: MaybeModule = MaybeImpl
   type Maybe[A] = Maybe.Maybe[A]
@@ -82,9 +88,4 @@ package object data {
   val Maybe2: Maybe2Module = Maybe2Impl
   type Maybe2[A, B] = Maybe2.Maybe2[A, B]
 
-  val IList: IListModule = IListImpl
-  type IList[A] = IList.IList[A]
-
-  val AList: AListModule = AListImpl
-  type AList[F[_, _], A, B] = AList.AList[F, A, B]
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/BifunctorClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/BifunctorClass.scala
@@ -1,0 +1,46 @@
+package scalaz
+package typeclass
+
+/** A typeclass for types which are (covariant) [[Functor]]s in both type parameters.
+  *
+  * Minimal definition:
+  * - `bimap` (using [[BifunctorClass.DeriveLmapRmap]])
+  * - `lmap` and `rmap` (using [[BifunctorClass.DeriveBimap]])
+  *
+  * The laws for a [[Bifunctor]] instance are:
+  * - for all `A`, `Bifunctor[A, ?]` must be a lawful [[Functor]] (with `map == rmap`);
+  * - for all `B`, `Bifunctor[?, B]` must be a lawful [[Functor]] (with `map == lmap`); and
+  * - for all types `A, B, S, T` functions `as: A => S, bt: B => T`, and `fab: F[A, B]`:
+  *   ```scala
+  *       lmap(rmap(fab)(bt))(as) === rmap(lmap(fab)(as))(bt) === bimap(fab)(as, bt)
+  *   ```
+  */
+trait BifunctorClass[F[_, _]] {
+
+  def bimap[A, B, S, T](fab: F[A, B])(as: A => S, bt: B => T): F[S, T]
+
+  def lmap[A, B, S](fab: F[A, B])(as: A => S): F[S, B]
+
+  def rmap[A, B, T](fab: F[A, B])(bt: B => T): F[A, T]
+
+}
+
+object BifunctorClass {
+
+  trait DeriveLmapRmap[F[_, _]] extends BifunctorClass[F] with Alt[DeriveLmapRmap[F]] {
+    def lmap[A, B, S](fab: F[A, B])(as: A => S): F[S, B] = bimap(fab)(as, identity)
+    def rmap[A, B, T](fab: F[A, B])(bt: B => T): F[A, T] = bimap(fab)(identity, bt)
+  }
+
+  trait DeriveBimap[F[_, _]] extends BifunctorClass[F] with Alt[DeriveBimap[F]] {
+    def bimap[A, B, S, T](fab: F[A, B])(as: A => S, bt: B => T): F[S, T] = rmap(lmap(fab)(as))(bt)
+  }
+
+  sealed trait Alt[D <: Alt[D]]
+
+  trait BifunctorFunctorTemplate[F[_, _], A] extends FunctorClass[F[A, ?]] {
+    val F: Bifunctor[F]
+
+    def map[B, BB](ma: F[A, B])(f: B => BB): F[A, BB] = F.rmap(ma)(f)
+  }
+}

--- a/base/shared/src/main/scala/scalaz/typeclass/BifunctorClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/BifunctorClass.scala
@@ -2,19 +2,19 @@ package scalaz
 package typeclass
 
 /** A typeclass for types which are (covariant) [[Functor]]s in both type parameters.
-  *
-  * Minimal definition:
-  * - `bimap` (using [[BifunctorClass.DeriveLmapRmap]])
-  * - `lmap` and `rmap` (using [[BifunctorClass.DeriveBimap]])
-  *
-  * The laws for a [[Bifunctor]] instance are:
-  * - for all `A`, `Bifunctor[A, ?]` must be a lawful [[Functor]] (with `map == rmap`);
-  * - for all `B`, `Bifunctor[?, B]` must be a lawful [[Functor]] (with `map == lmap`); and
-  * - for all types `A, B, S, T` functions `as: A => S, bt: B => T`, and `fab: F[A, B]`:
-  *   ```scala
-  *       lmap(rmap(fab)(bt))(as) === rmap(lmap(fab)(as))(bt) === bimap(fab)(as, bt)
-  *   ```
-  */
+ *
+ * Minimal definition:
+ * - `bimap` (using [[BifunctorClass.DeriveLmapRmap]])
+ * - `lmap` and `rmap` (using [[BifunctorClass.DeriveBimap]])
+ *
+ * The laws for a [[Bifunctor]] instance are:
+ * - for all `A`, `Bifunctor[A, ?]` must be a lawful [[Functor]] (with `map == rmap`);
+ * - for all `B`, `Bifunctor[?, B]` must be a lawful [[Functor]] (with `map == lmap`); and
+ * - for all types `A, B, S, T` functions `as: A => S, bt: B => T`, and `fab: F[A, B]`:
+ *   ```scala
+ *       lmap(rmap(fab)(bt))(as) === rmap(lmap(fab)(as))(bt) === bimap(fab)(as, bt)
+ *   ```
+ */
 trait BifunctorClass[F[_, _]] {
 
   def bimap[A, B, S, T](fab: F[A, B])(as: A => S, bt: B => T): F[S, T]

--- a/base/shared/src/main/scala/scalaz/typeclass/BifunctorInstances.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/BifunctorInstances.scala
@@ -1,0 +1,11 @@
+package scalaz
+package typeclass
+
+trait BifunctorInstances {
+
+  implicit final val tuple2Bifunctor: Bifunctor[Tuple2] =
+    instanceOf(new BifunctorClass[Tuple2] with BifunctorClass.DeriveBimap[Tuple2] {
+      def lmap[A, B, S](fab: (A, B))(f: A => S): (S, B) = fab.copy(_1 = f(fab._1))
+      def rmap[A, B, T](fab: (A, B))(f: B => T): (A, T) = fab.copy(_2 = f(fab._2))
+    })
+}

--- a/base/shared/src/main/scala/scalaz/typeclass/BifunctorSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/BifunctorSyntax.scala
@@ -1,0 +1,13 @@
+package scalaz
+package typeclass
+
+import language.experimental.macros
+
+trait BifunctorSyntax {
+  implicit final class ToBifunctorOps[F[_, _]: Bifunctor, A, B](ma: F[A, B]) {
+    def bimap[S, T](f: A => S, g: B => T): F[S, T] = macro meta.Ops.f_2
+
+    def lmap[S](f: A => S): F[S, B] = macro meta.Ops.f_1
+    def rmap[T](f: B => T): F[A, T] = macro meta.Ops.f_1
+  }
+}

--- a/base/shared/src/test/scala/SyntaxResolutionTest.scala
+++ b/base/shared/src/test/scala/SyntaxResolutionTest.scala
@@ -8,9 +8,9 @@ object SyntaxResolutionTest {
   def _apply[F[_]: Apply, A, B](fa: F[A], f: F[A => B]): F[B] = fa.ap(f)
 
   def _bifunctor[F[_, _]: Bifunctor, A, B, S, T](fab: F[A, B], as: A => S, bt: B => T) = {
-    fab.lmap(as)      : F[S, B]
-    fab.rmap(bt)      : F[A, T]
-    fab.bimap(as, bt) : F[S, T]
+    fab.lmap(as): F[S, B]
+    fab.rmap(bt): F[A, T]
+    fab.bimap(as, bt): F[S, T]
   }
 
   def _bind[F[_]: Bind, A, B](fa: F[A], f: A => F[B]): F[B] = fa.flatMap(f)

--- a/base/shared/src/test/scala/SyntaxResolutionTest.scala
+++ b/base/shared/src/test/scala/SyntaxResolutionTest.scala
@@ -7,6 +7,12 @@ object SyntaxResolutionTest {
 
   def _apply[F[_]: Apply, A, B](fa: F[A], f: F[A => B]): F[B] = fa.ap(f)
 
+  def _bifunctor[F[_, _]: Bifunctor, A, B, S, T](fab: F[A, B], as: A => S, bt: B => T) = {
+    fab.lmap(as)      : F[S, B]
+    fab.rmap(bt)      : F[A, T]
+    fab.bimap(as, bt) : F[S, T]
+  }
+
   def _bind[F[_]: Bind, A, B](fa: F[A], f: A => F[B]): F[B] = fa.flatMap(f)
 
   def _choice[F[_, _]: Choice, A, B, C](fab: F[A, B]) = {

--- a/example/src/main/resources/microsite/data/menu.yml
+++ b/example/src/main/resources/microsite/data/menu.yml
@@ -13,6 +13,12 @@ options:
     - title: Apply
       url: typeclass/Apply.html
       menu_section: typeclass
+    - tiel: Bifunctor
+      url: typeclass/Bifunctor.html
+      menu_section: typeclass
+    - title: Debug
+      url: typeclass/Debug.html
+      menu_section: typeclass
     - title: Functor
       url: typeclass/Functor.html
       menu_section: typeclass
@@ -25,9 +31,6 @@ options:
       menu_section: typeclass
     - title: Monoid
       url: typeclass/Monoid.html
-      menu_section: typeclass
-    - title: Show
-      url: typeclass/Show.html
       menu_section: typeclass
 
   - title: Data classes

--- a/example/src/main/tut/typeclass/Bifunctor.md
+++ b/example/src/main/tut/typeclass/Bifunctor.md
@@ -1,0 +1,39 @@
+---
+layout: docs
+title:  "Bifunctor"
+---
+
+# Bifunctor
+
+*The `Bifunctor` type class describes a type which has two type parameters,
+ each of which acts as a (covariant) [`Functor`](./Functor.html).*
+
+A `Bifunctor` must satisfy the following laws:
+
+- the `Functor` laws on the left:
+  - `lmap(elem)(identity) === elem`
+  - `lmap(elem)(f compose g) === lmap(lmap(elem(g)))(f)`
+- the `Functor` laws on the right:
+  - `rmap(elem)(identity) === elem`
+  - `rmap(elem)(f compose g) === rmap(rmap(elem(g)))(f)`
+- and a coherency law:
+  - `rmap(lmap(elem)(f))(g) === lmap(rmap(elem)(g))(f) == bimap(elem)(f, g)`
+
+## Instance declaration
+
+A `Bifunctor` can be declared by specifying either `bimap`, or both `lmap` and `rmap`.
+
+```tut
+import scalaz._, Prelude._, typeclass.BifunctorClass, data.These
+
+val tuple2Bifunctor: Bifunctor[Tuple2] =
+  instanceOf(new BifunctorClass[Tuple2] with BifunctorClass.DeriveBimap[Tuple2] {
+    def lmap[A, B, S](fab: (A, B))(f: A => S): (S, B) = fab.copy(_1 = f(fab._1))
+    def rmap[A, B, T](fab: (A, B))(f: B => T): (A, T) = fab.copy(_2 = f(fab._2))
+  })
+  
+val theseBifunctor: Bifunctor[These] = 
+  instanceOf(new BifunctorClass[These] with BifunctorClass.DeriveLmapRmap[These] {
+    def bimap[A, B, S, T](fab: A \&/ B)(as: A => S, bt: B => T): S \&/ T = fab.bimap(as)(bt)
+  })
+```


### PR DESCRIPTION
Instances for `\/`, `\&/`, `Tuple2`, `Maybe2`, and the doc page.

I considered ways to have `Bifunctor[F]` => `[A] => Functor[F[A, ?]]` and `Bifunctor[F]` => `[B] => Functor[Op[F, B, ?]]`, but I couldn't get the instances to resolve properly so here's the typeclass and syntax if nothing else.

Apropos of https://github.com/scalaz/scalaz/pull/1700#discussion_r180098197 and the impending bifunctoral `IO`.