### PR TITLE
Expose Inject typeclass

### DIFF
--- a/core/src/main/scala/scalaz/Inject.scala
+++ b/core/src/main/scala/scalaz/Inject.scala
@@ -7,7 +7,7 @@ import std.option.{none, some}
  *
  * @see [[http://www.staff.science.uu.nl/~swier004/Publications/DataTypesALaCarte.pdf]]
  */
-sealed abstract class Inject[F[_], G[_]] extends (F ~> G) {
+abstract class Inject[F[_], G[_]] extends (F ~> G) {
   def apply[A](fa: F[A]): G[A] = inj(fa)
   def unapply[A](ga: G[A]): Option[F[A]] = prj(ga)
   def inj[A](fa: F[A]): G[A]


### PR DESCRIPTION
It looks like the `Inject` typeclass has always been sealed (initial commit: https://github.com/scalaz/scalaz/commit/1d79ad50981db1a6931172d58baf5b341b223c87), but I've come across a use case where I'd like to define custom instances.