### PR TITLE
Fast String creation with a rewritten Cord

### DIFF
--- a/core/src/main/scala/scalaz/Cord.scala
+++ b/core/src/main/scala/scalaz/Cord.scala
@@ -1,5 +1,7 @@
 package scalaz
 
+import java.lang.StringBuilder
+
 import scala.annotation.tailrec
 
 /**
@@ -140,4 +142,5 @@ object Cord {
   // breaks out of the tail recursion
   private[this] def unsafeAppendTo_(c: Cord, sb: StringBuilder): Unit = unsafeAppendTo(c, sb)
 
+  type GlorifiedBrick = Cord
 }

--- a/core/src/main/scala/scalaz/Cord.scala
+++ b/core/src/main/scala/scalaz/Cord.scala
@@ -15,8 +15,8 @@ import scala.annotation.tailrec
  * network socket or file, consider https://github.com/scalaz/scalaz/issues/1797
  *
  * If you require a general text manipulation data structure, consider using
- * `Cord` or creating a custom structure to resemble that used by the popular
- * text editors:
+ * `FingerTree` or creating a custom structure to resemble that used by the
+ * popular text editors:
  *
  * - https://ecc-comp.blogspot.co.uk/2015/05/a-brief-glance-at-how-5-text-editors.html
  * - https://pavelfatin.com/typing-with-pleasure/

--- a/core/src/main/scala/scalaz/Digit.scala
+++ b/core/src/main/scala/scalaz/Digit.scala
@@ -144,6 +144,7 @@ sealed abstract class DigitInstances {
 
     override def max = Some(Digit._9)
 
+    override def show(f: Digit): Cord = Cord(shows(f))
     override def shows(f: Digit) = f.toChar.toString
     def order(x: Digit, y: Digit): Ordering = Order[Int].order(x.toInt, y.toInt)
     override def equal(x: Digit, y: Digit): Boolean = x == y

--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -306,11 +306,12 @@ sealed abstract class \/[A, B] extends Product with Serializable {
       }
     }
 
+  import syntax.show._
   /** Show for a disjunction value. */
   def show[AA >: A, BB >: B](implicit SA: Show[AA], SB: Show[BB]): Cord =
     this match {
-      case -\/(a) => ("-\\/(": Cord) ++ SA.show(a) :- ')'
-      case \/-(b) => ("\\/-(": Cord) ++ SB.show(b) :- ')'
+      case -\/(a) => cord"-\\/(${SA.show(a)})"
+      case \/-(b) => cord"\\/-(${SB.show(b)})"
     }
 
   /** Convert to a Validation. */

--- a/core/src/main/scala/scalaz/Either3.scala
+++ b/core/src/main/scala/scalaz/Either3.scala
@@ -47,9 +47,9 @@ object Either3 {
 
   implicit def show[A: Show, B: Show, C: Show]: Show[Either3[A, B, C]] = new Show[Either3[A, B, C]] {
     override def show(v: Either3[A, B, C]) = v match {
-      case Left3(a)   => Cord("Left3(", a.shows, ")")
-      case Middle3(b) => Cord("Middle3(", b.shows, ")")
-      case Right3(c)  => Cord("Right3(", c.shows, ")")
+      case Left3(a)   => cord"Left3($a)"
+      case Middle3(b) => cord"Middle3($b)"
+      case Right3(c)  => cord"Right3($c)"
     }
   }
 }

--- a/core/src/main/scala/scalaz/FingerTree.scala
+++ b/core/src/main/scala/scalaz/FingerTree.scala
@@ -596,11 +596,11 @@ sealed abstract class FingerTreeInstances {
     new Show[FingerTree[V,A]] {
       import std.iterable._
       val AS = Show[List[A]]
-      import Cord._
+      import syntax.show._
       override def show(t: FingerTree[V,A]) = t.fold(
-        empty = v => Cord(V.show(v), " []"),
-        single = (v, x) => Cord(V.show(v), " [", A.show(x), "]"),
-        deep = (v, pf, m, sf) => Cord(V.show(v), " [", AS.show(pf.toList), ", ?, ", AS.show(sf.toList), "]")
+        empty = v => cord"$v []",
+        single = (v, x) => cord"$v [$x]",
+        deep = (v, pf, m, sf) => cord"$v [${AS.show(pf.toList)}, ?, ${AS.show(sf.toList)}]"
       )
     }
 

--- a/core/src/main/scala/scalaz/IList.scala
+++ b/core/src/main/scala/scalaz/IList.scala
@@ -688,20 +688,11 @@ sealed abstract class IListInstances extends IListInstance0 {
       def zero: IList[A] = empty
     }
 
-  implicit def show[A](implicit A: Show[A]): Show[IList[A]] =
-    new Show[IList[A]] {
-      override def show(as: IList[A]) = {
-        @tailrec def commaSep(rest: IList[A], acc: Cord): Cord =
-          rest match {
-            case INil() => acc
-            case ICons(x, xs) => commaSep(xs, (acc :+ ",") ++ A.show(x))
-          }
-        "[" +: (as match {
-          case INil() => Cord()
-          case ICons(x, xs) => commaSep(xs, A.show(x))
-        }) :+ "]"
-      }
-    }
+  implicit def show[A](implicit A: Show[A]): Show[IList[A]] = Show.show { as =>
+    import scalaz.syntax.show._
+    val content = instances.intercalate(as.map(A.show), Cord(","))
+    cord"[$content]"
+  }
 
 }
 

--- a/core/src/main/scala/scalaz/ISet.scala
+++ b/core/src/main/scala/scalaz/ISet.scala
@@ -681,28 +681,13 @@ sealed abstract class ISetInstances {
       Order[IList[A]].order(x.toAscIList, y.toAscIList)
   }
 
