### PR TITLE
use Iterable instead of Traversable

### DIFF
--- a/effect/src/main/scala/scalaz/effect/ST.scala
+++ b/effect/src/main/scala/scalaz/effect/ST.scala
@@ -85,7 +85,7 @@ sealed abstract class STArray[S, A] {
   def freeze: ST[S, ImmutableArray[A]] = st(() => ImmutableArray.fromArray(value))
 
   /**Fill this array from the given association list. */
-  def fill[B](f: (A, B) => A, xs: Traversable[(Int, B)]): ST[S, Unit] = xs.toList match {
+  def fill[B](f: (A, B) => A, xs: Iterable[(Int, B)]): ST[S, Unit] = xs.toList match {
     case Nil             => returnST(())
     case ((i, v) :: ivs) => for {
       _ <- update(f, i, v)


### PR DESCRIPTION
https://github.com/scala/scala/blob/15cc7fe354e4e7dc43246d7c78301940686bb4fc/src/library/scala/package.scala#L44-L47

deprecated since Scala 2.13