### PR TITLE
Release snapshot versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ install:
   - gem install jekyll -v 3.6.2
 script:
   - sbt ++$TRAVIS_SCALA_VERSION scalafmtCheck test:scalafmtCheck scalafmtSbtCheck test example/makeMicrosite
+  - ./snapshotRelease.sh

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,12 @@
 import Scalaz._
 
+publishTo in ThisBuild := Some("snapshots" at sys.env.getOrElse("SNAPSHOT_REPO", ""))
+
+credentials += Credentials("Sonatype Nexus Repository Manager",
+                           "oss.sonatype.org",
+                           sys.env.getOrElse("SNAPSHOT_REPO_USER", ""),
+                           sys.env.getOrElse("SNAPSHOT_REPO_PASSWORD", ""))
+
 lazy val root = project
   .in(file("."))
   .aggregate(baseJVM, baseJS, metaJVM, metaJS, effectJVM, effectJS, example, benchmarks)

--- a/snapshotRelease.sh
+++ b/snapshotRelease.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+hash=`git rev-parse HEAD`
+sed -i -e "s/SNAPSHOT/$hash-SNAPSHOT/g" ./version.sbt
+sbt publish

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "8.0.0-SNAPSHOT"


### PR DESCRIPTION
Updated script to release snapshot versions on every commit, related to [1731](https://github.com/scalaz/scalaz/issues/1731)
Env variables that need to be set on travis: SNAPSHOT_REPO, SNAPSHOT_REPO_USER, SNAPSHOT_REPO_PASSWORD