### PR TITLE
Monad transformers switch type

### DIFF
--- a/core/src/main/scala/scalaz/EitherT.scala
+++ b/core/src/main/scala/scalaz/EitherT.scala
@@ -13,7 +13,7 @@ import Liskov.<~<
  * EitherT(x).map(1+).run // Some(\/-(2))
  * }}}
  * */
-final case class EitherT[F[_], A, B](run: F[A \/ B]) {
+final case class EitherT[A, F[_], B](run: F[A \/ B]) {
   import OptionT._
 
   final class Switching_\/[X](r: => X) {
@@ -45,63 +45,63 @@ final case class EitherT[F[_], A, B](run: F[A \/ B]) {
     F.map(run)(_.isRight)
 
   /** Flip the left/right values in this disjunction. Alias for `swap` */
-  def swap(implicit F: Functor[F]): EitherT[F, B, A] =
+  def swap(implicit F: Functor[F]): EitherT[B, F, A] =
     EitherT(F.map(run)(_.swap))
 
   /** Flip the left/right values in this disjunction. Alias for `unary_~` */
-  def unary_~(implicit F: Functor[F]): EitherT[F, B, A] =
+  def unary_~(implicit F: Functor[F]): EitherT[B, F, A] =
     swap
 
   /** Run the given function on this swapped value. Alias for `~` */
-  def swapped[AA, BB](k: (B \/ A) => (BB \/ AA))(implicit F: Functor[F]): EitherT[F, AA, BB] =
+  def swapped[AA, BB](k: (B \/ A) => (BB \/ AA))(implicit F: Functor[F]): EitherT[AA, F, BB] =
     EitherT(F.map(run)(_ swapped k))
 
   /** Run the given function on this swapped value. Alias for `swapped` */
-  def ~[AA, BB](k: (B \/ A) => (BB \/ AA))(implicit F: Functor[F]): EitherT[F, AA, BB] =
+  def ~[AA, BB](k: (B \/ A) => (BB \/ AA))(implicit F: Functor[F]): EitherT[AA, F, BB] =
     swapped(k)
 
   /** Binary functor map on this disjunction. */
-  def bimap[C, D](f: A => C, g: B => D)(implicit F: Functor[F]): EitherT[F, C, D] =
+  def bimap[C, D](f: A => C, g: B => D)(implicit F: Functor[F]): EitherT[C, F, D] =
     EitherT(F.map(run)(_.bimap(f, g)))
 
   /** Run the given function on the left value. */
-  def leftMap[C](f: A => C)(implicit F: Functor[F]): EitherT[F, C, B] =
+  def leftMap[C](f: A => C)(implicit F: Functor[F]): EitherT[C, F, B] =
     bimap(f, identity)
 
   /** Binary functor traverse on this disjunction. */
-  def bitraverse[G[_], C, D](f: A => G[C], g: B => G[D])(implicit F: Traverse[F], G: Applicative[G]): G[EitherT[F, C, D]] =
+  def bitraverse[G[_], C, D](f: A => G[C], g: B => G[D])(implicit F: Traverse[F], G: Applicative[G]): G[EitherT[C, F, D]] =
     Applicative[G].map(F.traverse(run)(Bitraverse[\/].bitraverseF(f, g)))(EitherT(_: F[C \/ D]))
 
   /** Map on the right of this disjunction. */
-  def map[C](f: B => C)(implicit F: Functor[F]): EitherT[F, A, C] =
+  def map[C](f: B => C)(implicit F: Functor[F]): EitherT[A, F, C] =
     EitherT(F.map(run)(_.map(f)))
 
   /** Map on the right of this disjunction. */
-  def mapF[C](f: B => F[C])(implicit M: Monad[F]): EitherT[F, A, C] =
+  def mapF[C](f: B => F[C])(implicit M: Monad[F]): EitherT[A, F, C] =
     flatMapF {
       f andThen (mb => M.map(mb)(b => \/-(b)))
     }
 
-  def mapT[G[_], C, D](f: F[A \/ B] => G[C \/ D]): EitherT[G, C, D] =
+  def mapT[G[_], C, D](f: F[A \/ B] => G[C \/ D]): EitherT[C, G, D] =
     EitherT(f(run))
 
   /** Traverse on the right of this disjunction. */
-  def traverse[G[_], C](f: B => G[C])(implicit F: Traverse[F], G: Applicative[G]): G[EitherT[F, A, C]] =
+  def traverse[G[_], C](f: B => G[C])(implicit F: Traverse[F], G: Applicative[G]): G[EitherT[A, F, C]] =
     G.map(F.traverse(run)(o => Traverse[A \/ ?].traverse(o)(f)))(EitherT(_))
 
   /** Apply a function in the environment of the right of this
     * disjunction.  Because it runs my `F` even when `f`'s `\/` fails,
     * it is not consistent with `ap`.
     */
-  def app[C](f: => EitherT[F, A, B => C])(implicit F: Apply[F]): EitherT[F, A, C] =
+  def app[C](f: => EitherT[A, F, B => C])(implicit F: Apply[F]): EitherT[A, F, C] =
     EitherT(F.apply2(f.run, run)((a, b) => b ap a))
 
   /** Bind through the right of this disjunction. */
-  def flatMap[C](f: B => EitherT[F, A, C])(implicit F: Monad[F]): EitherT[F, A, C] =
+  def flatMap[C](f: B => EitherT[A, F, C])(implicit F: Monad[F]): EitherT[A, F, C] =
     EitherT(F.bind(run)(_.fold(a => F.point(-\/(a): (A \/ C)), b => f(b).run)))
 
   /** Bind the inner monad through the right of this disjunction. */
-  def flatMapF[C](f: B => F[A \/ C])(implicit F: Monad[F]): EitherT[F, A, C] =
+  def flatMapF[C](f: B => F[A \/ C])(implicit F: Monad[F]): EitherT[A, F, C] =
     EitherT(F.bind(run)(_.fold(a => F.point(-\/(a): (A \/ C)), f)))
 
   /** Fold on the right of this disjunction. */
@@ -109,12 +109,12 @@ final case class EitherT[F[_], A, B](run: F[A \/ B]) {
     F.foldRight[A \/ B, Z](run, z)((a, b) => a.foldRight(b)(f))
 
   /** Filter on the right of this disjunction. */
-  def filter(p: B => Boolean)(implicit M: Monoid[A], F: Monad[F]): EitherT[F, A, B] =
-    MonadPlus[EitherT[F, A, ?]].filter(this)(p)
+  def filter(p: B => Boolean)(implicit M: Monoid[A], F: Monad[F]): EitherT[A, F, B] =
+    MonadPlus[EitherT[A, F, ?]].filter(this)(p)
 
   /** Alias for `filter`.
    */
-  def withFilter(p: B => Boolean)(implicit M: Monoid[A], F: Monad[F]): EitherT[F, A, B] =
+  def withFilter(p: B => Boolean)(implicit M: Monoid[A], F: Monad[F]): EitherT[A, F, B] =
     filter(p)(M, F)
 
   /** Return `true` if this disjunction is a right value satisfying the given predicate. */
@@ -161,7 +161,7 @@ final case class EitherT[F[_], A, B](run: F[A \/ B]) {
     F.map(run)(_ valueOr x)
 
   /** Return this if it is a right, otherwise, return the given value. Alias for `|||` */
-  def orElse(x: => EitherT[F, A, B])(implicit F: Monad[F]): EitherT[F, A, B] = {
+  def orElse(x: => EitherT[A, F, B])(implicit F: Monad[F]): EitherT[A, F, B] = {
     val g = run
     EitherT(F.bind(g) {
       case    -\/(_)  => x.run
@@ -170,7 +170,7 @@ final case class EitherT[F[_], A, B](run: F[A \/ B]) {
   }
 
   /** Return this if it is a right, otherwise, return the given value. Alias for `orElse` */
-  def |||(x: => EitherT[F, A, B])(implicit F: Monad[F]): EitherT[F, A, B] =
+  def |||(x: => EitherT[A, F, B])(implicit F: Monad[F]): EitherT[A, F, B] =
     orElse(x)
 
   /**
@@ -182,19 +182,19 @@ final case class EitherT[F[_], A, B](run: F[A \/ B]) {
    * -\/(v1) +++ -\/(v2) → -\/(v1 + v2)
    * }}}
    */
-  def +++(x: => EitherT[F, A, B])(implicit M1: Semigroup[B], M2: Semigroup[A], F: Apply[F]): EitherT[F, A, B] =
+  def +++(x: => EitherT[A, F, B])(implicit M1: Semigroup[B], M2: Semigroup[A], F: Apply[F]): EitherT[A, F, B] =
     EitherT(F.apply2(run, x.run)(_ +++ _))
 
   /** Ensures that the right value of this disjunction satisfies the given predicate, or returns left with the given value. */
-  def ensure(onLeft: => A)(f: B => Boolean)(implicit F: Functor[F]): EitherT[F, A, B] =
+  def ensure(onLeft: => A)(f: B => Boolean)(implicit F: Functor[F]): EitherT[A, F, B] =
     EitherT(F.map(run)(_.ensure(onLeft)(f)))
 
   /** Compare two disjunction values for equality. */
-  def ===(x: EitherT[F, A, B])(implicit EA: Equal[A], EB: Equal[B], F: Apply[F]): F[Boolean] =
+  def ===(x: EitherT[A, F, B])(implicit EA: Equal[A], EB: Equal[B], F: Apply[F]): F[Boolean] =
     F.apply2(run, x.run)(_ === _)
 
   /** Compare two disjunction values for ordering. */
-  def compare(x: EitherT[F, A, B])(implicit EA: Order[A], EB: Order[B], F: Apply[F]): F[Ordering] =
+  def compare(x: EitherT[A, F, B])(implicit EA: Order[A], EB: Order[B], F: Apply[F]): F[Ordering] =
     F.apply2(run, x.run)(_ compare _)
 
   /** Show for a disjunction value. */
@@ -210,7 +210,7 @@ final case class EitherT[F[_], A, B](run: F[A \/ B]) {
     F.map(run)(_.validation)
 
   /** Run a validation function and back to disjunction again. */
-  def validationed[AA, BB](k: Validation[A, B] => Validation[AA, BB])(implicit F: Functor[F]): EitherT[F, AA, BB] =
+  def validationed[AA, BB](k: Validation[A, B] => Validation[AA, BB])(implicit F: Functor[F]): EitherT[AA, F, BB] =
     EitherT(F.map(run)(_ validationed k))
 
   /** Return the value from whichever side of the disjunction is defined, given a commonly assignable type. */
@@ -223,18 +223,18 @@ final case class EitherT[F[_], A, B](run: F[A \/ B]) {
 }
 
 object EitherT extends EitherTInstances {
-  def eitherT[F[_], A, B](a: F[A \/ B]): EitherT[F, A, B] = apply(a)
-  def either[F[_]: Applicative, A, B](d: A \/ B): EitherT[F, A, B] = apply(Applicative[F].point(d))
-  def leftT[F[_]: Functor, A, B](fa: F[A]): EitherT[F, A, B] = apply(Functor[F].map(fa)(-\/(_)))
-  def rightT[F[_]: Functor, A, B](fb: F[B]): EitherT[F, A, B] = apply(Functor[F].map(fb)(\/-(_)))
-  def left[F[_]: Applicative, A, B](a: A): EitherT[F, A, B] = apply(Applicative[F].point(-\/(a)))
-  def right[F[_]: Applicative, A, B](b: B): EitherT[F, A, B] = apply(Applicative[F].point(\/-(b)))
-  def pure[F[_]: Applicative, A, B](b: B): EitherT[F, A, B] = right(b)
+  def eitherT[A, F[_], B](a: F[A \/ B]): EitherT[A, F, B] = apply(a)
+  def either[A, F[_]: Applicative, B](d: A \/ B): EitherT[A, F, B] = apply(Applicative[F].point(d))
+  def leftT[A, F[_]: Functor, B](fa: F[A]): EitherT[A, F, B] = apply(Functor[F].map(fa)(-\/(_)))
+  def rightT[A, F[_]: Functor, B](fb: F[B]): EitherT[A, F, B] = apply(Functor[F].map(fb)(\/-(_)))
+  def left[A, F[_]: Applicative, B](a: A): EitherT[A, F, B] = apply(Applicative[F].point(-\/(a)))
+  def right[A, F[_]: Applicative, B](b: B): EitherT[A, F, B] = apply(Applicative[F].point(\/-(b)))
+  def pure[A, F[_]: Applicative, B](b: B): EitherT[A, F, B] = right(b)
 
   def fromDisjunction[F[_]]: FromDisjunctionAux[F] = new FromDisjunctionAux
 
   final class FromDisjunctionAux[F[_]] private[EitherT] {
-    def apply[A, B](a: A \/ B)(implicit F: Applicative[F]): EitherT[F, A, B] =
+    def apply[A, B](a: A \/ B)(implicit F: Applicative[F]): EitherT[A, F, B] =
       eitherT(F.point(a))
   }
 
@@ -242,7 +242,7 @@ object EitherT extends EitherTInstances {
                                           u1: Unapply[Functor, FAB]{type A = AB},
                                           @deprecated("scala/bug#5075", "") u2: Unapply2[Bifunctor, AB]{type A = A0; type B = B0},
                                           l: AB === (A0 \/ B0)
-  ): EitherT[u1.M, A0, B0] = eitherT(l.subst[u1.M](u1(fab)))
+  ): EitherT[A0, u1.M, B0] = eitherT(l.subst[u1.M](u1(fab)))
 
   def monadTell[F[_], W, A](implicit MT0: MonadTell[F, W]): EitherTMonadTell[F, W, A] = new EitherTMonadTell[F, W, A]{
     def MT = MT0
@@ -265,27 +265,27 @@ object EitherT extends EitherTInstances {
     new EitherTRight[A](true)
 
   private[scalaz] final class EitherTLeft[B](private val dummy: Boolean) extends AnyVal {
-    def apply[FA](fa: FA)(implicit F: Unapply[Functor, FA]): EitherT[F.M, F.A, B] =
-      leftT[F.M, F.A, B](F(fa))(F.TC)
+    def apply[FA](fa: FA)(implicit F: Unapply[Functor, FA]): EitherT[F.A, F.M, B] =
+      leftT[F.A, F.M, B](F(fa))(F.TC)
   }
 
   private[scalaz] final class EitherTRight[A](private val dummy: Boolean) extends AnyVal {
-    def apply[FB](fb: FB)(implicit F: Unapply[Functor, FB]): EitherT[F.M, A, F.A] =
-      rightT[F.M, A, F.A](F(fb))(F.TC)
+    def apply[FB](fb: FB)(implicit F: Unapply[Functor, FB]): EitherT[A, F.M, F.A] =
+      rightT[A, F.M, F.A](F(fb))(F.TC)
   }
 
   /** Construct a disjunction value from a standard `scala.Either`. */
-  def fromEither[F[_], A, B](e: F[Either[A, B]])(implicit F: Functor[F]): EitherT[F, A, B] =
+  def fromEither[F[_], A, B](e: F[Either[A, B]])(implicit F: Functor[F]): EitherT[A, F, B] =
     apply(F.map(e)(_ fold (\/.left, \/.right)))
 
-  def fromTryCatchThrowable[F[_], A, B <: Throwable: NotNothing](a: => F[A])(implicit F: Applicative[F], ex: ClassTag[B]): EitherT[F, B, A] =
+  def fromTryCatchThrowable[F[_], A, B <: Throwable: NotNothing](a: => F[A])(implicit F: Applicative[F], ex: ClassTag[B]): EitherT[B, F, A] =
     try {
       rightT(a)
     } catch {
       case e if ex.runtimeClass.isInstance(e) => leftT(F.point(e.asInstanceOf[B]))
     }
 
-  def fromTryCatchNonFatal[F[_], A](a: => F[A])(implicit F: Applicative[F]): EitherT[F, Throwable, A] =
+  def fromTryCatchNonFatal[F[_], A](a: => F[A])(implicit F: Applicative[F]): EitherT[Throwable, F, A] =
     try {
       rightT(a)
     } catch {
@@ -295,14 +295,14 @@ object EitherT extends EitherTInstances {
 }
 
 sealed abstract class EitherTInstances5 {
-  implicit def eitherTNondeterminism[F[_], E](implicit F0: Nondeterminism[F]): Nondeterminism[EitherT[F, E, ?]] =
+  implicit def eitherTNondeterminism[F[_], E](implicit F0: Nondeterminism[F]): Nondeterminism[EitherT[E, F, ?]] =
     new EitherTNondeterminism[F, E] {
       implicit def F = F0
     }
 }
 
 sealed abstract class EitherTInstances4 extends EitherTInstances5{
-  implicit def eitherTBindRec[F[_], E](implicit F0: Monad[F], B0: BindRec[F]): BindRec[EitherT[F, E, ?]] =
+  implicit def eitherTBindRec[F[_], E](implicit F0: Monad[F], B0: BindRec[F]): BindRec[EitherT[E, F, ?]] =
     new EitherTBindRec[F, E] {
       implicit def F = F0
       implicit def B = B0
@@ -310,21 +310,21 @@ sealed abstract class EitherTInstances4 extends EitherTInstances5{
 }
 
 sealed abstract class EitherTInstances3 extends EitherTInstances4 {
-  implicit def eitherTMonadError[F[_], E](implicit F0: Monad[F]): MonadError[EitherT[F, E, ?], E] =
+  implicit def eitherTMonadError[F[_], E](implicit F0: Monad[F]): MonadError[EitherT[E, F, ?], E] =
     new EitherTMonadError[F, E] {
       implicit def F = F0
     }
 }
 
 sealed abstract class EitherTInstances2 extends EitherTInstances3 {
-  implicit def eitherTFunctor[F[_], L](implicit F0: Functor[F]): Functor[EitherT[F, L, ?]] =
+  implicit def eitherTFunctor[F[_], L](implicit F0: Functor[F]): Functor[EitherT[L, F, ?]] =
     new EitherTFunctor[F, L] {
       implicit def F = F0
     }
 }
 
 sealed abstract class EitherTInstances1 extends EitherTInstances2 {
-  implicit def eitherTPlus[F[_], L](implicit F0: Monad[F], L0: Semigroup[L]): Plus[EitherT[F, L, ?]] =
+  implicit def eitherTPlus[F[_], L](implicit F0: Monad[F], L0: Semigroup[L]): Plus[EitherT[L, F, ?]] =
     new EitherTPlus[F, L] {
       implicit def F = F0
       implicit def G = L0
@@ -332,63 +332,63 @@ sealed abstract class EitherTInstances1 extends EitherTInstances2 {
 }
 
 sealed abstract class EitherTInstances0 extends EitherTInstances1 {
-  implicit def eitherTBifunctor[F[_]](implicit F0: Functor[F]): Bifunctor[EitherT[F, ?, ?]] =
+  implicit def eitherTBifunctor[F[_]](implicit F0: Functor[F]): Bifunctor[EitherT[?, F, ?]] =
     new EitherTBifunctor[F] {
       implicit def F = F0
     }
-  implicit def eitherTBifoldable[F[_]](implicit F0: Foldable[F]): Bifoldable[EitherT[F, ?, ?]] =
+  implicit def eitherTBifoldable[F[_]](implicit F0: Foldable[F]): Bifoldable[EitherT[?, F, ?]] =
     new EitherTBifoldable[F] {
       implicit def F = F0
     }
-  implicit def eitherTMonadPlus[F[_], L](implicit F0: Monad[F], L0: Monoid[L]): MonadPlus[EitherT[F, L, ?]] =
+  implicit def eitherTMonadPlus[F[_], L](implicit F0: Monad[F], L0: Monoid[L]): MonadPlus[EitherT[L, F, ?]] =
     new EitherTMonadPlus[F, L] {
       implicit def F = F0
       implicit def G = L0
     }
-  implicit def eitherTFoldable[F[_], L](implicit F0: Foldable[F]): Foldable[EitherT[F, L, ?]] =
+  implicit def eitherTFoldable[F[_], L](implicit F0: Foldable[F]): Foldable[EitherT[L, F, ?]] =
     new EitherTFoldable[F, L] {
       implicit def F = F0
     }
 }
 
 sealed abstract class EitherTInstances extends EitherTInstances0 {
-  implicit def eitherTBitraverse[F[_]](implicit F0: Traverse[F]): Bitraverse[EitherT[F, ?, ?]] =
+  implicit def eitherTBitraverse[F[_]](implicit F0: Traverse[F]): Bitraverse[EitherT[?, F, ?]] =
     new EitherTBitraverse[F] {
       implicit def F = F0
     }
 
-  implicit def eitherTTraverse[F[_], L](implicit F0: Traverse[F]): Traverse[EitherT[F, L, ?]] =
+  implicit def eitherTTraverse[F[_], L](implicit F0: Traverse[F]): Traverse[EitherT[L, F, ?]] =
     new EitherTTraverse[F, L] {
       implicit def F = F0
     }
 
-  implicit def eitherTHoist[A]: Hoist[λ[(α[_], β) => EitherT[α, A, β]]] =
+  implicit def eitherTHoist[A]: Hoist[λ[(α[_], β) => EitherT[A, α, β]]] =
     new EitherTHoist[A] {}
 
-  implicit def eitherTEqual[F[_], A, B](implicit F0: Equal[F[A \/ B]]): Equal[EitherT[F, A, B]] =
-    F0.contramap((_: EitherT[F, A, B]).run)
+  implicit def eitherTEqual[F[_], A, B](implicit F0: Equal[F[A \/ B]]): Equal[EitherT[A, F, B]] =
+    F0.contramap((_: EitherT[A, F, B]).run)
 
-  implicit def eitherTShow[F[_], A, B](implicit F0: Show[F[A \/ B]]): Show[EitherT[F, A, B]] =
+  implicit def eitherTShow[F[_], A, B](implicit F0: Show[F[A \/ B]]): Show[EitherT[A, F, B]] =
     Contravariant[Show].contramap(F0)(_.run)
 }
 
-private trait EitherTFunctor[F[_], E] extends Functor[EitherT[F, E, ?]] {
+private trait EitherTFunctor[F[_], E] extends Functor[EitherT[E, F, ?]] {
   implicit def F: Functor[F]
 
-  override def map[A, B](fa: EitherT[F, E, A])(f: A => B): EitherT[F, E, B] = fa map f
+  override def map[A, B](fa: EitherT[E, F, A])(f: A => B): EitherT[E, F, B] = fa map f
 }
 
-private trait EitherTBind[F[_], E] extends Bind[EitherT[F, E, ?]] with EitherTFunctor[F, E] {
+private trait EitherTBind[F[_], E] extends Bind[EitherT[E, F, ?]] with EitherTFunctor[F, E] {
   implicit def F: Monad[F]
 
-  final def bind[A, B](fa: EitherT[F, E, A])(f: A => EitherT[F, E, B]): EitherT[F, E, B] = fa flatMap f
+  final def bind[A, B](fa: EitherT[E, F, A])(f: A => EitherT[E, F, B]): EitherT[E, F, B] = fa flatMap f
 }
 
-private trait EitherTBindRec[F[_], E] extends BindRec[EitherT[F, E, ?]] with EitherTBind[F, E] {
+private trait EitherTBindRec[F[_], E] extends BindRec[EitherT[E, F, ?]] with EitherTBind[F, E] {
   implicit def F: Monad[F]
   implicit def B: BindRec[F]
 
-  final def tailrecM[A, B](a: A)(f: A => EitherT[F, E, A \/ B]): EitherT[F, E, B] =
+  final def tailrecM[A, B](a: A)(f: A => EitherT[E, F, A \/ B]): EitherT[E, F, B] =
     EitherT(
       B.tailrecM[A, E \/ B](a)(a => F.map(f(a).run) {
         // E \/ (A \/ B) => A \/ (E \/ B) is _.sequenceU but can't use here
@@ -397,17 +397,17 @@ private trait EitherTBindRec[F[_], E] extends BindRec[EitherT[F, E, ?]] with Eit
     )
 }
 
-private trait EitherTMonad[F[_], E] extends Monad[EitherT[F, E, ?]] with EitherTBind[F, E] {
+private trait EitherTMonad[F[_], E] extends Monad[EitherT[E, F, ?]] with EitherTBind[F, E] {
   implicit def F: Monad[F]
 
-  def point[A](a: => A): EitherT[F, E, A] = EitherT(F.point(\/-(a)))
+  def point[A](a: => A): EitherT[E, F, A] = EitherT(F.point(\/-(a)))
 }
 
-private trait EitherTPlus[F[_], E] extends Plus[EitherT[F, E, ?]] {
+private trait EitherTPlus[F[_], E] extends Plus[EitherT[E, F, ?]] {
   def F: Monad[F]
   def G: Semigroup[E]
 
-  def plus[A](a: EitherT[F, E, A], b: => EitherT[F, E, A]): EitherT[F, E, A] =
+  def plus[A](a: EitherT[E, F, A], b: => EitherT[E, F, A]): EitherT[E, F, A] =
     EitherT(F.bind(a.run){
       case -\/(l) =>
         F.map(b.run){
@@ -419,96 +419,96 @@ private trait EitherTPlus[F[_], E] extends Plus[EitherT[F, E, ?]] {
     })
 }
 
-private trait EitherTMonadPlus[F[_], E] extends MonadPlus[EitherT[F, E, ?]] with EitherTMonad[F, E] with EitherTPlus[F, E] {
+private trait EitherTMonadPlus[F[_], E] extends MonadPlus[EitherT[E, F, ?]] with EitherTMonad[F, E] with EitherTPlus[F, E] {
   def G: Monoid[E]
 
-  def empty[A]: EitherT[F, E, A] = EitherT(F.point(-\/(G.zero)))
+  def empty[A]: EitherT[E, F, A] = EitherT(F.point(-\/(G.zero)))
 }
 
-private trait EitherTFoldable[F[_], E] extends Foldable.FromFoldr[EitherT[F, E, ?]] {
+private trait EitherTFoldable[F[_], E] extends Foldable.FromFoldr[EitherT[E, F, ?]] {
   implicit def F: Foldable[F]
 
-  override def foldRight[A, B](fa: EitherT[F, E, A], z: => B)(f: (A, => B) => B): B = fa.foldRight(z)(f)
+  override def foldRight[A, B](fa: EitherT[E, F, A], z: => B)(f: (A, => B) => B): B = fa.foldRight(z)(f)
 }
 
-private trait EitherTTraverse[F[_], E] extends Traverse[EitherT[F, E, ?]] with EitherTFoldable[F, E] {
+private trait EitherTTraverse[F[_], E] extends Traverse[EitherT[E, F, ?]] with EitherTFoldable[F, E] {
   implicit def F: Traverse[F]
 
-  def traverseImpl[G[_]: Applicative, A, B](fa: EitherT[F, E, A])(f: A => G[B]): G[EitherT[F, E, B]] = fa traverse f
+  def traverseImpl[G[_]: Applicative, A, B](fa: EitherT[E, F, A])(f: A => G[B]): G[EitherT[E, F, B]] = fa traverse f
 }
 
-private trait EitherTBifunctor[F[_]] extends Bifunctor[EitherT[F, ?, ?]] {
+private trait EitherTBifunctor[F[_]] extends Bifunctor[EitherT[?, F, ?]] {
   implicit def F: Functor[F]
 
-  override def bimap[A, B, C, D](fab: EitherT[F, A, B])(f: A => C, g: B => D): EitherT[F, C, D] = fab.bimap(f, g)
+  override def bimap[A, B, C, D](fab: EitherT[A, F, B])(f: A => C, g: B => D): EitherT[C, F, D] = fab.bimap(f, g)
 }
 
-private trait EitherTBifoldable[F[_]] extends Bifoldable.FromBifoldMap[EitherT[F, ?, ?]] {
+private trait EitherTBifoldable[F[_]] extends Bifoldable.FromBifoldMap[EitherT[?, F, ?]] {
   implicit def F: Foldable[F]
 
-  override final def bifoldMap[A, B, M: Monoid](fab: EitherT[F, A, B])(f: A => M)(g: B => M) =
+  override final def bifoldMap[A, B, M: Monoid](fab: EitherT[A, F, B])(f: A => M)(g: B => M) =
     F.foldMap(fab.run)(Bifoldable[\/].bifoldMap(_)(f)(g))
 }
 
-private trait EitherTBitraverse[F[_]] extends Bitraverse[EitherT[F, ?, ?]] with EitherTBifunctor[F] with EitherTBifoldable[F] {
+private trait EitherTBitraverse[F[_]] extends Bitraverse[EitherT[?, F, ?]] with EitherTBifunctor[F] with EitherTBifoldable[F] {
   implicit def F: Traverse[F]
 
-  def bitraverseImpl[G[_] : Applicative, A, B, C, D](fab: EitherT[F, A, B])
-                                                (f: A => G[C], g: B => G[D]): G[EitherT[F, C, D]] =
+  def bitraverseImpl[G[_] : Applicative, A, B, C, D](fab: EitherT[A, F, B])
+                                                (f: A => G[C], g: B => G[D]): G[EitherT[C, F, D]] =
     fab.bitraverse(f, g)
 }
 
-private trait EitherTHoist[A] extends Hoist[λ[(α[_], β) => EitherT[α, A, β]]] {
+private trait EitherTHoist[A] extends Hoist[λ[(α[_], β) => EitherT[A, α, β]]] {
   def hoist[M[_], N[_]](f: M ~> N)(implicit M: Monad[M]) =
-    λ[EitherT[M, A, ?] ~> EitherT[N, A, ?]](_ mapT f.apply)
+    λ[EitherT[A, M, ?] ~> EitherT[A, N, ?]](_ mapT f.apply)
 
-  def liftM[M[_], B](mb: M[B])(implicit M: Monad[M]): EitherT[M, A, B] = EitherT(M.map(mb)(\/.right))
+  def liftM[M[_], B](mb: M[B])(implicit M: Monad[M]): EitherT[A, M, B] = EitherT(M.map(mb)(\/.right))
 
-  implicit def apply[M[_] : Monad]: Monad[EitherT[M, A, ?]] = EitherT.eitherTMonadError
+  implicit def apply[M[_] : Monad]: Monad[EitherT[A, M, ?]] = EitherT.eitherTMonadError
 }
 
-private[scalaz] trait EitherTMonadTell[F[_], W, A] extends MonadTell[EitherT[F, A, ?], W] with EitherTMonad[F, A] with EitherTHoist[A] {
+private[scalaz] trait EitherTMonadTell[F[_], W, A] extends MonadTell[EitherT[A, F, ?], W] with EitherTMonad[F, A] with EitherTHoist[A] {
   def MT: MonadTell[F, W]
 
   implicit def F = MT
 
-  def writer[B](w: W, v: B): EitherT[F, A, B] =
+  def writer[B](w: W, v: B): EitherT[A, F, B] =
     liftM[F, B](MT.writer(w, v))
 
-  def left[B](v: => A): EitherT[F, A, B] =
-    EitherT.leftT[F, A, B](MT.point(v))
+  def left[B](v: => A): EitherT[A, F, B] =
+    EitherT.leftT[A, F, B](MT.point(v))
 
-  def right[B](v: => B): EitherT[F, A, B] =
-    EitherT.rightT[F, A, B](MT.point(v))
+  def right[B](v: => B): EitherT[A, F, B] =
+    EitherT.rightT[A, F, B](MT.point(v))
 }
 
-private[scalaz] trait EitherTMonadListen[F[_], W, A] extends MonadListen[EitherT[F, A, ?], W] with EitherTMonadTell[F, W, A] {
+private[scalaz] trait EitherTMonadListen[F[_], W, A] extends MonadListen[EitherT[A, F, ?], W] with EitherTMonadTell[F, W, A] {
   implicit def MT: MonadListen[F, W]
 
-  def listen[B](ma: EitherT[F, A, B]): EitherT[F, A, (B, W)] = {
+  def listen[B](ma: EitherT[A, F, B]): EitherT[A, F, (B, W)] = {
     val tmp = MT.bind[(A \/ B, W), A \/ (B, W)](MT.listen(ma.run)){
       case (-\/(a), _) => MT.point(-\/(a))
       case (\/-(b), w) => MT.point(\/-((b, w)))
     }
 
-    EitherT[F, A, (B, W)](tmp)
+    EitherT[A, F, (B, W)](tmp)
   }
 }
 
-private trait EitherTMonadError[F[_], E] extends MonadError[EitherT[F, E, ?], E] with EitherTMonad[F, E] {
+private trait EitherTMonadError[F[_], E] extends MonadError[EitherT[E, F, ?], E] with EitherTMonad[F, E] {
   implicit def F: Monad[F]
-  def raiseError[A](e: E): EitherT[F, E, A] = EitherT(F.point(-\/(e)))
-  def handleError[A](fa: EitherT[F, E, A])(f: E => EitherT[F, E, A]): EitherT[F, E, A] =
+  def raiseError[A](e: E): EitherT[E, F, A] = EitherT(F.point(-\/(e)))
+  def handleError[A](fa: EitherT[E, F, A])(f: E => EitherT[E, F, A]): EitherT[E, F, A] =
     EitherT(F.bind(fa.run) {
       case -\/(e) => f(e).run
       case r => F.point(r)
     })
 }
 
-private trait EitherTNondeterminism[F[_], E] extends Nondeterminism[EitherT[F, E, ?]] with EitherTMonad[F, E] {
+private trait EitherTNondeterminism[F[_], E] extends Nondeterminism[EitherT[E, F, ?]] with EitherTMonad[F, E] {
   implicit def F: Nondeterminism[F]
 
-  def chooseAny[A](head: EitherT[F, E, A], tail: IList[EitherT[F, E, A]]): EitherT[F, E, (A, IList[EitherT[F, E, A]])] =
+  def chooseAny[A](head: EitherT[E, F, A], tail: IList[EitherT[E, F, A]]): EitherT[E, F, (A, IList[EitherT[E, F, A]])] =
     EitherT(F.map(F.chooseAny(head.run, tail map (_.run))) {
       case (a, residuals) =>
         a.map((_, residuals.map(new EitherT(_))))

--- a/core/src/main/scala/scalaz/IndexedContsT.scala
+++ b/core/src/main/scala/scalaz/IndexedContsT.scala
@@ -1,6 +1,6 @@
 package scalaz
 
-final case class IndexedContsT[W[_], M[_], R, O, A](_run: W[A => M[O]] => M[R]) {
+final case class IndexedContsT[W[_], R, O, M[_], A](_run: W[A => M[O]] => M[R]) {
   def run(wamo: W[A => M[O]]): M[R] =
     _run(wamo)
 
@@ -10,48 +10,48 @@ final case class IndexedContsT[W[_], M[_], R, O, A](_run: W[A => M[O]] => M[R]) 
   def run_(implicit W: Applicative[W], M: Applicative[M], ev: A === O): M[R] =
     run(W.point(x => M.point(ev(x))))
 
-  def map[B](f: A => B)(implicit W: Functor[W]): IndexedContsT[W, M, R, O, B] =
+  def map[B](f: A => B)(implicit W: Functor[W]): IndexedContsT[W, R, O, M, B] =
     IndexedContsT { wbmo =>
       run(W.map(wbmo)(f andThen _))
     }
 
-  def flatten[E, B](implicit ev: A === IndexedContsT[W, M, O, E, B], W: Cobind[W]): IndexedContsT[W, M, R, E, B] = flatMap(ev)
+  def flatten[E, B](implicit ev: A === IndexedContsT[W, O, E, M, B], W: Cobind[W]): IndexedContsT[W, R, E, M, B] = flatMap(ev)
 
-  def flatMap[E, B](f: A => IndexedContsT[W, M, O, E, B])(implicit W: Cobind[W]): IndexedContsT[W, M, R, E, B] =
+  def flatMap[E, B](f: A => IndexedContsT[W, O, E, M, B])(implicit W: Cobind[W]): IndexedContsT[W, R, E, M, B] =
     IndexedContsT { wbme =>
       run(W.cobind(wbme) { wk => { a =>
         f(a).run(wk)
       } })
     }
 
-  def contramap[I](f: I => O)(implicit M: Functor[M], W: Functor[W]): IndexedContsT[W, M, R, I, A] =
+  def contramap[I](f: I => O)(implicit M: Functor[M], W: Functor[W]): IndexedContsT[W, R, I, M, A] =
     IndexedContsT { wami =>
       run(W.map(wami) { ami => { a => M.map(ami(a))(f) } })
     }
 
-  def imap[E](f: R => E)(implicit M: Functor[M]): IndexedContsT[W, M, E, O, A] =
+  def imap[E](f: R => E)(implicit M: Functor[M]): IndexedContsT[W, E, O, M, A] =
     IndexedContsT { wamo =>
       M.map(run(wamo))(f)
     }
 
-  def bimap[E, B](f: R => E, g: A => B)(implicit M: Functor[M], W: Functor[W]): IndexedContsT[W, M, E, O, B] =
+  def bimap[E, B](f: R => E, g: A => B)(implicit M: Functor[M], W: Functor[W]): IndexedContsT[W, E, O, M, B] =
     IndexedContsT { wbmo =>
       M.map(run(W.map(wbmo)(g andThen _)))(f)
     }
 
-  def xmap[E, I](f: R => E, g: I => O)(implicit M: Functor[M], W: Functor[W]): IndexedContsT[W, M, E, I, A] =
+  def xmap[E, I](f: R => E, g: I => O)(implicit M: Functor[M], W: Functor[W]): IndexedContsT[W, E, I, M, A] =
     IndexedContsT { wami =>
       M.map(run(W.map(wami) { ami => { a => M.map(ami(a))(g) } }))(f)
     }
 
   import BijectionT._
 
-  def bmap[X >: R <: O, Z](f: Bijection[X, Z])(implicit M: Functor[M], W: Functor[W]): ContsT[W, M, Z, A] =
+  def bmap[X >: R <: O, Z](f: Bijection[X, Z])(implicit M: Functor[M], W: Functor[W]): ContsT[W, Z, M, A] =
     IndexedContsT { wami =>
       M.map(run(W.map(wami) { ami => { a => M.map(ami(a))(f from _) } }))(f to _)
     }
 
-  def plus(that: IndexedContsT[W, M, R, O, A])(implicit M: Plus[M]): IndexedContsT[W, M, R, O, A] =
+  def plus(that: IndexedContsT[W, R, O, M, A])(implicit M: Plus[M]): IndexedContsT[W, R, O, M, A] =
     IndexedContsT { wamo =>
       M.plus(this(wamo), that(wamo))
     }
@@ -60,26 +60,26 @@ final case class IndexedContsT[W[_], M[_], R, O, A](_run: W[A => M[O]] => M[R]) 
 object IndexedContsT extends IndexedContsTInstances with IndexedContsTFunctions
 
 trait IndexedContsTFunctions {
-  def point[W[_], M[_], R, A](a: => A)(implicit W: Comonad[W]): ContsT[W, M, R, A] =
+  def point[W[_], R, M[_], A](a: => A)(implicit W: Comonad[W]): ContsT[W, R, M, A] =
     ContsT { k => W.copoint(k)(a) }
 
-  def empty[W[_], M[_], R, A](implicit M: PlusEmpty[M]): ContsT[W, M, R, A] =
+  def empty[W[_], R, M[_], A](implicit M: PlusEmpty[M]): ContsT[W, R, M, A] =
     ContsT { k => M.empty }
 
-  def liftM[W[_], M[_], R, A](a: => M[A])(implicit W: Comonad[W], M: Bind[M]): ContsT[W, M, R, A] =
+  def liftM[W[_], R, M[_], A](a: => M[A])(implicit W: Comonad[W], M: Bind[M]): ContsT[W, R, M, A] =
     ContsT { k => M.bind(a)(W.copoint(k)) }
 
-  def xhoist[W[_], M[_], N[_], R, O](f: M ~> N, g: N ~> M)(implicit W: Functor[W]): IndexedContsT[W, M, R, O, ?] ~> IndexedContsT[W, N, R, O, ?] =
-    λ[IndexedContsT[W, M, R, O, ?] ~> IndexedContsT[W, N, R, O, ?]](
+  def xhoist[W[_], R, O, M[_], N[_]](f: M ~> N, g: N ~> M)(implicit W: Functor[W]): IndexedContsT[W, R, O, M, ?] ~> IndexedContsT[W, R, O, N, ?] =
+    λ[IndexedContsT[W, R, O, M, ?] ~> IndexedContsT[W, R, O, N, ?]](
       fa => IndexedContsT { wk => f(fa.run(W.map(wk) { k => { x => g(k(x)) } })) }
     )
 
-  def contracohoist[W[_], V[_], M[_], R, O](f: V ~> W): (IndexedContsT[W, M, R, O, ?] ~> IndexedContsT[V, M, R, O, ?]) =
-    λ[IndexedContsT[W, M, R, O, ?] ~> IndexedContsT[V, M, R, O, ?]](
+  def contracohoist[W[_], V[_], R, O, M[_]](f: V ~> W): (IndexedContsT[W, R, O, M, ?] ~> IndexedContsT[V, R, O, M, ?]) =
+    λ[IndexedContsT[W, R, O, M, ?] ~> IndexedContsT[V, R, O, M, ?]](
       fa => IndexedContsT { k => fa.run(f(k)) }
     )
 
-  def shift[W[_], M[_], I, R, J, O, A](f: (A => IndexedContsT[W, M, I, I, O]) => IndexedContsT[W, M, R, J, J])(implicit W: Comonad[W], WA: Applicative[W], M: Monad[M]): IndexedContsT[W, M, R, O, A] =
+  def shift[W[_], I, R, J, O, M[_], A](f: (A => IndexedContsT[W, I, I, M, O]) => IndexedContsT[W, R, J, M, J])(implicit W: Comonad[W], WA: Applicative[W], M: Monad[M]): IndexedContsT[W, R, O, M, A] =
     IndexedContsT { k0 =>
       (f { a =>
         IndexedContsT { k1 =>
@@ -88,15 +88,15 @@ trait IndexedContsTFunctions {
       }).run_
     }
 
-  def reset[W[_], M[_], R, O, A](v: IndexedContsT[W, M, A, O, O])(implicit W: Comonad[W], WA: Applicative[W], M: Monad[M]): IndexedContsT[W, M, R, R, A] =
+  def reset[W[_], R, O, M[_], A](v: IndexedContsT[W, A, O, M, O])(implicit W: Comonad[W], WA: Applicative[W], M: Monad[M]): IndexedContsT[W, R, R, M, A] =
     IndexedContsT { k =>
       M.bind(v.run_)(W.copoint(k))
     }
 
-  def callCC[W[_], M[_], R, O, A, B](f: (A => IndexedContsT[W, M, O, O, B]) => IndexedContsT[W, M, R, O, A])(implicit W: Comonad[W]): IndexedContsT[W, M, R, O, A] =
+  def callCC[W[_], R, O, M[_], A, B](f: (A => IndexedContsT[W, O, O, M, B]) => IndexedContsT[W, R, O, M, A])(implicit W: Comonad[W]): IndexedContsT[W, R, O, M, A] =
     IndexedContsT { k =>
       (f { a =>
-        IndexedContsT[W, M, O, O, B] { _ =>
+        IndexedContsT[W, O, O, M, B] { _ =>
           W.copoint(k)(a)
         }
       }).run(k)
@@ -104,103 +104,103 @@ trait IndexedContsTFunctions {
 }
 
 sealed abstract class IndexedContsTInstances2 {
-  implicit def IndexedContsTFunctorRight[W[_], M[_], R, O](implicit W0: Functor[W]): Functor[IndexedContsT[W, M, R, O, ?]] =
+  implicit def IndexedContsTFunctorRight[W[_], R, M[_], O](implicit W0: Functor[W]): Functor[IndexedContsT[W, R, O, M, ?]] =
     new IndexedContsTFunctorRight[W, M, R, O] {
       implicit val W: Functor[W] = W0
     }
 }
 
 sealed abstract class IndexedContsTInstances1 extends IndexedContsTInstances2 {
-  implicit def ContsTBind[W[_], M[_], R](implicit W0: Cobind[W]): Bind[ContsT[W, M, R, ?]] =
+  implicit def ContsTBind[W[_], R, M[_]](implicit W0: Cobind[W]): Bind[ContsT[W, R, M, ?]] =
     new ContsTBind[W, M, R] {
       val W = W0
     }
 }
 
 sealed abstract class IndexedContsTInstances0 extends IndexedContsTInstances1 {
-  implicit def ContsTMonad[W[_], M[_], R](implicit W0: Comonad[W]): Monad[ContsT[W, M, R, ?]] =
+  implicit def ContsTMonad[W[_], R, M[_]](implicit W0: Comonad[W]): Monad[ContsT[W, R, M, ?]] =
     new ContsTMonad[W, M, R] {
       implicit val W: Comonad[W] = W0
     }
 }
 
 abstract class IndexedContsTInstances extends IndexedContsTInstances0 {
-  implicit def IndexedContsTFunctorLeft[W[_], M[_], O, A](implicit M0: Functor[M]): Functor[IndexedContsT[W, M, ?, O, A]] =
+  implicit def IndexedContsTFunctorLeft[W[_], O, M[_], A](implicit M0: Functor[M]): Functor[IndexedContsT[W, ?, O, M, A]] =
     new IndexedContsTFunctorLeft[W, M, O, A] {
       implicit val M: Functor[M] = M0
     }
 
-  implicit def IndexedContsTContravariant[W[_], M[_], R, A](implicit W0: Functor[W], M0: Functor[M]): Contravariant[IndexedContsT[W, M, R, ?, A]] =
+  implicit def IndexedContsTContravariant[W[_], R, M[_], A](implicit W0: Functor[W], M0: Functor[M]): Contravariant[IndexedContsT[W, R, ?, M, A]] =
     new IndexedContsTContravariant[W, M, R, A] {
       implicit val W: Functor[W] = W0
       implicit val M: Functor[M] = M0
     }
 
-  implicit def IndexedContsTBifunctor[W[_], M[_], O](implicit W0: Functor[W], M0: Functor[M]): Bifunctor[IndexedContsT[W, M, ?, O, ?]] =
+  implicit def IndexedContsTBifunctor[W[_], O, M[_]](implicit W0: Functor[W], M0: Functor[M]): Bifunctor[IndexedContsT[W, ?, O, M, ?]] =
     new IndexedContsTBifunctor[W, M, O] {
       implicit val W: Functor[W] = W0
       implicit val M: Functor[M] = M0
     }
 
-  implicit def ContsTMonadPlus[W[_], M[_], R](implicit W0: Comonad[W], M0: PlusEmpty[M]): MonadPlus[ContsT[W, M, R, ?]] =
+  implicit def ContsTMonadPlus[W[_], R, M[_]](implicit W0: Comonad[W], M0: PlusEmpty[M]): MonadPlus[ContsT[W, R, M, ?]] =
     new ContsTMonadPlus[W, M, R] {
       implicit val W: Comonad[W] = W0
       implicit val M: PlusEmpty[M] = M0
     }
 }
 
-private sealed trait IndexedContsTFunctorLeft[W[_], M[_], O, A0] extends Functor[IndexedContsT[W, M, ?, O, A0]] {
+private sealed trait IndexedContsTFunctorLeft[W[_], M[_], O, A0] extends Functor[IndexedContsT[W, ?, O, M, A0]] {
   implicit val M: Functor[M]
 
-  def map[A, B](fa: IndexedContsT[W, M, A, O, A0])(f: A => B): IndexedContsT[W, M, B, O, A0] = fa.imap(f)
+  def map[A, B](fa: IndexedContsT[W, A, O, M, A0])(f: A => B): IndexedContsT[W, B, O, M, A0] = fa.imap(f)
 }
 
-private sealed trait IndexedContsTFunctorRight[W[_], M[_], R, O] extends Functor[IndexedContsT[W, M, R, O, ?]] {
+private sealed trait IndexedContsTFunctorRight[W[_], M[_], R, O] extends Functor[IndexedContsT[W, R, O, M, ?]] {
   implicit val W: Functor[W]
 
-  override def map[A, B](fa: IndexedContsT[W, M, R, O, A])(f: A => B): IndexedContsT[W, M, R, O, B] = fa.map(f)
+  override def map[A, B](fa: IndexedContsT[W, R, O, M, A])(f: A => B): IndexedContsT[W, R, O, M, B] = fa.map(f)
 }
 
-private sealed trait IndexedContsTContravariant[W[_], M[_], R, A0] extends Contravariant[IndexedContsT[W, M, R, ?, A0]] {
-  implicit val W: Functor[W]
-  implicit val M: Functor[M]
-
-  def contramap[A, B](fa: IndexedContsT[W, M, R, A, A0])(f: B => A): IndexedContsT[W, M, R, B, A0] = fa.contramap(f)
-}
-
-private sealed trait IndexedContsTBifunctor[W[_], M[_], O] extends Bifunctor[IndexedContsT[W, M, ?, O, ?]] {
+private sealed trait IndexedContsTContravariant[W[_], M[_], R, A0] extends Contravariant[IndexedContsT[W, R, ?, M, A0]] {
   implicit val W: Functor[W]
   implicit val M: Functor[M]
 
-  def bimap[A, B, C, D](fab: IndexedContsT[W, M, A, O, B])(f: A => C, g: B => D): IndexedContsT[W, M, C, O, D] = fab.bimap(f, g)
-
-  override def leftFunctor[X]: Functor[IndexedContsT[W, M, ?, O, X]] = IndexedContsT.IndexedContsTFunctorLeft
-
-  override def leftMap[A, B, C](fa: IndexedContsT[W, M, A, O, B])(f: A => C): IndexedContsT[W, M, C, O, B] = fa.imap(f)
-
-  override def rightFunctor[X]: Functor[IndexedContsT[W, M, X, O, ?]] = IndexedContsT.IndexedContsTFunctorRight
-
-  override def rightMap[A, B, D](fa: IndexedContsT[W, M, A, O, B])(f: B => D): IndexedContsT[W, M, A, O, D] = fa.map(f)
+  def contramap[A, B](fa: IndexedContsT[W, R, A, M, A0])(f: B => A): IndexedContsT[W, R, B, M, A0] = fa.contramap(f)
 }
 
-private sealed trait ContsTBind[W[_], M[_], R] extends Bind[ContsT[W, M, R, ?]] with IndexedContsTFunctorRight[W, M, R, R] {
+private sealed trait IndexedContsTBifunctor[W[_], M[_], O] extends Bifunctor[IndexedContsT[W, ?, O, M, ?]] {
+  implicit val W: Functor[W]
+  implicit val M: Functor[M]
+
+  def bimap[A, B, C, D](fab: IndexedContsT[W, A, O, M, B])(f: A => C, g: B => D): IndexedContsT[W, C, O, M, D] = fab.bimap(f, g)
+
+  override def leftFunctor[X]: Functor[IndexedContsT[W, ?, O, M, X]] = IndexedContsT.IndexedContsTFunctorLeft
+
+  override def leftMap[A, B, C](fa: IndexedContsT[W, A, O, M, B])(f: A => C): IndexedContsT[W, C, O, M, B] = fa.imap(f)
+
+  override def rightFunctor[X]: Functor[IndexedContsT[W, X, O, M, ?]] = IndexedContsT.IndexedContsTFunctorRight
+
+  override def rightMap[A, B, D](fa: IndexedContsT[W, A, O, M, B])(f: B => D): IndexedContsT[W, A, O, M, D] = fa.map(f)
+}
+
+private sealed trait ContsTBind[W[_], M[_], R] extends Bind[ContsT[W, R, M, ?]] with IndexedContsTFunctorRight[W, M, R, R] {
   implicit val W: Cobind[W]
 
-  override def bind[A, B](fa: ContsT[W, M, R, A])(f: A => ContsT[W, M, R, B]) = fa.flatMap(f)
+  override def bind[A, B](fa: ContsT[W, R, M, A])(f: A => ContsT[W, R, M, B]) = fa.flatMap(f)
 
-  override def join[A](ffa: ContsT[W, M, R, ContsT[W, M, R, A]]) = ffa.flatten
+  override def join[A](ffa: ContsT[W, R, M, ContsT[W, R, M, A]]) = ffa.flatten
 }
 
-private sealed trait ContsTMonad[W[_], M[_], R] extends Monad[ContsT[W, M, R, ?]] with ContsTBind[W, M, R] {
+private sealed trait ContsTMonad[W[_], M[_], R] extends Monad[ContsT[W, R, M, ?]] with ContsTBind[W, M, R] {
   implicit val W: Comonad[W]
 
   override def point[A](a: => A) = IndexedContsT.point(a)
 }
 
-private sealed trait ContsTMonadPlus[W[_], M[_], R] extends MonadPlus[ContsT[W, M, R, ?]] with ContsTMonad[W, M, R] {
+private sealed trait ContsTMonadPlus[W[_], M[_], R] extends MonadPlus[ContsT[W, R, M, ?]] with ContsTMonad[W, M, R] {
   implicit val M: PlusEmpty[M]
 
-  override def empty[A]: ContsT[W, M, R, A] = IndexedContsT.empty
+  override def empty[A]: ContsT[W, R, M, A] = IndexedContsT.empty
 
-  override def plus[A](a: ContsT[W, M, R, A], b: => ContsT[W, M, R, A]): ContsT[W, M, R, A] = a.plus(b)
+  override def plus[A](a: ContsT[W, R, M, A], b: => ContsT[W, R, M, A]): ContsT[W, R, M, A] = a.plus(b)
 }

--- a/core/src/main/scala/scalaz/Kleisli.scala
+++ b/core/src/main/scala/scalaz/Kleisli.scala
@@ -66,7 +66,7 @@ final case class Kleisli[M[_], A, B](run: A => M[B]) { self =>
   def unliftId[N[_]](implicit M: Comonad[N], ev: this.type <~< Kleisli[N[?], A, B]): Reader[A, B] =
     unlift[N, Id]
 
-  def rwst[W, S](implicit M: Functor[M], W: Monoid[W]): ReaderWriterStateT[M, A, W, S, B] =
+  def rwst[W, S](implicit M: Functor[M], W: Monoid[W]): ReaderWriterStateT[A, W, S, M, B] =
     ReaderWriterStateT(
       (r, s) => M.map(self(r)) {
         b => (W.zero, b, s)

--- a/core/src/main/scala/scalaz/LazyOptionT.scala
+++ b/core/src/main/scala/scalaz/LazyOptionT.scala
@@ -40,10 +40,10 @@ final case class LazyOptionT[F[_], A](run: F[LazyOption[A]]) {
   def toLazyLeft[X](right: => X)(implicit F: Functor[F]): LazyEitherT[F, A, X] =
     lazyEitherT(F.map(run)(_.toLazyLeft(right)))
 
-  def toRight[X](left: => X)(implicit F: Functor[F]): EitherT[F, X, A] =
+  def toRight[X](left: => X)(implicit F: Functor[F]): EitherT[X, F, A] =
     eitherT(F.map(run)(_.fold[X \/ A](z => \/-(z), -\/(left))))
 
-  def toLeft[X](right: => X)(implicit F: Functor[F]): EitherT[F, A, X] =
+  def toLeft[X](right: => X)(implicit F: Functor[F]): EitherT[A, F, X] =
     eitherT(F.map(run)(_.fold[A \/ X](z => -\/(z), \/-(right))))
 
   def orElse(a: => LazyOptionT[F, A])(implicit F: Monad[F]): LazyOptionT[F, A] =

--- a/core/src/main/scala/scalaz/MaybeT.scala
+++ b/core/src/main/scala/scalaz/MaybeT.scala
@@ -83,9 +83,9 @@ final case class MaybeT[F[_], A](run: F[Maybe[A]]) {
   def |||(a: => MaybeT[F, A])(implicit F: Monad[F]): MaybeT[F, A] =
     orElse(a)
 
-  def toRight[E](e: => E)(implicit F: Functor[F]): EitherT[F,E,A] = EitherT(F.map(run)(_.toRight(e)))
+  def toRight[E](e: => E)(implicit F: Functor[F]): EitherT[E, F, A] = EitherT(F.map(run)(_.toRight(e)))
 
-  def toLeft[B](b: => B)(implicit F: Functor[F]): EitherT[F,A,B] = EitherT(F.map(run)(_.toLeft(b)))
+  def toLeft[B](b: => B)(implicit F: Functor[F]): EitherT[A, F, B] = EitherT(F.map(run)(_.toLeft(b)))
 
   private def mapO[B](f: Maybe[A] => B)(implicit F: Functor[F]) = F.map(run)(f)
 }

--- a/core/src/main/scala/scalaz/OptionT.scala
+++ b/core/src/main/scala/scalaz/OptionT.scala
@@ -99,12 +99,12 @@ final case class OptionT[F[_], A](run: F[Option[A]]) {
     orElse(a)
 
   /** @since 7.0.3 */
-  def toRight[E](e: => E)(implicit F: Functor[F]): EitherT[F,E,A] = EitherT(F.map(run)(std.option.toRight(_)(e)))
+  def toRight[E](e: => E)(implicit F: Functor[F]): EitherT[E, F, A] = EitherT(F.map(run)(std.option.toRight(_)(e)))
 
   def toListT(implicit F: Functor[F]) : ListT[F, A] =  ListT[F,A](F.map(run)(IList.fromOption))
 
   /** @since 7.0.3 */
-  def toLeft[B](b: => B)(implicit F: Functor[F]): EitherT[F,A,B] = EitherT(F.map(run)(std.option.toLeft(_)(b)))
+  def toLeft[B](b: => B)(implicit F: Functor[F]): EitherT[A, F, B] = EitherT(F.map(run)(std.option.toLeft(_)(b)))
 
   private def mapO[B](f: Option[A] => B)(implicit F: Functor[F]) = F.map(run)(f)
 }

--- a/core/src/main/scala/scalaz/ReaderWriterStateT.scala
+++ b/core/src/main/scala/scalaz/ReaderWriterStateT.scala
@@ -1,7 +1,7 @@
 package scalaz
 
 /** A monad transformer stack yielding `(R, S1) => F[(W, A, S2)]`. */
-sealed abstract class IndexedReaderWriterStateT[F[_], -R, W, -S1, S2, A] {
+sealed abstract class IndexedReaderWriterStateT[-R, W, -S1, S2, F[_], A] {
   self =>
 
   def getF[S <: S1, RR <: R]: Monad[F] => F[(RR, S) => F[(W, A, S2)]]
@@ -15,7 +15,7 @@ sealed abstract class IndexedReaderWriterStateT[F[_], -R, W, -S1, S2, A] {
       case (w, a, s1) => (s1, a)
     })
 
-  def mapT[G[_], B, WU, S2U](f: F[(W, A, S2)] => G[(WU, B, S2U)])(implicit F: Monad[F]): IndexedReaderWriterStateT[G, R, WU, S1, S2U, B] =
+  def mapT[G[_], B, WU, S2U](f: F[(W, A, S2)] => G[(WU, B, S2U)])(implicit F: Monad[F]): IndexedReaderWriterStateT[R, WU, S1, S2U, G, B] =
     IndexedReaderWriterStateT { case (r, s) => f(run(r, s)) }
 
   /** Calls `run` using `Monoid[S].zero` as the initial state */
@@ -38,11 +38,11 @@ sealed abstract class IndexedReaderWriterStateT[F[_], -R, W, -S1, S2, A] {
   def execZero[S <: S1](r:R)(implicit F: Monad[F], S: Monoid[S]): F[(W,S2)] =
     exec(r,S.zero)
 
-  def map[B](f: A => B)(implicit F: Functor[F]): IndexedReaderWriterStateT[F, R, W, S1, S2, B] =
-    IndexedReaderWriterStateT.create[F, R, W, S1, S2, B]( (G: Monad[F]) => (r: R, s: S1) => F.map(self.run(r, s)(G))(t => (t._1, f(t._2), t._3)))
+  def map[B](f: A => B)(implicit F: Functor[F]): IndexedReaderWriterStateT[R, W, S1, S2, F, B] =
+    IndexedReaderWriterStateT.create[R, W, S1, S2, F, B]( (G: Monad[F]) => (r: R, s: S1) => F.map(self.run(r, s)(G))(t => (t._1, f(t._2), t._3)))
 
-  def flatMap[B, RR <: R, S3](f: A => IndexedReaderWriterStateT[F, RR, W, S2, S3, B])(implicit F: Bind[F], W: Semigroup[W]): IndexedReaderWriterStateT[F, RR, W, S1, S3, B] =
-    IndexedReaderWriterStateT.create[F, RR, W, S1, S3, B]( (G: Monad[F]) => (r: RR, s1: S1) =>
+  def flatMap[B, RR <: R, S3](f: A => IndexedReaderWriterStateT[RR, W, S2, S3, F, B])(implicit F: Bind[F], W: Semigroup[W]): IndexedReaderWriterStateT[RR, W, S1, S3, F, B] =
+    IndexedReaderWriterStateT.create[RR, W, S1, S3, F, B]( (G: Monad[F]) => (r: RR, s1: S1) =>
       F.bind(self.run(r, s1)(G)) {
         case (w1, a, s2) => {
           F.map(f(a).run(r, s2)(G)) {
@@ -53,11 +53,11 @@ sealed abstract class IndexedReaderWriterStateT[F[_], -R, W, -S1, S2, A] {
 }
 
 object IndexedReaderWriterStateT extends ReaderWriterStateTInstances with ReaderWriterStateTFunctions {
-  def apply[F[_], R, W, S1, S2, A](f: (R, S1) => F[(W, A, S2)]): IndexedReaderWriterStateT[F, R, W, S1, S2, A] = new IndexedReaderWriterStateT[F, R, W, S1, S2, A] {
+  def apply[R, W, S1, S2, F[_], A](f: (R, S1) => F[(W, A, S2)]): IndexedReaderWriterStateT[R, W, S1, S2, F, A] = new IndexedReaderWriterStateT[R, W, S1, S2, F, A] {
     override def getF[S <: S1, RR <: R]: Monad[F] => F[(RR, S) => F[(W, A, S2)]] = (F: Monad[F]) => F.point((r: R, s: S) => f(r, s))
   }
 
-  def create[F[_], R, W, S1, S2, A](f: Monad[F] => (R, S1) => F[(W,A, S2)]): IndexedReaderWriterStateT[F, R, W, S1, S2, A] = new IndexedReaderWriterStateT[F, R, W, S1, S2, A] {
+  def create[R, W, S1, S2, F[_], A](f: Monad[F] => (R, S1) => F[(W,A, S2)]): IndexedReaderWriterStateT[R, W, S1, S2, F, A] = new IndexedReaderWriterStateT[R, W, S1, S2, F, A] {
     override def getF[S <: S1, RR <: R]: Monad[F] => F[(RR, S) => F[(W, A, S2)]] = (F: Monad[F]) => F.point(f(F))
   }
 }
@@ -67,14 +67,14 @@ trait ReaderWriterStateTFunctions {
 }
 
 sealed abstract class IndexedReaderWriterStateTInstances1 {
-  implicit def irwstFunctor[F[_], R, W, S1, S2](implicit F0: Functor[F]): Functor[IndexedReaderWriterStateT[F, R, W, S1, S2, ?]] =
+  implicit def irwstFunctor[R, W, S1, S2, F[_]](implicit F0: Functor[F]): Functor[IndexedReaderWriterStateT[R, W, S1, S2, F, ?]] =
     new IndexedReaderWriterStateTFunctor[F, R, W, S1, S2] {
       implicit def F = F0
     }
 }
 
 sealed abstract class IndexedReaderWriterStateTInstances0 extends IndexedReaderWriterStateTInstances1 {
-  implicit def rwstBind[F[_], R, W, S](implicit F0: Bind[F], W0: Semigroup[W]): Bind[ReaderWriterStateT[F, R, W, S, ?]] =
+  implicit def rwstBind[R, W, S, F[_]](implicit F0: Bind[F], W0: Semigroup[W]): Bind[ReaderWriterStateT[R, W, S, F, ?]] =
     new ReaderWriterStateTBind[F, R, W, S] {
       def F = F0
       def W = W0
@@ -82,19 +82,19 @@ sealed abstract class IndexedReaderWriterStateTInstances0 extends IndexedReaderW
 }
 
 sealed abstract class IndexedReaderWriterStateTInstances extends IndexedReaderWriterStateTInstances0 {
-  implicit def irwstPlus[F[_], R, W, S1, S2](implicit F0: Plus[F]): Plus[IndexedReaderWriterStateT[F, R, W, S1, S2, ?]] =
+  implicit def irwstPlus[R, W, S1, S2, F[_]](implicit F0: Plus[F]): Plus[IndexedReaderWriterStateT[R, W, S1, S2, F, ?]] =
     new IndexedReaderWriterStateTPlus[F, R, W, S1, S2] {
       override def F = F0
     }
 
-  implicit def rwstBindRec[F[_], R, W, S](implicit F0: BindRec[F], F1: Monad[F], W0: Semigroup[W]): BindRec[ReaderWriterStateT[F, R, W, S, ?]] =
+  implicit def rwstBindRec[R, W, S, F[_]](implicit F0: BindRec[F], F1: Monad[F], W0: Semigroup[W]): BindRec[ReaderWriterStateT[R, W, S, F, ?]] =
     new ReaderWriterStateTBindRec[F, R, W, S] {
       def F = F0
       def A = F1
       def W = W0
     }
 
-  implicit def rwstMonadError[F[_], R, W, S, E](implicit F0: MonadError[F, E], W0: Monoid[W]): MonadError[ReaderWriterStateT[F, R, W, S, ?], E] =
+  implicit def rwstMonadError[R, W, S, E, F[_]](implicit F0: MonadError[F, E], W0: Monoid[W]): MonadError[ReaderWriterStateT[R, W, S, F, ?], E] =
     new ReaderWriterStateTMonadError[F, R, W, S, E] {
       override implicit def F: MonadError[F, E] = F0
       override implicit def W: Monoid[W] = W0
@@ -102,15 +102,15 @@ sealed abstract class IndexedReaderWriterStateTInstances extends IndexedReaderWr
 }
 
 sealed abstract class ReaderWriterStateTInstances0 extends IndexedReaderWriterStateTInstances {
-  implicit def irwstPlusEmpty[F[_], R, W, S1, S2](implicit F0: PlusEmpty[F]): PlusEmpty[IndexedReaderWriterStateT[F, R, W, S1, S2, ?]] =
+  implicit def irwstPlusEmpty[R, W, S1, S2, F[_]](implicit F0: PlusEmpty[F]): PlusEmpty[IndexedReaderWriterStateT[R, W, S1, S2, F, ?]] =
     new IndexedReaderWriterStateTPlusEmpty[F, R, W, S1, S2] {
       override def F = F0
     }
 
-  implicit def rwstMonad[F[_], R, W, S](implicit W0: Monoid[W], F0: Monad[F]):
-  MonadReader[ReaderWriterStateT[F, R, W, S, ?], R] with
-  MonadState[ReaderWriterStateT[F, R, W, S, ?], S] with
-  MonadListen[ReaderWriterStateT[F, R, W, S, ?], W] =
+  implicit def rwstMonad[R, W, S, F[_]](implicit W0: Monoid[W], F0: Monad[F]):
+  MonadReader[ReaderWriterStateT[R, W, S, F, ?], R] with
+  MonadState[ReaderWriterStateT[R, W, S, F, ?], S] with
+  MonadListen[ReaderWriterStateT[R, W, S, F, ?], W] =
     new ReaderWriterStateTMonad[F, R, W, S] {
       implicit def F = F0
       implicit def W = W0
@@ -118,70 +118,70 @@ sealed abstract class ReaderWriterStateTInstances0 extends IndexedReaderWriterSt
 }
 
 abstract class ReaderWriterStateTInstances extends ReaderWriterStateTInstances0 {
-  implicit def rwstMonadPlus[F[_], R, W, S](implicit W0: Monoid[W], F0: MonadPlus[F]): MonadPlus[ReaderWriterStateT[F, R, W, S, ?]] =
+  implicit def rwstMonadPlus[R, W, S, F[_]](implicit W0: Monoid[W], F0: MonadPlus[F]): MonadPlus[ReaderWriterStateT[R, W, S, F, ?]] =
     new ReaderWriterStateTMonadPlus[F, R, W, S] {
       override def F = F0
       override def W = W0
     }
 
-  implicit def rwstHoist[R, W, S](implicit W0: Monoid[W]): Hoist[λ[(α[_], β) => ReaderWriterStateT[α, R, W, S, β]]] =
+  implicit def rwstHoist[R, W, S](implicit W0: Monoid[W]): Hoist[λ[(α[_], β) => ReaderWriterStateT[R, W, S, α, β]]] =
     new ReaderWriterStateTHoist[R, W, S] {
       implicit def W = W0
     }
 
 }
 
-private trait IndexedReaderWriterStateTPlus[F[_], R, W, S1, S2] extends Plus[IndexedReaderWriterStateT[F, R, W, S1, S2, ?]] {
+private trait IndexedReaderWriterStateTPlus[F[_], R, W, S1, S2] extends Plus[IndexedReaderWriterStateT[R, W, S1, S2, F, ?]] {
   def F: Plus[F]
 
-  override final def plus[A](a: IRWST[F, R, W, S1, S2, A], b: => IRWST[F, R, W, S1, S2, A]) =
+  override final def plus[A](a: IRWST[R, W, S1, S2, F, A], b: => IRWST[R, W, S1, S2, F, A]) =
     IRWST.create((G: Monad[F]) => (r: R, s: S1) => F.plus(a.run(r, s)(G), b.run(r, s)(G)))
 }
 
 private trait IndexedReaderWriterStateTPlusEmpty[F[_], R, W, S1, S2]
-  extends PlusEmpty[IndexedReaderWriterStateT[F, R, W, S1, S2, ?]]
+  extends PlusEmpty[IndexedReaderWriterStateT[R, W, S1, S2, F, ?]]
   with IndexedReaderWriterStateTPlus[F, R, W, S1, S2] {
   def F: PlusEmpty[F]
 
   override final def empty[A] = IRWST((_, _) => F.empty)
 }
 
-private trait IndexedReaderWriterStateTFunctor[F[_], R, W, S1, S2] extends Functor[IndexedReaderWriterStateT[F, R, W, S1, S2, ?]] {
+private trait IndexedReaderWriterStateTFunctor[F[_], R, W, S1, S2] extends Functor[IndexedReaderWriterStateT[R, W, S1, S2, F, ?]] {
   implicit def F: Functor[F]
 
-  override final def map[A, B](fa: IndexedReaderWriterStateT[F, R, W, S1, S2, A])(f: A => B): IndexedReaderWriterStateT[F, R, W, S1, S2, B] = fa map f
+  override final def map[A, B](fa: IndexedReaderWriterStateT[R, W, S1, S2, F, A])(f: A => B): IndexedReaderWriterStateT[R, W, S1, S2, F, B] = fa map f
 }
 
-private trait ReaderWriterStateTMonadError[F[_], R, W, S, E] extends MonadError[ReaderWriterStateT[F, R, W, S, ?], E] {
+private trait ReaderWriterStateTMonadError[F[_], R, W, S, E] extends MonadError[ReaderWriterStateT[R, W, S, F, ?], E] {
   implicit def F: MonadError[F, E]
   implicit def W: Monoid[W]
 
-  override def raiseError[A](e: E): RWST[F, R, W, S, A] =
+  override def raiseError[A](e: E): RWST[R, W, S, F, A] =
     RWST((_, _) => F.raiseError(e))
 
-  override def handleError[A](fa: RWST[F, R, W, S, A])(f: (E) => RWST[F, R, W, S, A]): RWST[F, R, W, S, A] =
+  override def handleError[A](fa: RWST[R, W, S, F, A])(f: (E) => RWST[R, W, S, F, A]): RWST[R, W, S, F, A] =
     RWST((r, s) => F.handleError(fa.run(r, s))(f(_).run(r, s)))
 
-  override def bind[A, B](fa: RWST[F, R, W, S, A])(f: (A) => RWST[F, R, W, S, B]): RWST[F, R, W, S, B] =
+  override def bind[A, B](fa: RWST[R, W, S, F, A])(f: (A) => RWST[R, W, S, F, B]): RWST[R, W, S, F, B] =
     fa flatMap f
 
-  override def point[A](a: => A): RWST[F, R, W, S, A] =
+  override def point[A](a: => A): RWST[R, W, S, F, A] =
     RWST((_, s) => F.point((W.zero, a, s)))
 }
 
-private trait ReaderWriterStateTBind[F[_], R, W, S] extends Bind[ReaderWriterStateT[F, R, W, S, ?]] with IndexedReaderWriterStateTFunctor[F, R, W, S, S] {
+private trait ReaderWriterStateTBind[F[_], R, W, S] extends Bind[ReaderWriterStateT[R, W, S, F, ?]] with IndexedReaderWriterStateTFunctor[F, R, W, S, S] {
   implicit def F: Bind[F]
   implicit def W: Semigroup[W]
 
-  override final def bind[A, B](fa: ReaderWriterStateT[F, R, W, S, A])(f: A => ReaderWriterStateT[F, R, W, S, B]) =
+  override final def bind[A, B](fa: ReaderWriterStateT[R, W, S, F, A])(f: A => ReaderWriterStateT[R, W, S, F, B]) =
     fa flatMap f
 }
 
-private trait ReaderWriterStateTBindRec[F[_], R, W, S] extends BindRec[ReaderWriterStateT[F, R, W, S, ?]] with ReaderWriterStateTBind[F, R, W, S] {
+private trait ReaderWriterStateTBindRec[F[_], R, W, S] extends BindRec[ReaderWriterStateT[R, W, S, F, ?]] with ReaderWriterStateTBind[F, R, W, S] {
   implicit def F: BindRec[F]
   implicit def A: Monad[F]
 
-  def tailrecM[A, B](a: A)(f: A => ReaderWriterStateT[F, R, W, S, A \/ B]): ReaderWriterStateT[F, R, W, S, B] = {
+  def tailrecM[A, B](a: A)(f: A => ReaderWriterStateT[R, W, S, F, A \/ B]): ReaderWriterStateT[R, W, S, F, B] = {
     def go(r: R)(t: (W, A, S)): F[(W, A, S) \/ (W, B, S)] =
       F.map(f(t._2).run(r, t._3)) {
         case (w0, e, s0) =>
@@ -197,55 +197,55 @@ private trait ReaderWriterStateTBindRec[F[_], R, W, S] extends BindRec[ReaderWri
 }
 
 private abstract class ReaderWriterStateTMonadPlus[F[_], R, W, S]
-  extends MonadPlus[ReaderWriterStateT[F, R, W, S, ?]]
+  extends MonadPlus[ReaderWriterStateT[R, W, S, F, ?]]
   with ReaderWriterStateTMonad[F, R, W, S]
   with IndexedReaderWriterStateTPlusEmpty[F, R, W, S, S] {
   override def F: MonadPlus[F]
 }
 
 private trait ReaderWriterStateTMonad[F[_], R, W, S]
-  extends MonadReader[ReaderWriterStateT[F, R, W, S, ?], R]
-  with MonadState[ReaderWriterStateT[F, R, W, S, ?], S]
-  with MonadListen[ReaderWriterStateT[F, R, W, S, ?], W]
+  extends MonadReader[ReaderWriterStateT[R, W, S, F, ?], R]
+  with MonadState[ReaderWriterStateT[R, W, S, F, ?], S]
+  with MonadListen[ReaderWriterStateT[R, W, S, F, ?], W]
   with ReaderWriterStateTBind[F, R, W, S] {
   implicit def F: Monad[F]
   implicit def W: Monoid[W]
 
-  def point[A](a: => A): ReaderWriterStateT[F, R, W, S, A] =
+  def point[A](a: => A): ReaderWriterStateT[R, W, S, F, A] =
     ReaderWriterStateT((_, s) => F.point((W.zero, a, s)))
-  def ask: ReaderWriterStateT[F, R, W, S, R] =
+  def ask: ReaderWriterStateT[R, W, S, F, R] =
     ReaderWriterStateT((r, s) => F.point((W.zero, r, s)))
-  def local[A](f: R => R)(fa: ReaderWriterStateT[F, R, W, S, A]): ReaderWriterStateT[F, R, W, S, A] =
+  def local[A](f: R => R)(fa: ReaderWriterStateT[R, W, S, F, A]): ReaderWriterStateT[R, W, S, F, A] =
     ReaderWriterStateT((r, s) => fa.run(f(r), s))
-  override def scope[A](k: R)(fa: ReaderWriterStateT[F, R, W, S, A]): ReaderWriterStateT[F, R, W, S, A] =
+  override def scope[A](k: R)(fa: ReaderWriterStateT[R, W, S, F, A]): ReaderWriterStateT[R, W, S, F, A] =
     ReaderWriterStateT((_, s) => fa.run(k, s))
-  override def asks[A](f: R => A): ReaderWriterStateT[F, R, W, S, A] =
+  override def asks[A](f: R => A): ReaderWriterStateT[R, W, S, F, A] =
     ReaderWriterStateT((r, s) => F.point((W.zero, f(r), s)))
-  def get: ReaderWriterStateT[F, R, W, S, S] =
+  def get: ReaderWriterStateT[R, W, S, F, S] =
     ReaderWriterStateT((_, s) => F.point((W.zero, s, s)))
-  def put(s: S): ReaderWriterStateT[F, R, W, S, Unit] =
+  def put(s: S): ReaderWriterStateT[R, W, S, F, Unit] =
     ReaderWriterStateT((r, _) => F.point((W.zero, (), s)))
-  override def modify(f: S => S): ReaderWriterStateT[F, R, W, S, Unit] =
+  override def modify(f: S => S): ReaderWriterStateT[R, W, S, F, Unit] =
     ReaderWriterStateT((r, s) => F.point((W.zero, (), f(s))))
-  override def gets[A](f: S => A): ReaderWriterStateT[F, R, W, S, A] =
+  override def gets[A](f: S => A): ReaderWriterStateT[R, W, S, F, A] =
     ReaderWriterStateT((_, s) => F.point((W.zero, f(s), s)))
-  def writer[A](w: W, v: A): ReaderWriterStateT[F, R, W, S, A] =
+  def writer[A](w: W, v: A): ReaderWriterStateT[R, W, S, F, A] =
     ReaderWriterStateT((_, s) => F.point((w, v, s)))
-  override def tell(w: W): ReaderWriterStateT[F, R, W, S, Unit] =
+  override def tell(w: W): ReaderWriterStateT[R, W, S, F, Unit] =
     ReaderWriterStateT((_, s) => F.point((w, (), s)))
-  def listen[A](ma: ReaderWriterStateT[F, R, W, S, A]): ReaderWriterStateT[F, R, W, S, (A, W)] =
+  def listen[A](ma: ReaderWriterStateT[R, W, S, F, A]): ReaderWriterStateT[R, W, S, F, (A, W)] =
     ReaderWriterStateT((r, s) => F.map(ma.run(r, s)) { case (w, a, s1) => (w, (a, w), s1)})
 }
 
-private trait ReaderWriterStateTHoist[R, W, S] extends Hoist[λ[(α[_], β) => ReaderWriterStateT[α, R, W, S, β]]] {
+private trait ReaderWriterStateTHoist[R, W, S] extends Hoist[λ[(α[_], β) => ReaderWriterStateT[R, W, S, α, β]]] {
   implicit def W: Monoid[W]
 
   def hoist[M[_], N[_]](f: M ~> N)(implicit M: Monad[M]) =
-    λ[ReaderWriterStateT[M, R, W, S, ?] ~> ReaderWriterStateT[N, R, W, S, ?]](_ mapT f.apply)
+    λ[ReaderWriterStateT[R, W, S, M, ?] ~> ReaderWriterStateT[R, W, S, N, ?]](_ mapT f.apply)
 
-  def liftM[M[_], A](ma: M[A])(implicit M: Monad[M]): ReaderWriterStateT[M, R, W, S, A] =
+  def liftM[M[_], A](ma: M[A])(implicit M: Monad[M]): ReaderWriterStateT[R, W, S, M, A] =
     ReaderWriterStateT( (r,s) => M.map(ma)((W.zero, _, s)))
 
-  implicit def apply[M[_] : Monad]: Monad[ReaderWriterStateT[M, R, W, S, ?]] =
+  implicit def apply[M[_] : Monad]: Monad[ReaderWriterStateT[R, W, S, M, ?]] =
     IndexedReaderWriterStateT.rwstMonad
 }

--- a/core/src/main/scala/scalaz/StateT.scala
+++ b/core/src/main/scala/scalaz/StateT.scala
@@ -125,7 +125,7 @@ sealed abstract class IndexedStateT[F[_], -S1, S2, A] { self =>
 
   def unliftId[M[_], S <: S1](implicit M: Comonad[M], F: Bind[M], ev: this.type <~< IndexedStateT[M, S, S2, A]): IndexedState[S, S2, A] = unlift[M, Id, S]
 
-  def rwst[W, R](implicit F: Bind[F], W: Monoid[W]): IndexedReaderWriterStateT[F, R, W, S1, S2, A] =
+  def rwst[W, R](implicit F: Bind[F], W: Monoid[W]): IndexedReaderWriterStateT[R, W, S1, S2, F, A] =
     IndexedReaderWriterStateT(
       (r, s) => F.map(run(s)) {
         case (s, a) => (W.zero, a, s)

--- a/core/src/main/scala/scalaz/Unapply.scala
+++ b/core/src/main/scala/scalaz/Unapply.scala
@@ -190,6 +190,20 @@ object Unapply2 {
       def TC = TC0
       def leibniz = refl
     }
+
+  /**Unpack a value of type `M0[A0, F0, B0]` into types `M0`, `A`, `F0`, and 'B', given an instance of `TC` */
+  implicit def unapplyMAFB[TC[_[_, _]], M0[_, _[_], _], A0, F0[_], B0](implicit TC0: TC[M0[?, F0, ?]]): Unapply2[TC, M0[A0, F0, B0]] {
+    type M[X, Y] = M0[X, F0, Y]
+    type A = A0
+    type B = B0
+  } =
+    new Unapply2[TC, M0[A0, F0, B0]] {
+      type M[X, Y] = M0[X, F0, Y]
+      type A = A0
+      type B = B0
+      def TC = TC0
+      def leibniz = refl
+    }
 }
 
 trait Unapply21[TC[_[_, _], _], MAB]{

--- a/core/src/main/scala/scalaz/UnwriterT.scala
+++ b/core/src/main/scala/scalaz/UnwriterT.scala
@@ -11,11 +11,11 @@ import Id._
 final case class UnwriterT[F[_], U, A](run: F[(U, A)]) { self =>
   import UnwriterT._
 
-  def on: WriterT[F, U, A] =
+  def on: WriterT[U, F, A] =
     WriterT(run)
 
   /** alias for `on` */
-  def unary_+ : WriterT[F, U, A] =
+  def unary_+ : WriterT[U, F, A] =
     WriterT(run)
 
   def mapValue[X, B](f: ((U, A)) => (X, B))(implicit F: Functor[F]): UnwriterT[F, X, B] =

--- a/core/src/main/scala/scalaz/WriterT.scala
+++ b/core/src/main/scala/scalaz/WriterT.scala
@@ -2,7 +2,7 @@ package scalaz
 
 import Id._
 
-final case class WriterT[F[_], W, A](run: F[(W, A)]) { self =>
+final case class WriterT[W, F[_], A](run: F[(W, A)]) { self =>
   import WriterT._
 
   def off: UnwriterT[F, W, A] =
@@ -12,13 +12,13 @@ final case class WriterT[F[_], W, A](run: F[(W, A)]) { self =>
   def unary_- : UnwriterT[F, W, A] =
     UnwriterT(run)
 
-  def mapValue[X, B](f: ((W, A)) => (X, B))(implicit F: Functor[F]): WriterT[F, X, B] =
+  def mapValue[X, B](f: ((W, A)) => (X, B))(implicit F: Functor[F]): WriterT[X, F, B] =
     writerT(F.map(run)(f))
 
-  def mapWritten[X](f: W => X)(implicit F: Functor[F]): WriterT[F, X, A] =
+  def mapWritten[X](f: W => X)(implicit F: Functor[F]): WriterT[X, F, A] =
     mapValue(wa => (f(wa._1), wa._2))
 
-  def mapT[G[_], W2, B](f: F[(W, A)] => G[(W2, B)]): WriterT[G, W2, B] =
+  def mapT[W2, G[_], B](f: F[(W, A)] => G[(W2, B)]): WriterT[W2, G, B] =
     WriterT(f(run))
 
   def written(implicit F: Functor[F]): F[W] =
@@ -27,47 +27,47 @@ final case class WriterT[F[_], W, A](run: F[(W, A)]) { self =>
   def value(implicit F: Functor[F]): F[A] =
     F.map(run)(_._2)
 
-  def swap(implicit F: Functor[F]): WriterT[F, A, W] =
+  def swap(implicit F: Functor[F]): WriterT[A, F, W] =
     mapValue(wa => (wa._2, wa._1))
 
-  def :++>(w: => W)(implicit F: Functor[F], W: Semigroup[W]): WriterT[F, W, A] =
+  def :++>(w: => W)(implicit F: Functor[F], W: Semigroup[W]): WriterT[W, F, A] =
     mapWritten(W.append(_, w))
 
-  def :++>>(f: A => W)(implicit F: Functor[F], W: Semigroup[W]): WriterT[F, W, A] =
+  def :++>>(f: A => W)(implicit F: Functor[F], W: Semigroup[W]): WriterT[W, F, A] =
     mapValue(wa => (W.append(wa._1, f(wa._2)), wa._2))
 
-  def <++:(w: W)(implicit F: Functor[F], W: Semigroup[W]): WriterT[F, W, A] =
+  def <++:(w: W)(implicit F: Functor[F], W: Semigroup[W]): WriterT[W, F, A] =
     mapWritten(W.append(w, _))
 
-  def <<++:(f: A => W)(implicit F: Functor[F], s: Semigroup[W]): WriterT[F, W, A] =
+  def <<++:(f: A => W)(implicit F: Functor[F], s: Semigroup[W]): WriterT[W, F, A] =
     mapValue(wa => (s.append(f(wa._2), wa._1), wa._2))
 
-  def reset(implicit Z: Monoid[W], F: Functor[F]): WriterT[F, W, A] =
+  def reset(implicit Z: Monoid[W], F: Functor[F]): WriterT[W, F, A] =
     mapWritten(_ => Z.zero)
 
-  def map[B](f: A => B)(implicit F: Functor[F]): WriterT[F, W, B] =
+  def map[B](f: A => B)(implicit F: Functor[F]): WriterT[W, F, B] =
     writerT(F.map(run)(wa => (wa._1, f(wa._2))))
 
-  def mapF[B](f: A => F[B])(implicit F: Bind[F]): WriterT[F, W, B] = writerT {
+  def mapF[B](f: A => F[B])(implicit F: Bind[F]): WriterT[W, F, B] = writerT {
     F.bind(run)(wa => F.map(f(wa._2))(a => (wa._1, a)))
   }
 
-  def ap[B](f: => WriterT[F, W, A => B])(implicit F: Apply[F], W: Semigroup[W]): WriterT[F, W, B] = writerT {
+  def ap[B](f: => WriterT[W, F, A => B])(implicit F: Apply[F], W: Semigroup[W]): WriterT[W, F, B] = writerT {
     F.apply2(f.run, run) {
       case ((w1, fab), (w2, a)) => (W.append(w1, w2), fab(a))
     }
   }
 
-  def flatMap[B](f: A => WriterT[F, W, B])(implicit F: Bind[F], s: Semigroup[W]): WriterT[F, W, B] =
+  def flatMap[B](f: A => WriterT[W, F, B])(implicit F: Bind[F], s: Semigroup[W]): WriterT[W, F, B] =
     flatMapF(f.andThen(_.run))
 
-  def flatMapF[B](f: A => F[(W, B)])(implicit F: Bind[F], s: Semigroup[W]): WriterT[F, W, B] =
+  def flatMapF[B](f: A => F[(W, B)])(implicit F: Bind[F], s: Semigroup[W]): WriterT[W, F, B] =
     writerT(F.bind(run){wa =>
       val z = f(wa._2)
       F.map(z)(wb => (s.append(wa._1, wb._1), wb._2))
     })
 
-  def traverse[G[_], B](f: A => G[B])(implicit G: Applicative[G], F: Traverse[F]): G[WriterT[F, W, B]] = {
+  def traverse[G[_], B](f: A => G[B])(implicit G: Applicative[G], F: Traverse[F]): G[WriterT[W, F, B]] = {
     G.map(F.traverse(run){
       case (w, a) => G.map(f(a))(b => (w, b))
     })(WriterT(_))
@@ -78,15 +78,15 @@ final case class WriterT[F[_], W, A](run: F[(W, A)]) { self =>
       f(a._2, b)
     }
 
-  def bimap[C, D](f: W => C, g: A => D)(implicit F: Functor[F]): WriterT[F, C, D] =
+  def bimap[C, D](f: W => C, g: A => D)(implicit F: Functor[F]): WriterT[C, F, D] =
     writerT[F, C, D](F.map(run)({
       case (a, b) => (f(a), g(b))
     }))
 
-  def leftMap[C](f: W => C)(implicit F: Functor[F]): WriterT[F, C, A] =
+  def leftMap[C](f: W => C)(implicit F: Functor[F]): WriterT[C, F, A] =
     bimap(f, identity)
 
-  def bitraverse[G[_], C, D](f: W => G[C], g: A => G[D])(implicit G: Applicative[G], F: Traverse[F]): G[WriterT[F, C, D]] =
+  def bitraverse[G[_], C, D](f: W => G[C], g: A => G[D])(implicit G: Applicative[G], F: Traverse[F]): G[WriterT[C, F, D]] =
     G.map(F.traverse[G, (W, A), (C, D)](run) {
       case (a, b) => G.tuple2(f(a), g(b))
     })(writerT(_))
@@ -97,24 +97,24 @@ final case class WriterT[F[_], W, A](run: F[(W, A)]) { self =>
     }
   )
 
-  def wpoint[G[_]](implicit F: Functor[F], P: Applicative[G]): WriterT[F, G[W], A] =
+  def wpoint[G[_]](implicit F: Functor[F], P: Applicative[G]): WriterT[G[W], F, A] =
     writerT(F.map(self.run) {
       case (w, a) => (P.point(w), a)
     })
 
-  def colocal[X](f: W => X)(implicit F: Functor[F]): WriterT[F, X, A] = mapWritten(f)
+  def colocal[X](f: W => X)(implicit F: Functor[F]): WriterT[X, F, A] = mapWritten(f)
 }
 
 object WriterT extends WriterTInstances with WriterTFunctions
 
 sealed abstract class WriterTInstances15 {
-  implicit def writerTMonoid[F[_], W, A](implicit M: Monoid[F[(W,A)]]): Monoid[WriterT[F, W, A]] =
-    new Monoid[WriterT[F, W, A]] {
+  implicit def writerTMonoid[W, F[_], A](implicit M: Monoid[F[(W,A)]]): Monoid[WriterT[W, F, A]] =
+    new Monoid[WriterT[W, F, A]] {
       def zero = WriterT(M.zero)
-      def append(a: WriterT[F, W, A], b: => WriterT[F, W, A]) = WriterT(M.append(a.run, b.run))
+      def append(a: WriterT[W, F, A], b: => WriterT[W, F, A]) = WriterT(M.append(a.run, b.run))
     }
 
-  implicit def writerTPlus[F[_], W](implicit F0: Plus[F]): Plus[WriterT[F, W, ?]] =
+  implicit def writerTPlus[W, F[_]](implicit F0: Plus[F]): Plus[WriterT[W, F, ?]] =
     new WriterTPlus[F, W] {
       def F = F0
     }
@@ -126,13 +126,13 @@ sealed abstract class WriterTInstances14 extends WriterTInstances15 {
       implicit def F = idInstance
     }
 
-  implicit def writerTPlusEmpty[F[_], W](implicit F0: PlusEmpty[F]): PlusEmpty[WriterT[F, W, ?]] =
+  implicit def writerTPlusEmpty[W, F[_]](implicit F0: PlusEmpty[F]): PlusEmpty[WriterT[W, F, ?]] =
     new WriterTPlusEmpty[F, W] {
       def F = F0
     }
 }
 sealed abstract class WriterTInstances13 extends WriterTInstances14 {
-  implicit def writerTFunctor[F[_], W](implicit F0: Functor[F]): Functor[WriterT[F, W, ?]] =
+  implicit def writerTFunctor[W, F[_]](implicit F0: Functor[F]): Functor[WriterT[W, F, ?]] =
     new WriterTFunctor[F, W] {
       implicit def F = F0
     }
@@ -147,7 +147,7 @@ sealed abstract class WriterTInstances12 extends WriterTInstances13 {
 }
 
 sealed abstract class WriterTInstances11 extends WriterTInstances12 {
-  implicit def writerTBindRec[F[_], W](implicit W0: Semigroup[W], F0: BindRec[F], F1: Applicative[F]): BindRec[WriterT[F, W, ?]] =
+  implicit def writerTBindRec[W, F[_]](implicit W0: Semigroup[W], F0: BindRec[F], F1: Applicative[F]): BindRec[WriterT[W, F, ?]] =
     new WriterTBindRec[F, W] {
       implicit def F = F0
       implicit def A = F1
@@ -156,7 +156,7 @@ sealed abstract class WriterTInstances11 extends WriterTInstances12 {
 }
 
 sealed abstract class WriterTInstances10 extends WriterTInstances11 {
-  implicit def writerTApply[F[_], W](implicit W0: Semigroup[W], F0: Apply[F]): Apply[WriterT[F, W, ?]] =
+  implicit def writerTApply[W, F[_]](implicit W0: Semigroup[W], F0: Apply[F]): Apply[WriterT[W, F, ?]] =
     new WriterTApply[F, W] {
       implicit def F = F0
       implicit def W = W0
@@ -164,7 +164,7 @@ sealed abstract class WriterTInstances10 extends WriterTInstances11 {
 }
 
 sealed abstract class WriterTInstances9 extends WriterTInstances10 {
-  implicit def writerTBind[F[_], W](implicit W0: Semigroup[W], F0: Bind[F]): Bind[WriterT[F, W, ?]] =
+  implicit def writerTBind[W, F[_]](implicit W0: Semigroup[W], F0: Bind[F]): Bind[WriterT[W, F, ?]] =
     new WriterTBind[F, W] {
       implicit def F = F0
       implicit def W = W0
@@ -172,7 +172,7 @@ sealed abstract class WriterTInstances9 extends WriterTInstances10 {
 }
 
 sealed abstract class WriterTInstances8 extends WriterTInstances9 {
-  implicit def writerTApplicative[F[_], W](implicit W0: Monoid[W], F0: Applicative[F]): Applicative[WriterT[F, W, ?]] =
+  implicit def writerTApplicative[W, F[_]](implicit W0: Monoid[W], F0: Applicative[F]): Applicative[WriterT[W, F, ?]] =
     new WriterTApplicative[F, W] {
       implicit def F = F0
       implicit def W = W0
@@ -197,7 +197,7 @@ sealed abstract class WriterTInstances6 extends WriterTInstances7 {
 }
 
 sealed abstract class WriterTInstance5 extends WriterTInstances6 {
-  implicit def writerTMonad[F[_], W](implicit W0: Monoid[W], F0: Monad[F]): Monad[WriterT[F, W, ?]] =
+  implicit def writerTMonad[W, F[_]](implicit W0: Monoid[W], F0: Monad[F]): Monad[WriterT[W, F, ?]] =
     new WriterTMonad[F, W] {
       implicit def F = F0
       implicit def W = W0
@@ -209,9 +209,9 @@ sealed abstract class WriterTInstances4 extends WriterTInstance5 {
     new WriterTFoldable[Id, W] {
       implicit def F = idInstance
     }
-  implicit def writerTEqual[F[_], W, A](implicit E: Equal[F[(W, A)]]): Equal[WriterT[F, W, A]] = E.contramap((_: WriterT[F, W, A]).run)
+  implicit def writerTEqual[F[_], W, A](implicit E: Equal[F[(W, A)]]): Equal[WriterT[W, F, A]] = E.contramap((_: WriterT[W, F, A]).run)
 
-  implicit def writerTMonadError[F[_], E, W](implicit F0: MonadError[F, E], W0: Monoid[W]): MonadError[WriterT[F, W, ?], E] =
+  implicit def writerTMonadError[F[_], E, W](implicit F0: MonadError[F, E], W0: Monoid[W]): MonadError[WriterT[W, F, ?], E] =
     new WriterTMonadError[F, E, W] {
       override def F = F0
       override def W = W0
@@ -219,17 +219,17 @@ sealed abstract class WriterTInstances4 extends WriterTInstance5 {
 }
 
 sealed abstract class WriterTInstances3 extends WriterTInstances4 {
-  implicit def writerTBifunctor[F[_]](implicit F0: Functor[F]): Bifunctor[WriterT[F, ?, ?]] =
+  implicit def writerTBifunctor[F[_]](implicit F0: Functor[F]): Bifunctor[WriterT[?, F, ?]] =
     new WriterTBifunctor[F] {
       implicit def F = F0
     }
-  implicit def writerTFoldable[F[_], W](implicit F0: Foldable[F]): Foldable[WriterT[F, W, ?]] =
+  implicit def writerTFoldable[W, F[_]](implicit F0: Foldable[F]): Foldable[WriterT[W, F, ?]] =
     new WriterTFoldable[F, W] {
       implicit def F = F0
     }
   implicit def writerEqual[W, A](implicit E: Equal[(W, A)]): Equal[Writer[W, A]] = E.contramap((_: Writer[W, A]).run)
 
-  implicit def writerTMonadPlus[F[_], W](implicit W0: Monoid[W], F0: MonadPlus[F]): MonadPlus[WriterT[F, W, ?]] =
+  implicit def writerTMonadPlus[W, F[_]](implicit W0: Monoid[W], F0: MonadPlus[F]): MonadPlus[WriterT[W, F, ?]] =
     new WriterTMonadPlus[F, W] {
       def F = F0
       def W = W0
@@ -248,14 +248,14 @@ sealed abstract class WriterTInstances1 extends WriterTInstances2 {
     new WriterTBitraverse[Id] {
       implicit def F = idInstance
     }
-  implicit def writerTTraverse[F[_], W](implicit F0: Traverse[F]): Traverse[WriterT[F, W, ?]] =
+  implicit def writerTTraverse[W, F[_]](implicit F0: Traverse[F]): Traverse[WriterT[W, F, ?]] =
     new WriterTTraverse[F, W] {
       implicit def F = F0
     }
 }
 
 sealed abstract class WriterTInstances0 extends WriterTInstances1 {
-  implicit def writerTBitraverse[F[_]](implicit F0: Traverse[F]): Bitraverse[WriterT[F, ?, ?]] =
+  implicit def writerTBitraverse[F[_]](implicit F0: Traverse[F]): Bitraverse[WriterT[?, F, ?]] =
     new WriterTBitraverse[F] {
       implicit def F = F0
     }
@@ -266,40 +266,40 @@ sealed abstract class WriterTInstances0 extends WriterTInstances1 {
 }
 
 sealed abstract class WriterTInstances extends WriterTInstances0 {
-  implicit def writerTMonadListen[F[_], W](implicit F0: Monad[F], W0: Monoid[W]): MonadListen[WriterT[F, W, ?], W] =
+  implicit def writerTMonadListen[W, F[_]](implicit F0: Monad[F], W0: Monoid[W]): MonadListen[WriterT[W, F, ?], W] =
     new WriterTMonadListen[F, W] {
       implicit def F = F0
       implicit def W = W0
     }
 
-  implicit def writerTHoist[W](implicit W0: Monoid[W]): Hoist[λ[(α[_], β) => WriterT[α, W, β]]] =
+  implicit def writerTHoist[W](implicit W0: Monoid[W]): Hoist[λ[(α[_], β) => WriterT[W, α, β]]] =
     new WriterTHoist[W] {
       implicit def W = W0
     }
 
-  implicit def writerTShow[F[_], W, A](implicit F0: Show[F[(W, A)]]): Show[WriterT[F, W, A]] =
+  implicit def writerTShow[F[_], W, A](implicit F0: Show[F[(W, A)]]): Show[WriterT[W, F, A]] =
     Contravariant[Show].contramap(F0)(_.run)
 }
 
 trait WriterTFunctions {
-  def writerT[F[_], W, A](v: F[(W, A)]): WriterT[F, W, A] = WriterT(v)
+  def writerT[F[_], W, A](v: F[(W, A)]): WriterT[W, F, A] = WriterT(v)
 
   def writerTU[FAB, AB, A0, B0](fab: FAB)(implicit
                                           u1: Unapply[Functor, FAB]{type A = AB},
                                           @deprecated("scala/bug#5075", "") u2: Unapply2[Bifunctor, AB]{type A = A0; type B = B0},
                                           l: AB === (A0, B0)
-  ): WriterT[u1.M, A0, B0] = WriterT(l.subst[u1.M](u1(fab)))
+  ): WriterT[A0, u1.M, B0] = WriterT(l.subst[u1.M](u1(fab)))
 
   def writer[W, A](v: (W, A)): Writer[W, A] =
     writerT[Id, W, A](v)
 
   def tell[W](w: W): Writer[W, Unit] = writer((w, ()))
 
-  def put[F[_], W, A](value: F[A])(w: W)(implicit F: Functor[F]): WriterT[F, W, A] =
+  def put[F[_], W, A](value: F[A])(w: W)(implicit F: Functor[F]): WriterT[W, F, A] =
     WriterT(F.map(value)(a => (w, a)))
 
   /** Puts the written value that is produced by applying the given function into a writer transformer and associates with `value` */
-  def putWith[F[_], W, A](value: F[A])(w: A => W)(implicit F: Functor[F]): WriterT[F, W, A] =
+  def putWith[F[_], W, A](value: F[A])(w: A => W)(implicit F: Functor[F]): WriterT[W, F, A] =
     WriterT(F.map(value)(a => (w(a), a)))
 
 }
@@ -309,48 +309,48 @@ trait WriterTFunctions {
 //
 import WriterT.writerT
 
-private trait WriterTPlus[F[_], W] extends Plus[WriterT[F, W, ?]] {
+private trait WriterTPlus[F[_], W] extends Plus[WriterT[W, F, ?]] {
   def F: Plus[F]
-  override final def plus[A](a: WriterT[F, W, A], b: => WriterT[F, W, A]) =
+  override final def plus[A](a: WriterT[W, F, A], b: => WriterT[W, F, A]) =
     WriterT(F.plus(a.run, b.run))
 }
 
-private trait WriterTPlusEmpty[F[_], W] extends PlusEmpty[WriterT[F, W, ?]] with WriterTPlus[F, W] {
+private trait WriterTPlusEmpty[F[_], W] extends PlusEmpty[WriterT[W, F, ?]] with WriterTPlus[F, W] {
   def F: PlusEmpty[F]
 
   override final def empty[A] = WriterT(F.empty)
 }
 
-private trait WriterTFunctor[F[_], W] extends Functor[WriterT[F, W, ?]] {
+private trait WriterTFunctor[F[_], W] extends Functor[WriterT[W, F, ?]] {
   implicit def F: Functor[F]
 
-  override def map[A, B](fa: WriterT[F, W, A])(f: A => B) = fa map f
+  override def map[A, B](fa: WriterT[W, F, A])(f: A => B) = fa map f
 }
 
-private trait WriterTApply[F[_], W] extends Apply[WriterT[F, W, ?]] with WriterTFunctor[F, W] {
+private trait WriterTApply[F[_], W] extends Apply[WriterT[W, F, ?]] with WriterTFunctor[F, W] {
   implicit def F: Apply[F]
   implicit def W: Semigroup[W]
 
-  override def ap[A, B](fa: => WriterT[F, W, A])(f: => WriterT[F, W, A => B]) = fa ap f
+  override def ap[A, B](fa: => WriterT[W, F, A])(f: => WriterT[W, F, A => B]) = fa ap f
 }
 
-private trait WriterTApplicative[F[_], W] extends Applicative[WriterT[F, W, ?]] with WriterTApply[F, W] {
+private trait WriterTApplicative[F[_], W] extends Applicative[WriterT[W, F, ?]] with WriterTApply[F, W] {
   implicit def F: Applicative[F]
   implicit def W: Monoid[W]
   def point[A](a: => A) = writerT(F.point((W.zero, a)))
 }
 
-private trait WriterTBind[F[_], W] extends Bind[WriterT[F, W, ?]] with WriterTApply[F, W] {
+private trait WriterTBind[F[_], W] extends Bind[WriterT[W, F, ?]] with WriterTApply[F, W] {
   implicit def F: Bind[F]
 
-  override final def bind[A, B](fa: WriterT[F, W, A])(f: A => WriterT[F, W, B]) = fa flatMap f
+  override final def bind[A, B](fa: WriterT[W, F, A])(f: A => WriterT[W, F, B]) = fa flatMap f
 }
 
-private trait WriterTBindRec[F[_], W] extends BindRec[WriterT[F, W, ?]] with WriterTBind[F, W] {
+private trait WriterTBindRec[F[_], W] extends BindRec[WriterT[W, F, ?]] with WriterTBind[F, W] {
   implicit def F: BindRec[F]
   implicit def A: Applicative[F]
 
-  def tailrecM[A, B](a: A)(f: A => WriterT[F, W, A \/ B]): WriterT[F, W, B] = {
+  def tailrecM[A, B](a: A)(f: A => WriterT[W, F, A \/ B]): WriterT[W, F, B] = {
     def go(t: (W, A)): F[(W, A) \/ (W, B)] =
       F.map(f(t._2).run) {
         case (w0, e) =>
@@ -365,47 +365,47 @@ private trait WriterTBindRec[F[_], W] extends BindRec[WriterT[F, W, ?]] with Wri
   }
 }
 
-private trait WriterTMonad[F[_], W] extends Monad[WriterT[F, W, ?]] with WriterTApplicative[F, W] with WriterTBind[F, W] {
+private trait WriterTMonad[F[_], W] extends Monad[WriterT[W, F, ?]] with WriterTApplicative[F, W] with WriterTBind[F, W] {
   implicit def F: Monad[F]
 }
 
-private trait WriterTMonadPlus[F[_], W] extends MonadPlus[WriterT[F, W, ?]] with WriterTMonad[F, W] with WriterTPlusEmpty[F, W] {
+private trait WriterTMonadPlus[F[_], W] extends MonadPlus[WriterT[W, F, ?]] with WriterTMonad[F, W] with WriterTPlusEmpty[F, W] {
   def F: MonadPlus[F]
 }
 
-private trait WriterTMonadError[F[_], E, W] extends MonadError[WriterT[F, W, ?], E] with WriterTMonad[F, W] {
+private trait WriterTMonadError[F[_], E, W] extends MonadError[WriterT[W, F, ?], E] with WriterTMonad[F, W] {
   implicit def F: MonadError[F, E]
 
-  override def handleError[A](fa: WriterT[F, W, A])(f: E => WriterT[F, W, A]) =
-    WriterT[F, W, A](F.handleError(fa.run)(f(_).run))
+  override def handleError[A](fa: WriterT[W, F, A])(f: E => WriterT[W, F, A]) =
+    WriterT[W, F, A](F.handleError(fa.run)(f(_).run))
 
   override def raiseError[A](e: E) =
-    WriterT[F, W, A](F.raiseError[(W, A)](e))
+    WriterT[W, F, A](F.raiseError[(W, A)](e))
 }
 
-private trait WriterTFoldable[F[_], W] extends Foldable.FromFoldr[WriterT[F, W, ?]] {
+private trait WriterTFoldable[F[_], W] extends Foldable.FromFoldr[WriterT[W, F, ?]] {
   implicit def F: Foldable[F]
 
-  override def foldRight[A, B](fa: WriterT[F, W, A], z: => B)(f: (A, => B) => B) = fa.foldRight(z)(f)
+  override def foldRight[A, B](fa: WriterT[W, F, A], z: => B)(f: (A, => B) => B) = fa.foldRight(z)(f)
 }
 
-private trait WriterTTraverse[F[_], W] extends Traverse[WriterT[F, W, ?]] with WriterTFoldable[F, W] {
+private trait WriterTTraverse[F[_], W] extends Traverse[WriterT[W, F, ?]] with WriterTFoldable[F, W] {
   implicit def F: Traverse[F]
 
-  def traverseImpl[G[_]: Applicative, A, B](fa: WriterT[F, W, A])(f: A => G[B]) = fa traverse f
+  def traverseImpl[G[_]: Applicative, A, B](fa: WriterT[W, F, A])(f: A => G[B]) = fa traverse f
 }
 
-private trait WriterTBifunctor[F[_]] extends Bifunctor[WriterT[F, ?, ?]] {
+private trait WriterTBifunctor[F[_]] extends Bifunctor[WriterT[?, F, ?]] {
   implicit def F: Functor[F]
 
-  override def bimap[A, B, C, D](fab: WriterT[F, A, B])(f: A => C, g: B => D) =
+  override def bimap[A, B, C, D](fab: WriterT[A, F, B])(f: A => C, g: B => D) =
     fab.bimap(f, g)
 }
 
-private trait WriterTBitraverse[F[_]] extends Bitraverse[WriterT[F, ?, ?]] with WriterTBifunctor[F] {
+private trait WriterTBitraverse[F[_]] extends Bitraverse[WriterT[?, F, ?]] with WriterTBifunctor[F] {
   implicit def F: Traverse[F]
 
-  def bitraverseImpl[G[_]: Applicative, A, B, C, D](fab: WriterT[F, A, B])(f: A => G[C], g: B => G[D]) =
+  def bitraverseImpl[G[_]: Applicative, A, B, C, D](fab: WriterT[A, F, B])(f: A => G[C], g: B => G[D]) =
     fab.bitraverse(f, g)
 }
 
@@ -419,24 +419,24 @@ private trait WriterComonad[W] extends Comonad[Writer[W, ?]] with WriterTFunctor
     Writer(fa.written, f(fa))
 }
 
-private trait WriterTHoist[W] extends Hoist[λ[(α[_], β) => WriterT[α, W, β]]] {
-  def liftM[M[_], B](mb: M[B])(implicit M: Monad[M]): WriterT[M, W, B] =
+private trait WriterTHoist[W] extends Hoist[λ[(α[_], β) => WriterT[W, α, β]]] {
+  def liftM[M[_], B](mb: M[B])(implicit M: Monad[M]): WriterT[W, M, B] =
     WriterT(M.map(mb)((W.zero, _)))
 
   implicit def W: Monoid[W]
 
-  implicit def apply[M[_]: Monad]: Monad[WriterT[M, W, ?]] = WriterT.writerTMonad
+  implicit def apply[M[_]: Monad]: Monad[WriterT[W, M, ?]] = WriterT.writerTMonad
 
   def hoist[M[_]: Monad, N[_]](f: M ~> N) =
-    λ[WriterT[M, W, ?] ~> WriterT[N, W, ?]](_ mapT f.apply)
+    λ[WriterT[W, M, ?] ~> WriterT[W, N, ?]](_ mapT f.apply)
 }
 
-private trait WriterTMonadListen[F[_], W] extends MonadListen[WriterT[F, W, ?], W] with WriterTMonad[F, W] {
+private trait WriterTMonadListen[F[_], W] extends MonadListen[WriterT[W, F, ?], W] with WriterTMonad[F, W] {
   implicit def F: Monad[F]
   implicit def W: Monoid[W]
 
-  def writer[A](w: W, v: A): WriterT[F, W, A] = WriterT.writerT(F.point((w, v)))
+  def writer[A](w: W, v: A): WriterT[W, F, A] = WriterT.writerT(F.point((w, v)))
 
-  def listen[A](fa: WriterT[F, W, A]): WriterT[F, W, (A, W)] =
+  def listen[A](fa: WriterT[W, F, A]): WriterT[W, F, (A, W)] =
     WriterT(F.map(fa.run){ case (w, a) => (w, (a, w)) })
 }

--- a/core/src/main/scala/scalaz/WriterT.scala
+++ b/core/src/main/scala/scalaz/WriterT.scala
@@ -91,7 +91,7 @@ final case class WriterT[W, F[_], A](run: F[(W, A)]) { self =>
       case (a, b) => G.tuple2(f(a), g(b))
     })(writerT(_))
 
-  def rwst[R, S](implicit F: Functor[F]): ReaderWriterStateT[F, R, W, S, A] = ReaderWriterStateT(
+  def rwst[R, S](implicit F: Functor[F]): ReaderWriterStateT[R, W, S, F, A] = ReaderWriterStateT(
     (r, s) => F.map(self.run) {
       case (w, a) => (w, a, s)
     }

--- a/core/src/main/scala/scalaz/package.scala
+++ b/core/src/main/scala/scalaz/package.scala
@@ -305,45 +305,45 @@ package object scalaz {
   type PState[S, A] = PStateT[Id, S, A]
 
   /** @template */
-  type IndexedConts[W[_], R, O, A] = IndexedContsT[W, Id, R, O, A]
+  type IndexedConts[W[_], R, O, A] = IndexedContsT[W, R, O, Id, A]
   object IndexedConts extends IndexedContsTInstances with IndexedContsTFunctions {
-    def apply[W[_], R, O, A](f: W[A => O] => R): IndexedConts[W, R, O, A] = IndexedContsT[W, Id, R, O, A](f)
+    def apply[W[_], R, O, A](f: W[A => O] => R): IndexedConts[W, R, O, A] = IndexedContsT[W, R, O, Id, A](f)
   }
 
   /** @template */
-  type IndexedContT[M[_], R, O, A] = IndexedContsT[Id, M, R, O, A]
+  type IndexedContT[R, O, M[_], A] = IndexedContsT[Id, R, O, M, A]
   object IndexedContT extends IndexedContsTInstances with IndexedContsTFunctions {
-    def apply[M[_], R, O, A](f: (A => M[O]) => M[R]): IndexedContT[M, R, O, A] = IndexedContsT[Id, M, R, O, A](f)
+    def apply[M[_], R, O, A](f: (A => M[O]) => M[R]): IndexedContT[R, O, M, A] = IndexedContsT[Id, R, O, M, A](f)
   }
   
   /** @template */
-  type IndexedCont[R, O, A] = IndexedContT[Id, R, O, A]
+  type IndexedCont[R, O, A] = IndexedContT[R, O, Id, A]
   object IndexedCont extends IndexedContsTInstances with IndexedContsTFunctions {
-    def apply[R, O, A](f: (A => O) => R): IndexedCont[R, O, A] = IndexedContsT[Id, Id, R, O, A](f)
+    def apply[R, O, A](f: (A => O) => R): IndexedCont[R, O, A] = IndexedContsT[Id, R, O, Id, A](f)
   }
 
   /** @template */
-  type ContsT[W[_], M[_], R, A] = IndexedContsT[W, M, R, R, A]
+  type ContsT[W[_], R, M[_], A] = IndexedContsT[W, R, R, M, A]
   object ContsT extends IndexedContsTInstances with IndexedContsTFunctions {
-    def apply[W[_], M[_], R, A](f: W[A => M[R]] => M[R]): ContsT[W, M, R, A] = IndexedContsT[W, M, R, R, A](f)
+    def apply[W[_], M[_], R, A](f: W[A => M[R]] => M[R]): ContsT[W, R, M, A] = IndexedContsT[W, R, R, M, A](f)
   }
 
   /** @template */
-  type Conts[W[_], R, A] = ContsT[W, Id, R, A]
+  type Conts[W[_], R, A] = ContsT[W, R, Id, A]
   object Conts extends IndexedContsTInstances with IndexedContsTFunctions {
-    def apply[W[_], R, A](f: W[A => R] => R): Conts[W, R, A] = IndexedContsT[W, Id, R, R, A](f)
+    def apply[W[_], R, A](f: W[A => R] => R): Conts[W, R, A] = IndexedContsT[W, R, R, Id, A](f)
   }
 
   /** @template */
-  type ContT[M[_], R, A] = ContsT[Id, M, R, A]
+  type ContT[R, M[_], A] = ContsT[Id, R, M, A]
   object ContT extends IndexedContsTInstances with IndexedContsTFunctions {
-    def apply[M[_], R, A](f: (A => M[R]) => M[R]): ContT[M, R, A] = IndexedContsT[Id, M, R, R, A](f)
+    def apply[M[_], R, A](f: (A => M[R]) => M[R]): ContT[R, M, A] = IndexedContsT[Id, R, R, M, A](f)
   }
 
   /** @template */
-  type Cont[R, A] = ContT[Id, R, A]
+  type Cont[R, A] = ContT[R, Id, A]
   object Cont extends IndexedContsTInstances with IndexedContsTFunctions {
-    def apply[R, A](f: (A => R) => R): Cont[R, A] = IndexedContsT[Id, Id, R, R, A](f)
+    def apply[R, A](f: (A => R) => R): Cont[R, A] = IndexedContsT[Id, R, R, Id, A](f)
   }
 
   /** [[scalaz.Inject]][F, G] */

--- a/core/src/main/scala/scalaz/package.scala
+++ b/core/src/main/scala/scalaz/package.scala
@@ -200,27 +200,27 @@ package object scalaz {
   def Traced[A, B](f: A => B): Traced[A, B] = TracedT[Id, A, B](f)
 
   /** @template */
-  type ReaderWriterStateT[F[_], -R, W, S, A] = IndexedReaderWriterStateT[F, R, W, S, S, A]
+  type ReaderWriterStateT[-R, W, S, F[_], A] = IndexedReaderWriterStateT[R, W, S, S, F, A]
   object ReaderWriterStateT extends ReaderWriterStateTInstances with ReaderWriterStateTFunctions {
-    def apply[F[_], R, W, S, A](f: (R, S) => F[(W, A, S)]): ReaderWriterStateT[F, R, W, S, A] = IndexedReaderWriterStateT[F, R, W, S, S, A] { (r: R, s: S) => f(r, s) }
+    def apply[R, W, S, F[_], A](f: (R, S) => F[(W, A, S)]): ReaderWriterStateT[R, W, S, F, A] = IndexedReaderWriterStateT[R, W, S, S, F, A] { (r: R, s: S) => f(r, s) }
   }
 
   /** @template */
-  type IndexedReaderWriterState[-R, W, -S1, S2, A] = IndexedReaderWriterStateT[Id, R, W, S1, S2, A]
+  type IndexedReaderWriterState[-R, W, -S1, S2, A] = IndexedReaderWriterStateT[R, W, S1, S2, Id, A]
   object IndexedReaderWriterState extends ReaderWriterStateTInstances with ReaderWriterStateTFunctions {
-    def apply[R, W, S1, S2, A](f: (R, S1) => (W, A, S2)): IndexedReaderWriterState[R, W, S1, S2, A] = IndexedReaderWriterStateT[Id, R, W, S1, S2, A] { (r: R, s: S1) => f(r, s) }
+    def apply[R, W, S1, S2, A](f: (R, S1) => (W, A, S2)): IndexedReaderWriterState[R, W, S1, S2, A] = IndexedReaderWriterStateT[R, W, S1, S2, Id, A] { (r: R, s: S1) => f(r, s) }
   }
 
   /** @template */
-  type ReaderWriterState[-R, W, S, A] = ReaderWriterStateT[Id, R, W, S, A]
+  type ReaderWriterState[-R, W, S, A] = ReaderWriterStateT[R, W, S, Id, A]
   object ReaderWriterState extends ReaderWriterStateTInstances with ReaderWriterStateTFunctions {
-    def apply[R, W, S, A](f: (R, S) => (W, A, S)): ReaderWriterState[R, W, S, A] = IndexedReaderWriterStateT[Id, R, W, S, S, A] { (r: R, s: S) => f(r, s) }
+    def apply[R, W, S, A](f: (R, S) => (W, A, S)): ReaderWriterState[R, W, S, A] = IndexedReaderWriterStateT[R, W, S, S, Id, A] { (r: R, s: S) => f(r, s) }
   }
-  type IRWST[F[_], -R, W, -S1, S2, A] = IndexedReaderWriterStateT[F, R, W, S1, S2, A]
+  type IRWST[-R, W, -S1, S2, F[_], A] = IndexedReaderWriterStateT[R, W, S1, S2, F, A]
   val IRWST: IndexedReaderWriterStateT.type = IndexedReaderWriterStateT
   type IRWS[-R, W, -S1, S2, A] = IndexedReaderWriterState[R, W, S1, S2, A]
   val IRWS: IndexedReaderWriterState.type = IndexedReaderWriterState
-  type RWST[F[_], -R, W, S, A] = ReaderWriterStateT[F, R, W, S, A]
+  type RWST[-R, W, S, F[_], A] = ReaderWriterStateT[R, W, S, F, A]
   val RWST: ReaderWriterStateT.type = ReaderWriterStateT
   type RWS[-R, W, S, A] = ReaderWriterState[R, W, S, A]
   val RWS: ReaderWriterState.type = ReaderWriterState

--- a/core/src/main/scala/scalaz/package.scala
+++ b/core/src/main/scala/scalaz/package.scala
@@ -121,18 +121,21 @@ package object scalaz {
 
   type ∨[A, B] = A \/ B
 
-  type ReaderT[F[_], E, A] = Kleisli[F, E, A]
-  val ReaderT = Kleisli
+  type ReaderT[E, F[_], A] = Kleisli[F, E, A]
   type =?>[E, A] = Kleisli[Option, E, A]
   
   /** @template */
-  type Reader[E, A] = ReaderT[Id, E, A]
+  type Reader[E, A] = ReaderT[E, Id, A]
 
   /** @template */
   type Writer[W, A] = WriterT[W, Id, A]
 
   /** @template */
   type Unwriter[W, A] = UnwriterT[Id, W, A]
+
+  object ReaderT {
+    def apply[E, F[_], A](f: E => F[A]): ReaderT[E, F, A] = Kleisli[F, E, A](f)
+  }
 
   object Reader {
     def apply[E, A](f: E => A): Reader[E, A] = Kleisli[Id, E, A](f)

--- a/core/src/main/scala/scalaz/package.scala
+++ b/core/src/main/scala/scalaz/package.scala
@@ -129,7 +129,7 @@ package object scalaz {
   type Reader[E, A] = ReaderT[Id, E, A]
 
   /** @template */
-  type Writer[W, A] = WriterT[Id, W, A]
+  type Writer[W, A] = WriterT[W, Id, A]
 
   /** @template */
   type Unwriter[W, A] = UnwriterT[Id, W, A]
@@ -139,7 +139,7 @@ package object scalaz {
   }
 
   object Writer {
-    def apply[W, A](w: W, a: A): WriterT[Id, W, A] = WriterT[Id, W, A]((w, a))
+    def apply[W, A](w: W, a: A): WriterT[W, Id, A] = WriterT[W, Id, A]((w, a))
   }
 
   object Unwriter {

--- a/core/src/main/scala/scalaz/package.scala
+++ b/core/src/main/scala/scalaz/package.scala
@@ -367,6 +367,6 @@ package object scalaz {
   type DRight[A, B] = \/-[A, B]
   val DRight = \/-
 
-  type DisjunctionT[F[_], A, B] = EitherT[F, A, B]
+  type DisjunctionT[A, F[_], B] = EitherT[A, F, B]
   val DisjunctionT = EitherT
 }

--- a/core/src/main/scala/scalaz/syntax/ContTOps.scala
+++ b/core/src/main/scala/scalaz/syntax/ContTOps.scala
@@ -2,10 +2,10 @@ package scalaz
 package syntax
 
 final class ContTOps[M[_], A](private val self: M[A]) extends AnyVal {
-  final def cps[R](implicit M: Bind[M]): ContT[M, R, A] =
+  final def cps[R](implicit M: Bind[M]): ContT[R, M, A] =
     ContT((f: A => M[R]) => M.bind(self)(f))
 
-  final def cps_(implicit M: Bind[M]): ContT[M, Unit, A] =
+  final def cps_(implicit M: Bind[M]): ContT[Unit, M, A] =
     cps[Unit]
 }
 

--- a/core/src/main/scala/scalaz/syntax/KleisliOps.scala
+++ b/core/src/main/scala/scalaz/syntax/KleisliOps.scala
@@ -16,7 +16,7 @@ final class KleisliFAOps[F[_], A](private val self: F[A]) extends AnyVal {
   def liftKleisli[R]: Kleisli[F, R, A] = Kleisli[F, R, A](_ => self)
 
   /** Lift the computation into a ReaderT. Alias for liftKleisli */
-  def liftReaderT[R]: ReaderT[F, R, A] = liftKleisli
+  def liftReaderT[R]: ReaderT[R, F, A] = liftKleisli
 }
 
 sealed trait ToKleisliOps0 {

--- a/effect/src/main/scala/scalaz/effect/LiftIO.scala
+++ b/effect/src/main/scala/scalaz/effect/LiftIO.scala
@@ -58,7 +58,7 @@ object LiftIO {
     }
 
   implicit def writerTLiftIO[F[_]: LiftIO, W: Monoid] =
-    new LiftIO[WriterT[F, W, ?]] {
+    new LiftIO[WriterT[W, F, ?]] {
       def liftIO[A](ioa: IO[A]) = WriterT(LiftIO[F].liftIO(ioa.map((Monoid[W].zero, _))))
     }
 

--- a/effect/src/main/scala/scalaz/effect/LiftIO.scala
+++ b/effect/src/main/scala/scalaz/effect/LiftIO.scala
@@ -37,7 +37,7 @@ object LiftIO {
     }
 
   implicit def eitherTLiftIO[F[_]: LiftIO, E] =
-    new LiftIO[EitherT[F, E, ?]] {
+    new LiftIO[EitherT[E, F, ?]] {
       def liftIO[A](ioa: IO[A]) = EitherT(LiftIO[F].liftIO(ioa.map(\/.right)))
     }
 

--- a/effect/src/main/scala/scalaz/effect/MonadIO.scala
+++ b/effect/src/main/scala/scalaz/effect/MonadIO.scala
@@ -54,7 +54,7 @@ object MonadIO {
 
   implicit def kleisliMonadIO[F[_]: MonadIO, E] = fromLiftIO[Kleisli[F, E, ?]]
 
-  implicit def writerTMonadIO[F[_]: MonadIO, W: Monoid] = fromLiftIO[WriterT[F, W, ?]]
+  implicit def writerTMonadIO[F[_]: MonadIO, W: Monoid] = fromLiftIO[WriterT[W, F, ?]]
 
   implicit def stateTMonadIO[F[_]: MonadIO, S] = fromLiftIO[StateT[F, S, ?]]
 

--- a/effect/src/main/scala/scalaz/effect/MonadIO.scala
+++ b/effect/src/main/scala/scalaz/effect/MonadIO.scala
@@ -46,7 +46,7 @@ object MonadIO {
 
   implicit def optionTMonadIO[F[_]: MonadIO] = fromLiftIO[OptionT[F, ?]]
 
-  implicit def eitherTMonadIO[F[_]: MonadIO, E] = fromLiftIO[EitherT[F, E, ?]]
+  implicit def eitherTMonadIO[F[_]: MonadIO, E] = fromLiftIO[EitherT[E, F, ?]]
 
   implicit def theseTMonadIO[F[_]: MonadIO, E: Semigroup] = fromLiftIO[TheseT[F, E, ?]]
 

--- a/example/src/main/scala/scalaz/example/ContTUsage.scala
+++ b/example/src/main/scala/scalaz/example/ContTUsage.scala
@@ -5,7 +5,7 @@ import scalaz.syntax.all._
 
 object ContTUsage extends App {
 
-  def syntaxUsage[M[_]: Bind, R, A, B, C](ma: M[A], cmb: ContT[M, R, B], f: (A, B) => M[C]): ContT[M, R, C] = for {
+  def syntaxUsage[M[_]: Bind, R, A, B, C](ma: M[A], cmb: ContT[R, M, B], f: (A, B) => M[C]): ContT[R, M, C] = for {
     a <- ma.cps[R]
     b <- cmb
     c <- f(a, b).cps[R]

--- a/example/src/main/scala/scalaz/example/ReaderWriterStateTUsage.scala
+++ b/example/src/main/scala/scalaz/example/ReaderWriterStateTUsage.scala
@@ -82,7 +82,7 @@ object CABRunLengthEncoder {
   import Token._
   import Free.Trampoline
 
-  type RunLength[A] = ReaderWriterStateT[Trampoline, RunLengthConfig, Cord, RunLengthState, A]
+  type RunLength[A] = ReaderWriterStateT[RunLengthConfig, Cord, RunLengthState, Trampoline, A]
 
   // At its essence the RWST monad transformer is a wrap around a function with the following shape:
   // (ReaderType, StateType) => Monad[WriterType, Result, StateType]
@@ -103,7 +103,7 @@ object CABRunLengthEncoder {
   // modify -- alter the current state
   // tell   -- append to the writer
   // ask    -- read from the reader
-  val rle = ReaderWriterStateT.rwstMonad[Trampoline, RunLengthConfig, Cord, RunLengthState]
+  val rle = ReaderWriterStateT.rwstMonad[RunLengthConfig, Cord, RunLengthState, Trampoline]
   import rle._
 
   /**

--- a/example/src/main/scala/scalaz/example/UnapplyInference.scala
+++ b/example/src/main/scala/scalaz/example/UnapplyInference.scala
@@ -19,9 +19,9 @@ object UnapplyInference extends App {
     import syntax.all._
 
     val either: (List[Int] \/ List[Int]) = \/.right(List(1))
-    val eitherT: EitherT[Option, List[Int], List[Int]] = EitherT(some(either))
+    val eitherT: EitherT[List[Int], Option, List[Int]] = EitherT(some(either))
 
-    val bisequence: List[EitherT[Option, Int, Int]] = eitherT.bisequence[List, Int, Int]
+    val bisequence: List[EitherT[Int, Option, Int]] = eitherT.bisequence[List, Int, Int]
   }
 
   // Without Unapply

--- a/example/src/main/scala/scalaz/example/transformers/typecheck/TypeCheckerWithExplicitTypes_MonadTransformers.scala
+++ b/example/src/main/scala/scalaz/example/transformers/typecheck/TypeCheckerWithExplicitTypes_MonadTransformers.scala
@@ -20,9 +20,9 @@ object TypeCheckerWithExplicitTypes_MonadTransformers {
 
   type V[T] = String \/ T
 
-  def liftK[T, U](e: String \/ U): ReaderT[V, T, U] = kleisli[V, T, U]((env: T) => e)
+  def liftK[T, U](e: String \/ U): ReaderT[T, V, U] = kleisli[V, T, U]((env: T) => e)
 
-  def typeCheck(expr: Exp): ReaderT[V, TypeEnv, Type] = expr match {
+  def typeCheck(expr: Exp): ReaderT[TypeEnv, V, Type] = expr match {
     case Lit(v) => liftK(success(litToTy(v)))
     case Id(x)  => for {env <- ask[V, TypeEnv]; res <- liftK(find(x, env))} yield res
     // make sure the first branch is a boolean and then

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
@@ -552,7 +552,7 @@ object ScalazArbitrary extends ScalazArbitraryPlatform {
   implicit def indexedStateTArb[F[_], S1, S2, A](implicit A: Arbitrary[S1 => F[(S2, A)]]): Arbitrary[IndexedStateT[F, S1, S2, A]] =
     Functor[Arbitrary].map(A)(IndexedStateT[F, S1, S2, A](_))
 
-  implicit def eitherTArb[F[_], A, B](implicit A: Arbitrary[F[A \/ B]]): Arbitrary[EitherT[A, F, B]] =
+  implicit def eitherTArb[A, F[_], B](implicit A: Arbitrary[F[A \/ B]]): Arbitrary[EitherT[A, F, B]] =
       Functor[Arbitrary].map(A)(EitherT[A, F, B](_))
 
   implicit def theseTArb[F[_], A, B](implicit A: Arbitrary[F[A \&/ B]]): Arbitrary[TheseT[F, A, B]] =

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
@@ -509,7 +509,7 @@ object ScalazArbitrary extends ScalazArbitraryPlatform {
   implicit def CoproductArbitrary[F[_], G[_], A](implicit a: Arbitrary[F[A] \/ G[A]]): Arbitrary[Coproduct[F, G, A]] =
     Functor[Arbitrary].map(a)(Coproduct(_))
 
-  implicit def writerTArb[F[_], W, A](implicit A: Arbitrary[F[(W, A)]]): Arbitrary[WriterT[W, F, A]] =
+  implicit def writerTArb[W, F[_], A](implicit A: Arbitrary[F[(W, A)]]): Arbitrary[WriterT[W, F, A]] =
     Functor[Arbitrary].map(A)(WriterT[W, F, A](_))
 
   implicit def unwriterTArb[F[_], U, A](implicit A: Arbitrary[F[(U, A)]]): Arbitrary[UnwriterT[F, U, A]] =

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
@@ -125,7 +125,7 @@ object ScalazArbitrary extends ScalazArbitraryPlatform {
   implicit def cogenContravariantCoyoneda[F[_]: Contravariant, A](implicit F: Cogen[F[A]]): Cogen[ContravariantCoyoneda[F, A]] =
     Cogen[F[A]].contramap(_.run)
 
-  implicit def cogenEitherT[F[_], A, B](implicit F: Cogen[F[A \/ B]]): Cogen[EitherT[F, A, B]] =
+  implicit def cogenEitherT[A, F[_], B](implicit F: Cogen[F[A \/ B]]): Cogen[EitherT[A, F, B]] =
     F.contramap(_.run)
 
   implicit def cogenLazyEitherT[F[_], A, B](implicit F: Cogen[F[LazyEither[A, B]]]): Cogen[LazyEitherT[F, A, B]] =
@@ -552,8 +552,8 @@ object ScalazArbitrary extends ScalazArbitraryPlatform {
   implicit def indexedStateTArb[F[_], S1, S2, A](implicit A: Arbitrary[S1 => F[(S2, A)]]): Arbitrary[IndexedStateT[F, S1, S2, A]] =
     Functor[Arbitrary].map(A)(IndexedStateT[F, S1, S2, A](_))
 
-  implicit def eitherTArb[F[_], A, B](implicit A: Arbitrary[F[A \/ B]]): Arbitrary[EitherT[F, A, B]] =
-      Functor[Arbitrary].map(A)(EitherT[F, A, B](_))
+  implicit def eitherTArb[F[_], A, B](implicit A: Arbitrary[F[A \/ B]]): Arbitrary[EitherT[A, F, B]] =
+      Functor[Arbitrary].map(A)(EitherT[A, F, B](_))
 
   implicit def theseTArb[F[_], A, B](implicit A: Arbitrary[F[A \&/ B]]): Arbitrary[TheseT[F, A, B]] =
     Functor[Arbitrary].map(A)(TheseT[F, A, B](_))

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
@@ -101,7 +101,7 @@ object ScalazArbitrary extends ScalazArbitraryPlatform {
   implicit def cogenIndexedStoreT[F[_], I: Cogen, A, B](implicit F: Cogen[F[A => B]]): Cogen[IndexedStoreT[F, I, A, B]] =
     Cogen[(F[A => B], I)].contramap(_.run)
 
-  implicit def cogenIndexedContsT[W[_], M[_], R, O, A](implicit F: Cogen[W[A => M[O]] => M[R]]): Cogen[IndexedContsT[W, M, R, O, A]] =
+  implicit def cogenIndexedContsT[W[_], R, O, M[_], A](implicit F: Cogen[W[A => M[O]] => M[R]]): Cogen[IndexedContsT[W, R, O, M, A]] =
     F.contramap(_.run)
 
   implicit def cogenEndo[A](implicit A: Cogen[A => A]): Cogen[Endo[A]] =
@@ -546,7 +546,7 @@ object ScalazArbitrary extends ScalazArbitraryPlatform {
   implicit def tracedTArb[W[_], A, B](implicit A: Arbitrary[W[A => B]]): Arbitrary[TracedT[W, A, B]] =
     Functor[Arbitrary].map(A)(TracedT(_))
 
-  implicit def indexedContsTArb[W[_], M[_], R, O, A](implicit A: Arbitrary[W[A => M[O]] => M[R]]): Arbitrary[IndexedContsT[W, M, R, O, A]] =
+  implicit def indexedContsTArb[W[_], M[_], R, O, A](implicit A: Arbitrary[W[A => M[O]] => M[R]]): Arbitrary[IndexedContsT[W, R, O, M, A]] =
     Functor[Arbitrary].map(A)(IndexedContsT(_))
 
   implicit def indexedStateTArb[F[_], S1, S2, A](implicit A: Arbitrary[S1 => F[(S2, A)]]): Arbitrary[IndexedStateT[F, S1, S2, A]] =

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
@@ -546,7 +546,7 @@ object ScalazArbitrary extends ScalazArbitraryPlatform {
   implicit def tracedTArb[W[_], A, B](implicit A: Arbitrary[W[A => B]]): Arbitrary[TracedT[W, A, B]] =
     Functor[Arbitrary].map(A)(TracedT(_))
 
-  implicit def indexedContsTArb[W[_], M[_], R, O, A](implicit A: Arbitrary[W[A => M[O]] => M[R]]): Arbitrary[IndexedContsT[W, R, O, M, A]] =
+  implicit def indexedContsTArb[W[_], R, O, M[_], A](implicit A: Arbitrary[W[A => M[O]] => M[R]]): Arbitrary[IndexedContsT[W, R, O, M, A]] =
     Functor[Arbitrary].map(A)(IndexedContsT(_))
 
   implicit def indexedStateTArb[F[_], S1, S2, A](implicit A: Arbitrary[S1 => F[(S2, A)]]): Arbitrary[IndexedStateT[F, S1, S2, A]] =

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
@@ -155,7 +155,7 @@ object ScalazArbitrary extends ScalazArbitraryPlatform {
   implicit def cogenIndexedStateT[F[_]: Monad, S1, S2, A](implicit F: Cogen[S1 => F[(S2, A)]]): Cogen[IndexedStateT[F, S1, S2, A]] =
     F.contramap(s => s.apply(_))
 
-  implicit def cogenWriterT[F[_], A, B](implicit F: Cogen[F[(A, B)]]): Cogen[WriterT[F, A, B]] =
+  implicit def cogenWriterT[A, F[_], B](implicit F: Cogen[F[(A, B)]]): Cogen[WriterT[A, F, B]] =
     F.contramap(_.run)
 
   implicit def cogenUnwriterT[F[_], A, B](implicit F: Cogen[F[(A, B)]]): Cogen[UnwriterT[F, A, B]] =
@@ -509,8 +509,8 @@ object ScalazArbitrary extends ScalazArbitraryPlatform {
   implicit def CoproductArbitrary[F[_], G[_], A](implicit a: Arbitrary[F[A] \/ G[A]]): Arbitrary[Coproduct[F, G, A]] =
     Functor[Arbitrary].map(a)(Coproduct(_))
 
-  implicit def writerTArb[F[_], W, A](implicit A: Arbitrary[F[(W, A)]]): Arbitrary[WriterT[F, W, A]] =
-    Functor[Arbitrary].map(A)(WriterT[F, W, A](_))
+  implicit def writerTArb[F[_], W, A](implicit A: Arbitrary[F[(W, A)]]): Arbitrary[WriterT[W, F, A]] =
+    Functor[Arbitrary].map(A)(WriterT[W, F, A](_))
 
   implicit def unwriterTArb[F[_], U, A](implicit A: Arbitrary[F[(U, A)]]): Arbitrary[UnwriterT[F, U, A]] =
     Functor[Arbitrary].map(A)(UnwriterT[F, U, A](_))

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
@@ -149,7 +149,7 @@ object ScalazArbitrary extends ScalazArbitraryPlatform {
   implicit def cogenIdT[F[_], A](implicit F: Cogen[F[A]]): Cogen[IdT[F, A]] =
     F.contramap(_.run)
 
-  implicit def cogenIndexedReaderWriterStateT[F[_]: Monad, R, W, S1, S2, A](implicit F: Cogen[(R, S1) => F[(W, A, S2)]]): Cogen[IndexedReaderWriterStateT[F, R, W, S1, S2, A]] =
+  implicit def cogenIndexedReaderWriterStateT[R, W, S1, S2, F[_]: Monad, A](implicit F: Cogen[(R, S1) => F[(W, A, S2)]]): Cogen[IndexedReaderWriterStateT[R, W, S1, S2, F, A]] =
     F.contramap(_.run)
 
   implicit def cogenIndexedStateT[F[_]: Monad, S1, S2, A](implicit F: Cogen[S1 => F[(S2, A)]]): Cogen[IndexedStateT[F, S1, S2, A]] =
@@ -540,8 +540,8 @@ object ScalazArbitrary extends ScalazArbitraryPlatform {
   def stateTArb[F[+_], S, A](implicit A: Arbitrary[S => F[(S, A)]]): Arbitrary[StateT[F, S, A]] =
     indexedStateTArb[F, S, S, A](A)
 
-  implicit def indexedReaderWriterStateTArb[F[_], R, W, S1, S2, A](implicit A: Arbitrary[(R, S1) => F[(W, A, S2)]]): Arbitrary[IndexedReaderWriterStateT[F, R, W, S1, S2, A]] =
-    Functor[Arbitrary].map(A)(IndexedReaderWriterStateT[F, R, W, S1, S2, A](_))
+  implicit def indexedReaderWriterStateTArb[R, W, S1, S2, F[_], A](implicit A: Arbitrary[(R, S1) => F[(W, A, S2)]]): Arbitrary[IndexedReaderWriterStateT[R, W, S1, S2, F, A]] =
+    Functor[Arbitrary].map(A)(IndexedReaderWriterStateT[R, W, S1, S2, F, A](_))
 
   implicit def tracedTArb[W[_], A, B](implicit A: Arbitrary[W[A => B]]): Arbitrary[TracedT[W, A, B]] =
     Functor[Arbitrary].map(A)(TracedT(_))

--- a/tests/src/test/scala/scalaz/EitherTTest.scala
+++ b/tests/src/test/scala/scalaz/EitherTTest.scala
@@ -9,10 +9,10 @@ import org.scalacheck.Prop.forAll
 
 object EitherTTest extends SpecLite {
 
-  type EitherTList[A, B] = EitherT[List, A, B]
-  type EitherTListInt[A] = EitherT[List, Int, A]
-  type EitherTOptionInt[A] = EitherT[Option, Int, A]
-  type EitherTComputation[A] = EitherT[Function0, Int, A] // in lieu of IO
+  type EitherTList[A, B] = EitherT[A, List, B]
+  type EitherTListInt[A] = EitherT[Int, List, A]
+  type EitherTOptionInt[A] = EitherT[Int, Option, A]
+  type EitherTComputation[A] = EitherT[Int, Function0, A] // in lieu of IO
 
   checkAll(equal.laws[EitherTListInt[Int]])
   checkAll(bindRec.laws[EitherTListInt])
@@ -20,12 +20,12 @@ object EitherTTest extends SpecLite {
   checkAll(monadError.laws[EitherTListInt, Int])
   checkAll(traverse.laws[EitherTListInt])
   checkAll(bitraverse.laws[EitherTList])
-  checkAll(monadTrans.laws[EitherT[?[_], Int, ?], List])
+  checkAll(monadTrans.laws[EitherT[Int, ?[_], ?], List])
 
   "rightU" should {
     val a: String \/ Int = \/-(1)
-    val b: EitherT[({type l[a] = String \/ a})#l, Boolean, Int] = EitherT.rightU[Boolean](a)
-    b must_== EitherT.rightT[({type l[a] = String \/ a})#l, Boolean, Int](a)
+    val b: EitherT[Boolean, ({type l[a] = String \/ a})#l, Int] = EitherT.rightU[Boolean](a)
+    b must_== EitherT.rightT[Boolean, ({type l[a] = String \/ a})#l, Int](a)
   }
 
   "consistent Bifoldable" ! forAll { a: EitherTList[Int, Int] =>
@@ -77,32 +77,32 @@ object EitherTTest extends SpecLite {
   }
 
   object instances {
-    def functor[F[_] : Functor, A] = Functor[EitherT[F, A, ?]]
-    def bindRec[F[_] : Monad: BindRec, A] = BindRec[EitherT[F, A, ?]]
-    def monad[F[_] : Monad, A] = Monad[EitherT[F, A, ?]]
-    def plus[F[_] : Monad, A: Semigroup] = Plus[EitherT[F, A, ?]]
-    def monadPlus[F[_] : Monad, A: Monoid] = MonadPlus[EitherT[F, A, ?]]
-    def foldable[F[_] : Foldable, A] = Foldable[EitherT[F, A, ?]]
-    def traverse[F[_] : Traverse, A] = Traverse[EitherT[F, A, ?]]
-    def bifunctor[F[_] : Functor] = Bifunctor[EitherT[F, ?, ?]]
-    def bifoldable[F[_] : Foldable] = Bifoldable[EitherT[F, ?, ?]]
-    def bitraverse[F[_] : Traverse] = Bitraverse[EitherT[F, ?, ?]]
+    def functor[A, F[_] : Functor] = Functor[EitherT[A, F, ?]]
+    def bindRec[A, F[_] : Monad: BindRec] = BindRec[EitherT[A, F, ?]]
+    def monad[A, F[_] : Monad] = Monad[EitherT[A, F, ?]]
+    def plus[A: Semigroup, F[_] : Monad] = Plus[EitherT[A, F, ?]]
+    def monadPlus[A: Monoid, F[_] : Monad] = MonadPlus[EitherT[A, F, ?]]
+    def foldable[A, F[_] : Foldable] = Foldable[EitherT[A, F, ?]]
+    def traverse[A, F[_] : Traverse] = Traverse[EitherT[A, F, ?]]
+    def bifunctor[F[_] : Functor] = Bifunctor[EitherT[?, F, ?]]
+    def bifoldable[F[_] : Foldable] = Bifoldable[EitherT[?, F, ?]]
+    def bitraverse[F[_] : Traverse] = Bitraverse[EitherT[?, F, ?]]
 
     // checking absence of ambiguity
-    def functor[F[_] : BindRec, A] = Functor[EitherT[F, A, ?]]
-    def functor[F[_] : Monad, A: Monoid] = Functor[EitherT[F, A, ?]]
-    def functor[F[_] : Monad : BindRec, A: Monoid] = Functor[EitherT[F, A, ?]]
-    def apply[F[_] : Monad, A: Monoid] = Apply[EitherT[F, A, ?]]
-    def monad[F[_] : Monad, A: Monoid] = Monad[EitherT[F, A, ?]]
-    def plus[F[_] : Monad, A: Monoid] = Plus[EitherT[F, A, ?]]
-    def foldable[F[_] : Traverse, A] = Foldable[EitherT[F, A, ?]]
-    def bifunctor[F[_] : Traverse] = Bifunctor[EitherT[F, ?, ?]]
-    def bifoldable[F[_] : Traverse] = Bifoldable[EitherT[F, ?, ?]]
-    def monadError[F[_] : Monad, A] = MonadError[EitherT[F, A, ?], A]
-    def nondeterminism[F[_] : Nondeterminism, A] = Nondeterminism[EitherT[F, A, ?]]
-    def nondeterminismMonad[F[_] : Nondeterminism, A] = Monad[EitherT[F, A, ?]]
-    def nondeterminismFunctor[F[_] : Nondeterminism: BindRec: Traverse, A] = Functor[EitherT[F, A, ?]]
-    def nondeterminismMonad[F[_] : Nondeterminism: BindRec: Traverse, A] = Monad[EitherT[F, A, ?]]
+    def functor[A, F[_] : BindRec] = Functor[EitherT[A, F, ?]]
+    def functor[A: Monoid, F[_] : Monad] = Functor[EitherT[A, F, ?]]
+    def functor[A: Monoid, F[_] : Monad : BindRec] = Functor[EitherT[A, F, ?]]
+    def apply[A: Monoid, F[_] : Monad] = Apply[EitherT[A, F, ?]]
+    def monad[A: Monoid, F[_] : Monad] = Monad[EitherT[A, F, ?]]
+    def plus[A: Monoid, F[_] : Monad] = Plus[EitherT[A, F, ?]]
+    def foldable[A, F[_] : Traverse] = Foldable[EitherT[A, F, ?]]
+    def bifunctor[F[_] : Traverse] = Bifunctor[EitherT[?, F, ?]]
+    def bifoldable[F[_] : Traverse] = Bifoldable[EitherT[?, F, ?]]
+    def monadError[A, F[_] : Monad] = MonadError[EitherT[A, F, ?], A]
+    def nondeterminism[A, F[_] : Nondeterminism] = Nondeterminism[EitherT[A, F, ?]]
+    def nondeterminismMonad[A, F[_] : Nondeterminism] = Monad[EitherT[A, F, ?]]
+    def nondeterminismFunctor[A, F[_] : Nondeterminism: BindRec: Traverse] = Functor[EitherT[A, F, ?]]
+    def nondeterminismMonad[A, F[_] : Nondeterminism: BindRec: Traverse] = Monad[EitherT[A, F, ?]]
   }
 
   def compilationTests() = {
@@ -118,7 +118,7 @@ object EitherTTest extends SpecLite {
         def append(f1: (ABC, Int), f2: => (ABC, Int)): (ABC, Int) = f1
       }
 
-      def brokenMethod: EitherT[Option, (ABC, Int), (ABC, String)] =
+      def brokenMethod: EitherT[(ABC, Int), Option, (ABC, String)] =
         EitherT(Some((ABC("abcData"),"Success").right))
 
       def filterComp =

--- a/tests/src/test/scala/scalaz/IndexedContsTTest.scala
+++ b/tests/src/test/scala/scalaz/IndexedContsTTest.scala
@@ -7,12 +7,12 @@ import scalaz.std.anyVal._
 
 object IndexedContsTTest extends SpecLite {
 
-  type ContTMaybeBoolean[A] = ContT[Maybe, Boolean, A]
+  type ContTMaybeBoolean[A] = ContT[Boolean, Maybe, A]
 
-  private[this] implicit def contTEqual[F[_], A, B](implicit
+  private[this] implicit def contTEqual[A, F[_], B](implicit
     A: Arbitrary[A => F[B]],
     B: Equal[F[B]]
-  ): Equal[ContT[F, B, A]] = {
+  ): Equal[ContT[B, F, A]] = {
     val functions = Stream.continually(
       A.arbitrary.sample
     ).flatten.take(5).toList
@@ -27,16 +27,16 @@ object IndexedContsTTest extends SpecLite {
   checkAll(monadPlus.laws[ContTMaybeBoolean])
 
   object instances {
-    def functorRight[W[_]: Functor, M[_], R, O] = Functor[IndexedContsT[W, M, R, O, ?]]
-    def functorLeft[W[_], M[_]: Functor, O, A] = Functor[IndexedContsT[W, M, ?, O, A]]
-    def contravariant[W[_]: Functor, M[_]: Functor, R, A] = Contravariant[IndexedContsT[W, M, R, ?, A]]
-    def bifunctor[W[_]: Functor, M[_]: Functor, O] = Bifunctor[IndexedContsT[W, M, ?, O, ?]]
-    def bind[W[_]: Cobind, M[_], R] = Bind[ContsT[W, M, R, ?]]
-    def monad[W[_]: Comonad, M[_], R] = Monad[ContsT[W, M, R, ?]]
+    def functorRight[W[_]: Functor, R, M[_], O] = Functor[IndexedContsT[W, R, O, M, ?]]
+    def functorLeft[W[_], O, M[_]: Functor, A] = Functor[IndexedContsT[W, ?, O, M, A]]
+    def contravariant[W[_]: Functor, R, M[_]: Functor, A] = Contravariant[IndexedContsT[W, R, ?, M, A]]
+    def bifunctor[W[_]: Functor, O, M[_]: Functor] = Bifunctor[IndexedContsT[W, ?, O, M, ?]]
+    def bind[W[_]: Cobind, R, M[_]] = Bind[ContsT[W, R, M, ?]]
+    def monad[W[_]: Comonad, R, M[_]] = Monad[ContsT[W, R, M, ?]]
 
     // checking absence of ambiguity
-    def functor[W[_]: Comonad, M[_], R] = Functor[ContsT[W, M, R, ?]]
-    def functor[W[_]: Cobind, M[_], R] = Functor[ContsT[W, M, R, ?]]
-    def bind[W[_]: Comonad, M[_], R] = Bind[ContsT[W, M, R, ?]]
+    def functor[W[_]: Comonad, R, M[_]] = Functor[ContsT[W, R, M, ?]]
+    def functor[W[_]: Cobind, R, M[_]] = Functor[ContsT[W, R, M, ?]]
+    def bind[W[_]: Comonad, R, M[_]] = Bind[ContsT[W, R, M, ?]]
   }
 }

--- a/tests/src/test/scala/scalaz/MonadErrorTest.scala
+++ b/tests/src/test/scala/scalaz/MonadErrorTest.scala
@@ -19,12 +19,12 @@ object MonadErrorTest extends SpecLite {
     // type aliases are needed to help with type inference, even kind-projector
     // fails us...
     type Out[a] = String \/ a
-    type MT[a] = ReaderT[Out, String, a]
+    type MT[a] = ReaderT[String, Out, a]
     implicit val string: Decoder[String] = instance(_.right)
     implicit val isoReaderT: Decoder <~> MT =
       new IsoFunctorTemplate[Decoder, MT] {
         def from[A](fa: MT[A]) = instance(fa.run(_))
-        def to[A](fa: Decoder[A]) = ReaderT[Out, String, A](fa.decode)
+        def to[A](fa: Decoder[A]) = ReaderT[String, Out, A](fa.decode)
       }
 
     implicit val monad: MonadError[Decoder, String] = MonadError.fromIso(isoReaderT)

--- a/tests/src/test/scala/scalaz/ReaderWriterStateTTest.scala
+++ b/tests/src/test/scala/scalaz/ReaderWriterStateTTest.scala
@@ -5,14 +5,14 @@ import scalaz.scalacheck.ScalazArbitrary._
 import std.AllInstances._
 
 object ReaderWriterStateTTest extends SpecLite {
-  type RWSOptInt[A] = RWST[Option, Int, Int, Int, A]
+  type RWSOptInt[A] = RWST[Int, Int, Int, Option, A]
 
   implicit val RWSOptIntEqual = new Equal[RWSOptInt[Int]] {
     def equal(a1: RWSOptInt[Int], a2: RWSOptInt[Int]) = a1.run(0, 0) == a2.run(0, 0)
   }
 
-  private[this] implicit val RWSEitherIntEqual: Equal[RWST[Either[Int, ?], Int, Int, Int, Int]] =
-    Equal.equal[RWST[Either[Int, ?], Int, Int, Int, Int]] { (a1, a2) =>
+  private[this] implicit val RWSEitherIntEqual: Equal[RWST[Int, Int, Int, Either[Int, ?], Int]] =
+    Equal.equal[RWST[Int, Int, Int, Either[Int, ?], Int]] { (a1, a2) =>
       (1 to 5).forall{ x =>
         (1 to 5).forall{ y =>
           Equal[Either[Int, (Int, Int, Int)]].equal(a1.run(x, y), a2.run(x, y))
@@ -22,36 +22,36 @@ object ReaderWriterStateTTest extends SpecLite {
 
   checkAll(bindRec.laws[RWSOptInt])
   checkAll(monadPlus.strongLaws[RWSOptInt])
-  checkAll(monadTrans.laws[ReaderWriterStateT[?[_], Int, Int, Int, ?], Option])
-  checkAll(monadError.laws[RWST[Either[Int, ?], Int, Int, Int, ?], Int])
+  checkAll(monadTrans.laws[ReaderWriterStateT[Int, Int, Int, ?[_], ?], Option])
+  checkAll(monadError.laws[RWST[Int, Int, Int, Either[Int, ?], ?], Int])
 
   "ReaderWriterStateT can be trampolined without stack overflow" in {
     import scalaz.Free._
-    val result = (0 to 10000).toList.map(ii => ReaderWriterStateT[Trampoline, Unit, String, Int, Int]((_, i: Int) => Trampoline.done(("", i, ii))))
-      .foldLeft(ReaderWriterStateT[Trampoline, Unit, String, Int, Int]((_, i: Int) => Trampoline.done(("", i, i))))( (a, b) => a.flatMap(_ => b))
+    val result = (0 to 10000).toList.map(ii => ReaderWriterStateT[Unit, String, Int, Trampoline, Int]((_, i: Int) => Trampoline.done(("", i, ii))))
+      .foldLeft(ReaderWriterStateT[Unit, String, Int, Trampoline, Int]((_, i: Int) => Trampoline.done(("", i, i))))( (a, b) => a.flatMap(_ => b))
     10000 must_=== result.run((),0).run._3
   }
 
   object instances {
-    def functor[F[_]: Functor, R, W, S] = Functor[RWST[F, R, W, S, ?]]
-    def plus[F[_]: Plus, R, W, S1, S2] = Plus[IRWST[F, R, W, S1, S2, ?]]
-    def plusEmpty[F[_]: PlusEmpty, R, W, S1, S2] = PlusEmpty[IRWST[F, R, W, S1, S2, ?]]
-    def bindRec[F[_]: BindRec : Monad, R, W: Semigroup, S] = BindRec[RWST[F, R, W, S, ?]]
-    def monad[F[_]: Monad, R, W: Monoid, S] = Monad[RWST[F, R, W, S, ?]]
-    def monadPlus[F[_]: MonadPlus, R, W: Monoid, S] = MonadPlus[RWST[F, R, W, S, ?]]
-    def bind[F[_]: Bind, R, W: Semigroup, S] = Bind[RWST[F, R, W, S, ?]]
-    def monadReader[F[_]: Monad, R, W: Monoid, S] = MonadReader[RWST[F, R, W, S, ?], R]
-    def monadState[F[_]: Monad, R, W: Monoid, S] = MonadState[RWST[F, R, W, S, ?], S]
-    def monadTrans[R, W: Monoid, S] = MonadTrans[λ[(f[_], α) => RWST[f, R, W, S, α]]]
+    def functor[R, W, S, F[_]: Functor] = Functor[RWST[R, W, S, F, ?]]
+    def plus[R, W, S1, S2, F[_]: Plus] = Plus[IRWST[R, W, S1, S2, F, ?]]
+    def plusEmpty[R, W, S1, S2, F[_]: PlusEmpty] = PlusEmpty[IRWST[R, W, S1, S2, F, ?]]
+    def bindRec[R, W: Semigroup, S, F[_]: BindRec : Monad] = BindRec[RWST[R, W, S, F, ?]]
+    def monad[R, W: Monoid, S, F[_]: Monad] = Monad[RWST[R, W, S, F, ?]]
+    def monadPlus[R, W: Monoid, S, F[_]: MonadPlus] = MonadPlus[RWST[R, W, S, F, ?]]
+    def bind[R, W: Semigroup, S, F[_]: Bind] = Bind[RWST[R, W, S, F, ?]]
+    def monadReader[R, W: Monoid, S, F[_]: Monad] = MonadReader[RWST[R, W, S, F, ?], R]
+    def monadState[R, W: Monoid, S, F[_]: Monad] = MonadState[RWST[R, W, S, F, ?], S]
+    def monadTrans[R, W: Monoid, S] = MonadTrans[λ[(f[_], α) => RWST[R, W, S, f, α]]]
     // checking absence of ambiguity
-    def functor[F[_]: Monad, R, W: Monoid, S] = Functor[RWST[F, R, W, S, ?]]
-    def functor[F[_]: Bind, R, W: Semigroup, S] = Functor[RWST[F, R, W, S, ?]]
-    def functor[F[_]: MonadPlus, R, W: Monoid, S] = Functor[RWST[F, R, W, S, ?]]
-    def plus[F[_]: PlusEmpty, R, W, S] = Plus[RWST[F, R, W, S, ?]]
-    def plus[F[_]: MonadPlus, R, W, S] = Plus[RWST[F, R, W, S, ?]]
-    def plusEmpty[F[_]: MonadPlus, R, W, S] = PlusEmpty[RWST[F, R, W, S, ?]]
-    def bind[F[_]: Monad, R, W: Monoid, S] = Bind[RWST[F, R, W, S, ?]]
-    def bind[F[_]: MonadPlus, R, W: Monoid, S] = Bind[RWST[F, R, W, S, ?]]
-    def monad[F[_]: MonadPlus, R, W: Monoid, S] = Monad[RWST[F, R, W, S, ?]]
+    def functor[R, W: Monoid, S, F[_]: Monad] = Functor[RWST[R, W, S, F, ?]]
+    def functor[R, W: Semigroup, S, F[_]: Bind] = Functor[RWST[R, W, S, F, ?]]
+    def functor[R, W: Monoid, S, F[_]: MonadPlus] = Functor[RWST[R, W, S, F, ?]]
+    def plus[R, W, S, F[_]: PlusEmpty] = Plus[RWST[R, W, S, F, ?]]
+    def plus[R, W, S, F[_]: MonadPlus] = Plus[RWST[R, W, S, F, ?]]
+    def plusEmpty[R, W, S, F[_]: MonadPlus] = PlusEmpty[RWST[R, W, S, F, ?]]
+    def bind[R, W: Monoid, S, F[_]: Monad] = Bind[RWST[R, W, S, F, ?]]
+    def bind[R, W: Monoid, S, F[_]: MonadPlus] = Bind[RWST[R, W, S, F, ?]]
+    def monad[R, W: Monoid, S, F[_]: MonadPlus] = Monad[RWST[R, W, S, F, ?]]
   }
 }

--- a/tests/src/test/scala/scalaz/WriterTTest.scala
+++ b/tests/src/test/scala/scalaz/WriterTTest.scala
@@ -10,10 +10,10 @@ import org.scalacheck.Prop.forAll
 
 object WriterTTest extends SpecLite {
 
-  type WriterTOpt[W, A] = WriterT[Option, W, A]
+  type WriterTOpt[W, A] = WriterT[W, Option, A]
   type WriterTOptInt[A] = WriterTOpt[Int, A]
   type IntOr[A] = Int \/ A
-  type WriterTEither[A] = WriterT[IntOr, Int, A]
+  type WriterTEither[A] = WriterT[Int, IntOr, A]
 
   checkAll(equal.laws[WriterTOptInt[Int]])
   checkAll(monoid.laws[WriterTOptInt[Int]])
@@ -22,9 +22,9 @@ object WriterTTest extends SpecLite {
   checkAll(bindRec.laws[WriterTOptInt])
   checkAll(monadPlus.strongLaws[WriterTOptInt])
   checkAll(bifunctor.laws[WriterTOpt])
-  checkAll(functor.laws[WriterT[NonEmptyList, Int, ?]])
+  checkAll(functor.laws[WriterT[Int, NonEmptyList, ?]])
   checkAll(bitraverse.laws[WriterTOpt])
-  checkAll(monadTrans.laws[WriterT[?[_], Int, ?], List])
+  checkAll(monadTrans.laws[WriterT[Int, ?[_], ?], List])
 
   implicit def writerArb[W, A](implicit W: Arbitrary[W], A: Arbitrary[A]): Arbitrary[Writer[W, A]] =
     Applicative[Arbitrary].apply2(W, A)((w, a) => Writer[W, A](w, a))
@@ -51,53 +51,53 @@ object WriterTTest extends SpecLite {
   }
 
   object instances {
-    def monoid[F[_], W, A](implicit F: Monoid[F[(W,A)]]) = Monoid[WriterT[F, W, A]]
-    def plus[F[_]: Plus, W] = Plus[WriterT[F, W, ?]]
-    def plusEmpty[F[_]: PlusEmpty, W] = PlusEmpty[WriterT[F, W, ?]]
-    def functor[F[_]: Functor, W] = Functor[WriterT[F, W, ?]]
-    def apply[F[_]: Apply, W: Semigroup] = Apply[WriterT[F, W, ?]]
-    def applicative[F[_]: Applicative, W: Monoid] = Applicative[WriterT[F, W, ?]]
-    def bind[F[_]: Bind, W: Semigroup] = Bind[WriterT[F, W, ?]]
-    def bindRec[F[_]: BindRec: Applicative, W: Semigroup] = BindRec[WriterT[F, W, ?]]
-    def monad[F[_]: Monad, W: Monoid] = Monad[WriterT[F, W, ?]]
-    def monadPlus[F[_]: MonadPlus, W: Monoid] = MonadPlus[WriterT[F, W, ?]]
-    def monadError[F[_], W: Monoid, E](implicit F: MonadError[F, E]) = MonadError[WriterT[F, W, ?], E]
-    def foldable[F[_]: Foldable, W] = Foldable[WriterT[F, W, ?]]
-    def traverse[F[_]: Traverse, W] = Traverse[WriterT[F, W, ?]]
+    def monoid[W, F[_], A](implicit F: Monoid[F[(W,A)]]) = Monoid[WriterT[W, F, A]]
+    def plus[W, F[_]: Plus] = Plus[WriterT[W, F, ?]]
+    def plusEmpty[W, F[_]: PlusEmpty] = PlusEmpty[WriterT[W, F, ?]]
+    def functor[W, F[_]: Functor] = Functor[WriterT[W, F, ?]]
+    def apply[W: Semigroup, F[_]: Apply] = Apply[WriterT[W, F, ?]]
+    def applicative[W: Monoid, F[_]: Applicative] = Applicative[WriterT[W, F, ?]]
+    def bind[W: Semigroup, F[_]: Bind] = Bind[WriterT[W, F, ?]]
+    def bindRec[W: Semigroup, F[_]: BindRec: Applicative] = BindRec[WriterT[W, F, ?]]
+    def monad[W: Monoid, F[_]: Monad] = Monad[WriterT[W, F, ?]]
+    def monadPlus[W: Monoid, F[_]: MonadPlus] = MonadPlus[WriterT[W, F, ?]]
+    def monadError[W: Monoid, F[_], E](implicit F: MonadError[F, E]) = MonadError[WriterT[W, F, ?], E]
+    def foldable[W, F[_]: Foldable] = Foldable[WriterT[W, F, ?]]
+    def traverse[W, F[_]: Traverse] = Traverse[WriterT[W, F, ?]]
 
     // checking absence of ambiguity
-    def plus[F[_]: PlusEmpty, W] = Plus[WriterT[F, W, ?]]
-    def plus[F[_]: MonadPlus, W] = Plus[WriterT[F, W, ?]]
-    def plusEmpty[F[_]: MonadPlus, W] = PlusEmpty[WriterT[F, W, ?]]
-    def functor[F[_]: Apply, W: Semigroup] = Functor[WriterT[F, W, ?]]
-    def functor[F[_]: Apply, W: Monoid] = Functor[WriterT[F, W, ?]]
-    def functor[F[_]: Bind, W: Semigroup] = Functor[WriterT[F, W, ?]]
-    def functor[F[_]: Bind, W: Monoid] = Functor[WriterT[F, W, ?]]
-    def functor[F[_]: Traverse, W: Semigroup] = Functor[WriterT[F, W, ?]]
-    def functor[F[_]: Traverse, W: Monoid] = Functor[WriterT[F, W, ?]]
-    def functor[F[_]: Monad, W: Semigroup] = Functor[WriterT[F, W, ?]]
-    def functor[F[_]: Monad, W: Monoid] = Functor[WriterT[F, W, ?]]
-    def functor[F[_]: MonadPlus, W: Semigroup] = Functor[WriterT[F, W, ?]]
-    def functor[F[_]: MonadPlus, W: Monoid] = Functor[WriterT[F, W, ?]]
-    def apply[F[_]: MonadPlus, W: Monoid] = Apply[WriterT[F, W, ?]]
-    def apply[F[_]: Monad, W: Monoid] = Apply[WriterT[F, W, ?]]
-    def apply[F[_]: Monad, W: Semigroup] = Apply[WriterT[F, W, ?]]
-    def apply[F[_]: Bind, W: Monoid] = Apply[WriterT[F, W, ?]]
-    def apply[F[_]: Bind, W: Semigroup] = Apply[WriterT[F, W, ?]]
-    def apply[F[_]: Apply, W: Monoid] = Apply[WriterT[F, W, ?]]
-    def applicative[F[_]: Monad, W: Monoid] = Applicative[WriterT[F, W, ?]]
-    def applicative[F[_]: MonadPlus, W: Monoid] = Applicative[WriterT[F, W, ?]]
-    def bind[F[_]: MonadPlus, W: Monoid] = Bind[WriterT[F, W, ?]]
-    def bind[F[_]: Monad, W: Monoid] = Bind[WriterT[F, W, ?]]
-    def bind[F[_]: Monad, W: Semigroup] = Bind[WriterT[F, W, ?]]
-    def bind[F[_]: Bind, W: Monoid] = Bind[WriterT[F, W, ?]]
-    def bindRec[F[_]: BindRec: Monad, W: Semigroup] = BindRec[WriterT[F, W, ?]]
-    def bindRec[F[_]: BindRec: Applicative, W: Monoid] = BindRec[WriterT[F, W, ?]]
-    def bindRec[F[_]: BindRec: Monad, W: Monoid] = BindRec[WriterT[F, W, ?]]
-    def bindRec[F[_]: BindRec: MonadPlus, W: Semigroup] = BindRec[WriterT[F, W, ?]]
-    def bindRec[F[_]: BindRec: MonadPlus, W: Monoid] = BindRec[WriterT[F, W, ?]]
-    def monad[F[_]: MonadPlus, W: Monoid] = Monad[WriterT[F, W, ?]]
-    def foldable[F[_]: Traverse, W] = Foldable[WriterT[F, W, ?]]
+    def plus[W, F[_]: PlusEmpty] = Plus[WriterT[W, F, ?]]
+    def plus[W, F[_]: MonadPlus] = Plus[WriterT[W, F, ?]]
+    def plusEmpty[W, F[_]: MonadPlus] = PlusEmpty[WriterT[W, F, ?]]
+    def functor[W: Semigroup, F[_]: Apply] = Functor[WriterT[W, F, ?]]
+    def functor[W: Monoid, F[_]: Apply] = Functor[WriterT[W, F, ?]]
+    def functor[W: Semigroup, F[_]: Bind] = Functor[WriterT[W, F, ?]]
+    def functor[W: Monoid, F[_]: Bind] = Functor[WriterT[W, F, ?]]
+    def functor[W: Semigroup, F[_]: Traverse] = Functor[WriterT[W, F, ?]]
+    def functor[W: Monoid, F[_]: Traverse] = Functor[WriterT[W, F, ?]]
+    def functor[W: Semigroup, F[_]: Monad] = Functor[WriterT[W, F, ?]]
+    def functor[W: Monoid, F[_]: Monad] = Functor[WriterT[W, F, ?]]
+    def functor[W: Semigroup, F[_]: MonadPlus] = Functor[WriterT[W, F, ?]]
+    def functor[W: Monoid, F[_]: MonadPlus] = Functor[WriterT[W, F, ?]]
+    def apply[W: Monoid, F[_]: MonadPlus] = Apply[WriterT[W, F, ?]]
+    def apply[W: Monoid, F[_]: Monad] = Apply[WriterT[W, F, ?]]
+    def apply[W: Semigroup, F[_]: Monad] = Apply[WriterT[W, F, ?]]
+    def apply[W: Monoid, F[_]: Bind] = Apply[WriterT[W, F, ?]]
+    def apply[W: Semigroup, F[_]: Bind] = Apply[WriterT[W, F, ?]]
+    def apply[W: Monoid, F[_]: Apply] = Apply[WriterT[W, F, ?]]
+    def applicative[W: Monoid, F[_]: Monad] = Applicative[WriterT[W, F, ?]]
+    def applicative[W: Monoid, F[_]: MonadPlus] = Applicative[WriterT[W, F, ?]]
+    def bind[W: Monoid, F[_]: MonadPlus] = Bind[WriterT[W, F, ?]]
+    def bind[W: Monoid, F[_]: Monad] = Bind[WriterT[W, F, ?]]
+    def bind[W: Semigroup, F[_]: Monad] = Bind[WriterT[W, F, ?]]
+    def bind[W: Monoid, F[_]: Bind] = Bind[WriterT[W, F, ?]]
+    def bindRec[W: Semigroup, F[_]: BindRec: Monad] = BindRec[WriterT[W, F, ?]]
+    def bindRec[W: Monoid, F[_]: BindRec: Applicative] = BindRec[WriterT[W, F, ?]]
+    def bindRec[W: Monoid, F[_]: BindRec: Monad] = BindRec[WriterT[W, F, ?]]
+    def bindRec[W: Semigroup, F[_]: BindRec: MonadPlus] = BindRec[WriterT[W, F, ?]]
+    def bindRec[W: Monoid, F[_]: BindRec: MonadPlus] = BindRec[WriterT[W, F, ?]]
+    def monad[W: Monoid, F[_]: MonadPlus] = Monad[WriterT[W, F, ?]]
+    def foldable[W, F[_]: Traverse] = Foldable[WriterT[W, F, ?]]
 
     object writer {
       def functor[W] = Functor[Writer[W, ?]]
@@ -107,7 +107,7 @@ object WriterTTest extends SpecLite {
       def bind[W: Semigroup] = Bind[Writer[W, ?]]
       def bind[W: Monoid] = Bind[Writer[W, ?]]
       def monad[W: Monoid] = Monad[Writer[W, ?]]
-      def foldable[W] = Foldable[Writer[W, ?]](WriterT.writerTFoldable[Id, W])
+      def foldable[W] = Foldable[Writer[W, ?]](WriterT.writerTFoldable[W, Id])
       def traverse[W] = Traverse[Writer[W, ?]]
       def comonad[W] = Comonad[Writer[W, ?]]
     }


### PR DESCRIPTION
Addresses #1305 

Note:
- Did not do ReaderWriterStateT due to not knowing where the `F[_]` should go in the type signature (e.g. `RWST[R, F, W, S, A]` or `RWST[R, W, S, F, A]`? I'm assuming the latter...?)
- Not sure whether the swap for StateT and ContT are supposed to go deeper (e.g. also do swap in `IndexedStateT`)
- Some cases of using `StateT[S, F, A]` would not compile unless type was changed to that which it aliases: `IndexedStateT[F, S, S, A]`
- Not sure whether methods types or other classes should also be changed (e.g. `method[F[_], A]` stays the same? or becomes `method[A, F[_]]`? / `MonadPlus[F[_], A]` or `MonadPlus[A, F[_]]`)
- "Fix Later" commit: code wasn't compiling and I'm not sure how to fix it. Figured it'd be better to get more of this PR done and then figure that out with everyone else's help.

I'm going to sleep after this, so won't respond until Monday.