### PR TITLE
optimise {NonEmptyList, IList}.apply to avoid Seq construction

### DIFF
--- a/concurrent/src/main/scala/scalaz/concurrent/Task.scala
+++ b/concurrent/src/main/scala/scalaz/concurrent/Task.scala
@@ -220,7 +220,7 @@ class Task[A](val get: Future[Throwable \/ A]) {
         }
       }
 
-    Task.async { help(delays, Stream()).unsafePerformAsync }.map(tup => (tup._1, IList(tup._2: _*)))
+    Task.async { help(delays, Stream()).unsafePerformAsync }.map(tup => (tup._1, IList.fromSeq(tup._2)))
     }
 
   /** Ensures that the result of this Task satisfies the given predicate, or fails with the given value. */

--- a/core/src/main/scala/scalaz/Cord.scala
+++ b/core/src/main/scala/scalaz/Cord.scala
@@ -117,8 +117,8 @@ object Cord {
   final class CordInterpolator(private val sc: StringContext) extends AnyVal {
     def cord(args: CordInterpolator.Cords*): Cord = {
       import StringContext.treatEscapes
-      val strings = IList(sc.parts: _*).map(s => Cord(treatEscapes(s)))
-      val cords   = IList(args: _*).map(_.cord)
+      val strings = IList.fromSeq(sc.parts).map(s => Cord(treatEscapes(s)))
+      val cords   = IList.fromSeq(args).map(_.cord)
       strings.interleave(cords).foldRight(Cord())((c, acc) => monoid.append(c, acc))
     }
   }

--- a/core/src/main/scala/scalaz/DList.scala
+++ b/core/src/main/scala/scalaz/DList.scala
@@ -68,7 +68,7 @@ final class DList[A] private[scalaz](f: IList[A] => Trampoline[IList[A]]) {
 }
 
 object DList extends DListInstances {
-  def apply[A](xs: A*): DList[A] = fromIList(IList(xs: _*))
+  def apply[A](xs: A*): DList[A] = fromIList(IList.fromSeq(xs))
 
   def mkDList[A](f: (IList[A]) => Trampoline[IList[A]]): DList[A] =
     new DList[A](f)

--- a/core/src/main/scala/scalaz/Digit.scala
+++ b/core/src/main/scala/scalaz/Digit.scala
@@ -53,7 +53,7 @@ object Digit extends DigitInstances {
 
   private val digitsArray: Array[Digit] = Array(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9)
 
-  val digits: IList[Digit] = IList(digitsArray : _*)
+  val digits: IList[Digit] = IList.fromSeq(digitsArray)
 
   implicit def DigitLong(d: Digit): Long = d.toLong
 

--- a/core/src/main/scala/scalaz/Heap.scala
+++ b/core/src/main/scala/scalaz/Heap.scala
@@ -87,14 +87,14 @@ sealed abstract class Heap[A] {
 
   def toUnsortedList: List[A] = toUnsortedStream.toList
 
-  def toUnsortedIList: IList[A] = IList(toUnsortedStream: _*)
+  def toUnsortedIList: IList[A] = IList.fromSeq(toUnsortedStream)
 
   def toStream: Stream[A] =
     std.stream.unfold(this)(_.uncons)
 
   def toList: List[A] = toStream.toList
 
-  def toIList: IList[A] = IList(toStream: _*)
+  def toIList: IList[A] = IList.fromSeq(toStream)
 
   /**Map a function over the heap, returning a new heap ordered appropriately. O(n)*/
   def map[B: Order](f: A => B): Heap[B] = fold(Empty[B], (_, _, t) => t.foldMap(x => singleton(f(x.value))))

--- a/core/src/main/scala/scalaz/NonEmptyList.scala
+++ b/core/src/main/scala/scalaz/NonEmptyList.scala
@@ -139,23 +139,24 @@ final class NonEmptyList[A] private[scalaz](val head: A, val tail: IList[A]) {
 }
 
 object NonEmptyList extends NonEmptyListInstances {
-  def apply[A](h: A, t: A*): NonEmptyList[A] =
-    nels(h, t: _*)
-
   // optimised versions of apply(A*)
+  @inline final def apply[A](a: A): NonEmptyList[A] = nel(a, IList.empty)
+  @inline final def apply[A](a: A, b: A): NonEmptyList[A] = nel(a, IList(b))
   @inline final def apply[A](a: A, b: A, c: A): NonEmptyList[A] = nel(a, IList(b, c))
   @inline final def apply[A](a: A, b: A, c: A, d: A): NonEmptyList[A] = nel(a, IList(b, c, d))
   @inline final def apply[A](a: A, b: A, c: A, d: A, e: A): NonEmptyList[A] = nel(a, IList(b, c, d, e))
   @inline final def apply[A](a: A, b: A, c: A, d: A, e: A, f: A): NonEmptyList[A] = nel(a, IList(b, c, d, e, f))
+
+  @inline final def apply[A](a: A, b: A, c: A, d: A, e: A, f: A, as: A*): NonEmptyList[A] = a <:: b <:: c <:: d <:: e <:: fromSeq(f, as)
+
+  def fromSeq[A](h: A, t: Seq[A]): NonEmptyList[A] =
+    nel(h, IList.fromSeq(t))
 
   def unapply[A](v: NonEmptyList[A]): Option[(A, IList[A])] =
     Some((v.head, v.tail))
 
   def nel[A](h: A, t: IList[A]): NonEmptyList[A] =
     new NonEmptyList(h, t)
-
-  def nels[A](h: A, t: A*): NonEmptyList[A] =
-    nel(h, IList(t: _*))
 
   def lift[A, B](f: NonEmptyList[A] => B): IList[A] => Option[B] = {
     case INil() ⇒ None

--- a/tests/jvm/src/test/scala/scalaz/std/FutureTest.scala
+++ b/tests/jvm/src/test/scala/scalaz/std/FutureTest.scala
@@ -92,7 +92,7 @@ class FutureTest extends SpecLite {
         is match {
           case i :: is0 =>
             promises(i).complete(scala.util.Try(xs(i)))
-            Nondeterminism[Future].chooseAny(IList(fs: _*)).get.flatMap { case (x, fs0) =>
+            Nondeterminism[Future].chooseAny(IList.fromSeq(fs)).get.flatMap { case (x, fs0) =>
               loop(is0, fs0.toList, acc :+ x)
             }
           case Nil =>
@@ -106,11 +106,11 @@ class FutureTest extends SpecLite {
 
     "gather maintains order" ! forAll { (xs: List[Int]) =>
       val promises = Vector.fill(xs.size)(Promise[Int]())
-      val f = Nondeterminism[Future].gather(IList(promises.map(_.future): _*))
+      val f = Nondeterminism[Future].gather(IList.fromSeq(promises.map(_.future)))
       (promises zip xs).reverseIterator.foreach { case (p, x) =>
         p.complete(scala.util.Try(x))
       }
-      Await.result(f, duration) must_== IList(xs: _*)
+      Await.result(f, duration) must_== IList.fromSeq(xs)
     }
   }
 }

--- a/tests/src/test/scala/scalaz/IListTest.scala
+++ b/tests/src/test/scala/scalaz/IListTest.scala
@@ -365,31 +365,31 @@ object IListTest extends SpecLite {
   }
 
   "toEphemeralStream" ! forAll { ns: List[Int] =>
-    IList(ns: _*).toEphemeralStream.toList must_=== EphemeralStream(ns: _*).toList
+    IList.fromSeq(ns).toEphemeralStream.toList must_=== EphemeralStream(ns: _*).toList
   }
 
   "toList" ! forAll { ns: List[Int] =>
-    IList(ns: _*).toList must_=== ns
+    IList.fromSeq(ns).toList must_=== ns
   }
 
   "toMap" ! forAll { ps: List[(String, Int)] =>
-    IList(ps: _*).toMap must_=== ==>>(ps: _*)
+    IList.fromSeq(ps).toMap must_=== ==>>(ps: _*)
   }
 
   "toNel" ! forAll { ns: List[Int] =>
-    IList(ns: _*).toNel must_=== Scalaz.ToListOpsFromList(ns).toNel
+    IList.fromSeq(ns).toNel must_=== Scalaz.ToListOpsFromList(ns).toNel
   }
 
   "toStream" ! forAll { ns: List[Int] =>
-    IList(ns: _*).toStream must_=== ns.toStream
+    IList.fromSeq(ns).toStream must_=== ns.toStream
   }
 
   "toVector" ! forAll { ns: Vector[Int] =>
-    IList(ns: _*).toVector must_=== ns
+    IList.fromSeq(ns).toVector must_=== ns
   }
 
   "toZipper" ! forAll { ns: List[Int] =>
-    IList(ns: _*).toZipper must_=== scalaz.std.stream.toZipper(ns.toStream)
+    IList.fromSeq(ns).toZipper must_=== scalaz.std.stream.toZipper(ns.toStream)
   }
 
   // uncons is tested everywhere

--- a/tests/src/test/scala/scalaz/ZipperTest.scala
+++ b/tests/src/test/scala/scalaz/ZipperTest.scala
@@ -1,7 +1,6 @@
 package scalaz
 
 import Scalaz._
-import NonEmptyList.nels
 import Zipper._
 import scalaz.scalacheck.ScalazProperties._
 import scalaz.scalacheck.ScalazArbitrary._
@@ -25,7 +24,7 @@ object ZipperTest extends SpecLite {
   }
 
   "Zipper Move Then To Stream" in check {
-    val n = nels(1, 2, 3, 4)
+    val n = NonEmptyList(1, 2, 3, 4)
     n.toZipper.move(2).map(_.toStream).exists(_ ==(n.stream))
   }
 


### PR DESCRIPTION
I wanted to do this in 7.2 but couldn't because of bincompat.

The `IList` and `NonEmptyList` constructors create intermediate `Seq` objects, and then all the foldLeft machinary inside the stdlib, which turns out is a huge bottleneck.

This creates convenient constructors for smaller arity, with a backcompat varargs after 6, at the cost of requiring people to call `.fromSeq` if they have a varargs value already.

I think it's a good tradeoff as it gives preferential treatment to people using scalazzi, and additional boilerplate for those who don't.