### PR TITLE
optimised IList / NonEmptyList constructors

### DIFF
--- a/core/src/main/scala/scalaz/IList.scala
+++ b/core/src/main/scala/scalaz/IList.scala
@@ -477,10 +477,17 @@ final case class ICons[A](head: A, tail: IList[A]) extends IList[A]
 object IList extends IListInstances {
   private[this] val nil: IList[Nothing] = INil()
 
+  // optimised versions of apply(A*)
+  @inline final def apply[A](a: A, b: A): IList[A] = a :: single(b)
+  @inline final def apply[A](a: A, b: A, c: A): IList[A] = a :: apply(b, c)
+  @inline final def apply[A](a: A, b: A, c: A, d: A): IList[A] = a :: apply(b, c, d)
+  @inline final def apply[A](a: A, b: A, c: A, d: A, e: A): IList[A] = a :: apply(b, c, d, e)
+  @inline final def apply[A](a: A, b: A, c: A, d: A, e: A, f: A): IList[A] = a :: apply(b, c, d, e, f)
+
   def apply[A](as: A*): IList[A] =
     as.foldRight(empty[A])(ICons(_, _))
 
-  def single[A](a: A): IList[A] =
+  @inline final def single[A](a: A): IList[A] =
     ICons(a, empty)
 
   def empty[A]: IList[A] =

--- a/core/src/main/scala/scalaz/IList.scala
+++ b/core/src/main/scala/scalaz/IList.scala
@@ -237,8 +237,7 @@ sealed abstract class IList[A] extends Product with Serializable {
   def length: Int =
     foldLeft(0)((n, _) => n + 1)
 
-  def map[B](f: A => B): IList[B] =
-    foldRight(IList.empty[B])(f(_) :: _)
+  def map[B](f: A => B): IList[B] = reverse.reverseMap(f)
 
   // private helper for mapAccumLeft/Right below
   private[this] def mapAccum[B, C](as: IList[A])(c: C, f: (C, A) => (C, B)): (C, IList[B]) =
@@ -293,11 +292,21 @@ sealed abstract class IList[A] extends Product with Serializable {
   def reduceRightOption(f: (A, A) => A): Option[A] =
     reverse.reduceLeftOption((a, b) => f(b, a))
 
-  def reverse: IList[A] =
-    foldLeft(IList.empty[A])((as, a) => a :: as)
+  def reverse: IList[A] = {
+    @tailrec def go(as: IList[A], acc: IList[A]): IList[A] = as match {
+      case c : ICons[_] => go(c.tail, c.head :: acc)
+      case _ : INil[_] => acc
+    }
+    go(this, IList.empty)
+  }
 
-  def reverseMap[B](f: A => B): IList[B] =
-    foldLeft(IList.empty[B])((bs, a) => f(a) :: bs)
+  def reverseMap[B](f: A => B): IList[B] = {
+    @tailrec def go(as: IList[A], acc: IList[B]): IList[B] = as match {
+      case c : ICons[_] => go(c.tail, f(c.head) :: acc)
+      case _ : INil[_] => acc
+    }
+    go(this, IList.empty)
+  }
 
   def reverse_:::(as: IList[A]): IList[A] =
     as.foldLeft(this)((as, a) => a :: as)

--- a/core/src/main/scala/scalaz/IList.scala
+++ b/core/src/main/scala/scalaz/IList.scala
@@ -294,7 +294,7 @@ sealed abstract class IList[A] extends Product with Serializable {
 
   def reverse: IList[A] = {
     @tailrec def go(as: IList[A], acc: IList[A]): IList[A] = as match {
-      case c : ICons[_] => go(c.tail, c.head :: acc)
+      case c : ICons[_] => go(c.tail, ICons(c.head, acc))
       case _ : INil[_] => acc
     }
     go(this, IList.empty)
@@ -302,7 +302,7 @@ sealed abstract class IList[A] extends Product with Serializable {
 
   def reverseMap[B](f: A => B): IList[B] = {
     @tailrec def go(as: IList[A], acc: IList[B]): IList[B] = as match {
-      case c : ICons[_] => go(c.tail, f(c.head) :: acc)
+      case c : ICons[_] => go(c.tail, ICons(f(c.head), acc))
       case _ : INil[_] => acc
     }
     go(this, IList.empty)
@@ -496,7 +496,7 @@ object IList extends IListInstances {
   def apply[A](as: A*): IList[A] =
     as.foldRight(empty[A])(ICons(_, _))
 
-  @inline final def single[A](a: A): IList[A] =
+  @inline def single[A](a: A): IList[A] =
     ICons(a, empty)
 
   def empty[A]: IList[A] =

--- a/core/src/main/scala/scalaz/NonEmptyList.scala
+++ b/core/src/main/scala/scalaz/NonEmptyList.scala
@@ -139,6 +139,12 @@ object NonEmptyList extends NonEmptyListInstances {
   def apply[A](h: A, t: A*): NonEmptyList[A] =
     nels(h, t: _*)
 
+  // optimised versions of apply(A*)
+  @inline final def apply[A](a: A, b: A, c: A): NonEmptyList[A] = nel(a, IList(b, c))
+  @inline final def apply[A](a: A, b: A, c: A, d: A): NonEmptyList[A] = nel(a, IList(b, c, d))
+  @inline final def apply[A](a: A, b: A, c: A, d: A, e: A): NonEmptyList[A] = nel(a, IList(b, c, d, e))
+  @inline final def apply[A](a: A, b: A, c: A, d: A, e: A, f: A): NonEmptyList[A] = nel(a, IList(b, c, d, e, f))
+
   def unapply[A](v: NonEmptyList[A]): Option[(A, IList[A])] =
     Some((v.head, v.tail))
 


### PR DESCRIPTION
I've been doing some benchmarking and the varargs constructors (everywhere in the codebase) are a problem. It causes a `Seq` to be created, and then a further `List`.

There is not much we can do in 7.2, but for 7.3+ we should

- have explicit arity constructors
- (optionally) have a varargs after that

but there is arguably limited value in a varargs constructor anyway because of the performance hit.

Here I have added some binary compatible (and source equivalent) methods that should speed up a lot of codepaths. But I can't catch zero, 1 and 2 arguments because of source incompatible conflicts.