### PR TITLE
Disable test parallelism in testsJS to reduce occurrences of OutOfMemoryError in Travis builds.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -149,7 +149,8 @@ lazy val tests = crossProject(JSPlatform, JVMPlatform).crossType(ScalazCrossType
     minSuccessfulTests := 33
   )
   .jsSettings(
-    minSuccessfulTests := 10
+    minSuccessfulTests := 10,
+    parallelExecution in Test := false
   )
   .dependsOn(core, effect, iteratee, scalacheckBinding)
   .jvmConfigure(_ dependsOn concurrent)


### PR DESCRIPTION
I've been getting `OutOfMemoryError` frequently in JS Travis builds (see e.g. https://travis-ci.org/scalaz/scalaz/builds/364824915).

Disabling test parallelism in JS tests seems to help, without increasing the build duration (see https://travis-ci.org/scalaz/scalaz/builds/365092254, which includes the change of this PR).