### PR TITLE
Use hidden-covariance trick to avoid dead code warning.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,15 @@ Define type class instances in the same files as the data structure. Type class 
     trait MyDataStructureFunctions {
         final def emptyMds[A]: MyDataStructure[A] = ...
     }
+    
+### Variance
+
+Avoid using variant type parameters in defining data structures, even if they
+behave variantly. Instead, provide `widen` or `narrow` methods which allow for
+explicit use of variance.
+
+If there are branches without type parameters, use a `sealed abstract case class`
+to enable easy pattern matching support. See `IList.scala` for an example.
 
 ## Type Class Instances
 

--- a/core/src/main/scala/scalaz/IList.scala
+++ b/core/src/main/scala/scalaz/IList.scala
@@ -477,6 +477,7 @@ sealed abstract class IList[A] extends Product with Serializable {
 
 sealed abstract case class INil[A] private() extends IList[A]
 object INil {
+  // #1712: covariant subclass of `INil` makes the pattern matcher see it as covariant
   private[this] final class _INil[+A] extends INil[A]
   private[this] val value = new _INil[Nothing]
   def apply[A](): IList[A] = value.asInstanceOf[IList[A]]

--- a/core/src/main/scala/scalaz/IList.scala
+++ b/core/src/main/scala/scalaz/IList.scala
@@ -477,7 +477,8 @@ sealed abstract class IList[A] extends Product with Serializable {
 
 sealed abstract case class INil[A] private() extends IList[A]
 object INil {
-  private[this] val value: INil[Nothing] = new INil[Nothing]{}
+  private[this] final class _INil[+A] extends INil[A]
+  private[this] val value = new _INil[Nothing]
   def apply[A](): IList[A] = value.asInstanceOf[IList[A]]
 }
 final case class ICons[A](head: A, tail: IList[A]) extends IList[A]

--- a/core/src/main/scala/scalaz/Maybe.scala
+++ b/core/src/main/scala/scalaz/Maybe.scala
@@ -158,7 +158,8 @@ object Maybe extends MaybeInstances {
 
   sealed abstract case class Empty[A] private() extends Maybe[A]
   object Empty {
-    private[this] val value: Empty[Nothing] = new Empty[Nothing]{}
+    private[this] final class _Empty[+A] extends Empty[A]
+    private[this] val value = new _Empty[Nothing]
     def apply[A](): Maybe[A] = value.asInstanceOf[Empty[A]]
   }
 

--- a/core/src/main/scala/scalaz/Maybe.scala
+++ b/core/src/main/scala/scalaz/Maybe.scala
@@ -158,6 +158,7 @@ object Maybe extends MaybeInstances {
 
   sealed abstract case class Empty[A] private() extends Maybe[A]
   object Empty {
+    // #1712: covariant subclass of `INil` makes the pattern matcher see it as covariant
     private[this] final class _Empty[+A] extends Empty[A]
     private[this] val value = new _Empty[Nothing]
     def apply[A](): Maybe[A] = value.asInstanceOf[Empty[A]]


### PR DESCRIPTION
Previously:

```scala
def test(mi: Maybe[Int]) = mi match {
  case Maybe.Just(_) => "J"
  case Maybe.Empty() => "E"
}
```

would give a dead code warning on the `Empty` case, because Scala thinks that it will only match when `mi` could be a `Maybe[Nothing]`.

Closes scalaz/scalaz#1712.