### PR TITLE
Issue #1706 - Potentially short-circuiting foldMap

### DIFF
--- a/core/src/main/scala/scalaz/IList.scala
+++ b/core/src/main/scala/scalaz/IList.scala
@@ -626,14 +626,6 @@ sealed abstract class IListInstances extends IListInstance0 {
           case INil() => None
         }
 
-      // WARNING: not stack safe, but expected to short-circuit
-      override def psumMap[A, B, G[_]](fa: IList[A])(f: A => G[B])(implicit G: PlusEmpty[G]): G[B] =
-        fa match {
-          case INil() => G.empty[B]
-          case ICons(head, tail) =>
-            G.plus(f(head), psumMap(tail)(f)(G))
-        }
-
       override def index[A](fa: IList[A], i: Int) = {
         @tailrec def go(as: IList[A], n: Int): Option[A] = as match {
           case ICons(h, t) => if(n == i) Some(h) else go(t, n + 1)

--- a/core/src/main/scala/scalaz/IList.scala
+++ b/core/src/main/scala/scalaz/IList.scala
@@ -609,7 +609,10 @@ sealed abstract class IListInstances extends IListInstance0 {
         foldMapLeft1Opt(fa.reverse)(z)((b, a) => f(a, b))
 
       override def foldMap[A, B](fa: IList[A])(f: A => B)(implicit M: Monoid[B]) =
-        fa.foldLeft(M.zero)((b, a) => M.append(b, f(a)))
+        M.unfoldrSum(fa)(as => as.headOption match {
+          case Some(a) => Maybe.just((f(a), as.tailOption.getOrElse(IList.empty)))          
+          case None => Maybe.empty
+        })
 
       override def foldMap1Opt[A, B](fa: IList[A])(f: A => B)(implicit M: Semigroup[B]) =
         fa match {

--- a/core/src/main/scala/scalaz/NonEmptyList.scala
+++ b/core/src/main/scala/scalaz/NonEmptyList.scala
@@ -167,6 +167,12 @@ sealed abstract class NonEmptyListInstances extends NonEmptyListInstances0 {
       override def findLeft[A](fa: NonEmptyList[A])(f: A => Boolean) =
         if(f(fa.head)) Some(fa.head) else fa.tail.find(f)
 
+      override def foldMap[A, B](fa: NonEmptyList[A])(f: A => B)(implicit M: Monoid[B]) =
+        M.unfoldrSum(fa.list)(as => as.headOption match {
+          case Some(a) => Maybe.just((f(a), as.tailOption.getOrElse(IList.empty)))
+          case None => Maybe.empty
+        })   
+
       def traverse1Impl[G[_] : Apply, A, B](fa: NonEmptyList[A])(f: A => G[B]): G[NonEmptyList[B]] =
         fa traverse1 f
 
@@ -181,12 +187,6 @@ sealed abstract class NonEmptyListInstances extends NonEmptyListInstances0 {
       override def foldMap1[A, B](fa: NonEmptyList[A])(f: A => B)(implicit F: Semigroup[B]): B = {
         fa.tail.foldLeft(f(fa.head))((x, y) => F.append(x, f(y)))
       }
-
-      override def foldMap[A, B](fa: NonEmptyList[A])(f: A => B)(implicit M: Monoid[B]) =
-        M.unfoldrSum(fa.list)(as => as.headOption match {
-          case Some(a) => Maybe.just((f(a), as.tailOption.getOrElse(IList.empty)))
-          case None => Maybe.empty
-        })   
 
       override def psumMap1[A, B, G[_]](fa: NonEmptyList[A])(f: A => G[B])(implicit G: Plus[G]): G[B] =
         fa.tail match {

--- a/core/src/main/scala/scalaz/NonEmptyList.scala
+++ b/core/src/main/scala/scalaz/NonEmptyList.scala
@@ -182,6 +182,12 @@ sealed abstract class NonEmptyListInstances extends NonEmptyListInstances0 {
         fa.tail.foldLeft(f(fa.head))((x, y) => F.append(x, f(y)))
       }
 
+      override def foldMap[A, B](fa: NonEmptyList[A])(f: A => B)(implicit M: Monoid[B]) =
+        M.unfoldrSum(fa.list)(as => as.headOption match {
+          case Some(a) => Maybe.just((f(a), as.tailOption.getOrElse(IList.empty)))
+          case None => Maybe.empty
+        })   
+
       override def psumMap1[A, B, G[_]](fa: NonEmptyList[A])(f: A => G[B])(implicit G: Plus[G]): G[B] =
         fa.tail match {
           case INil() => f(fa.head)

--- a/core/src/main/scala/scalaz/NonEmptyList.scala
+++ b/core/src/main/scala/scalaz/NonEmptyList.scala
@@ -168,10 +168,7 @@ sealed abstract class NonEmptyListInstances extends NonEmptyListInstances0 {
         if(f(fa.head)) Some(fa.head) else fa.tail.find(f)
 
       override def foldMap[A, B](fa: NonEmptyList[A])(f: A => B)(implicit M: Monoid[B]) =
-        M.unfoldrSum(fa.list)(as => as.headOption match {
-          case Some(a) => Maybe.just((f(a), as.tailOption.getOrElse(IList.empty)))
-          case None => Maybe.empty
-        })   
+        Foldable[IList].foldMap(fa.list)(f)(M)
 
       def traverse1Impl[G[_] : Apply, A, B](fa: NonEmptyList[A])(f: A => G[B]): G[NonEmptyList[B]] =
         fa traverse1 f

--- a/core/src/main/scala/scalaz/std/List.scala
+++ b/core/src/main/scala/scalaz/std/List.scala
@@ -64,6 +64,12 @@ trait ListInstances extends ListInstances0 {
         r
       }
 
+      override def foldMap[A, B](fa: List[A])(f: A => B)(implicit M: Monoid[B]) =
+        M.unfoldrSum(fa)(as => as.headOption match {
+          case Some(a) => Maybe.just((f(a), as.tail))
+          case None => Maybe.empty
+        })
+
       override def psumMap[A, B, G[_]](fa: List[A])(f: A => G[B])(implicit G: PlusEmpty[G]): G[B] =
         fa match {
           case Nil => G.empty[B]

--- a/core/src/main/scala/scalaz/std/List.scala
+++ b/core/src/main/scala/scalaz/std/List.scala
@@ -70,12 +70,6 @@ trait ListInstances extends ListInstances0 {
           case None => Maybe.empty
         })
 
-      override def psumMap[A, B, G[_]](fa: List[A])(f: A => G[B])(implicit G: PlusEmpty[G]): G[B] =
-        fa match {
-          case Nil => G.empty[B]
-          case head :: tail => G.plus(f(head), psumMap(tail)(f)(G))
-        }
-
       def cobind[A, B](fa: List[A])(f: List[A] => B) =
         fa match {
           case Nil => Nil

--- a/tests/src/test/scala/scalaz/FoldableTest.scala
+++ b/tests/src/test/scala/scalaz/FoldableTest.scala
@@ -6,7 +6,7 @@ import syntax.foldable._
 import syntax.equal._
 import org.scalacheck.Prop.forAll
 import org.scalacheck.{Arbitrary, Properties}
-import scalaz.Foldable.FromFoldMap
+//import scalaz.Foldable.FromFoldMap
 
 object FoldableTest extends SpecLite {
   "to" ! forAll {
@@ -144,7 +144,8 @@ object FoldableTest extends SpecLite {
   "psumMap should be stack-safe and short-circuiting with EphemeralStream" in {
     import Maybe.{empty, just}
     val N = 10000
-    EphemeralStream.fromStream(Stream.from(1)).psumMap(i =>
+    val xs = EphemeralStream.fromStream(Stream.from(1))
+    xs.psumMap(i =>
       if(i < N) empty[String]
       else if(i == N) just("Stop")
       else sys.error("BOOM!")
@@ -154,7 +155,7 @@ object FoldableTest extends SpecLite {
   "psumMap should be stack-safe and short-circuiting with List" in {
     import Maybe.{empty, just}
     val N = 10000
-    List.range(1,11000).psumMap(i =>
+    List.range(1, 11000).psumMap(i =>
       if(i < N) empty[String]
       else if(i == N) just("Stop")
       else sys.error("BOOM!")
@@ -164,7 +165,8 @@ object FoldableTest extends SpecLite {
   "psumMap should be stack-safe and short-circuiting with IList" in {
     import Maybe.{empty, just}
     val N = 10000
-    IList.fromList(List.range(1,11000)).psumMap(i =>
+    val xs = IList.fromList(List.range(1, 11000))
+    xs.psumMap(i =>
       if(i < N) empty[String]
       else if(i == N) just("Stop")
       else sys.error("BOOM!")
@@ -173,8 +175,9 @@ object FoldableTest extends SpecLite {
   
   "psumMap should be short-circuiting with NonEmptyList" in {
     import Maybe.{empty, just}
-    val N = 4
-    NonEmptyList(1,2,3,4,5,6,7,8).psumMap(i =>
+    val N = 10000
+    val xs = NonEmptyList.nel(1, IList.fromList(List.range(2, 11000)))
+    xs.psumMap(i =>
       if(i < N) empty[String]
       else if(i == N) just("Stop")
       else sys.error("BOOM!")

--- a/tests/src/test/scala/scalaz/FoldableTest.scala
+++ b/tests/src/test/scala/scalaz/FoldableTest.scala
@@ -143,9 +143,10 @@ object FoldableTest extends SpecLite {
 
   "psumMap should be stack-safe and short-circuiting with EphemeralStream" in {
     import Maybe.{empty, just}
-    EphemeralStream(1,2,3,4,5,6,7).psumMap(i =>
-      if(i < 4) empty[String]
-      else if(i < 4 + 2) just("Stop")
+    val N = 10000
+    EphemeralStream.fromStream(Stream.from(1)).psumMap(i =>
+      if(i < N) empty[String]
+      else if(i == N) just("Stop")
       else sys.error("BOOM!")
     ) must_=== just("Stop")
   }
@@ -286,7 +287,7 @@ object FoldableTest extends SpecLite {
     }
 
     "foldRight should be stack-safe and short-circuiting" in {
-      fromFoldMap.foldRight[Int,Option[Int]](EphemeralStream(1,2,3,4,5,6), None){ (i, acc) =>
+      fromFoldMap.foldRight[Int,Option[Int]](EphemeralStream.fromStream(Stream(1,2,3,4,5,6)), None){ (i, acc) =>
         if(i < 5) Some(i + acc.getOrElse(0))
         else if(i == 5) None
         else sys.error("Boom")

--- a/tests/src/test/scala/scalaz/FoldableTest.scala
+++ b/tests/src/test/scala/scalaz/FoldableTest.scala
@@ -151,20 +151,20 @@ object FoldableTest extends SpecLite {
     ) must_=== just("Stop")
   }
 
-  "psumMap should be short-circuiting with List" in {
+  "psumMap should be stack-safe and short-circuiting with List" in {
     import Maybe.{empty, just}
-    val N = 100
-    List.range(1,1000).psumMap(i =>
+    val N = 10000
+    List.range(1,11000).psumMap(i =>
       if(i < N) empty[String]
       else if(i == N) just("Stop")
       else sys.error("BOOM!")
     ) must_=== just("Stop")
   }
 
-  "psumMap should be short-circuiting with IList" in {
+  "psumMap should be stack-safe and short-circuiting with IList" in {
     import Maybe.{empty, just}
-    val N = 100    
-    IList.fromList(List.range(1,1000)).psumMap(i =>
+    val N = 10000
+    IList.fromList(List.range(1,11000)).psumMap(i =>
       if(i < N) empty[String]
       else if(i == N) just("Stop")
       else sys.error("BOOM!")

--- a/tests/src/test/scala/scalaz/FoldableTest.scala
+++ b/tests/src/test/scala/scalaz/FoldableTest.scala
@@ -151,27 +151,29 @@ object FoldableTest extends SpecLite {
     ) must_=== just("Stop")
   }
 
-  "psumMap should be stack-safe and short-circuiting with List" in {
-    import Maybe.{empty, just}    
-    List(1,2,3,4,5,6,7).psumMap(i =>
-      if(i < 4) empty[String]
-      else if(i < 4 + 2) just("Stop")
+  "psumMap should be short-circuiting with List" in {
+    import Maybe.{empty, just}
+    val N = 100
+    List.range(1,1000).psumMap(i =>
+      if(i < N) empty[String]
+      else if(i == N) just("Stop")
       else sys.error("BOOM!")
     ) must_=== just("Stop")
   }
 
-  "psumMap should be stack-safe and short-circuiting with IList" in {
-    import Maybe.{empty, just}    
-    IList(1,2,3,4,5,6,7).psumMap(i =>
-      if(i < 4) empty[String]
-      else if(i < 4 + 2) just("Stop")
+  "psumMap should be short-circuiting with IList" in {
+    import Maybe.{empty, just}
+    val N = 100    
+    IList.fromList(List.range(1,1000)).psumMap(i =>
+      if(i < N) empty[String]
+      else if(i == N) just("Stop")
       else sys.error("BOOM!")
     ) must_=== just("Stop")
   }
   
-  "psumMap should be stack-safe and short-circuiting with NonEmptyList" in {
+  "psumMap should be short-circuiting with NonEmptyList" in {
     import Maybe.{empty, just}    
-    NonEmptyList(1,2,3,4,5,6,7).psumMap(i =>
+    NonEmptyList(1,2,3,4,5,5).psumMap(i =>
       if(i < 4) empty[String]
       else if(i < 4 + 2) just("Stop")
       else sys.error("BOOM!")
@@ -281,17 +283,18 @@ object FoldableTest extends SpecLite {
   }
 
   "foldRight from foldMap" should {
-    
     val fromFoldMap: Foldable[EphemeralStream] = new FromFoldMap[EphemeralStream] {
       override def foldMap[A, B](fa: EphemeralStream[A])(f: A => B)(implicit F: Monoid[B]): B = EphemeralStream.ephemeralStreamInstance.foldMap(fa)(f)
     }
 
     "foldRight should be stack-safe and short-circuiting" in {
-      fromFoldMap.foldRight[Int,Option[Int]](EphemeralStream.fromStream(Stream(1,2,3,4,5,6)), None){ (i, acc) =>
-        if(i < 5) Some(i + acc.getOrElse(0))
-        else if(i == 5) None
+      import Maybe.{empty, just}      
+      val N =8
+      fromFoldMap.foldRight[Int,Option[Int]](EphemeralStream(1,2,3,4,5,6,7,8,9,10), None){ (i, acc) =>
+        if(i < N) Some(0 + acc.getOrElse(0))
+        else if(i == N) None
         else sys.error("Boom")
-      } must_=== Some(10)
+      } must_=== Some(0)
     }
   }
 }

--- a/tests/src/test/scala/scalaz/FoldableTest.scala
+++ b/tests/src/test/scala/scalaz/FoldableTest.scala
@@ -283,20 +283,23 @@ object FoldableTest extends SpecLite {
        must_===((l ++ l2).reverse))
   }
 
+  /*
   "foldRight from foldMap" should {
+
     val fromFoldMap: Foldable[EphemeralStream] = new FromFoldMap[EphemeralStream] {
       override def foldMap[A, B](fa: EphemeralStream[A])(f: A => B)(implicit F: Monoid[B]): B = EphemeralStream.ephemeralStreamInstance.foldMap(fa)(f)
     }
 
-    "foldRight should be short-circuiting" in {   
-      val N = 5
-      fromFoldMap.foldRight[Int,Option[Int]](EphemeralStream(1,2,3,4,5,6,7,8,9,10), None){ (i, acc) =>
-        if(i < N) Some(i + acc.getOrElse(0))
-        else if(i == N) None
-        else sys.error("Boom")
-      } must_=== Some(10)
+    "foldRight is Lazy" in {
+      val infiniteStream = EphemeralStream.iterate(0)(_ + 1)
+
+      // This would failed with a StackOverflowError if foldRight was not lazy, which was the case with strict Endo:
+      val stream: Stream[Int] = fromFoldMap.foldRight(infiniteStream, Stream.empty[Int]){ (i, is) => Stream.cons(i, is)}
+
+      stream.take(100) must_=== infiniteStream.take(100).toStream
     }
   }
+  */
 }
 
 object FoldableTests {

--- a/tests/src/test/scala/scalaz/FoldableTest.scala
+++ b/tests/src/test/scala/scalaz/FoldableTest.scala
@@ -131,12 +131,48 @@ object FoldableTest extends SpecLite {
     ).psum must_=== just("Stop")
   }
 
-  "psumMap should be stack-safe and short-circuiting" in {
+  "psumMap should be stack-safe and short-circuiting with Stream" in {
     import Maybe.{empty, just}
     val N = 10000
     Stream.from(1).psumMap(i =>
       if(i < N) empty[String]
       else if(i == N) just("Stop")
+      else sys.error("BOOM!")
+    ) must_=== just("Stop")
+  }
+
+  "psumMap should be stack-safe and short-circuiting with EphemeralStream" in {
+    import Maybe.{empty, just}
+    EphemeralStream(1,2,3,4,5,6,7).psumMap(i =>
+      if(i < 4) empty[String]
+      else if(i < 4 + 2) just("Stop")
+      else sys.error("BOOM!")
+    ) must_=== just("Stop")
+  }
+
+  "psumMap should be stack-safe and short-circuiting with List" in {
+    import Maybe.{empty, just}    
+    List(1,2,3,4,5,6,7).psumMap(i =>
+      if(i < 4) empty[String]
+      else if(i < 4 + 2) just("Stop")
+      else sys.error("BOOM!")
+    ) must_=== just("Stop")
+  }
+
+  "psumMap should be stack-safe and short-circuiting with IList" in {
+    import Maybe.{empty, just}    
+    IList(1,2,3,4,5,6,7).psumMap(i =>
+      if(i < 4) empty[String]
+      else if(i < 4 + 2) just("Stop")
+      else sys.error("BOOM!")
+    ) must_=== just("Stop")
+  }
+  
+  "psumMap should be stack-safe and short-circuiting with NonEmptyList" in {
+    import Maybe.{empty, just}    
+    NonEmptyList(1,2,3,4,5,6,7).psumMap(i =>
+      if(i < 4) empty[String]
+      else if(i < 4 + 2) just("Stop")
       else sys.error("BOOM!")
     ) must_=== just("Stop")
   }

--- a/tests/src/test/scala/scalaz/FoldableTest.scala
+++ b/tests/src/test/scala/scalaz/FoldableTest.scala
@@ -287,14 +287,13 @@ object FoldableTest extends SpecLite {
       override def foldMap[A, B](fa: EphemeralStream[A])(f: A => B)(implicit F: Monoid[B]): B = EphemeralStream.ephemeralStreamInstance.foldMap(fa)(f)
     }
 
-    "foldRight should be stack-safe and short-circuiting" in {
-      import Maybe.{empty, just}      
-      val N =8
+    "foldRight should be short-circuiting" in {   
+      val N = 5
       fromFoldMap.foldRight[Int,Option[Int]](EphemeralStream(1,2,3,4,5,6,7,8,9,10), None){ (i, acc) =>
-        if(i < N) Some(0 + acc.getOrElse(0))
+        if(i < N) Some(i + acc.getOrElse(0))
         else if(i == N) None
         else sys.error("Boom")
-      } must_=== Some(0)
+      } must_=== Some(10)
     }
   }
 }

--- a/tests/src/test/scala/scalaz/FoldableTest.scala
+++ b/tests/src/test/scala/scalaz/FoldableTest.scala
@@ -172,10 +172,11 @@ object FoldableTest extends SpecLite {
   }
   
   "psumMap should be short-circuiting with NonEmptyList" in {
-    import Maybe.{empty, just}    
-    NonEmptyList(1,2,3,4,5,5).psumMap(i =>
-      if(i < 4) empty[String]
-      else if(i < 4 + 2) just("Stop")
+    import Maybe.{empty, just}
+    val N = 4
+    NonEmptyList(1,2,3,4,5,6,7,8).psumMap(i =>
+      if(i < N) empty[String]
+      else if(i == N) just("Stop")
       else sys.error("BOOM!")
     ) must_=== just("Stop")
   }

--- a/tests/src/test/scala/scalaz/IListTest.scala
+++ b/tests/src/test/scala/scalaz/IListTest.scala
@@ -67,7 +67,7 @@ object IListTest extends SpecLite {
   }
 
   "foldMap" ! forAll { xs: IList[Int]  =>
-    xs.foldMap(i => i) must_=== xs.foldRight(0)(_+_)  
+    xs.foldMap(identity) must_=== xs.foldRight(0)(_+_)  
   }
 
   "mapAccumLeft" ! forAll { xs: IList[Int] =>

--- a/tests/src/test/scala/scalaz/IListTest.scala
+++ b/tests/src/test/scala/scalaz/IListTest.scala
@@ -66,6 +66,10 @@ object IListTest extends SpecLite {
     ns.foldMap1Opt(identity) must_=== ns.toList.reduceLeftOption(_ ::: _)
   }
 
+  "foldMap" ! forAll { xs: IList[Int]  =>
+    xs.foldMap(i => i) must_=== xs.foldRight(0)(_+_)  
+  }
+
   "mapAccumLeft" ! forAll { xs: IList[Int] =>
     val f = (_: Int) + 1
     xs.mapAccumLeft(IList[Int]())((c, a) => (c :+ a, f(a))) must_=== (xs -> xs.map(f))

--- a/tests/src/test/scala/scalaz/NonEmptyListTest.scala
+++ b/tests/src/test/scala/scalaz/NonEmptyListTest.scala
@@ -38,6 +38,11 @@ object NonEmptyListTest extends SpecLite {
     Foldable[NonEmptyList].findRight(a)(_ % 2 == 0) must_=== Some(4)
   }
 
+  "foldMap" in {
+    val a = NonEmptyList(1, 2, 3, 4, 5)
+    Foldable[NonEmptyList].foldMap(a)(identity) must_=== 15
+  }
+
   "findLeft" ! forAll{ a: NonEmptyList[Int] =>
     val f = (_: Int) % 3 == 0
     Foldable[NonEmptyList].findLeft(a)(f) must_=== Foldable[IList].findLeft(a.list)(f)

--- a/tests/src/test/scala/scalaz/std/ListTest.scala
+++ b/tests/src/test/scala/scalaz/std/ListTest.scala
@@ -136,7 +136,7 @@ object ListTest extends SpecLite {
   }
 
   "foldMap" ! forAll { xs: List[Int]  => 
-    xs.foldMap(i => i) must_=== xs.foldRight(0)(_+_)  
+    xs.foldMap(identity) must_=== xs.foldRight(0)(_+_)  
   }
 
   "index" ! forAll { (xs: List[Int], n: Int) =>

--- a/tests/src/test/scala/scalaz/std/ListTest.scala
+++ b/tests/src/test/scala/scalaz/std/ListTest.scala
@@ -135,6 +135,10 @@ object ListTest extends SpecLite {
       must_===(F.foldRight(rnge, List[Int]())(_++_)))
   }
 
+  "foldMap" ! forAll { xs: List[Int]  => 
+    xs.foldMap(i => i) must_=== xs.foldRight(0)(_+_)  
+  }
+
   "index" ! forAll { (xs: List[Int], n: Int) =>
     (xs index n) must_===(if (n >= 0 && xs.size > n) Some(xs(n)) else None)
   }


### PR DESCRIPTION
## [Issue #1706 ](https://github.com/scalaz/scalaz/issues/1706)

I have a question regarding adding tests for the new implementations. I was unable to add a test for the NonEmptyList foldMap implementation to `NonEmptyListTest.scala` but was able to add corresponding tests for the other data structures. Is there something different about that data structure? Also, I was curious if adding more psumMap test cases utilizing the different data structures like I did made sense.