### PR TITLE
rename show"" -> z"", and use @implicitAmbiguous for more explanatory error messages

### DIFF
--- a/core/src/main/scala-2.11/scalaz/compat.scala
+++ b/core/src/main/scala-2.11/scalaz/compat.scala
@@ -1,0 +1,6 @@
+package scalaz
+
+private[scalaz] object compat {
+  // dummy for 2.11
+  final class implicitAmbiguous(msg: String) extends annotation.StaticAnnotation
+}

--- a/core/src/main/scala-2.12/scalaz/compat.scala
+++ b/core/src/main/scala-2.12/scalaz/compat.scala
@@ -1,0 +1,5 @@
+package scalaz
+
+private[scalaz] object compat {
+  type implicitAmbiguous = scala.annotation.implicitAmbiguous
+}

--- a/core/src/main/scala-2.13/scalaz/compat.scala
+++ b/core/src/main/scala-2.13/scalaz/compat.scala
@@ -1,0 +1,5 @@
+package scalaz
+
+private[scalaz] object compat {
+  type implicitAmbiguous = scala.annotation.implicitAmbiguous
+}

--- a/core/src/main/scala/scalaz/Show.scala
+++ b/core/src/main/scala/scalaz/Show.scala
@@ -45,8 +45,13 @@ object Show {
   implicit val showContravariant: Contravariant[Show] = new ShowContravariant
 
   final case class Shows(override val toString: String) extends AnyVal
-  object Shows {
+  object Shows extends Shows0 {
     implicit def mat[A](x: A)(implicit S: Show[A]): Shows = Shows(S.shows(x))
+  }
+  sealed abstract class Shows0 { this: Shows.type =>
+    @annotation.implicitAmbiguous("Cannot use value of type ${A} in the `show` interpolator, as no `Show[${A}]` instance could be found")
+    implicit def showsAmbig0[A](x: A): Shows = sys.error("showsAmbig0")
+    implicit def showsAmbig1[A](x: A): Shows = sys.error("showsAmbig1")
   }
 
   final case class ShowInterpolator(sc: StringContext) extends AnyVal {

--- a/core/src/main/scala/scalaz/Show.scala
+++ b/core/src/main/scala/scalaz/Show.scala
@@ -55,7 +55,7 @@ object Show {
   }
 
   final case class ShowInterpolator(sc: StringContext) extends AnyVal {
-    def show(args: Shows*): String = sc.s(args: _*)
+    def z(args: Shows*): String = sc.s(args: _*)
   }
   ////
 }

--- a/core/src/main/scala/scalaz/Show.scala
+++ b/core/src/main/scala/scalaz/Show.scala
@@ -44,9 +44,9 @@ object Show {
   }
   implicit val showContravariant: Contravariant[Show] = new ShowContravariant
 
-  final case class Shows(override val toString: String) extends AnyVal
+  final class Shows private[Show] (override val toString: String) extends AnyVal
   object Shows extends Shows0 {
-    implicit def mat[A](x: A)(implicit S: Show[A]): Shows = Shows(S.shows(x))
+    implicit def mat[A](x: A)(implicit S: Show[A]): Shows = new Shows(S.shows(x))
   }
   sealed abstract class Shows0 { this: Shows.type =>
     @compat.implicitAmbiguous("Cannot use value of type ${A} in the `show` interpolator, as no `Show[${A}]` instance could be found")
@@ -55,7 +55,17 @@ object Show {
   }
 
   final case class ShowInterpolator(sc: StringContext) extends AnyVal {
+
+    /** A string interpolator which uses the [[Show]] typeclass to convert
+      * its arguments to strings. At the call site, each interpolated expression
+      * must have a type with an implicit `Show` instance, which will be used
+      * to convert it to a string before using the standard `s""` interpolator.
+      *
+      * @note the name of this method is meant to pun on `s` being Scala's
+      *       basic string interpolator, whereas this is Scalaz's.
+      */
     def z(args: Shows*): String = sc.s(args: _*)
+
   }
   ////
 }

--- a/core/src/main/scala/scalaz/Show.scala
+++ b/core/src/main/scala/scalaz/Show.scala
@@ -49,7 +49,7 @@ object Show {
     implicit def mat[A](x: A)(implicit S: Show[A]): Shows = Shows(S.shows(x))
   }
   sealed abstract class Shows0 { this: Shows.type =>
-    @annotation.implicitAmbiguous("Cannot use value of type ${A} in the `show` interpolator, as no `Show[${A}]` instance could be found")
+    @compat.implicitAmbiguous("Cannot use value of type ${A} in the `show` interpolator, as no `Show[${A}]` instance could be found")
     implicit def showsAmbig0[A](x: A): Shows = sys.error("showsAmbig0")
     implicit def showsAmbig1[A](x: A): Shows = sys.error("showsAmbig1")
   }

--- a/project/build.scala
+++ b/project/build.scala
@@ -112,7 +112,7 @@ object build {
   )
 
   val lintOptions = Seq(
-    "-Xlint:_,-type-parameter-shadow",
+    "-Xlint:_,-type-parameter-shadow,-missing-interpolator",
     "-Ywarn-dead-code",
     "-Ywarn-unused-import",
     "-Ywarn-numeric-widen",
@@ -164,6 +164,8 @@ object build {
     },
     scalacOptions in (Compile, compile) ++= "-Yno-adapted-args" +: lintOptions,
     scalacOptions in (Test, compile) ++= lintOptions,
+
+    scala213_pre_cross_setting,
 
     scalacOptions in (Compile, doc) ++= {
       val base = (baseDirectory in LocalRootProject).value.getAbsolutePath
@@ -283,6 +285,19 @@ object build {
       baseDirectory.value.getParentFile / "jvm_js/src/main/scala/"
     }
   )
+
+  private[this] val scala213_pre_cross_setting = {
+    // sbt wants `scala-2.13.0-M1`, `scala-2.13.0-M2`, ... (sbt/sbt#2819)
+    // @fommil tells me we could use sbt-sensible for this
+    unmanagedSourceDirectories in Compile ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2L, minor)) =>
+          Some((baseDirectory in Compile).value.getParentFile / s"src/main/scala-2.$minor")
+        case _               =>
+          None
+      }
+    }
+  }
 
   val nativeSettings = Seq(
     scalacOptions --= Scala211_jvm_and_js_options,

--- a/tests/src/test/scala/scalaz/SyntaxTest.scala
+++ b/tests/src/test/scala/scalaz/SyntaxTest.scala
@@ -26,7 +26,7 @@ object SyntaxTest extends SpecLite {
 
     val x = "string"
     val resultString = s"""I've found a "$x""""
-    show"I've found a $x" must_===(resultString)
+    z"I've found a $x" must_===(resultString)
   }
 
   "show interpolator works with case classes" in {
@@ -39,7 +39,7 @@ object SyntaxTest extends SpecLite {
     val f = TestFoo("bar")
     val result = "I'd like a TestFoo(bar)"
 
-    show"I'd like a $f" must_===(result)
+    z"I'd like a $f" must_===(result)
   }
 
 
@@ -59,6 +59,6 @@ object SyntaxTest extends SpecLite {
 
     val r : CoproductT = Result1T
 
-    show"We have a $r" must_===("We have a Result1T")
+    z"We have a $r" must_===("We have a Result1T")
   }
 }


### PR DESCRIPTION
I don't know how to make this work with the test suite without setting up all the macro-based `shouldNotCompile` stuff, but it works.

Additionally, rename `show""` to `z""`, because I like it more. I'll be glad to take it out if other people don't like it, though.

cc @ChristopherDavenport 