### PR TITLE
no array copy IO Stack

### DIFF
--- a/effect/jvm/src/main/scala/scalaz/effect/RTS.scala
+++ b/effect/jvm/src/main/scala/scalaz/effect/RTS.scala
@@ -62,9 +62,9 @@ trait RTS {
         result.set(v)
 
       case _ =>
-        while (result.get == null) {
+        while (result.get eq null) {
           result.synchronized {
-            if (result.get == null) result.wait()
+            if (result.get eq null) result.wait()
           }
         }
     }
@@ -257,11 +257,11 @@ private object RTS {
             val f = f0.asInstanceOf[Finalizer[E]]
 
             // Lazy initialization of body:
-            if (body == null) body = ExitResult.Failed(err)
+            if (body eq null) body = ExitResult.Failed(err)
 
             val currentFinalizer: IO[E2, List[Throwable]] = f.finalizer(body).run.map(collectDefect)
 
-            if (finalizer == null) finalizer = currentFinalizer
+            if (finalizer eq null) finalizer = currentFinalizer
             else finalizer = finalizer.zipWith(currentFinalizer)(_ ++ _)
           case _ =>
         }
@@ -302,11 +302,11 @@ private object RTS {
               val f = f0.asInstanceOf[Finalizer[E]]
 
               // Lazy initialization of body:
-              if (body == null) body = ExitResult.Terminated(error)
+              if (body eq null) body = ExitResult.Terminated(error)
 
               val currentFinalizer = f.finalizer(body).run[E2].map(collectDefect)
 
-              if (finalizer == null) finalizer = currentFinalizer
+              if (finalizer eq null) finalizer = currentFinalizer
               else finalizer = finalizer.zipWith(currentFinalizer)(_ ++ _)
             case _ =>
           }
@@ -329,7 +329,7 @@ private object RTS {
       // or Scala will wrap them in ObjectRef and performance will plummet.
       var curIo: IO[E, Any] = io0.asInstanceOf[IO[E, Any]]
 
-      while (curIo != null) {
+      while (curIo ne null) {
         try {
           // Put the maximum operation count on the stack for fast access:
           val maxopcount = YieldMaxOpCount
@@ -399,7 +399,7 @@ private object RTS {
 
                     curIo = nextInstr[E](value, stack)
 
-                    if (curIo == null) {
+                    if (curIo eq null) {
                       eval = false
                       result = ExitResult.Completed(value)
                     }
@@ -411,7 +411,7 @@ private object RTS {
 
                     curIo = nextInstr[E](value, stack)
 
-                    if (curIo == null) {
+                    if (curIo eq null) {
                       eval = false
                       result = ExitResult.Completed(value)
                     }
@@ -423,7 +423,7 @@ private object RTS {
 
                     curIo = nextInstr[E](value, stack)
 
-                    if (curIo == null) {
+                    if (curIo eq null) {
                       eval = false
                       result = ExitResult.Completed(value)
                     }
@@ -437,7 +437,7 @@ private object RTS {
 
                     if (stack.isEmpty) {
                       // Error not caught, stack is empty:
-                      if (finalizer == null) {
+                      if (finalizer eq null) {
                         // No finalizer, so immediately produce the error.
                         eval = false
                         result = ExitResult.Failed(error)
@@ -459,11 +459,11 @@ private object RTS {
                       // Error caught:
                       val value = -\/(error)
 
-                      if (finalizer == null) {
+                      if (finalizer eq null) {
                         // No finalizer to run:
                         curIo = nextInstr[E](value, stack)
 
-                        if (curIo == null) {
+                        if (curIo eq null) {
                           eval = false
                           result = ExitResult.Completed(value)
                         }
@@ -494,7 +494,7 @@ private object RTS {
                               case ExitResult.Completed(v) =>
                                 curIo = nextInstr[E](v, stack)
 
-                                if (curIo == null) {
+                                if (curIo eq null) {
                                   eval = false
                                   result = value
                                 }
@@ -535,7 +535,7 @@ private object RTS {
                           case ExitResult.Completed(v) =>
                             curIo = nextInstr[E](v, stack)
 
-                            if (curIo == null) {
+                            if (curIo eq null) {
                               eval = false
                               result = value.asInstanceOf[ExitResult[E, Any]]
                             }
@@ -570,7 +570,7 @@ private object RTS {
 
                     curIo = nextInstr[E](value, stack)
 
-                    if (curIo == null) {
+                    if (curIo eq null) {
                       eval = false
                       result = ExitResult.Completed(value)
                     }
@@ -591,7 +591,7 @@ private object RTS {
                     val ref = new AtomicReference[Any]()
 
                     val finalizer =
-                      Finalizer[E](rez => IO.suspend(if (ref.get != null) io.release(rez, ref.get) else IO.unit))
+                      Finalizer[E](rez => IO.suspend(if (null != ref.get) io.release(rez, ref.get) else IO.unit))
 
                     stack.push(finalizer)
 
@@ -637,7 +637,7 @@ private object RTS {
 
                     val finalizer = interruptStack[Void](cause)
 
-                    if (finalizer == null) {
+                    if (finalizer eq null) {
                       // No finalizers, simply produce error:
                       eval = false
                       result = ExitResult.Terminated(cause)
@@ -660,7 +660,7 @@ private object RTS {
 
                     curIo = nextInstr[E](value, stack)
 
-                    if (curIo == null) {
+                    if (curIo eq null) {
                       eval = false
                       result = ExitResult.Completed(value)
                     }
@@ -691,7 +691,7 @@ private object RTS {
             opcount = opcount + 1
           } while (eval)
 
-          if (result != null) {
+          if (result ne null) {
             done(result.asInstanceOf[ExitResult[E, A]])
           }
 
@@ -728,7 +728,7 @@ private object RTS {
           // Async produced a value:
           val io = nextInstr[E](v, stack)
 
-          if (io == null) done(value.asInstanceOf[ExitResult[E, A]])
+          if (io eq null) done(value.asInstanceOf[ExitResult[E, A]])
           else evaluate(io)
 
         case ExitResult.Failed(t) => evaluate(IO.Fail[E, Any](t))
@@ -814,7 +814,7 @@ private object RTS {
 
         val canceler = combineCancelers(c1, c2)
 
-        if (canceler == null) Async.later[E, IO[E, C]]
+        if (canceler eq null) Async.later[E, IO[E, C]]
         else Async.maybeLater(canceler)
       })
     }
@@ -1035,7 +1035,7 @@ private object RTS {
 
             val finalizer = interruptStack[Void](t)
 
-            if (finalizer != null) {
+            if (finalizer ne null) {
               fork[Void, Unit](dispatchErrors(finalizer), unhandled)
             }
 
@@ -1107,10 +1107,10 @@ private object RTS {
   final def SuccessUnit[E]: ExitResult[E, Unit] = _SuccessUnit.asInstanceOf[ExitResult[E, Unit]]
 
   final def combineCancelers(c1: Throwable => Unit, c2: Throwable => Unit): Throwable => Unit =
-    if (c1 == null) {
-      if (c2 == null) null
+    if (c1 eq null) {
+      if (c2 eq null) null
       else c2
-    } else if (c2 == null) {
+    } else if (c2 eq null) {
       c1
     } else
       (t: Throwable) => {

--- a/effect/jvm/src/main/scala/scalaz/effect/RTS.scala
+++ b/effect/jvm/src/main/scala/scalaz/effect/RTS.scala
@@ -499,9 +499,9 @@ private object RTS {
                                   result = value
                                 }
                               case ExitResult.Terminated(t) =>
-                                curIo = IO.Terminate(t)
+                                curIo = IO.terminate(t)
                               case ExitResult.Failed(e) =>
-                                curIo = IO.Fail(e)
+                                curIo = IO.fail(e)
                             }
                           } else {
                             // Completion handled by interruptor:
@@ -540,9 +540,9 @@ private object RTS {
                               result = value.asInstanceOf[ExitResult[E, Any]]
                             }
                           case ExitResult.Terminated(t) =>
-                            curIo = IO.Terminate(t)
+                            curIo = IO.terminate(t)
                           case ExitResult.Failed(e) =>
-                            curIo = IO.Fail(e)
+                            curIo = IO.fail(e)
                         }
                       } else {
                         // Completion handled by interruptor:
@@ -618,7 +618,7 @@ private object RTS {
                   case IO.Tags.Sleep =>
                     val io = curIo.asInstanceOf[IO.Sleep[E]]
 
-                    curIo = IO.AsyncEffect { callback =>
+                    curIo = IO.async0 { callback =>
                       rts
                         .schedule(callback(SuccessUnit[E].asInstanceOf[ExitResult[E, Any]]), io.duration)
                         .asInstanceOf[Async[E, Any]]
@@ -685,7 +685,7 @@ private object RTS {
               // Interruption cannot be interrupted:
               this.noInterrupt += 1
 
-              curIo = IO.Terminate[E, Any](die.get)
+              curIo = IO.terminate[E, Any](die.get)
             }
 
             opcount = opcount + 1
@@ -704,7 +704,7 @@ private object RTS {
             // Interruption cannot be interrupted:
             this.noInterrupt += 1
 
-            curIo = IO.Terminate[E, Any](t)
+            curIo = IO.terminate[E, Any](t)
         }
       }
     }
@@ -731,9 +731,9 @@ private object RTS {
           if (io eq null) done(value.asInstanceOf[ExitResult[E, A]])
           else evaluate(io)
 
-        case ExitResult.Failed(t) => evaluate(IO.Fail[E, Any](t))
+        case ExitResult.Failed(t) => evaluate(IO.fail[E, Any](t))
 
-        case ExitResult.Terminated(t) => evaluate(IO.Terminate[E, Any](t))
+        case ExitResult.Terminated(t) => evaluate(IO.terminate[E, Any](t))
       }
 
     /**

--- a/effect/jvm/src/test/scala/scalaz/effect/RTSTest.scala
+++ b/effect/jvm/src/test/scala/scalaz/effect/RTSTest.scala
@@ -180,7 +180,7 @@ class RTSSpec(implicit ee: ExecutionEnv) extends Specification with AroundTimeou
     }
 
     // FIXME: Is this an issue with thread synchronization?
-    while (reported == null) Thread.`yield`()
+    while (reported eq null) Thread.`yield`()
 
     ((throw reported): Int) must (throwA(ExampleError))
   }

--- a/effect/shared/src/main/scala/scalaz/effect/IO.scala
+++ b/effect/shared/src/main/scala/scalaz/effect/IO.scala
@@ -59,16 +59,16 @@ sealed abstract class IO[E, A] { self =>
     case IO.Tags.Point =>
       val io = self.asInstanceOf[IO.Point[E, A]]
 
-      IO.Point(() => f(io.value()))
+      new IO.Point(() => f(io.value()))
 
     case IO.Tags.Strict =>
       val io = self.asInstanceOf[IO.Strict[E, A]]
 
-      IO.Strict(f(io.value))
+      new IO.Strict(f(io.value))
 
     case IO.Tags.Fail => self.asInstanceOf[IO[E, B]]
 
-    case _ => IO.FlatMap(self, (a: A) => IO.Strict(f(a)))
+    case _ => new IO.FlatMap(self, (a: A) => new IO.Strict(f(a)))
   }
 
   /**
@@ -79,7 +79,7 @@ sealed abstract class IO[E, A] { self =>
    * val parsed = readFile("foo.txt").flatMap(file => parseFile(file))
    * }}}
    */
-  final def flatMap[B](f0: A => IO[E, B]): IO[E, B] = IO.FlatMap(self, f0)
+  final def flatMap[B](f0: A => IO[E, B]): IO[E, B] = new IO.FlatMap(self, f0)
 
   /**
    * Forks this action into its own separate fiber, returning immediately
@@ -97,14 +97,14 @@ sealed abstract class IO[E, A] { self =>
    * } yield a
    * }}}
    */
-  final def fork[E2]: IO[E2, Fiber[E, A]] = IO.Fork(this, Maybe.empty)
+  final def fork[E2]: IO[E2, Fiber[E, A]] = new IO.Fork(this, Maybe.empty)
 
   /**
    * A more powerful version of `fork` that allows specifying a handler to be
    * invoked on any exceptions that are not handled by the forked fiber.
    */
   final def fork0[E2](handler: Throwable => IO[Void, Unit]): IO[E2, Fiber[E, A]] =
-    IO.Fork(this, Maybe.just(handler))
+    new IO.Fork(this, Maybe.just(handler))
 
   /**
    * Executes both this action and the specified action in parallel,
@@ -141,7 +141,7 @@ sealed abstract class IO[E, A] { self =>
    */
   final def raceWith[B, C](that: IO[E, B])(finishLeft: (A, Fiber[E, B]) => IO[E, C],
                                            finishRight: (B, Fiber[E, A]) => IO[E, C]): IO[E, C] =
-    IO.Race[E, A, B, C](self, that, finishLeft, finishRight)
+    new IO.Race[E, A, B, C](self, that, finishLeft, finishRight)
 
   /**
    * Executes this action and returns its value, if it succeeds, but
@@ -178,24 +178,24 @@ sealed abstract class IO[E, A] { self =>
     case IO.Tags.Point =>
       val io = self.asInstanceOf[IO.Point[E, A]]
 
-      IO.Point(() => \/-(io.value()))
+      new IO.Point(() => \/-(io.value()))
 
     case IO.Tags.Strict =>
       val io = self.asInstanceOf[IO.Strict[E, A]]
 
-      IO.Strict(\/-(io.value))
+      new IO.Strict(\/-(io.value))
 
     case IO.Tags.SyncEffect =>
       val io = self.asInstanceOf[IO.SyncEffect[E, A]]
 
-      IO.SyncEffect(() => \/-(io.effect()))
+      new IO.SyncEffect(() => \/-(io.effect()))
 
     case IO.Tags.Fail =>
       val io = self.asInstanceOf[IO.Fail[E, A]]
 
-      IO.Strict(-\/(io.error))
+      new IO.Strict(-\/(io.error))
 
-    case _ => IO.Attempt(self)
+    case _ => new IO.Attempt(self)
   }
 
   /**
@@ -228,14 +228,14 @@ sealed abstract class IO[E, A] { self =>
    * }}}
    */
   final def bracket[B](release: A => IO[Void, Unit])(use: A => IO[E, B]): IO[E, B] =
-    IO.Bracket(this, (_: ExitResult[E, B], a: A) => release(a), use)
+    new IO.Bracket(this, (_: ExitResult[E, B], a: A) => release(a), use)
 
   /**
    * A more powerful version of `bracket` that provides information on whether
    * or not `use` succeeded to the release action.
    */
   final def bracket0[B](release: (ExitResult[E, B], A) => IO[Void, Unit])(use: A => IO[E, B]): IO[E, B] =
-    IO.Bracket(this, release, use)
+    new IO.Bracket(this, release, use)
 
   /**
    * A less powerful variant of `bracket` where the value produced by this
@@ -284,14 +284,14 @@ sealed abstract class IO[E, A] { self =>
    * the action are interrupted with the specified error when this action
    * completes.
    */
-  final def supervised(error: Throwable): IO[E, A] = IO.Supervise(self, error)
+  final def supervised(error: Throwable): IO[E, A] = new IO.Supervise(self, error)
 
   /**
    * Performs this action non-interruptibly. This will prevent the action from
    * being terminated externally, but the action may fail for internal reasons
    * (e.g. an uncaught error) or terminate due to defect.
    */
-  final def uninterruptibly: IO[E, A] = IO.Uninterruptible(self)
+  final def uninterruptibly: IO[E, A] = new IO.Uninterruptible(self)
 
   /**
    * Recovers from all errors.
@@ -472,7 +472,7 @@ sealed abstract class IO[E, A] { self =>
   /**
    * Runs this action in a new fiber, resuming when the fiber terminates.
    */
-  final def run[E2]: IO[E2, ExitResult[E, A]] = IO.Run(self)
+  final def run[E2]: IO[E2, ExitResult[E, A]] = new IO.Run(self)
 
   /**
    * An integer that identifies the term in the `IO` sum type to which this
@@ -482,7 +482,7 @@ sealed abstract class IO[E, A] { self =>
 }
 
 object IO extends IOInstances {
-  object Tags {
+  final object Tags {
     final val FlatMap         = 0
     final val Point           = 1
     final val Strict          = 2
@@ -502,103 +502,104 @@ object IO extends IOInstances {
     final val Supervisor      = 16
     final val Run             = 17
   }
-  final case class FlatMap[E, A0, A](io: IO[E, A0], flatMapper: A0 => IO[E, A]) extends IO[E, A] {
-    override final def tag = Tags.FlatMap
+  final class FlatMap[E, A0, A] private[IO] (val io: IO[E, A0], val flatMapper: A0 => IO[E, A]) extends IO[E, A] {
+    override def tag = Tags.FlatMap
   }
 
-  final case class Point[E, A](value: () => A) extends IO[E, A] {
-    override final def tag = Tags.Point
+  final class Point[E, A] private[IO] (val value: () => A) extends IO[E, A] {
+    override def tag = Tags.Point
   }
 
-  final case class Strict[E, A](value: A) extends IO[E, A] {
-    override final def tag = Tags.Strict
+  final class Strict[E, A] private[IO] (val value: A) extends IO[E, A] {
+    override def tag = Tags.Strict
   }
 
-  final case class SyncEffect[E, A](effect: () => A) extends IO[E, A] {
-    override final def tag = Tags.SyncEffect
+  final class SyncEffect[E, A] private[IO] (val effect: () => A) extends IO[E, A] {
+    override def tag = Tags.SyncEffect
   }
 
-  final case class Fail[E, A](error: E) extends IO[E, A] {
-    override final def tag = Tags.Fail
+  final class Fail[E, A] private[IO] (val error: E) extends IO[E, A] {
+    override def tag = Tags.Fail
   }
 
-  final case class AsyncEffect[E, A](register: (ExitResult[E, A] => Unit) => Async[E, A]) extends IO[E, A] {
-    override final def tag = Tags.AsyncEffect
+  final class AsyncEffect[E, A] private[IO] (val register: (ExitResult[E, A] => Unit) => Async[E, A]) extends IO[E, A] {
+    override def tag = Tags.AsyncEffect
   }
 
-  final case class AsyncIOEffect[E, A](register: (ExitResult[E, A] => Unit) => IO[E, Unit]) extends IO[E, A] {
-    override final def tag = Tags.AsyncIOEffect
-  }
-
-  final case class Attempt[E1, E2, A](value: IO[E1, A]) extends IO[E2, E1 \/ A] {
-    override final def tag = Tags.Attempt
-  }
-
-  final case class Fork[E1, E2, A](value: IO[E1, A], handler: Maybe[Throwable => IO[Void, Unit]])
-      extends IO[E2, Fiber[E1, A]] {
-    override final def tag = Tags.Fork
-  }
-
-  final case class Race[E, A0, A1, A](left: IO[E, A0],
-                                      right: IO[E, A1],
-                                      finishLeft: (A0, Fiber[E, A1]) => IO[E, A],
-                                      finishRight: (A1, Fiber[E, A0]) => IO[E, A])
+  final class AsyncIOEffect[E, A] private[IO] (val register: (ExitResult[E, A] => Unit) => IO[E, Unit])
       extends IO[E, A] {
-    override final def tag = Tags.Race
+    override def tag = Tags.AsyncIOEffect
   }
 
-  final case class Suspend[E, A](value: () => IO[E, A]) extends IO[E, A] {
-    override final def tag = Tags.Suspend
+  final class Attempt[E1, E2, A] private[IO] (val value: IO[E1, A]) extends IO[E2, E1 \/ A] {
+    override def tag = Tags.Attempt
   }
 
-  final case class Bracket[E, A, B](acquire: IO[E, A],
-                                    release: (ExitResult[E, B], A) => IO[Void, Unit],
-                                    use: A => IO[E, B])
+  final class Fork[E1, E2, A] private[IO] (val value: IO[E1, A], val handler: Maybe[Throwable => IO[Void, Unit]])
+      extends IO[E2, Fiber[E1, A]] {
+    override def tag = Tags.Fork
+  }
+
+  final class Race[E, A0, A1, A] private[IO] (val left: IO[E, A0],
+                                              val right: IO[E, A1],
+                                              val finishLeft: (A0, Fiber[E, A1]) => IO[E, A],
+                                              val finishRight: (A1, Fiber[E, A0]) => IO[E, A])
+      extends IO[E, A] {
+    override def tag = Tags.Race
+  }
+
+  final class Suspend[E, A] private[IO] (val value: () => IO[E, A]) extends IO[E, A] {
+    override def tag = Tags.Suspend
+  }
+
+  final class Bracket[E, A, B] private[IO] (val acquire: IO[E, A],
+                                            val release: (ExitResult[E, B], A) => IO[Void, Unit],
+                                            val use: A => IO[E, B])
       extends IO[E, B] {
-    override final def tag = Tags.Bracket
+    override def tag = Tags.Bracket
   }
 
-  final case class Uninterruptible[E, A](io: IO[E, A]) extends IO[E, A] {
-    override final def tag = Tags.Uninterruptible
+  final class Uninterruptible[E, A] private[IO] (val io: IO[E, A]) extends IO[E, A] {
+    override def tag = Tags.Uninterruptible
   }
 
-  final case class Sleep[E](duration: Duration) extends IO[E, Unit] {
-    override final def tag = Tags.Sleep
+  final class Sleep[E] private[IO] (val duration: Duration) extends IO[E, Unit] {
+    override def tag = Tags.Sleep
   }
 
-  final case class Supervise[E, A](value: IO[E, A], error: Throwable) extends IO[E, A] {
-    override final def tag = Tags.Supervise
+  final class Supervise[E, A] private[IO] (val value: IO[E, A], val error: Throwable) extends IO[E, A] {
+    override def tag = Tags.Supervise
   }
 
-  final case class Terminate[E, A](cause: Throwable) extends IO[E, A] {
-    override final def tag = Tags.Terminate
+  final class Terminate[E, A] private[IO] (val cause: Throwable) extends IO[E, A] {
+    override def tag = Tags.Terminate
   }
 
-  final case class Supervisor[E]() extends IO[E, Throwable => IO[Void, Unit]] {
-    override final def tag = Tags.Supervisor
+  final class Supervisor[E] private[IO] () extends IO[E, Throwable => IO[Void, Unit]] {
+    override def tag = Tags.Supervisor
   }
 
-  final case class Run[E1, E2, A](value: IO[E1, A]) extends IO[E2, ExitResult[E1, A]] {
-    override final def tag = Tags.Run
+  final class Run[E1, E2, A] private[IO] (val value: IO[E1, A]) extends IO[E2, ExitResult[E1, A]] {
+    override def tag = Tags.Run
   }
 
   /**
    * Lifts a strictly evaluated value into the `IO` monad.
    */
-  final def now[E, A](a: A): IO[E, A] = Strict(a)
+  final def now[E, A](a: A): IO[E, A] = new Strict(a)
 
   /**
    * Lifts a non-strictly evaluated value into the `IO` monad. Do not use this
    * function to capture effectful code. The result is undefined but may
    * include duplicated effects.
    */
-  final def point[E, A](a: => A): IO[E, A] = Point(() => a)
+  final def point[E, A](a: => A): IO[E, A] = new Point(() => a)
 
   /**
    * Creates an `IO` value that represents failure with the specified error.
    * The moral equivalent of `throw` for pure code.
    */
-  final def fail[E, A](error: E): IO[E, A] = Fail(error)
+  final def fail[E, A](error: E): IO[E, A] = new Fail(error)
 
   /**
    * Strictly-evaluated unit lifted into the `IO` monad.
@@ -608,14 +609,14 @@ object IO extends IOInstances {
   /**
    * Sleeps for the specified duration. This is always asynchronous.
    */
-  final def sleep[E](duration: Duration): IO[E, Unit] = Sleep(duration)
+  final def sleep[E](duration: Duration): IO[E, Unit] = new Sleep(duration)
 
   /**
    * Supervises the specified action, which ensures that any actions directly
    * forked by the action are killed with the specified error upon the action's
    * own termination.
    */
-  final def supervise[E, A](io: IO[E, A], error: Throwable): IO[E, A] = Supervise(io, error)
+  final def supervise[E, A](io: IO[E, A], error: Throwable): IO[E, A] = new Supervise(io, error)
 
   /**
    * Flattens a nested action.
@@ -630,12 +631,12 @@ object IO extends IOInstances {
    * will be undefined and most likely involve the physical explosion of your
    * computer in a heap of rubble.
    */
-  final def suspend[E, A](io: => IO[E, A]): IO[E, A] = Suspend(() => io)
+  final def suspend[E, A](io: => IO[E, A]): IO[E, A] = new Suspend(() => io)
 
   /**
    * Terminates the fiber executing this action, running all finalizers.
    */
-  final def terminate[E, A](t: Throwable): IO[E, A] = Terminate(t)
+  final def terminate[E, A](t: Throwable): IO[E, A] = new Terminate(t)
 
   /**
    * Imports a synchronous effect into a pure `IO` value.
@@ -644,7 +645,7 @@ object IO extends IOInstances {
    * val nanoTime: IO[Void, Long] = IO.sync(System.nanoTime())
    * }}}
    */
-  final def sync[E, A](effect: => A): IO[E, A] = SyncEffect(() => effect)
+  final def sync[E, A](effect: => A): IO[E, A] = new SyncEffect(() => effect)
 
   /**
    *
@@ -690,17 +691,18 @@ object IO extends IOInstances {
    * Imports an asynchronous effect into a pure `IO` value. See `async0` for
    * the more expressive variant of this function.
    */
-  final def async[E, A](register: (ExitResult[E, A] => Unit) => Unit): IO[E, A] = AsyncEffect { callback =>
-    register(callback)
+  final def async[E, A](register: (ExitResult[E, A] => Unit) => Unit): IO[E, A] =
+    new AsyncEffect(callback => {
+      register(callback)
 
-    Async.later[E, A]
-  }
+      Async.later[E, A]
+    })
 
   /**
    * Imports an asynchronous effect into a pure `IO` value. This formulation is
    * necessary when the effect is itself expressed in terms of `IO`.
    */
-  final def asyncPure[E, A](register: (ExitResult[E, A] => Unit) => IO[E, Unit]): IO[E, A] = AsyncIOEffect(register)
+  final def asyncPure[E, A](register: (ExitResult[E, A] => Unit) => IO[E, Unit]): IO[E, A] = new AsyncIOEffect(register)
 
   /**
    * Imports an asynchronous effect into a pure `IO` value. The effect has the
@@ -710,7 +712,7 @@ object IO extends IOInstances {
    * returning a canceler, which will be used by the runtime to cancel the
    * asynchronous effect if the fiber executing the effect is interrupted.
    */
-  final def async0[E, A](register: (ExitResult[E, A] => Unit) => Async[E, A]): IO[E, A] = AsyncEffect(register)
+  final def async0[E, A](register: (ExitResult[E, A] => Unit) => Async[E, A]): IO[E, A] = new AsyncEffect(register)
 
   /**
    * Returns a action that will never produce anything. The moral
@@ -732,7 +734,7 @@ object IO extends IOInstances {
    * Retrieves the supervisor associated with the fiber running the action
    * returned by this method.
    */
-  def supervisor[E]: IO[E, Throwable => IO[Void, Unit]] = Supervisor()
+  def supervisor[E]: IO[E, Throwable => IO[Void, Unit]] = new Supervisor()
 
   /**
    * Requires that the given `IO[E, Maybe[A]]` contain a value. If there is no

--- a/effect/shared/src/main/scala/scalaz/effect/IO.scala
+++ b/effect/shared/src/main/scala/scalaz/effect/IO.scala
@@ -367,7 +367,7 @@ sealed abstract class IO[E, A] { self =>
    * elapses.
    */
   final def retryFor(duration: Duration): IO[E, Maybe[A]] =
-    retry.map(Maybe.just[A](_)) race
+    retry.map(Maybe.just[A]) race
       (IO.sleep[E](duration) *> IO.now[E, Maybe[A]](Maybe.empty[A]))
 
   /**
@@ -437,7 +437,7 @@ sealed abstract class IO[E, A] { self =>
   final def timeout(duration: Duration): IO[E, Maybe[A]] = {
     val timer = IO.now[E, Maybe[A]](Maybe.empty[A])
 
-    self.map(Maybe.just[A](_)).race(timer.delay(duration))
+    self.map(Maybe.just[A]).race(timer.delay(duration))
   }
 
   /**
@@ -741,7 +741,7 @@ object IO extends IOInstances {
    * value, then the specified error will be raised.
    */
   final def require[E, A](error: E): IO[E, Maybe[A]] => IO[E, A] =
-    (io: IO[E, Maybe[A]]) => io.flatMap(Maybe.maybe(IO.fail[E, A](error))(IO.now[E, A](_)))
+    (io: IO[E, Maybe[A]]) => io.flatMap(Maybe.maybe(IO.fail[E, A](error))(IO.now[E, A]))
 
   // TODO: Make this fast, generalize from `Unit` to `A: Semigroup`,
   // and use `IList` instead of `List`.


### PR DESCRIPTION
Implementation of `Stack` with always O(1) push/pop by avoiding array copy, using array nesting instead. Also has the nice property to "shrink" as the stack unroll.

Benchmarks show a 5% percent perf improvement, but I'd like someone else confirm this on a desktop because I do not trust by laptop cpu to yield continuous/consistent performance.

And also some other minor commits. 