### PR TITLE
Symbolic ops macros.

### DIFF
--- a/base/shared/src/main/scala/scalaz/typeclass/EqSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/EqSyntax.scala
@@ -5,7 +5,7 @@ import scala.language.experimental.macros
 
 trait EqSyntax {
   implicit final class ToEqOps[A: Eq](a: A) {
-    private[typeclass] type Equal
-    def ===(f: A): Boolean = macro meta.SymOps.fa_1[Equal]
+    private[typeclass] type equal
+    def ===(f: A): Boolean = macro meta.SymOps.fa_1[equal]
   }
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/EqSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/EqSyntax.scala
@@ -1,9 +1,11 @@
 package scalaz
 package typeclass
 
+import scala.language.experimental.macros
+
 trait EqSyntax {
   implicit final class ToEqOps[A: Eq](a: A) {
-    // TODO: macro syntax
-    def ===(b: A): Boolean = implicitly[Eq[A]].equal(a, b)
+    private[typeclass] type Equal
+    def ===(f: A): Boolean = macro meta.SymOps.fa_1[Equal]
   }
 }

--- a/meta/shared/src/main/scala/scalaz/meta/Ops.scala
+++ b/meta/shared/src/main/scala/scalaz/meta/Ops.scala
@@ -117,9 +117,8 @@ class SymOps(val c: blackbox.Context) {
       case t => c.abort(c.enclosingPosition, s"Cannot extract subject of operation (tree = $t)")
     }
 
-    val methodNameEnd      = T.tpe.typeSymbol.name.encodedName.toString
-    val uncappedMethodName = String.valueOf(Character.toLowerCase(methodNameEnd.charAt(0))) + methodNameEnd.substring(1)
-    (ev, TermName(uncappedMethodName), lhs)
+    val methodName = T.tpe.typeSymbol.name.encodedName.toString
+    (ev, TermName(methodName), lhs)
   }
 }
 

--- a/meta/shared/src/main/scala/scalaz/meta/Ops.scala
+++ b/meta/shared/src/main/scala/scalaz/meta/Ops.scala
@@ -63,6 +63,66 @@ class Ops(val c: blackbox.Context) {
     }
 }
 
+/* Version of the zero-cost syntax macro that allows you to pass
+ * the method name in as a type.
+ */
+class SymOps(val c: blackbox.Context) {
+  import c.universe._
+
+  /* def method: R */
+  def f_0[T](implicit T: c.WeakTypeTag[T]): Tree = {
+    val (ev, name, lhs) = unpack[T]
+    q"$ev.$name($lhs)"
+  }
+
+  /* def method(a: A): R */
+  def f_1[T](f: Tree)(implicit T: c.WeakTypeTag[T]): Tree = {
+    val (ev, name, lhs) = unpack[T]
+    q"$ev.$name($lhs)($f)"
+  }
+
+  /* def method(f: A): R */
+  def fa_1[T](f: Tree)(implicit T: c.WeakTypeTag[T]): Tree = {
+    val (ev, name, lhs) = unpack[T]
+    q"$ev.$name($lhs, $f)"
+  }
+
+  /* def method(f: A)(g: B): R */
+  def f_1_1[T](f: Tree)(g: Tree)(implicit T: c.WeakTypeTag[T]): Tree = {
+    val (ev, name, lhs) = unpack[T]
+    q"$ev.$name($lhs)($f)($g)"
+  }
+
+  /* def method(f: A)(g: B): R */
+  def fa_1_1[T](f: Tree)(g: Tree)(implicit T: c.WeakTypeTag[T]): Tree = {
+    val (ev, name, lhs) = unpack[T]
+    q"$ev.$name($lhs, $f)($g)"
+  }
+
+  /* def method(f: A, g: B): R */
+  def f_2[T](f: Tree, g: Tree)(implicit T: c.WeakTypeTag[T]): Tree = {
+    val (ev, name, lhs) = unpack[T]
+    q"$ev.$name($lhs)($f, $g)"
+  }
+
+  /** Destructured macro application.
+   * - `ev`: the typeclass evidence
+   * - `name`: the name of the invoked method
+   * - `lhs`: the invocation target of the call
+   */
+  private def unpack[T](implicit T: c.WeakTypeTag[T]): (c.Tree, TermName, c.Tree) = {
+    val (ev, lhs) = c.prefix.tree match {
+      case Apply(Apply(TypeApply(_, _), List(lhs)), List(ev)) =>
+        (ev, lhs)
+      case t => c.abort(c.enclosingPosition, s"Cannot extract subject of operation (tree = $t)")
+    }
+
+    val methodNameEnd      = T.tpe.typeSymbol.name.encodedName.toString
+    val uncappedMethodName = String.valueOf(Character.toLowerCase(methodNameEnd.charAt(0))) + methodNameEnd.substring(1)
+    (ev, TermName(uncappedMethodName), lhs)
+  }
+}
+
 /** Versions of the zero-cost macros for when the receiver is not an instance
  * of the typeclass in question.
  */


### PR DESCRIPTION
https://github.com/scalaz/scalaz/pull/1411 served as inspiration.
See https://github.com/scalaz/scalaz/pull/1711/files#diff-726e672735d618c9d9bc069c449a4fbeL6 for an example.