### PR TITLE
convenient syntax for repeated pattern matches

### DIFF
--- a/core/src/main/scala/scalaz/syntax/IdOps.scala
+++ b/core/src/main/scala/scalaz/syntax/IdOps.scala
@@ -17,7 +17,7 @@ final class IdOps[A](val self: A) extends AnyVal {
     f(self)
 
   /** Alternative syntax for the Thrush combinator or a total `match`. */
-  @inline final def switch[B](f: A => B): B = f(self)
+  @inline final def into[B](f: A => B): B = f(self)
 
   /**Applies `self` to the provide function for its side effect, and returns `self`. The Kestrel combinator.
    * Mostly for use with dodgy libraries that give you values that need additional initialization or

--- a/core/src/main/scala/scalaz/syntax/IdOps.scala
+++ b/core/src/main/scala/scalaz/syntax/IdOps.scala
@@ -16,6 +16,9 @@ final class IdOps[A](val self: A) extends AnyVal {
   final def ▹[B](f: A => B): B =
     f(self)
 
+  /** Alternative syntax for the Thrush combinator or a total `match`. */
+  @inline final def switch[B](f: A => B): B = f(self)
+
   /**Applies `self` to the provide function for its side effect, and returns `self`. The Kestrel combinator.
    * Mostly for use with dodgy libraries that give you values that need additional initialization or
    * mutation before they're valid to use.


### PR DESCRIPTION
This might seem superflous, but the problem I have is that when I want to flatMap or map over the result of a match statement

```
foo match {
  ...
}.flatMap {...}
```

the compiler complains unless I put some extra parens in.

```
{foo match {
  ...
}}.flatMap {...}
```

which looks very ugly and is just intrusive.

A fix I've been playing with is to do

```
foo.|> {
  ...
}.flatMap {...}
```

which is kinda weird because of the dot `.` when used with a symbolic operator. I settled on `switch` in my own code and I thought others might benefit.

Also this helps keep you honest as the type signature is `Function` not `PartialFunction` so I think it's a better alternative to `match`.

This is a candidate for being replaced with a macro in a future version of scalaz.