-  implicit def setShow[A: Show]: Show[ISet[A]] = new Show[ISet[A]] {
-    override def shows(f: ISet[A]) = {
-      if(f.isEmpty) {
-        "ISet()"
-      } else {
-        val buf = new java.lang.StringBuilder("ISet(")
-        val A = Show[A]
-        @tailrec
-        def go(list: List[A]): Unit = (list: @unchecked) match {
-          case x :: Nil =>
-            buf.append(A.shows(x))
-            buf.append(')')
-            ()
-          case x :: xs =>
-            buf.append(A.shows(x))
-            buf.append(',')
-            go(xs)
-        }
-        go(f.toAscList)
-        buf.toString
-      }
-    }
+  implicit def setShow[A](implicit A: Show[A]): Show[ISet[A]] = Show.show { as =>
+    import scalaz.syntax.show._
+    val content = IList.instances.intercalate(
+      as.toIList.map(A.show),
+      Cord(",")
+    )
+    cord"ISet($content)"
   }
 
   implicit def setMonoid[A: Order]: Monoid[ISet[A]] with SemiLattice[ISet[A]] =

--- a/core/src/main/scala/scalaz/LazyTuple.scala
+++ b/core/src/main/scala/scalaz/LazyTuple.scala
@@ -305,18 +305,19 @@ private trait LazyTuple4Equal[A1, A2, A3, A4] extends Equal[LazyTuple4[A1, A2, A
     _1.equal(f1._1, f2._1) && _2.equal(f1._2, f2._2) && _3.equal(f1._3, f2._3) && _4.equal(f1._4, f2._4)
 }
 
+import scalaz.syntax.show._
 private trait LazyTuple2Show[A1, A2] extends Show[LazyTuple2[A1, A2]] {
   implicit def _1 : Show[A1]
   implicit def _2 : Show[A2]
-  override def show(f: LazyTuple2[A1, A2]) =
-    Cord("(", _1.show(f._1), ",", _2.show(f._2), ")")
+  override def show(f: LazyTuple2[A1, A2]): Cord =
+    cord"(${f._1},${f._2})"
 }
 private trait LazyTuple3Show[A1, A2, A3] extends Show[LazyTuple3[A1, A2, A3]] {
   implicit def _1 : Show[A1]
   implicit def _2 : Show[A2]
   implicit def _3 : Show[A3]
-  override def show(f: LazyTuple3[A1, A2, A3]) =
-    Cord("(", _1.show(f._1), ",", _2.show(f._2), ",", _3.show(f._3), ")")
+  override def show(f: LazyTuple3[A1, A2, A3]): Cord =
+    cord"(${f._1},${f._2},${f._3})"
 }
 private trait LazyTuple4Show[A1, A2, A3, A4] extends Show[LazyTuple4[A1, A2, A3, A4]] {
   implicit def _1 : Show[A1]
@@ -324,7 +325,7 @@ private trait LazyTuple4Show[A1, A2, A3, A4] extends Show[LazyTuple4[A1, A2, A3,
   implicit def _3 : Show[A3]
   implicit def _4 : Show[A4]
   override def show(f: LazyTuple4[A1, A2, A3, A4]) =
-    Cord("(", _1.show(f._1), ",", _2.show(f._2), ",", _3.show(f._3), ",", _4.show(f._4), ")")
+    cord"(${f._1},${f._2},${f._3},${f._4})"
 }
 
 private trait LazyTuple2Order[A1, A2] extends Order[LazyTuple2[A1, A2]] with LazyTuple2Equal[A1, A2] {

--- a/core/src/main/scala/scalaz/Maybe.scala
+++ b/core/src/main/scala/scalaz/Maybe.scala
@@ -229,10 +229,12 @@ sealed abstract class MaybeInstances extends MaybeInstances0 {
         fa2.cata(_ => LT, EQ))
   }
 
-  implicit def maybeShow[A](implicit A: Show[A]): Show[Maybe[A]] =
+  implicit def maybeShow[A](implicit A: Show[A]): Show[Maybe[A]] = {
+    import scalaz.syntax.show._
     Show.show(_.cata(
-      a => Cord("Just(", A.show(a), ")"),
-      "Empty"))
+      a => cord"Just($a)",
+      Cord("Empty")))
+  }
 
   implicit def maybeMonoid[A: Semigroup]: Monoid[Maybe[A]] =
     new MaybeMonoid[A] {

--- a/core/src/main/scala/scalaz/OneAnd.scala
+++ b/core/src/main/scala/scalaz/OneAnd.scala
@@ -288,11 +288,10 @@ sealed abstract class OneAndInstances extends OneAndInstances0 {
       def F = implicitly
     }
 
-  implicit def oneAndShow[F[_], A](implicit A: Show[A], FA: Show[F[A]]): Show[OneAnd[F, A]] =
-    new Show[OneAnd[F, A]] {
-      override def show(f: OneAnd[F, A]) =
-        Cord("OneAnd(", A.show(f.head), ",", FA.show(f.tail), ")")
-    }
+  implicit def oneAndShow[F[_], A](implicit A: Show[A], FA: Show[F[A]]): Show[OneAnd[F, A]] = {
+    import scalaz.syntax.show._
+    Show.show { f => cord"OneAnd(${f.head},${f.tail})" }
+  }
 
   implicit def oneAndOrder[F[_], A](implicit A: Order[A], FA: Order[F[A]]): Order[OneAnd[F, A]] =
     new Order[OneAnd[F, A]] with OneAndEqual[F, A] {

--- a/core/src/main/scala/scalaz/Ordering.scala
+++ b/core/src/main/scala/scalaz/Ordering.scala
@@ -38,6 +38,7 @@ sealed abstract class OrderingInstances {
       case (GT, GT)      => EQ
     }
 
+    override def show(f: Ordering): Cord = Cord(shows(f))
     override def shows(f: Ordering) = f.name
 
     def append(f1: Ordering, f2: => Ordering): Ordering = f1 match {

--- a/core/src/main/scala/scalaz/Show.scala
+++ b/core/src/main/scala/scalaz/Show.scala
@@ -8,8 +8,8 @@ package scalaz
 ////
 trait Show[F]  { self =>
   ////
-  def show(f: F): Cord = Cord(shows(f))
-  def shows(f: F): String = show(f).toString
+  def show(f: F): Cord
+  def shows(f: F): String = show(f).shows
 
   // derived functions
   ////
@@ -22,6 +22,7 @@ object Show {
   ////
 
   def showFromToString[A]: Show[A] = new Show[A] {
+    override def show(f: A): Cord = Cord(shows(f))
     override def shows(f: A): String = f.toString
   }
 
@@ -33,6 +34,7 @@ object Show {
   }
 
   def shows[A](f: A => String): Show[A] = new Show[A] {
+    override def show(f: A): Cord = Cord(shows(f))
     override def shows(a: A): String = f(a)
   }
 

--- a/core/src/main/scala/scalaz/These.scala
+++ b/core/src/main/scala/scalaz/These.scala
@@ -245,18 +245,6 @@ sealed abstract class \&/[A, B] extends Product with Serializable {
             false
         }
     }
-
-  def show[AA >: A, BB >: B](implicit SA: Show[AA], SB: Show[BB]): Cord =
-    this match {
-      case This(a) =>
-        "This(" +: SA.show(a) :+ ")"
-      case That(b) =>
-        "That(" +: SB.show(b) :+ ")"
-      case Both(a, b) =>
-        ("Both(" +: SA.show(a) :+ ",") ++ SB.show(b) :+ ")"
-    }
-
-
 }
 
 object \&/ extends TheseInstances {
@@ -455,6 +443,13 @@ sealed abstract class TheseInstances1 {
   implicit def TheseSemigroup[A, B](implicit SA: Semigroup[A], SB: Semigroup[B]): Semigroup[A \&/ B] =
     Semigroup.instance(_.append(_))
 
-  implicit def TheseShow[A, B](implicit SA: Show[A], SB: Show[B]): Show[A \&/ B] =
-    Show.show(_.show)
+  implicit def TheseShow[A, B](implicit SA: Show[A], SB: Show[B]): Show[A \&/ B] = {
+    import scalaz.syntax.show._
+    Show.show {
+      case \&/.This(a)    => cord"This($a)"
+      case \&/.That(b)    => cord"That($b)"
+      case \&/.Both(a, b) => cord"Both($a,$b)"
+    }
+  }
+
 }

--- a/core/src/main/scala/scalaz/TheseT.scala
+++ b/core/src/main/scala/scalaz/TheseT.scala
@@ -82,7 +82,7 @@ final case class TheseT[F[_], A, B](run: F[A \&/ B]) {
   = TheseT(F.apply2(run, t.run)(_ &&& _))
 
   def show(implicit SA: Show[A], SB: Show[B], F: Functor[F]): F[Cord]
-  = F.map(run)(_.show)
+  = F.map(run)(\&/.TheseShow[A, B].show(_))
 
   def foldRight[Z](z: => Z)(f: (B, => Z) => Z)(implicit F: Foldable[F]): Z
   = F.foldRight[A \&/ B, Z](run, z)((a, b) => a.foldRight(b)(f))

--- a/core/src/main/scala/scalaz/Validation.scala
+++ b/core/src/main/scala/scalaz/Validation.scala
@@ -291,13 +291,6 @@ sealed abstract class Validation[E, A] extends Product with Serializable {
       }
     }
 
-  /** Show for a validation value. */
-  def show(implicit SE: Show[E], SA: Show[A]): Cord =
-    this match {
-      case Failure(e) => ("Failure(": Cord) ++ SE.show(e) :- ')'
-      case Success(a) => ("Success(": Cord) ++ SA.show(a) :- ')'
-    }
-
   /** If `this` and `that` are both success, or both a failure, combine them with the provided `Semigroup` for each. Otherwise, return the success. Alias for `+|+` */
   def append(that: Validation[E, A])(implicit es: Semigroup[E], as: Semigroup[A]): Validation[E, A] = (this, that) match {
     case (Success(a1), Success(a2))   => Success(as.append(a1, a2))
@@ -492,8 +485,13 @@ sealed abstract class ValidationInstances1 extends ValidationInstances2 {
           a1 === a2
       }
 
-  implicit def ValidationShow[E: Show, A: Show]: Show[Validation[E, A]] =
-    Show.show(_.show)
+  implicit def ValidationShow[E: Show, A: Show]: Show[Validation[E, A]] = {
+    import scalaz.syntax.show._
+    Show.show {
+      case Failure(e) => cord"Failure($e)"
+      case Success(a) => cord"Success($a)"
+    }
+  }
 
   implicit def ValidationSemigroup[E: Semigroup, A: Semigroup]: Semigroup[Validation[E, A]] =
     new Semigroup[Validation[E, A]] {

--- a/core/src/main/scala/scalaz/Zipper.scala
+++ b/core/src/main/scala/scalaz/Zipper.scala
@@ -432,13 +432,11 @@ sealed abstract class ZipperInstances {
       streamEqual[A].equal(a1.lefts, a2.lefts) && Equal[A].equal(a1.focus, a2.focus) && streamEqual[A].equal(a1.rights, a2.rights)
   }
 
-  implicit def zipperShow[A: Show]: Show[Zipper[A]] = new Show[Zipper[A]]{
+  implicit def zipperShow[A: Show]: Show[Zipper[A]] = Show.show { f =>
     import std.stream._
-
-    override def show(f: Zipper[A]) =
-      Cord("Zipper(",
-        Show[Stream[A]].show(f.lefts), ", ",
-        Show[A].show(f.focus), ", ",
-        Show[Stream[A]].show(f.rights), ")")
+    import syntax.show._
+    val left = Show[Stream[A]].show(f.lefts)
+    val right = Show[Stream[A]].show(f.rights)
+    cord"Zipper($left,${f.focus},$right)"
   }
 }

--- a/core/src/main/scala/scalaz/std/AnyVal.scala
+++ b/core/src/main/scala/scalaz/std/AnyVal.scala
@@ -9,6 +9,7 @@ import Id._
 trait AnyValInstances {
 
   implicit val unitInstance: Monoid[Unit] with Enum[Unit] with Show[Unit] with SemiLattice[Unit] = new Monoid[Unit] with Enum[Unit] with Show[Unit] with SemiLattice[Unit] {
+    override def show(f: Unit): Cord = Cord()
     override def shows(f: Unit) = ().toString
 
     def append(f1: Unit, f2: => Unit) = ()
@@ -35,6 +36,7 @@ trait AnyValInstances {
   import Tags.{Conjunction, Disjunction}
 
   implicit object booleanInstance extends Enum[Boolean] with Show[Boolean] {
+    override def show(f: Boolean): Cord = Cord(shows(f))
     override def shows(f: Boolean) = f.toString
 
     def order(x: Boolean, y: Boolean) = if (x < y) Ordering.LT else if (x == y) Ordering.EQ else Ordering.GT
@@ -144,6 +146,7 @@ trait AnyValInstances {
   }
 
   implicit val byteInstance: Monoid[Byte] with Enum[Byte] with Show[Byte] = new Monoid[Byte] with Enum[Byte] with Show[Byte] {
+    override def show(f: Byte): Cord = Cord(shows(f))
     override def shows(f: Byte) = f.toString
 
     def append(f1: Byte, f2: => Byte) = (f1 + f2).toByte
@@ -188,6 +191,7 @@ trait AnyValInstances {
   }
 
   implicit val char: Monoid[Char] with Enum[Char] with Show[Char] = new Monoid[Char] with Enum[Char] with Show[Char] {
+    override def show(f: Char): Cord = Cord(shows(f))
     override def shows(f: Char) = f.toString
 
     def append(f1: Char, f2: => Char) = (f1 + f2).toChar
@@ -229,6 +233,7 @@ trait AnyValInstances {
   }
 
   implicit val shortInstance: Monoid[Short] with Enum[Short] with Show[Short] = new Monoid[Short] with Enum[Short] with Show[Short] {
+    override def show(f: Short): Cord = Cord(shows(f))
     override def shows(f: Short) = f.toString
 
     def append(f1: Short, f2: => Short) = (f1 + f2).toShort
@@ -268,6 +273,7 @@ trait AnyValInstances {
   }
 
   implicit val intInstance: Monoid[Int] with Enum[Int] with Show[Int] = new Monoid[Int] with Enum[Int] with Show[Int] {
+    override def show(f: Int): Cord = Cord(shows(f))
     override def shows(f: Int) = f.toString
 
     def append(f1: Int, f2: => Int) = f1 + f2
@@ -323,6 +329,7 @@ trait AnyValInstances {
   }
 
   implicit val longInstance: Monoid[Long] with Enum[Long] with Show[Long] = new Monoid[Long] with Enum[Long] with Show[Long] {
+    override def show(f: Long): Cord = Cord(shows(f))
     override def shows(f: Long) = f.toString
 
     def append(f1: Long, f2: => Long) = f1 + f2
@@ -362,6 +369,7 @@ trait AnyValInstances {
   }
 
   implicit val floatInstance: Order[Float] with Show[Float] = new Order[Float] with Show[Float] {
+    override def show(f: Float): Cord = Cord(shows(f))
     override def shows(f: Float) = f.toString
 
     override def equalIsNatural: Boolean = true
@@ -370,6 +378,7 @@ trait AnyValInstances {
   }
 
   implicit val doubleInstance: Order[Double] with Show[Double] = new Order[Double] with Show[Double] {
+    override def show(f: Double): Cord = Cord(shows(f))
     override def shows(f: Double) = f.toString
 
     override def equalIsNatural: Boolean = true

--- a/core/src/main/scala/scalaz/std/Either.scala
+++ b/core/src/main/scala/scalaz/std/Either.scala
@@ -97,10 +97,11 @@ trait EitherInstances extends EitherInstances0 {
 
   }
 
-  implicit def eitherShow[A,B](implicit SA: Show[A], SB: Show[B]) : Show[Either[A,B]] = new Show[Either[A,B]] {
-    override def show(f: Either[A, B]): Cord = f match {
-      case Left(a) => ("Left(" : Cord) ++ SA.show(a) :- ')'
-      case Right(b) => ("Right(" : Cord) ++ SB.show(b) :- ')'
+  implicit def eitherShow[A,B](implicit SA: Show[A], SB: Show[B]) : Show[Either[A,B]] = {
+    import scalaz.syntax.show._
+    Show.show {
+      case Left(a) => cord"Left($a)"
+      case Right(b) => cord"Right($b)"
     }
   }
 }

--- a/core/src/main/scala/scalaz/std/Iterable.scala
+++ b/core/src/main/scala/scalaz/std/Iterable.scala
@@ -5,8 +5,8 @@ import collection.immutable.Seq
 
 trait IterableInstances {
 
-  implicit def iterableShow[CC[X] <: Iterable[X], A: Show]: Show[CC[A]] = new Show[CC[A]] {
-    override def show(as: CC[A]) = "[" +: Cord.mkCord(",", as.map(Show[A].show(_)).toSeq:_*) :+ "]"
+  implicit def iterableShow[CC[X] <: Iterable[X], A: Show]: Show[CC[A]] = Show.show {
+    as => list.listShow[A].show(as.toList)
   }
 
   /** Lexicographical ordering */

--- a/core/src/main/scala/scalaz/std/List.scala
+++ b/core/src/main/scala/scalaz/std/List.scala
@@ -110,18 +110,10 @@ trait ListInstances extends ListInstances0 {
 
   implicit def listMonoid[A]: Monoid[List[A]] = listInstance.monoid[A]
 
-  implicit def listShow[A: Show]: Show[List[A]] = new Show[List[A]] {
-    override def show(as: List[A]) = {
-      def commaSep(rest: List[A], acc: Cord): Cord =
-        rest match {
-          case Nil => acc
-          case x::xs => commaSep(xs, (acc :+ ",") ++ Show[A].show(x))
-        }
-      "[" +: (as match {
-        case Nil => Cord()
-        case x::xs => commaSep(xs, Show[A].show(x))
-      }) :+ "]"
-    }
+  implicit def listShow[A](implicit A: Show[A]): Show[List[A]] = Show.show { as =>
+    import scalaz.syntax.show._
+    val content = Foldable[List].intercalate(as.map(A.show), Cord(","))
+    cord"[$content]"
   }
 
   implicit def listOrder[A](implicit A0: Order[A]): Order[List[A]] = new ListOrder[A] {

--- a/core/src/main/scala/scalaz/std/Map.scala
+++ b/core/src/main/scala/scalaz/std/Map.scala
@@ -111,10 +111,14 @@ trait MapInstances extends MapInstances0 with MapFunctions {
     }
 
   implicit def mapShow[K, V](implicit K: Show[K], V: Show[V]): Show[Map[K, V]] =
-    Show.show(m => "Map[" +:
-                Cord.mkCord(", ", m.toSeq.map{
-                  case (k, v) => Cord(K show k, "->", V show v)
-                }: _*) :+ "]")
+    Show.show { m =>
+      import list.listInstance
+      import scalaz.syntax.show._
+
+      val els = m.toList.map { case (k, v) => cord"$k -> $v" }
+      val content = Foldable[List].intercalate(els, Cord(","))
+      cord"Map[$content]"
+    }
 
   implicit def mapOrder[K: Order, V: Order]: Order[Map[K, V]] =
     new Order[Map[K, V]] with MapEqual[K, V] {

--- a/core/src/main/scala/scalaz/std/Option.scala
+++ b/core/src/main/scala/scalaz/std/Option.scala
@@ -107,10 +107,11 @@ trait OptionInstances extends OptionInstances0 {
     implicit def A = A0
   }
 
-  implicit def optionShow[A: Show]: Show[Option[A]] = new Show[Option[A]] {
-    override def show(o1: Option[A]) = o1 match {
-      case Some(a1) => Cord("Some(", Show[A].show(a1), ")")
-      case None     => "None"
+  implicit def optionShow[A: Show]: Show[Option[A]] = {
+    import scalaz.syntax.show._
+    Show.show {
+      case Some(a1) => cord"Some($a1)"
+      case None     => Cord("None")
     }
   }
 

--- a/core/src/main/scala/scalaz/std/Set.scala
+++ b/core/src/main/scala/scalaz/std/Set.scala
@@ -61,8 +61,10 @@ trait SetInstances {
       def zero: Set[A] = Set[A]()
     }
 
-  implicit def setShow[A: Show]: Show[Set[A]] = new Show[Set[A]] {
-    override def show(as: Set[A]) = Cord("Set(", Cord.mkCord(",", as.map(Show[A].show).toSeq:_*), ")")
+  implicit def setShow[A](implicit A: Show[A]): Show[Set[A]] = Show.show { as =>
+    import scalaz.syntax.show._
+    val content = Foldable[Set].intercalate(as.map(A.show), Cord(","))
+    cord"Set($content)"
   }
 
 }

--- a/core/src/main/scala/scalaz/std/SortedMap.scala
+++ b/core/src/main/scala/scalaz/std/SortedMap.scala
@@ -115,11 +115,13 @@ trait SortedMapInstances extends SortedMapInstances0 with SortedMapFunctions {
       override def O = K
     }
 
-  implicit def sortedMapShow[K, V](implicit K: Show[K], V: Show[V]): Show[SortedMap[K, V]] =
-    Show.show(m => "SortedMap[" +:
-                Cord.mkCord(", ", m.toSeq.map{
-                  case (k, v) => Cord(K show k, "->", V show v)
-                }: _*) :+ "]")
+  implicit def sortedMapShow[K, V](implicit K: Show[K], V: Show[V]): Show[SortedMap[K, V]] = Show.show { m =>
+      import list.listInstance
+      import scalaz.syntax.show._
+      val els = m.toList.map { case (k, v) => cord"$k -> $v" }
+      val content = Foldable[List].intercalate(els, Cord(","))
+      cord"SortedMap[$content]"
+    }
 
   implicit def sortedMapOrder[K: Order, V: Order]: Order[SortedMap[K, V]] =
     new Order[SortedMap[K, V]] with SortedMapEqual[K, V] {

--- a/core/src/main/scala/scalaz/std/Stream.scala
+++ b/core/src/main/scala/scalaz/std/Stream.scala
@@ -160,11 +160,11 @@ trait StreamInstances {
           }
         }
     }
-  implicit def streamShow[A](implicit A0: Show[A]): Show[Stream[A]] =
-    new Show[Stream[A]] {
-      override def show(as: Stream[A]) = "Stream(" +: stream.intersperse(as.map(A0.show), Cord(",")).foldLeft(Cord())(_ ++ _) :+ ")"
-    }
-
+  implicit def streamShow[A](implicit A0: Show[A]): Show[Stream[A]] = Show.show { as =>
+    import scalaz.syntax.show._
+    val content = Foldable[Stream].intercalate(as.map(A0.show), Cord(","))
+    cord"Stream($content)"
+  }
 
 }
 

--- a/core/src/main/scala/scalaz/std/String.scala
+++ b/core/src/main/scala/scalaz/std/String.scala
@@ -11,9 +11,7 @@ trait StringInstances {
     type SA[α] = String
     def append(f1: String, f2: => String) = f1 + f2
     def zero: String = ""
-    import std.anyVal.intInstance
-    import Cord.sizer
-    override def show(f: String): Cord = new Cord(FingerTree.three[Int, String]("\"", f, "\"").toTree)
+    override def show(f: String): Cord = Cord("\"") ++ (Cord(f) ++ Cord("\""))
     override def shows(f: String): String = '"' + f + '"'
     def order(x: String, y: String) = Ordering.fromInt(x.compareTo(y))
     override def equal(x: String, y: String) = x == y

--- a/core/src/main/scala/scalaz/std/String.scala
+++ b/core/src/main/scala/scalaz/std/String.scala
@@ -11,7 +11,7 @@ trait StringInstances {
     type SA[α] = String
     def append(f1: String, f2: => String) = f1 + f2
     def zero: String = ""
-    override def show(f: String): Cord = Cord("\"") ++ (Cord(f) ++ Cord("\""))
+    override def show(f: String): Cord = Cord("\"") :: Cord(f) :: Cord("\"")
     override def shows(f: String): String = '"' + f + '"'
     def order(x: String, y: String) = Ordering.fromInt(x.compareTo(y))
     override def equal(x: String, y: String) = x == y

--- a/core/src/main/scala/scalaz/std/Tuple.scala
+++ b/core/src/main/scala/scalaz/std/Tuple.scala
@@ -816,23 +816,25 @@ private trait Tuple8Equal[A1, A2, A3, A4, A5, A6, A7, A8] extends Equal[(A1, A2,
     _1.equal(f1._1, f2._1) && _2.equal(f1._2, f2._2) && _3.equal(f1._3, f2._3) && _4.equal(f1._4, f2._4) && _5.equal(f1._5, f2._5) && _6.equal(f1._6, f2._6) && _7.equal(f1._7, f2._7) && _8.equal(f1._8, f2._8)
   override val equalIsNatural: Boolean = _1.equalIsNatural && _2.equalIsNatural && _3.equalIsNatural && _4.equalIsNatural && _5.equalIsNatural && _6.equalIsNatural && _7.equalIsNatural && _8.equalIsNatural
 }
+
+import scalaz.syntax.show._
 private trait Tuple1Show[A1] extends Show[Tuple1[A1]] {
   implicit def _1 : Show[A1]
   override def show(f: Tuple1[A1]) =
-    Cord("(", _1.show(f._1), ")")
+    cord"(${f._1})"
 }
 private trait Tuple2Show[A1, A2] extends Show[(A1, A2)] {
   implicit def _1 : Show[A1]
   implicit def _2 : Show[A2]
   override def show(f: (A1, A2)) =
-    Cord("(", _1.show(f._1), ",", _2.show(f._2), ")")
+    cord"(${f._1},${f._2})"
 }
 private trait Tuple3Show[A1, A2, A3] extends Show[(A1, A2, A3)] {
   implicit def _1 : Show[A1]
   implicit def _2 : Show[A2]
   implicit def _3 : Show[A3]
   override def show(f: (A1, A2, A3)) =
-    Cord("(", _1.show(f._1), ",", _2.show(f._2), ",", _3.show(f._3), ")")
+    cord"(${f._1},${f._2},${f._3})"
 }
 private trait Tuple4Show[A1, A2, A3, A4] extends Show[(A1, A2, A3, A4)] {
   implicit def _1 : Show[A1]
@@ -840,7 +842,7 @@ private trait Tuple4Show[A1, A2, A3, A4] extends Show[(A1, A2, A3, A4)] {
   implicit def _3 : Show[A3]
   implicit def _4 : Show[A4]
   override def show(f: (A1, A2, A3, A4)) =
-    Cord("(", _1.show(f._1), ",", _2.show(f._2), ",", _3.show(f._3), ",", _4.show(f._4), ")")
+    cord"(${f._1},${f._2},${f._3},${f._4})"
 }
 private trait Tuple5Show[A1, A2, A3, A4, A5] extends Show[(A1, A2, A3, A4, A5)] {
   implicit def _1 : Show[A1]
@@ -849,7 +851,7 @@ private trait Tuple5Show[A1, A2, A3, A4, A5] extends Show[(A1, A2, A3, A4, A5)] 
   implicit def _4 : Show[A4]
   implicit def _5 : Show[A5]
   override def show(f: (A1, A2, A3, A4, A5)) =
-    Cord("(", _1.show(f._1), ",", _2.show(f._2), ",", _3.show(f._3), ",", _4.show(f._4), ",", _5.show(f._5), ")")
+    cord"(${f._1},${f._2},${f._3},${f._4},${f._5})"
 }
 private trait Tuple6Show[A1, A2, A3, A4, A5, A6] extends Show[(A1, A2, A3, A4, A5, A6)] {
   implicit def _1 : Show[A1]
@@ -859,7 +861,7 @@ private trait Tuple6Show[A1, A2, A3, A4, A5, A6] extends Show[(A1, A2, A3, A4, A
   implicit def _5 : Show[A5]
   implicit def _6 : Show[A6]
   override def show(f: (A1, A2, A3, A4, A5, A6)) =
-    Cord("(", _1.show(f._1), ",", _2.show(f._2), ",", _3.show(f._3), ",", _4.show(f._4), ",", _5.show(f._5), ",", _6.show(f._6), ")")
+    cord"(${f._1},${f._2},${f._3},${f._4},${f._5},${f._6})"
 }
 private trait Tuple7Show[A1, A2, A3, A4, A5, A6, A7] extends Show[(A1, A2, A3, A4, A5, A6, A7)] {
   implicit def _1 : Show[A1]
@@ -870,7 +872,7 @@ private trait Tuple7Show[A1, A2, A3, A4, A5, A6, A7] extends Show[(A1, A2, A3, A
   implicit def _6 : Show[A6]
   implicit def _7 : Show[A7]
   override def show(f: (A1, A2, A3, A4, A5, A6, A7)) =
-    Cord("(", _1.show(f._1), ",", _2.show(f._2), ",", _3.show(f._3), ",", _4.show(f._4), ",", _5.show(f._5), ",", _6.show(f._6), ",", _7.show(f._7), ")")
+    cord"(${f._1},${f._2},${f._3},${f._4},${f._5},${f._6},${f._7})"
 }
 private trait Tuple8Show[A1, A2, A3, A4, A5, A6, A7, A8] extends Show[(A1, A2, A3, A4, A5, A6, A7, A8)] {
   implicit def _1 : Show[A1]
@@ -882,7 +884,7 @@ private trait Tuple8Show[A1, A2, A3, A4, A5, A6, A7, A8] extends Show[(A1, A2, A
   implicit def _7 : Show[A7]
   implicit def _8 : Show[A8]
   override def show(f: (A1, A2, A3, A4, A5, A6, A7, A8)) =
-    Cord("(", _1.show(f._1), ",", _2.show(f._2), ",", _3.show(f._3), ",", _4.show(f._4), ",", _5.show(f._5), ",", _6.show(f._6), ",", _7.show(f._7), ",", _8.show(f._8), ")")
+    cord"(${f._1},${f._2},${f._3},${f._4},${f._5},${f._6},${f._7},${f._8})"
 }
 
 private trait Tuple1Order[A1] extends Order[Tuple1[A1]] with Tuple1Equal[A1] {

--- a/core/src/main/scala/scalaz/std/Vector.scala
+++ b/core/src/main/scala/scalaz/std/Vector.scala
@@ -73,11 +73,9 @@ trait VectorInstances extends VectorInstances0 {
   // Vector concat was reduced to O(n) in Scala 2.11 - ideally it would be O(log n)
   // https://issues.scala-lang.org/browse/SI-4442
   implicit def vectorMonoid[A]: Monoid[Vector[A]] = vectorInstance.monoid[A]
- 
-  implicit def vectorShow[A: Show]: Show[Vector[A]] = new Show[Vector[A]] {
-    import Cord._
-    override def show(as: Vector[A]) =
-      Cord("[", mkCord(",", as.map(Show[A].show(_)):_*), "]")
+
+  implicit def vectorShow[A: Show]: Show[Vector[A]] = Show.show { as =>
+    list.listShow[A].show(as.toList)
   }
 
   implicit def vectorOrder[A](implicit A0: Order[A]): Order[Vector[A]] = new VectorOrder[A] {

--- a/core/src/main/scala/scalaz/std/java/math/BigDecimal.scala
+++ b/core/src/main/scala/scalaz/std/java/math/BigDecimal.scala
@@ -5,6 +5,7 @@ import java.math.BigDecimal
 
 trait BigDecimalInstances {
   implicit val javaBigDecimalInstance: Show[BigDecimal] with Equal[BigDecimal] = new Show[BigDecimal] with Equal[BigDecimal] {
+    override def show(f: BigDecimal): Cord = Cord(shows(f))
     override def shows(f: BigDecimal) = f.toString
     override def equal(x: BigDecimal, y: BigDecimal) = x.equals(y)
   }

--- a/core/src/main/scala/scalaz/std/java/math/BigInteger.scala
+++ b/core/src/main/scala/scalaz/std/java/math/BigInteger.scala
@@ -5,6 +5,7 @@ import java.math.BigInteger
 
 trait BigIntegerInstances {
   implicit val bigIntegerInstance: Monoid[BigInteger] with Enum[BigInteger] with Show[BigInteger] = new Monoid[BigInteger] with Enum[BigInteger] with Show[BigInteger] {
+    override def show(f: BigInteger): Cord = Cord(shows(f))
     override def shows(f: BigInteger) = f.toString
 
     def append(f1: BigInteger, f2: => BigInteger) = f1 add f2
@@ -28,7 +29,8 @@ trait BigIntegerInstances {
   import Tags.Multiplication
 
   implicit val bigIntegerMultiplication: Monoid[BigInteger @@ Multiplication] with Order[BigInteger @@ Multiplication] with Show[BigInteger @@ Multiplication] = new Monoid[BigInteger @@ Multiplication] with Order[BigInteger @@ Multiplication] with Show[BigInteger @@ Multiplication] {
-    override def shows(f: scalaz.@@[BigInteger, Multiplication]) = f.toString
+    override def show(f: BigInteger @@ Multiplication): Cord = Cord(shows(f))
+    override def shows(f: BigInteger @@ Multiplication) = f.toString
 
     def append(f1: BigInteger @@ Multiplication, f2: => BigInteger @@ Multiplication) = Multiplication(Tag.unwrap(f1) multiply Tag.unwrap(f2))
 

--- a/core/src/main/scala/scalaz/std/math/BigDecimal.scala
+++ b/core/src/main/scala/scalaz/std/math/BigDecimal.scala
@@ -4,6 +4,7 @@ package math
 
 trait BigDecimalInstances {
   implicit val bigDecimalInstance: Monoid[BigDecimal] with Enum[BigDecimal] with Show[BigDecimal] = new Monoid[BigDecimal] with Enum[BigDecimal] with Show[BigDecimal] {
+    override def show(f: BigDecimal): Cord = Cord(shows(f))
     override def shows(f: BigDecimal) = f.toString
 
     def append(f1: BigDecimal, f2: => BigDecimal) = f1 + f2

--- a/core/src/main/scala/scalaz/std/math/BigInt.scala
+++ b/core/src/main/scala/scalaz/std/math/BigInt.scala
@@ -4,6 +4,7 @@ package math
 
 trait BigInts {
   implicit val bigIntInstance: Monoid[BigInt] with Enum[BigInt] with Show[BigInt] = new Monoid[BigInt] with Enum[BigInt] with Show[BigInt] {
+    override def show(f: BigInt): Cord = Cord(shows(f))
     override def shows(f: BigInt) = f.toString
 
     def append(f1: BigInt, f2: => BigInt): BigInt = f1 + f2
@@ -23,7 +24,8 @@ trait BigInts {
   import Tags.Multiplication
 
   implicit val bigIntMultiplication: Monoid[BigInt @@ Multiplication] with Order[BigInt @@ Multiplication] with Show[BigInt @@ Multiplication] = new Monoid[BigInt @@ Multiplication] with Order[BigInt @@ Multiplication] with Show[BigInt @@ Multiplication] {
-    override def shows(f: scalaz.@@[BigInt, Multiplication]) = f.toString
+    override def show(f: BigInt @@ Multiplication): Cord = Cord(shows(f))
+    override def shows(f: BigInt @@ Multiplication) = f.toString
 
     def append(f1: BigInt @@ Multiplication, f2: => BigInt @@ Multiplication): BigInt @@ Multiplication = Multiplication(Tag.unwrap(f1) * Tag.unwrap(f2))
 

--- a/core/src/main/scala/scalaz/syntax/ShowSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/ShowSyntax.scala
@@ -17,6 +17,7 @@ trait ToShowOps  {
 
   ////
   implicit final def showInterpolator(sc: StringContext): Show.ShowInterpolator = Show.ShowInterpolator(sc)
+  implicit final def cordInterpolator(sc: StringContext): Cord.CordInterpolator = new Cord.CordInterpolator(sc)
   ////
 }
 

--- a/example/src/main/scala/scalaz/example/ReaderWriterStateTUsage.scala
+++ b/example/src/main/scala/scalaz/example/ReaderWriterStateTUsage.scala
@@ -178,7 +178,7 @@ object CABRunLengthEncoder {
     val config = RunLengthConfig(minRun)
     val initialState = RunLengthState.initial(input)
     val (output, result, finalState) = untilM_(maybeEmit, done).run(config, initialState).run
-    output.shows
+    output.toString
   }
 }
 

--- a/example/src/main/scala/scalaz/example/ReaderWriterStateTUsage.scala
+++ b/example/src/main/scala/scalaz/example/ReaderWriterStateTUsage.scala
@@ -140,7 +140,7 @@ object CABRunLengthEncoder {
     if(length <= minRun)
       tell(Monoid[Cord].multiply(token.show, length))
     else
-      tell(length.show ++ token.show)
+      tell(length.show :: token.show)
 
 
   /**

--- a/iteratee/src/main/scala/scalaz/iteratee/Input.scala
+++ b/iteratee/src/main/scala/scalaz/iteratee/Input.scala
@@ -131,13 +131,14 @@ sealed abstract class InputInstances {
      )
    }
 
-   implicit def inputShow[A](implicit A: Show[A]): Show[Input[A]] = new Show[Input[A]] {
-     override def shows(f: Input[A]) = f.fold(
-       empty = "empty-input"
-       , el = a => "el-input(" + A.shows(a) + ")"
-       , eof = "eof-input"
-     )
-   }
+  implicit def inputShow[A](implicit A: Show[A]): Show[Input[A]] = Show.show { i =>
+    import scalaz.syntax.show._
+    i.fold(
+      empty = Cord("empty-input"),
+      el = a => cord"el-input($a)",
+      eof = Cord("eof-input")
+    )
+  }
 }
 
 trait InputFunctions {

--- a/tests/src/test/scala/scalaz/CordTest.scala
+++ b/tests/src/test/scala/scalaz/CordTest.scala
@@ -1,49 +1,105 @@
 package scalaz
 
-import org.scalacheck.Arbitrary
+import org.scalacheck.{ Arbitrary, Gen }
 import scalaz.scalacheck.ScalazProperties._
-import scalaz.scalacheck.ScalaCheckBinding._
-import Cord._
-import org.scalacheck.Prop.forAll
+
+import scalaz.syntax.enum._
+import scalaz.std.anyVal._
+import scalaz.std.string._
 
 object CordTest extends SpecLite {
-  "split() must result in two cords whose summary length is equal to the length of original cord " in {
-    val x = Cord("Once upon a midnight dreary")
-    for (i <- 0 until x.length) {
-      val split = x split i
-      split._1.length + split._2.length must_== x.length
+  ".toString must produce expected output" in {
+    val lefts = (0 |-> 9).foldLeft(Cord())((acc, i) => acc ++ Cord(i.toString))
+    lefts.toString.must_===(lefts.shows)
+    lefts.toString.must_===("0123456789")
+
+    val rights = (0 |-> 9).foldRight(Cord())((i, acc) => Cord(i.toString) ++ acc)
+    rights.toString.must_===(rights.shows)
+    rights.toString.must_===(lefts.toString)
+  }
+
+  ".shows must be stack safe" in {
+    val nums = (1 |-> 99999).map(_.toString)
+    val lefts = nums.foldLeft(Cord())((acc, i) => acc ++ Cord(i))
+    lefts.shows.length.must_===(488889)
+
+    // it's ok to change these assertions if you optimise the representation, so
+    // long as they are asserting the expectation that foldLeft / foldRight
+    // produce expected structures, and that you've stressed tested stack safety
+    // with any new corner cases that your repr may be susceptible to. This
+    // level of detail is not exposed to the public API.
+
+    lefts match {
+      case Cord.Branch(8, _, Cord.Leaf("99999")) =>
+      case Cord.Branch(x, _, _) => fail(s"lefts: unexpected depth $x")
+      case _ => fail("lefts: unexpected leaf")
+    }
+
+    val rights = nums.foldRight(Cord())((i, acc) => Cord(i) ++ acc)
+
+    // prefer minimal error output when these fail, otherwise they spam the buffer
+    assert(rights.shows == lefts.shows)
+    assert(lefts === rights)
+
+    rights match {
+      case Cord.Branch(1, Cord.Leaf("1"), _) =>
+      case Cord.Branch(x, _, _) => fail(s"rights: unexpected depth $x")
+      case _ => fail("rights: unexpected leaf")
     }
   }
 
-  "drop() must make cord shorter" in {
-    val theString = "While I pondered, weak and weary"
-    val x = Cord(theString)
-    for (i <- 0 until x.length) {
-      val y = x drop i
-      y.toString must_== theString.substring(i)
+  "cord interpolator should produce expected Cords" in {
+    import scalaz.syntax.show._
+
+    // trivial strings
+    cord"hello".shows.must_===("hello")
+
+    // interpolate Cord values
+    {
+      val a = Cord("hello")
+      val b = Cord("world")
+      cord"$a $b".shows.must_===("hello world")
+    }
+
+    // interpolate via Show instances
+    {
+      val a = "hello"
+      val b = "world"
+      cord"$a $b".shows.must_===("\"hello\" \"world\"")
+      cord" $a $b ".shows.must_===(" \"hello\" \"world\" ")
+    }
+
+    // handle escape characters
+    {
+      val a = "hello"
+      val b = "world"
+      cord"$a\n$b".shows.must_===("\"hello\"\n\"world\"")
+
+      cord"""
+$a
+
+$b
+""".shows.must_===("\n\"hello\"\n\n\"world\"\n")
     }
   }
 
-  "tail() must be smaller than the whole, generally" in {
-    val x = Cord("abc")
-    x.tail.toString must_== "bc"
-    x.tail.tail.toString must_== "c"
-    x.tail.tail.tail.toString must_== ""
+  // avoid stack overflows...
+  def fallback(c: Cord, backup: Cord.Leaf): Cord = c match {
+    case Cord.Branch(d, _, _) if d >= 5 => backup
+    case _ => c
   }
+  lazy val genLeaf = for {
+    str <- Arbitrary.arbitrary[String]
+  } yield Cord.Leaf(str)
+  lazy val genBranch = for {
+    backup1 <- genLeaf
+    backup2 <- genLeaf
+    left <- genCord
+    right <- genCord
+  } yield Cord.Branch(fallback(left, backup1), fallback(right, backup2))
+  lazy val genCord: Gen[Cord] = Gen.oneOf(genLeaf, genBranch)
 
-  "isEmpty() must indicate string is empty" ! forAll { (a:Cord, b:Cord) =>
-    a.isEmpty == a.toString.isEmpty &&
-    b.isEmpty == b.toString.isEmpty &&
-    (a ++ b).isEmpty == (a.toString.isEmpty && b.toString.isEmpty)
-  }
-
-  "nonEmpty() must indicate string is non-empty" ! forAll { (a:Cord, b:Cord) =>
-    a.nonEmpty == !a.toString.isEmpty &&
-    b.nonEmpty == !b.toString.isEmpty &&
-    (a ++ b).nonEmpty == (!a.toString.isEmpty || !b.toString.isEmpty)
-  }
-
-  implicit def ArbitraryCord: Arbitrary[Cord] = Functor[Arbitrary].map(implicitly[Arbitrary[String]])(Cord.stringToCord)
+  implicit def ArbitraryCord: Arbitrary[Cord] = Arbitrary(genCord)
 
   checkAll(monoid.laws[Cord])
   checkAll(equal.laws[Cord])

--- a/tests/src/test/scala/scalaz/NonEmptyListTest.scala
+++ b/tests/src/test/scala/scalaz/NonEmptyListTest.scala
@@ -94,6 +94,12 @@ object NonEmptyListTest extends SpecLite {
     xs.zipWithIndex.list must_== xs.list.zipWithIndex
   }
 
+  "show should look like IList" in {
+    import scalaz.syntax.show._
+
+    NonEmptyList(1, 2, 3).shows.must_===("[1,2,3]")
+  }
+
   "psumMap should be lazy" in {
     import scalaz.syntax.either._
     import scalaz.syntax.foldable1._

--- a/tests/src/test/scala/scalaz/SyntaxTest.scala
+++ b/tests/src/test/scala/scalaz/SyntaxTest.scala
@@ -51,9 +51,9 @@ object SyntaxTest extends SpecLite {
     case object Result1T extends CoproductT
     case object Result2T extends CoproductT
     object CoproductT {
-      implicit val coproductTShow : Show[CoproductT] = Show.show[CoproductT]{
-        case Result1T => "Result1T"
-        case Result2T => "Result2T"
+      implicit val coproductTShow : Show[CoproductT] = Show.show {
+        case Result1T => Cord("Result1T")
+        case Result2T => Cord("Result2T")
       }
     }
 


### PR DESCRIPTION
Not as epic as @edmundnoble's `DankCord` in scalaz 8 but still about 4x faster than `Cord`  in 7.2 (and about twice as fast as building intermediate `String`s). Benched at https://gitlab.com/fommil/scalaz-deriving/blob/master/examples/xmlformat/src/jmh/scala/xmlformat/Benchmarks.scala on XML data which is roughly equivalent to ADTs of about 4 or 5 layers deep.

I added plenty of code comments.

The only thing remaining that I want to do is to go through all the `Show` instances and make sure they are using the interpolator and/or `Foldable.intercalate`. Uses of `Foldable.foldLeft` or `Foldable.fold` result in the least efficient `Cord`s so best to avoid.