### PR TITLE
NaturalTransformation.or

### DIFF
--- a/core/src/main/scala/scalaz/NaturalTransformation.scala
+++ b/core/src/main/scala/scalaz/NaturalTransformation.scala
@@ -39,17 +39,16 @@ trait NaturalTransformations {
 
   /** Reify a `NaturalTransformation`. */
   implicit def natToFunction[F[_], G[_], A](f: F ~> G): F[A] => G[A] = x => f(x)
+}
 
+object NaturalTransformation extends NaturalTransformations {
   /**
    * Construct a natural transformation over a coproduct from its parts.
    * Useful for combining Free interpreters.
    */
   def or[F[_], G[_], H[_]](fg: F ~> G, hg: H ~> G): Coproduct[F, H, ?] ~> G =
     λ[Coproduct[F, H, ?] ~> G](_.fold(fg, hg))
-
 }
-
-object NaturalTransformation extends NaturalTransformations
 
 /** A function universally quantified over two parameters. */
 trait BiNaturalTransformation[-F[_, _], +G[_, _]] {

--- a/core/src/main/scala/scalaz/NaturalTransformation.scala
+++ b/core/src/main/scala/scalaz/NaturalTransformation.scala
@@ -39,6 +39,14 @@ trait NaturalTransformations {
 
   /** Reify a `NaturalTransformation`. */
   implicit def natToFunction[F[_], G[_], A](f: F ~> G): F[A] => G[A] = x => f(x)
+
+  /**
+   * Construct a natural transformation over a coproduct from its parts.
+   * Useful for combining Free interpreters.
+   */
+  def or[F[_], G[_], H[_]](fg: F ~> G, hg: H ~> G): Coproduct[F, H, ?] ~> G =
+    λ[Coproduct[F, H, ?] ~> G](_.fold(fg, hg))
+
 }
 
 object NaturalTransformation extends NaturalTransformations


### PR DESCRIPTION
backport @lloydmeta's `or`, but without the subtyping.