### PR TITLE
Change deep map to synchronous deep bind tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.idea


### PR DESCRIPTION
- The deep map tests currently are simply wrong, and it's supposed to stackoverflow now. Encouraging deep map means you hate all that is good in the world. 
- We have no test for deep synchronous binds.