### PR TITLE
WIP sufficient definition checker based on macros

### DIFF
--- a/base/shared/src/main/scala/scalaz/data/DisjunctionInstances.scala
+++ b/base/shared/src/main/scala/scalaz/data/DisjunctionInstances.scala
@@ -27,11 +27,13 @@ trait DisjunctionInstances {
     }
 
   implicit val disjunctionBifunctor: Bifunctor[Disjunction] =
-    instanceOf(new BifunctorClass[Disjunction] with BifunctorClass.DeriveLmapRmap[Disjunction] {
-      def bimap[A, B, S, T](fab: A \/ B)(as: A => S, bt: B => T): S \/ T = fab match {
-        case -\/(a) => -\/(as(a))
-        case \/-(b) => \/-(bt(b))
-      }
+    instanceOf(new BifunctorClass[Disjunction] {
+      val minimal = meta.IsMinimal()
+      override def bimap[A, B, S, T](fab: A \/ B)(as: A => S, bt: B => T): S \/ T =
+        fab match {
+          case -\/(a) => -\/(as(a))
+          case \/-(b) => \/-(bt(b))
+        }
     })
 
   implicit def disjunctionEq[A, B](implicit A: Eq[A], B: Eq[B]): Eq[A \/ B] =

--- a/base/shared/src/main/scala/scalaz/data/Maybe2.scala
+++ b/base/shared/src/main/scala/scalaz/data/Maybe2.scala
@@ -1,7 +1,7 @@
 package scalaz
 package data
 
-import scalaz.typeclass.{ BifunctorClass, DebugClass, EqClass }
+import scalaz.typeclass.{BifunctorClass, DebugClass, EqClass}
 
 sealed trait Maybe2Module {
 
@@ -61,8 +61,9 @@ private[data] object Maybe2Impl extends Maybe2Module {
     }
 
   implicit def bifunctor: scalaz.Bifunctor[Maybe2] =
-    instanceOf(new BifunctorClass[Maybe2] with BifunctorClass.DeriveLmapRmap[Maybe2] {
-      def bimap[A, B, S, T](fab: Maybe2[A, B])(as: A => S, bt: B => T): Maybe2[S, T] =
+    instanceOf(new BifunctorClass[Maybe2] {
+      val minimal = meta.IsMinimal()
+      override def bimap[A, B, S, T](fab: Maybe2[A, B])(as: A => S, bt: B => T): Maybe2[S, T] =
         fab match {
           case Some2(_1, _2) => Some2(as(_1), bt(_2))
           case None2         => None2

--- a/base/shared/src/main/scala/scalaz/data/TheseInstances.scala
+++ b/base/shared/src/main/scala/scalaz/data/TheseInstances.scala
@@ -6,10 +6,11 @@ import scalaz.typeclass._
 trait TheseInstances {
   implicit def bifunctor: Bifunctor[These] =
     instanceOf(new BifunctorClass[These] {
-      def bimap[A, B, S, T](fab: These[A, B])(as: A => S, bt: B => T) = fab.bimap(as)(bt)
+      val minimal = meta.IsMinimal()
+      override def bimap[A, B, S, T](fab: These[A, B])(as: A => S, bt: B => T) = fab.bimap(as)(bt)
 
-      def lmap[A, B, S](fab: These[A, B])(as: A => S) = fab.lmap(as)
-      def rmap[A, B, T](fab: These[A, B])(bt: B => T) = fab.rmap(bt)
+      override def lmap[A, B, S](fab: These[A, B])(as: A => S) = fab.lmap(as)
+      override def rmap[A, B, T](fab: These[A, B])(bt: B => T) = fab.rmap(bt)
     })
 
   implicit final def theseMonad[L: Semigroup]: Monad[These[L, ?]] =

--- a/base/shared/src/main/scala/scalaz/typeclass/BifunctorInstances.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/BifunctorInstances.scala
@@ -4,8 +4,11 @@ package typeclass
 trait BifunctorInstances {
 
   implicit final val tuple2Bifunctor: Bifunctor[Tuple2] =
-    instanceOf(new BifunctorClass[Tuple2] with BifunctorClass.DeriveBimap[Tuple2] {
-      def lmap[A, B, S](fab: (A, B))(f: A => S): (S, B) = fab.copy(_1 = f(fab._1))
-      def rmap[A, B, T](fab: (A, B))(f: B => T): (A, T) = fab.copy(_2 = f(fab._2))
+    instanceOf(new BifunctorClass[Tuple2] {
+      val minimal = meta.IsMinimal()
+      override def lmap[A, B, S](fab: (A, B))(f: A => S): (S, B) =
+        fab.copy(_1 = f(fab._1))
+      override def rmap[A, B, T](fab: (A, B))(f: B => T): (A, T) =
+        fab.copy(_2 = f(fab._2))
     })
 }

--- a/base/shared/src/main/scala/scalaz/typeclass/TypeClass.scala
+++ b/base/shared/src/main/scala/scalaz/typeclass/TypeClass.scala
@@ -1,0 +1,6 @@
+package scalaz
+package typeclass
+
+trait TypeClass {
+  protected val minimal: meta.IsMinimal
+}

--- a/effect/shared/src/main/scala/scalaz/effect/IOInstances.scala
+++ b/effect/shared/src/main/scala/scalaz/effect/IOInstances.scala
@@ -2,7 +2,7 @@
 package scalaz
 package effect
 
-import scalaz.typeclass.{ BifunctorClass, BindClass, MonadClass }
+import scalaz.typeclass.{BifunctorClass, BindClass, MonadClass}
 
 trait IOInstances {
   implicit def monad[E]: Monad[IO[E, ?]] =
@@ -20,7 +20,8 @@ trait IOInstances {
     })
 
   implicit final val bifunctor: Bifunctor[IO] =
-    instanceOf(new BifunctorClass.DeriveBimap[IO] {
+    instanceOf(new BifunctorClass[IO] {
+      val minimal = meta.IsMinimal()
       override def lmap[A, B, S](fab: IO[A, B])(as: A => S): IO[S, B] = fab.leftMap(as)
       override def rmap[A, B, T](fab: IO[A, B])(bt: B => T): IO[A, T] = fab.map(bt)
     })

--- a/meta/shared/src/main/scala/scalaz/meta/minimal.scala
+++ b/meta/shared/src/main/scala/scalaz/meta/minimal.scala
@@ -1,0 +1,95 @@
+package scalaz
+package meta
+
+import language.experimental.macros
+import reflect.macros.blackbox
+
+@com.github.ghik.silencer.silent
+final class minimal(methods: Any*) extends annotation.StaticAnnotation
+
+final class IsMinimal //private ()
+
+object IsMinimal {
+  def apply(): IsMinimal = macro proveMinimality_impl
+
+  def proveMinimality_impl(c: blackbox.Context)(): c.Tree = {
+    import c.universe._, c.internal._
+
+    def minimalNames(sym: Symbol): Option[List[List[TermName]]] = {
+      def isTupleApply(s: Symbol): Boolean = {
+        s.isMethod && definitions.TupleClass.seq.contains(s.owner.companion)
+      }
+
+      sym.annotations.find(_.tree.tpe.typeSymbol eq symbolOf[minimal]).map { ann =>
+        ann.tree match {
+          case Apply(Select(New(_), _), argss) =>
+            argss.map {
+              case Literal(Constant(name: String)) => TermName(name) :: Nil
+              case Apply(fun, args) if isTupleApply(fun.symbol) =>
+                args.map {
+                  case Literal(Constant(name: String)) => TermName(name)
+                }
+            }
+        }
+      }
+    }
+    object solver extends Solver[TermName]
+
+    val enclClass = Iterator
+      .iterate(enclosingOwner)(_.owner)
+      .takeWhile(_ ne NoSymbol)
+      .collectFirst { case cls: ClassSymbol => cls }
+      .getOrElse {
+        c.abort(c.enclosingPosition, s"proveMinimality not called inside a class!")
+      }
+
+    if (enclClass.isAbstract) // includes traits
+      c.error(c.enclosingPosition, s"IsMinimal may only be implemented in classes")
+
+    val bases = enclClass.baseClasses.tail
+
+    bases.flatMap(b => minimalNames(b).map(b -> _)).foreach {
+      case (b, namess) =>
+        val implemented =
+          namess.flatten.flatMap { name =>
+            enclClass.info.member(name) match {
+              case NoSymbol => ???
+              case found =>
+                if (found.owner eq b) None // not implemented if impl hails from its own owner
+                else Some(found.name.decodedName.toTermName)
+            }
+          }.toSet
+        solver.isFormulaSatisfied(implemented)(namess) match {
+          case None => // yep, we're good
+          case Some(unsat) =>
+            c.error(enclClass.pos, s"missing implementations: ${solver.showFormula(unsat)}")
+        }
+    }
+
+    Literal(Constant(null))
+  }
+}
+
+private[meta] class Solver[Literal] {
+  type Clause = List[Literal] // conjoined
+  type Formula = List[Clause] // disjoined
+  type Axioms = Set[Literal]
+
+  def isClauseSatisfied(axioms: Axioms)(clause: Clause): Option[Clause] =
+    clause.filterNot(axioms.contains) match {
+      case Nil   => None
+      case unsat => Some(unsat)
+    }
+
+  def isFormulaSatisfied(axioms: Axioms)(formula: Formula): Option[Formula] = {
+    val satisfictions = formula.map(isClauseSatisfied(axioms))
+    if (satisfictions contains None) None
+    else Some(satisfictions.flatten)
+  }
+
+  def showClause(clause: Clause): String =
+    clause.mkString("(", " AND ", ")")
+  def showFormula(formula: Formula): String =
+    formula.map(showClause).mkString(" OR ")
+
+}


### PR DESCRIPTION
This one is based on macros.

[This one](https://github.com/hrhino/plugin-poc) is more extensible and based on a plugin. (I named it more broadly because @alexknvl had mentioned wanting a place to put some plugin stuff under the scalaz banner.)

I'm putting this up here to invite discussion on whether this is the right way to go about this. I have similar functionality as a compiler plugin. There are pros and cons to each approach:

The main reason to use macros is that they will be available to 3rd party implementors, so we can run the minimality checking without them needing to do anything. If this is implemented as a compiler plugin, typeclass implementors would need to remember to compile with the plugin enabled. (I know sbt models compiler plugins as dependencies; there's no way to "transitively" enable a plugin, is there?)

The upshot to a compiler plugin is that it's a compiler plugin and therefore not based on this pretty meh API, and doesn't need the `protected val minimal` thing to make it work.

This uses only names, and therefore prevents overloading. I think that's a good thing, so I'll consider it on purpose.

TODO, assuming we go the macro way:

- [ ] tests
- [ ] apply everywhere, remove `Alt` traits
- [ ] more sanity checks (methods must exist, no overloading ...)