### PR TITLE
Replace all usages of "=:=" with "==="

### DIFF
--- a/core/src/main/scala/scalaz/BijectionT.scala
+++ b/core/src/main/scala/scalaz/BijectionT.scala
@@ -17,26 +17,26 @@ final class BijectionT[F[_], G[_], A, B] private[scalaz](_to: A => F[B], _from: 
   def fromK: Kleisli[G, B, A] =
     Kleisli(_from)
 
-  def lens(implicit evF: F[B] =:= Id[B], evG: G[A] =:= Id[A]): Lens[A, B] =
-    Lens(a => Store(from(_), to(a)))
+  def lens(implicit evF: F[B] === Id[B], evG: G[A] === Id[A]): Lens[A, B] =
+    Lens(a => Store(b => evG(from(b)), evF(to(a))))
 
-  def partial(implicit evF: F[B] =:= Id[B], evG: G[A] =:= Id[A]): PLens[A, B] =
+  def partial(implicit evF: F[B] === Id[B], evG: G[A] === Id[A]): PLens[A, B] =
     lens.partial
 
   /** alias for `partial` */
-  def unary_~(implicit evF: F[B] =:= Id[B], evG: G[A] =:= Id[A]) : PLens[A, B] =
+  def unary_~(implicit evF: F[B] === Id[B], evG: G[A] === Id[A]) : PLens[A, B] =
     partial
 
-  def bimap[C, X[_, _], D](g: Bijection[C, D])(implicit F: Bifunctor[X], evF: F[B] =:= Id[B], evG: G[A] =:= Id[A]): Bijection[X[A, C], X[B, D]] =
+  def bimap[C, X[_, _], D](g: Bijection[C, D])(implicit F: Bifunctor[X], evF: F[B] === Id[B], evG: G[A] === Id[A]): Bijection[X[A, C], X[B, D]] =
     bijection(
       F.bimap(_)(_to andThen evF, g.to(_)): Id[X[B, D]]
     , F.bimap(_)(_from andThen evG, g.from(_)): Id[X[A, C]]
     )
 
-  def ***[C, D](g: Bijection[C, D])(implicit evF: F[B] =:= Id[B], evG: G[A] =:= Id[A]): Bijection[(A, C), (B, D)] =
+  def ***[C, D](g: Bijection[C, D])(implicit evF: F[B] === Id[B], evG: G[A] === Id[A]): Bijection[(A, C), (B, D)] =
     bimap[C, Tuple2, D](g)
 
-  def ^^^[C, D](g: Bijection[C, D])(implicit evF: F[B] =:= Id[B], evG: G[A] =:= Id[A]): Bijection[A \/ C, B \/ D] =
+  def ^^^[C, D](g: Bijection[C, D])(implicit evF: F[B] === Id[B], evG: G[A] === Id[A]): Bijection[A \/ C, B \/ D] =
     bimap[C, \/, D](g)
 
   def compose[C](g: BijectionT[F, G, C, A])(implicit FM: Bind[F], GM: Bind[G]): BijectionT[F, G, C, B] =

--- a/core/src/main/scala/scalaz/Cokleisli.scala
+++ b/core/src/main/scala/scalaz/Cokleisli.scala
@@ -27,7 +27,6 @@ final case class Cokleisli[F[_], A, B](run: F[A] => B) { self =>
   def =<=[C](c: Cokleisli[F, C, A])(implicit F: Cobind[F]): Cokleisli[F, C, B] =
     compose(c)
 
-  import Leibniz.===
   def endo(implicit ev: B === A): Endomorphic[Cokleisli[F, ?, ?], A] =
     Endomorphic[Cokleisli[F, ?, ?], A](ev.subst[Cokleisli[F, A, ?]](this))
 }

--- a/core/src/main/scala/scalaz/EitherT.scala
+++ b/core/src/main/scala/scalaz/EitherT.scala
@@ -241,7 +241,7 @@ object EitherT extends EitherTInstances {
   def eitherTU[FAB, AB, A0, B0](fab: FAB)(implicit
                                           u1: Unapply[Functor, FAB]{type A = AB},
                                           @deprecated("scala/bug#5075", "") u2: Unapply2[Bifunctor, AB]{type A = A0; type B = B0},
-                                          l: Leibniz.===[AB, A0 \/ B0]
+                                          l: AB === (A0 \/ B0)
   ): EitherT[u1.M, A0, B0] = eitherT(l.subst[u1.M](u1(fab)))
 
   def monadTell[F[_], W, A](implicit MT0: MonadTell[F, W]): EitherTMonadTell[F, W, A] = new EitherTMonadTell[F, W, A]{

--- a/core/src/main/scala/scalaz/Free.scala
+++ b/core/src/main/scala/scalaz/Free.scala
@@ -293,7 +293,7 @@ sealed abstract class Free[S[_], A] {
     }
 
   /** Runs a trampoline all the way to the end, tail-recursively. */
-  final def run(implicit ev: Free[S, A] =:= Trampoline[A]): A =
+  final def run(implicit ev: Free[S, A] === Trampoline[A]): A =
     ev(this).go(_())
 
   /** Interleave this computation with another, combining the results with the given function. */
@@ -311,7 +311,7 @@ sealed abstract class Free[S[_], A] {
   }
 
   /** Runs a `Source` all the way to the end, tail-recursively, collecting the produced values. */
-  def collect[B](implicit ev: Free[S, A] =:= Source[B, A]): (Vector[B], A) = {
+  def collect[B](implicit ev: Free[S, A] === Source[B, A]): (Vector[B], A) = {
     @tailrec def go(c: Source[B, A], v: Vector[B] = Vector()): (Vector[B], A) =
       c.resume match {
         case -\/((b, cont)) => go(cont, v :+ b)
@@ -321,7 +321,7 @@ sealed abstract class Free[S[_], A] {
   }
 
   /** Drive this `Source` with the given Sink. */
-  def drive[E, B](sink: Sink[Option[E], B])(implicit ev: Free[S, A] =:= Source[E, A]): (A, B) = {
+  def drive[E, B](sink: Sink[Option[E], B])(implicit ev: Free[S, A] === Source[E, A]): (A, B) = {
     @tailrec def go(src: Source[E, A], snk: Sink[Option[E], B]): (A, B) =
       (src.resume, snk.resume) match {
         case (-\/((e, c)), -\/(f)) => go(c, f(Some(e)))
@@ -333,7 +333,7 @@ sealed abstract class Free[S[_], A] {
   }
 
   /** Feed the given stream to this `Source`. */
-  def feed[E](ss: Stream[E])(implicit ev: Free[S, A] =:= Sink[E, A]): A = {
+  def feed[E](ss: Stream[E])(implicit ev: Free[S, A] === Sink[E, A]): A = {
     @tailrec def go(snk: Sink[E, A], rest: Stream[E]): A = (rest, snk.resume) match {
       case (x #:: xs, -\/(f)) => go(f(x), xs)
       case (Stream(), -\/(f)) => go(f(sys.error("No more values.")), Stream())
@@ -343,7 +343,7 @@ sealed abstract class Free[S[_], A] {
   }
 
   /** Feed the given source to this `Sink`. */
-  def drain[E, B](source: Source[E, B])(implicit ev: Free[S, A] =:= Sink[E, A]): (A, B) = {
+  def drain[E, B](source: Source[E, B])(implicit ev: Free[S, A] === Sink[E, A]): (A, B) = {
     @tailrec def go(src: Source[E, B], snk: Sink[E, A]): (A, B) = (src.resume, snk.resume) match {
       case (-\/((e, c)), -\/(f)) => go(c, f(e))
       case (-\/((e, c)), \/-(y)) => go(c, Monad[Sink[E, ?]].pure(y))

--- a/core/src/main/scala/scalaz/IndexedContsT.scala
+++ b/core/src/main/scala/scalaz/IndexedContsT.scala
@@ -7,15 +7,15 @@ final case class IndexedContsT[W[_], M[_], R, O, A](_run: W[A => M[O]] => M[R]) 
   def apply(wamo: W[A => M[O]]): M[R] =
     run(wamo)
 
-  def run_(implicit W: Applicative[W], M: Applicative[M], ev: A =:= O): M[R] =
-    run(W.point(x => M.point(x)))
+  def run_(implicit W: Applicative[W], M: Applicative[M], ev: A === O): M[R] =
+    run(W.point(x => M.point(ev(x))))
 
   def map[B](f: A => B)(implicit W: Functor[W]): IndexedContsT[W, M, R, O, B] =
     IndexedContsT { wbmo =>
       run(W.map(wbmo)(f andThen _))
     }
 
-  def flatten[E, B](implicit ev: A =:= IndexedContsT[W, M, O, E, B], W: Cobind[W]): IndexedContsT[W, M, R, E, B] = flatMap(ev)
+  def flatten[E, B](implicit ev: A === IndexedContsT[W, M, O, E, B], W: Cobind[W]): IndexedContsT[W, M, R, E, B] = flatMap(ev)
 
   def flatMap[E, B](f: A => IndexedContsT[W, M, O, E, B])(implicit W: Cobind[W]): IndexedContsT[W, M, R, E, B] =
     IndexedContsT { wbme =>

--- a/core/src/main/scala/scalaz/LazyEitherT.scala
+++ b/core/src/main/scala/scalaz/LazyEitherT.scala
@@ -107,7 +107,7 @@ object LazyEitherT extends LazyEitherTInstances {
   def lazyEitherTU[FAB, AB, A0, B0](fab: FAB)(implicit
                                               u1: Unapply[Functor, FAB]{type A = AB},
                                               @deprecated("scala/bug#5075", "") u2: Unapply2[Bifunctor, AB]{type A = A0; type B = B0},
-                                              l: Leibniz.===[AB, LazyEither[A0, B0]]
+                                              l: AB === LazyEither[A0, B0]
   ): LazyEitherT[u1.M, A0, B0] = LazyEitherT(l.subst[u1.M](u1(fab)))
 
   import LazyEither._

--- a/core/src/main/scala/scalaz/Leibniz.scala
+++ b/core/src/main/scala/scalaz/Leibniz.scala
@@ -69,7 +69,8 @@ sealed abstract class LeibnizInstances {
 object Leibniz extends LeibnizInstances {
 
   /** `(A === B)` is a supertype of `Leibniz[L,H,A,B]` */
-  type ===[A,B] = Leibniz[⊥, ⊤, A, B]
+  @deprecated("Use scalaz's package's type alias instead", "7.3.x")
+  type ===[A,B] = scalaz.===[A, B]
 
   /** Equality is reflexive -- we rely on subtyping to expand this type */
   implicit def refl[A]: Leibniz[A, A, A, A] = new Leibniz[A, A, A, A] {

--- a/core/src/main/scala/scalaz/Leibniz.scala
+++ b/core/src/main/scala/scalaz/Leibniz.scala
@@ -35,7 +35,7 @@ sealed abstract class Leibniz[-L, +H >: L, A >: L <: H, B >: L <: H] {
 }
 
 sealed abstract class LeibnizInstances {
-  import Leibniz._
+  import Leibniz.{=== => _, _}
 
   implicit val leibniz: Category[===] = new Category[===] {
     def id[A]: (A === A) = refl[A]
@@ -80,10 +80,10 @@ object Leibniz extends LeibnizInstances {
   /** We can witness equality by using it to convert between types
    * We rely on subtyping to enable this to work for any Leibniz arrow
    */
-  implicit def witness[A, B](f: A === B): A => B =
+  implicit def witness[A, B](f: scalaz.===[A, B]): A => B =
     f.subst[A => ?](identity)
 
-  implicit def subst[A, B](a: A)(implicit f: A === B): B = f.subst[Id](a)
+  implicit def subst[A, B](a: A)(implicit f: scalaz.===[A, B]): B = f.subst[Id](a)
 
   /** Equality is transitive */
   def trans[L, H >: L, A >: L <: H, B >: L <: H, C >: L <: H](
@@ -165,7 +165,7 @@ object Leibniz extends LeibnizInstances {
     T[_ >: LA <: HA] /*: Injective*/,
     A >: LA <: HA, A2 >: LA <: HA
   ](
-    t: T[A] === T[A2]
+    t: scalaz.===[T[A], T[A2]]
   ): Leibniz[LA, HA, A, A2] = force[LA, HA, A, A2]
 
   def lower2[
@@ -175,6 +175,6 @@ object Leibniz extends LeibnizInstances {
     A >: LA <: HA, A2 >: LA <: HA,
     B >: LB <: HB, B2 >: LB <: HB
   ](
-   t: T[A, B] === T[A2, B2]
+   t: scalaz.===[T[A, B], T[A2, B2]]
   ): (Leibniz[LA, HA, A, A2], Leibniz[LB, HB, B, B2]) = (force[LA, HA, A, A2], force[LB, HB, B, B2])
 }

--- a/core/src/main/scala/scalaz/Lens.scala
+++ b/core/src/main/scala/scalaz/Lens.scala
@@ -7,7 +7,7 @@ import scala.collection.immutable
  * A Lens Family, offering a purely functional means to access and retrieve
  * a field transitioning from type `B1` to type `B2` in a record simultaneously
  * transitioning from type `A1` to type `A2`.  [[scalaz.Lens]] is a convenient
- * alias for when `A1 =:= A2`, and `B1 =:= B2`.
+ * alias for when `A1 === A2`, and `B1 === B2`.
  *
  * The term ''field'' should not be interpreted restrictively to mean a member of a class. For example, a lens
  * family can address membership of a `Set`.

--- a/core/src/main/scala/scalaz/PLens.scala
+++ b/core/src/main/scala/scalaz/PLens.scala
@@ -4,7 +4,7 @@ package scalaz
  * Partial Lens Families, offering a purely functional means to access and retrieve
  * an optional field transitioning from type `B1` to type `B2` in a record that is
  * simultaneously transitioning from type `A1` to type `A2`.  [[scalaz.PLens]] is a
- * convenient alias for when `A1 =:= A2`, and `B1 =:= B2`.
+ * convenient alias for when `A1 === A2`, and `B1 === B2`.
  *
  * The term ''field'' should not be interpreted restrictively to mean a member of a class. For example, a partial lens
  * family can address the nth element of a `List`.

--- a/core/src/main/scala/scalaz/StreamT.scala
+++ b/core/src/main/scala/scalaz/StreamT.scala
@@ -156,7 +156,7 @@ sealed class StreamT[M[_], A](val step: M[StreamT.Step[A, StreamT[M, A]]]) {
    * of this stream will be evaluated, and depending on the structure of
    * this stream, up to two elements might be evaluated.
    */
-  def asStream(implicit ev: M[Step[A, StreamT[M, A]]] =:= Id[Step[A, StreamT[Id, A]]]): Stream[A] = {
+  def asStream(implicit ev: M[Step[A, StreamT[M, A]]] === Id[Step[A, StreamT[Id, A]]]): Stream[A] = {
     def go(s: StreamT[Id, A]): Stream[A] = s.unconsRec match {
       case None => Stream.empty[A]
       case Some((a, s1)) => Stream.cons(a, go(s1))

--- a/core/src/main/scala/scalaz/TracedT.scala
+++ b/core/src/main/scala/scalaz/TracedT.scala
@@ -109,7 +109,7 @@ object TracedT extends TracedTInstances {
   def tracedTU[WAB, AB, A0, B0](wab: WAB)(implicit
                                           U1: Unapply[Functor, WAB]{type A = AB},
                                           @deprecated("scala/bug#5075", "") U2: Unapply2[Profunctor, AB]{type A = A0; type B = B0},
-                                          L: Leibniz.===[AB, A0 => B0]
+                                          L: AB === (A0 => B0)
   ): TracedT[U1.M, A0, B0] = TracedT(L.subst[U1.M](U1(wab)))
 
   import scalaz.Isomorphism._

--- a/core/src/main/scala/scalaz/Unapply.scala
+++ b/core/src/main/scala/scalaz/Unapply.scala
@@ -59,7 +59,7 @@ trait Unapply[TC[_[_]], MA] {
   /** The instance of the type class */
   def TC: TC[M]
 
-  /** Evidence that MA =:= M[A] */
+  /** Evidence that MA === M[A] */
   def leibniz: MA === M[A]
 
   /** Compatibility. */
@@ -162,7 +162,7 @@ trait Unapply2[TC[_[_, _]], MAB] {
   /** The instance of the type class */
   def TC: TC[M]
 
-  /** Evidence that MAB =:= M[A, B] */
+  /** Evidence that MAB === M[A, B] */
   def leibniz: MAB === M[A, B]
 
   /** Compatibility. */

--- a/core/src/main/scala/scalaz/Unapply.scala
+++ b/core/src/main/scala/scalaz/Unapply.scala
@@ -1,7 +1,7 @@
 package scalaz
 
 import scala.annotation._
-import Leibniz.{===, refl}
+import Leibniz.refl
 
 /**
  * Represents a type `MA` that has been destructured into as a type constructor `M[_]`

--- a/core/src/main/scala/scalaz/WriterT.scala
+++ b/core/src/main/scala/scalaz/WriterT.scala
@@ -287,7 +287,7 @@ trait WriterTFunctions {
   def writerTU[FAB, AB, A0, B0](fab: FAB)(implicit
                                           u1: Unapply[Functor, FAB]{type A = AB},
                                           @deprecated("scala/bug#5075", "") u2: Unapply2[Bifunctor, AB]{type A = A0; type B = B0},
-                                          l: Leibniz.===[AB, (A0, B0)]
+                                          l: AB === (A0, B0)
   ): WriterT[u1.M, A0, B0] = WriterT(l.subst[u1.M](u1(fab)))
 
   def writer[W, A](v: (W, A)): Writer[W, A] =

--- a/core/src/main/scala/scalaz/package.scala
+++ b/core/src/main/scala/scalaz/package.scala
@@ -113,6 +113,9 @@ package object scalaz {
   type <~[+F[_], -G[_]] = NaturalTransformation[G, F]
   type ~~>[-F[_,_], +G[_,_]] = BiNaturalTransformation[F, G]
 
+  /** `(A === B)` is a supertype of `Leibniz[L,H,A,B]` */
+  type ===[A,B] = Leibniz[⊥, ⊤, A, B]
+
   type ⊥ = Nothing
   type ⊤ = Any
 

--- a/core/src/main/scala/scalaz/syntax/BifunctorSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/BifunctorSyntax.scala
@@ -10,7 +10,7 @@ final class BifunctorOps[F[_, _],A, B] private[syntax](val self: F[A, B])(implic
   final def :->[D](g: B => D): F[A, D] = F.bimap(self)(a => a, g)
   final def <-:[C](f: A => C): F[C, B] = F.bimap(self)(f, b => b)
   final def <:>[C](f: A => C)(implicit z: B <~< C): F[C, C] = F.bimap(self)(f, z)
-  final def umap[C](f: A => C)(implicit ev: F[A, B] =:= F[A, A]): F[C, C] = F.umap(ev(self))(f)
+  final def umap[C](f: A => C)(implicit ev: F[A, B] === F[A, A]): F[C, C] = F.umap(ev(self))(f)
   final def rightMap[D](g: B => D): F[A, D] = F.bimap(self)(a => a, g)
   final def leftMap[C](f: A => C): F[C, B] = F.bimap(self)(f, b => b)
   final def rightAs[C](c: => C): F[A, C] = F.bimap(self)(a => a, _ => c)

--- a/core/src/main/scala/scalaz/syntax/BindSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/BindSyntax.scala
@@ -4,7 +4,7 @@ package syntax
 /** Wraps a value `self` and provides methods related to `Bind` */
 final class BindOps[F[_],A] private[syntax](val self: F[A])(implicit val F: Bind[F]) extends Ops[F[A]] {
   ////
-  import Liskov.<~<, Leibniz.===
+  import Liskov.<~<
 
   def flatMap[B](f: A => F[B]): F[B] = F.bind(self)(f)
 

--- a/core/src/main/scala/scalaz/syntax/BitraverseSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/BitraverseSyntax.scala
@@ -10,7 +10,6 @@ final class BitraverseOps[F[_, _],A, B] private[syntax](val self: F[A, B])(impli
   final def bitraverseU[GC, GD](f: A => GC, g: B => GD)(implicit G1: UnapplyProduct[Applicative, GC, GD]): G1.M[F[G1.A, G1.B]] =
       F.bitraverseImpl(self)(a => G1._1(f(a)), b => G1._2(g(b)))(G1.TC)
 
-  import Leibniz.===
 
   final def bisequence[G[_], A1, B1](implicit G: Applicative[G], eva: A === G[A1], evb: B === G[B1]): G[F[A1, B1]] =
     bitraverse(fa => eva(fa), fb => evb(fb))

--- a/core/src/main/scala/scalaz/syntax/Foldable1Syntax.scala
+++ b/core/src/main/scala/scalaz/syntax/Foldable1Syntax.scala
@@ -4,7 +4,6 @@ package syntax
 /** Wraps a value `self` and provides methods related to `Foldable1` */
 final class Foldable1Ops[F[_],A] private[syntax](val self: F[A])(implicit val F: Foldable1[F]) extends Ops[F[A]] {
   ////
-  import Leibniz.===
 
   final def foldMapRight1[B](z: A => B)(f: (A, => B) => B): B = F.foldMapRight1(self)(z)(f)
   final def foldMapLeft1[B](z: A => B)(f: (B, A) => B): B = F.foldMapLeft1(self)(z)(f)

--- a/core/src/main/scala/scalaz/syntax/FoldableSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/FoldableSyntax.scala
@@ -5,7 +5,6 @@ package syntax
 final class FoldableOps[F[_],A] private[syntax](val self: F[A])(implicit val F: Foldable[F]) extends Ops[F[A]] {
   ////
   import collection.generic.CanBuildFrom
-  import Leibniz.===
   import Liskov.<~<
 
   final def foldMap[B: Monoid](f: A => B = (a: A) => a): B = F.foldMap(self)(f)

--- a/core/src/main/scala/scalaz/syntax/FunctorSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/FunctorSyntax.scala
@@ -4,7 +4,6 @@ package syntax
 /** Wraps a value `self` and provides methods related to `Functor` */
 final class FunctorOps[F[_],A] private[syntax](val self: F[A])(implicit val F: Functor[F]) extends Ops[F[A]] {
   ////
-  import Leibniz.===
   import Liskov.<~<
 
   final def map[B](f: A => B): F[B] = F.map(self)(f)

--- a/core/src/main/scala/scalaz/syntax/MonadPlusSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadPlusSyntax.scala
@@ -4,7 +4,6 @@ package syntax
 /** Wraps a value `self` and provides methods related to `MonadPlus` */
 final class MonadPlusOps[F[_],A] private[syntax](val self: F[A])(implicit val F: MonadPlus[F]) extends Ops[F[A]] {
   ////
-  import Leibniz.===
 
   def filter(f: A => Boolean): F[A] =
     F.filter(self)(f)

--- a/core/src/main/scala/scalaz/syntax/Traverse1Syntax.scala
+++ b/core/src/main/scala/scalaz/syntax/Traverse1Syntax.scala
@@ -5,7 +5,6 @@ package syntax
 final class Traverse1Ops[F[_],A] private[syntax](val self: F[A])(implicit val F: Traverse1[F]) extends Ops[F[A]] {
   ////
 
-  import Leibniz.===
 
   final def traverse1[G[_], B](f: A => G[B])(implicit G: Apply[G]): G[F[B]] =
     G.traverse1(self)(f)

--- a/core/src/main/scala/scalaz/syntax/TraverseSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/TraverseSyntax.scala
@@ -5,7 +5,6 @@ package syntax
 final class TraverseOps[F[_],A] private[syntax](val self: F[A])(implicit val F: Traverse[F]) extends Ops[F[A]] {
   ////
 
-  import Leibniz.===
 
   final def tmap[B](f: A => B): F[B] =
     F.map(self)(f)

--- a/core/src/main/scala/scalaz/syntax/std/Function1Ops.scala
+++ b/core/src/main/scala/scalaz/syntax/std/Function1Ops.scala
@@ -2,7 +2,6 @@ package scalaz
 package syntax
 package std
 
-import Leibniz.===
 
 final class Function1Ops[T, R](private val self: T => R) extends AnyVal {
 

--- a/core/src/main/scala/scalaz/syntax/std/Function1Ops.scala
+++ b/core/src/main/scala/scalaz/syntax/std/Function1Ops.scala
@@ -16,8 +16,8 @@ final class Function1Ops[T, R](private val self: T => R) extends AnyVal {
 
   def unary_!(implicit m: Memo[T, R]): T => R = m(self)
 
-  def toValidation[E](e: => E)(implicit ev: R =:= Boolean): T => Validation[NonEmptyList[E], T] =
-    (t: T) => (if (self(t): Boolean) Success(t) else Failure(NonEmptyList(e)))
+  def toValidation[E](e: => E)(implicit ev: R === Boolean): T => Validation[NonEmptyList[E], T] =
+    (t: T) => (if (ev(self(t))) Success(t) else Failure(NonEmptyList(e)))
 
   def byName: (=> T) => R = t => self(t)
 

--- a/core/src/main/scala/scalaz/syntax/std/Function2Ops.scala
+++ b/core/src/main/scala/scalaz/syntax/std/Function2Ops.scala
@@ -7,7 +7,7 @@ final class Function2Ops[T1, T2, R](private val self: (T1, T2) => R) extends Any
 
   def on[X](f: (R, R) => X, t1: (T1, T1), t2: (T2, T2)): X = f(self(t1._1, t2._1), self(t1._2, t2._2))
 
-  def contramap[TT](f: TT => T1)(implicit ev: T1 =:= T2): (TT, TT) => R = (t1, t2) => self(f(t1), ev(f(t2)))
+  def contramap[TT](f: TT => T1)(implicit ev: T1 === T2): (TT, TT) => R = (t1, t2) => self(f(t1), ev(f(t2)))
 
   def lift[F[_]](implicit F: Applicative[F]): (F[T1], F[T2]) => F[R] = F.lift2(self)
 

--- a/core/src/main/scala/scalaz/syntax/std/ListOps.scala
+++ b/core/src/main/scala/scalaz/syntax/std/ListOps.scala
@@ -40,7 +40,7 @@ final class ListOps[A](private val self: List[A]) extends AnyVal {
 
   final def groupWhen(p: (A, A) => Boolean): List[NonEmptyList[A]] = l.groupWhen(self)(p)
 
-  final def lookup[B, C](key: B)(implicit eq: Equal[B], ev: A =:= (B, C)): Option[C] = self.find((x: A) => eq.equal(ev(x)._1, key)).map(_._2)
+  final def lookup[B, C](key: B)(implicit eq: Equal[B], ev: A === (B, C)): Option[C] = self.find((x: A) => eq.equal(ev(x)._1, key)).map(ev(_)._2)
 
   final def mapAccumLeft[B, C](c: C, f: (C, A) => (C, B)): (C, List[B]) = l.mapAccumLeft(self)(c, f)
 

--- a/example/src/main/scala/scalaz/example/TraverseUsage.scala
+++ b/example/src/main/scala/scalaz/example/TraverseUsage.scala
@@ -61,7 +61,7 @@ object TraverseUsage extends App {
   // val result = validations.sequence
 
   // it gives you the perhaps hard to understand error:
-  // could not find implicit value for parameter ev: scalaz.Leibniz.===[scalaz.Validation[String,Int],G[B]
+  // could not find implicit value for parameter ev: scalaz.===[scalaz.Validation[String,Int],G[B]
 
   // these however work:
   val result: ValidationNel[String, Vector[Int]] = validations.sequenceU

--- a/iteratee/src/main/scala/scalaz/iteratee/EnumeratorT.scala
+++ b/iteratee/src/main/scala/scalaz/iteratee/EnumeratorT.scala
@@ -22,7 +22,7 @@ trait EnumeratorT[E, F[_]] { self =>
   def flatMap[B](f: E => EnumeratorT[B, F])(implicit M1: Monad[F]): EnumeratorT[B, F] =
     EnumerateeT.flatMap(f) run self
 
-  def flatten[B](implicit ev: E =:= F[B], F: Monad[F]): EnumeratorT[B, F] =
+  def flatten[B](implicit ev: E === F[B], F: Monad[F]): EnumeratorT[B, F] =
     flatMap(e => EnumeratorT.enumeratorTMonadTrans.liftM(ev(e)))
 
   def bindM[B, G[_]](f: E => G[EnumeratorT[B, F]])(implicit F: Monad[F], G: Monad[G]): F[G[EnumeratorT[B, F]]] = {

--- a/iteratee/src/main/scala/scalaz/iteratee/IterateeT.scala
+++ b/iteratee/src/main/scala/scalaz/iteratee/IterateeT.scala
@@ -116,7 +116,7 @@ sealed abstract class IterateeT[E, F[_], A] {
     ))
   }
 
-  def joinI[I, B](implicit outer: IterateeT[E, F, A] =:= IterateeT[E, F, StepT[I, F, B]], M: Monad[F]): IterateeT[E, F, B] = {
+  def joinI[I, B](implicit outer: IterateeT[E, F, A] === IterateeT[E, F, StepT[I, F, B]], M: Monad[F]): IterateeT[E, F, B] = {
     val M0 = IterateeT.IterateeTMonad[E, F]
     def check: StepT[I, F, B] => IterateeT[E, F, B] = _.fold(
       cont = k => k(eofInput) >>== {

--- a/tests/src/test/scala/scalaz/UnapplyTest.scala
+++ b/tests/src/test/scala/scalaz/UnapplyTest.scala
@@ -1,6 +1,5 @@
 package scalaz
 
-import Leibniz.===
 
 object UnapplyTest extends SpecLite {
   def teq[A[_], B[X] >: A[X] <: A[X]]: Unit = ()


### PR DESCRIPTION
As suggested in fommil/fpmortals#49

I couldn't compile and test this on my local machine due to a "file name too long" error during compilation.