### PR TITLE
Delete version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,6 @@ import Scalaz._
 
 organization in ThisBuild := "org.scalaz"
 
-version in ThisBuild := "8.0.0-SNAPSHOT"
-
 publishTo in ThisBuild := {
   val nexus = "https://oss.sonatype.org/"
   if (isSnapshot.value)


### PR DESCRIPTION
At the end I wanted to set default version to 8.0.0 which overrides sbt-dynber. I assume that the only way to set it is creating a tag like "8.0.0-SNAPSHOT"
@jdegoes @NeQuissimus 