### PR TITLE
Add `IsCovariant` instance for `IO[E, ?]`. Fixes #1764

### DIFF
--- a/base/shared/src/main/scala/scalaz/types/IsCovariantClass.scala
+++ b/base/shared/src/main/scala/scalaz/types/IsCovariantClass.scala
@@ -22,6 +22,15 @@ trait IsCovariantClass[F[_]] {
 
 object IsCovariantClass {
 
+  /** Unsafe witness that the type constructor `F[_]` is covariant. */
+  def unsafeForce[F[_]]: IsCovariant[F] =
+    instanceOf(new IsCovariantClass.LiftLiskov[F] {
+      override def liftLiskov[A, B](implicit ev: A <~< B): F[A] <~< F[B] = {
+        val _ = ev
+        As.unsafeForce[F[A], F[B]]
+      }
+    })
+
   trait SubstCv[F[_]] extends IsCovariantClass[F] with Alt[SubstCv[F]] {
     final override def substCt[G[- _], A, B](g: G[F[B]])(implicit ev: A <~< B): G[F[A]] = {
       type H[+a] = G[a] => G[F[A]]

--- a/effect/shared/src/main/scala/scalaz/effect/IOInstances.scala
+++ b/effect/shared/src/main/scala/scalaz/effect/IOInstances.scala
@@ -2,7 +2,8 @@
 package scalaz
 package effect
 
-import ct._
+import scalaz.ct._
+import scalaz.types.IsCovariantClass
 
 trait IOInstances {
   implicit def monad[E]: Monad[IO[E, ?]] =
@@ -24,5 +25,7 @@ trait IOInstances {
       override def lmap[A, B, S](fab: IO[A, B])(as: A => S): IO[S, B] = fab.leftMap(as)
       override def rmap[A, B, T](fab: IO[A, B])(bt: B => T): IO[A, T] = fab.map(bt)
     })
+
+  implicit def isCovariant[E]: IsCovariant[IO[E, ?]] = IsCovariantClass.unsafeForce[IO[E, ?]]
 
 }

--- a/effect/shared/src/test/scala/scalaz/effect/CovariantResolutionTest.scala
+++ b/effect/shared/src/test/scala/scalaz/effect/CovariantResolutionTest.scala
@@ -1,0 +1,7 @@
+package scalaz.effect
+
+import scalaz.IsCovariant
+
+class CovariantResolutionTest {
+  implicitly[IsCovariant[IO[Int, ?]]]
+}


### PR DESCRIPTION
Hello,

this a WIP attempt to resolve #1764. 
(Also, my first attempt to contribute to scalaz).
Is using `As.unsafeForce` the correct approach?
