### PR TITLE
No std imports

### DIFF
--- a/base/shared/src/main/scala/scalaz/algebra/Ord.scala
+++ b/base/shared/src/main/scala/scalaz/algebra/Ord.scala
@@ -1,6 +1,8 @@
 package scalaz
 package algebra
 
+import scala.{ Product, Serializable }
+
 import core.EqClass
 
 sealed abstract class Ordering extends Product with Serializable

--- a/base/shared/src/main/scala/scalaz/core/Void.scala
+++ b/base/shared/src/main/scala/scalaz/core/Void.scala
@@ -1,7 +1,12 @@
 package scalaz
 package core
 
+import java.lang.RuntimeException
+
+import scala.Nothing
+
 import com.github.ghik.silencer.silent
+
 import scalaz.algebra.SemigroupClass
 import scalaz.types.{ As, Is }
 

--- a/base/shared/src/main/scala/scalaz/ct/ApplicativeSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/ct/ApplicativeSyntax.scala
@@ -1,7 +1,7 @@
 package scalaz
 package ct
 
-import language.experimental.macros
+import scala.language.experimental.macros
 
 trait ApplicativeSyntax {
   implicit final class ToApplicativeOps[A](a: A) {

--- a/base/shared/src/main/scala/scalaz/ct/BifunctorInstances.scala
+++ b/base/shared/src/main/scala/scalaz/ct/BifunctorInstances.scala
@@ -1,8 +1,9 @@
 package scalaz
 package ct
 
-trait BifunctorInstances {
+import scala.Tuple2
 
+trait BifunctorInstances {
   implicit final val tuple2Bifunctor: Bifunctor[Tuple2] =
     instanceOf(new BifunctorClass[Tuple2] with BifunctorClass.DeriveBimap[Tuple2] {
       def lmap[A, B, S](fab: (A, B))(f: A => S): (S, B) = fab.copy(_1 = f(fab._1))

--- a/base/shared/src/main/scala/scalaz/ct/BifunctorSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/ct/BifunctorSyntax.scala
@@ -1,7 +1,7 @@
 package scalaz
 package ct
 
-import language.experimental.macros
+import scala.language.experimental.macros
 
 trait BifunctorSyntax {
   implicit final class ToBifunctorOps[F[_, _]: Bifunctor, A, B](ma: F[A, B]) {

--- a/base/shared/src/main/scala/scalaz/ct/ChoiceInstances.scala
+++ b/base/shared/src/main/scala/scalaz/ct/ChoiceInstances.scala
@@ -1,6 +1,8 @@
 package scalaz
 package ct
 
+import scala.Function
+
 import data.Disjunction
 
 trait ChoiceInstances {

--- a/base/shared/src/main/scala/scalaz/ct/CobindInstances.scala
+++ b/base/shared/src/main/scala/scalaz/ct/CobindInstances.scala
@@ -1,6 +1,8 @@
 package scalaz
 package ct
 
+import scala.{ List, Option, Some }
+
 trait CobindInstances {
   implicit val optionCobind: Cobind[Option] = instanceOf(new CobindClass.DeriveCojoin[Option] {
     override def map[A, B](fa: Option[A])(f: A => B): Option[B] = fa.map(f)

--- a/base/shared/src/main/scala/scalaz/ct/ComonadInstances.scala
+++ b/base/shared/src/main/scala/scalaz/ct/ComonadInstances.scala
@@ -1,6 +1,8 @@
 package scalaz
 package ct
 
+import scala.{ Function0, Tuple2 }
+
 trait ComonadInstances { instances =>
   implicit def tuple2Cobind[A1]: Comonad[Tuple2[A1, ?]] =
     instanceOf(new ComonadClass[Tuple2[A1, ?]] with CobindClass.DeriveCojoin[Tuple2[A1, ?]] {

--- a/base/shared/src/main/scala/scalaz/ct/FoldableClass.scala
+++ b/base/shared/src/main/scala/scalaz/ct/FoldableClass.scala
@@ -1,6 +1,8 @@
 package scalaz
 package ct
 
+import scala.List
+
 trait FoldableClass[F[_]] {
 
   def foldMap[A, B: Monoid](fa: F[A])(f: A => B): B

--- a/base/shared/src/main/scala/scalaz/ct/FoldableSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/ct/FoldableSyntax.scala
@@ -1,6 +1,8 @@
 package scalaz
 package ct
 
+import scala.List
+
 import scala.language.experimental.macros
 
 trait FoldableSyntax {

--- a/base/shared/src/main/scala/scalaz/ct/MonadInstances.scala
+++ b/base/shared/src/main/scala/scalaz/ct/MonadInstances.scala
@@ -1,6 +1,8 @@
 package scalaz
 package ct
 
+import scala.{ Function0, Function1, List, Option }
+
 trait MonadInstances {
   implicit val optionMonad: Monad[Option] = instanceOf(new MonadClass[Option] with BindClass.DeriveFlatten[Option] {
     override def ap[A, B](oa: Option[A])(f: Option[A => B]): Option[B]      = oa.flatMap(a => f.map(_(a)))

--- a/base/shared/src/main/scala/scalaz/ct/StrongInstances.scala
+++ b/base/shared/src/main/scala/scalaz/ct/StrongInstances.scala
@@ -1,14 +1,16 @@
 package scalaz
 package ct
 
+import scala.Function
+
 trait StrongInstances { instances =>
   implicit val functionStrong: Strong[Function] = instanceOf(
     new StrongClass[Function] with ProfunctorClass.DeriveDimap[Function] {
 
-      override def lmap[A, B, C](fab: Function[A, B])(ca: C => A): Function[C, B] =
+      override def lmap[A, B, C](fab: A => B)(ca: C => A): C => B =
         fab compose ca
 
-      override def rmap[A, B, C](fab: Function[A, B])(bc: B => C): Function[A, C] =
+      override def rmap[A, B, C](fab: A => B)(bc: B => C): A => C =
         fab andThen bc
 
       override def first[A, B, C](pab: A => B): ((A, C)) => (B, C) = {

--- a/base/shared/src/main/scala/scalaz/ct/TraversableInstances.scala
+++ b/base/shared/src/main/scala/scalaz/ct/TraversableInstances.scala
@@ -1,6 +1,8 @@
 package scalaz
 package ct
 
+import scala.{ List, Tuple2 }
+
 trait TraversableInstances {
   implicit val listTraversable: Traversable[List] = instanceOf(
     new TraversableClass.DeriveSequence[List] with FoldableClass.DeriveFoldMap[List] {

--- a/base/shared/src/main/scala/scalaz/data/AList.scala
+++ b/base/shared/src/main/scala/scalaz/data/AList.scala
@@ -3,6 +3,9 @@ package data
 
 import Prelude._
 
+import java.lang.StringBuilder
+
+import scala.AnyVal
 import scala.annotation.tailrec
 import scala.language.implicitConversions
 

--- a/base/shared/src/main/scala/scalaz/data/AList1.scala
+++ b/base/shared/src/main/scala/scalaz/data/AList1.scala
@@ -1,7 +1,7 @@
 package scalaz
 package data
 
-import scala.{ Either, Left, Right, sys }
+import scala.{ sys, Either, Left, Right }
 
 import Prelude._
 import AList.aListOps

--- a/base/shared/src/main/scala/scalaz/data/AList1.scala
+++ b/base/shared/src/main/scala/scalaz/data/AList1.scala
@@ -1,6 +1,8 @@
 package scalaz
 package data
 
+import scala.{ Either, Left, Right, sys }
+
 import Prelude._
 import AList.aListOps
 

--- a/base/shared/src/main/scala/scalaz/data/AMaybe.scala
+++ b/base/shared/src/main/scala/scalaz/data/AMaybe.scala
@@ -1,6 +1,8 @@
 package scalaz
 package data
 
+import scala.Nothing
+
 import scalaz.types.Is
 
 /** Similar to `Option[F[A, B]]`, except that

--- a/base/shared/src/main/scala/scalaz/data/AMaybe2.scala
+++ b/base/shared/src/main/scala/scalaz/data/AMaybe2.scala
@@ -1,6 +1,8 @@
 package scalaz
 package data
 
+import scala.{ AnyVal, Nothing }
+
 import scalaz.types.Is
 
 /**

--- a/base/shared/src/main/scala/scalaz/data/APair.scala
+++ b/base/shared/src/main/scala/scalaz/data/APair.scala
@@ -1,6 +1,8 @@
 package scalaz
 package data
 
+import scala.{ Option, Some }
+
 /**
  * Type-aligned pair with upper-bounded type parameter. Isomorphic to
  *

--- a/base/shared/src/main/scala/scalaz/data/ConstInstances.scala
+++ b/base/shared/src/main/scala/scalaz/data/ConstInstances.scala
@@ -1,6 +1,8 @@
 package scalaz
 package data
 
+import scala.{ List, Nil }
+
 import scalaz.algebra._
 import scalaz.core.EqClass
 import scalaz.ct._

--- a/base/shared/src/main/scala/scalaz/data/Disjunction.scala
+++ b/base/shared/src/main/scala/scalaz/data/Disjunction.scala
@@ -1,6 +1,8 @@
 package scalaz
 package data
 
+import scala.Either
+
 sealed trait Disjunction[L, R] {
   final def fold[A](la: L => A)(ra: R => A): A = this match {
     case -\/(l) => la(l)

--- a/base/shared/src/main/scala/scalaz/data/DisjunctionSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/data/DisjunctionSyntax.scala
@@ -1,6 +1,8 @@
 package scalaz
 package data
 
+import scala.Either
+
 trait DisjunctionSyntax {
   implicit final class ToDisjunctionOps[A](a: A) {
     def left[B]: A \/ B  = -\/(a)

--- a/base/shared/src/main/scala/scalaz/data/DownStar.scala
+++ b/base/shared/src/main/scala/scalaz/data/DownStar.scala
@@ -1,6 +1,8 @@
 package scalaz
 package data
 
+import scala.AnyVal
+
 final case class DownStar[F[_], A, B](run: F[A] => B) extends AnyVal
 
 object DownStar extends DownStarInstances

--- a/base/shared/src/main/scala/scalaz/data/Forall.scala
+++ b/base/shared/src/main/scala/scalaz/data/Forall.scala
@@ -1,6 +1,8 @@
 package scalaz
 package data
 
+import scala.{ Any, AnyVal }
+
 import scalaz.types.As
 
 trait ForallModule {

--- a/base/shared/src/main/scala/scalaz/data/Forall2.scala
+++ b/base/shared/src/main/scala/scalaz/data/Forall2.scala
@@ -1,6 +1,8 @@
 package scalaz
 package data
 
+import scala.{ Any, AnyVal }
+
 trait Forall2Module {
   type Forall2[F[_, _]]
 

--- a/base/shared/src/main/scala/scalaz/data/Identity.scala
+++ b/base/shared/src/main/scala/scalaz/data/Identity.scala
@@ -1,4 +1,6 @@
 package scalaz
 package data
 
+import scala.AnyVal
+
 final case class Identity[A](run: A) extends AnyVal

--- a/base/shared/src/main/scala/scalaz/data/Maybe.scala
+++ b/base/shared/src/main/scala/scalaz/data/Maybe.scala
@@ -1,6 +1,8 @@
 package scalaz
 package data
 
+import scala.{ List, None, Option, Some }
+
 import scalaz.core.EqClass
 import scalaz.ct._
 import scalaz.debug.DebugClass

--- a/base/shared/src/main/scala/scalaz/data/Maybe2.scala
+++ b/base/shared/src/main/scala/scalaz/data/Maybe2.scala
@@ -1,7 +1,7 @@
 package scalaz
 package data
 
-import scala.{ AnyVal, Nothing, sys }
+import scala.{ sys, AnyVal, Nothing }
 
 import scalaz.core.EqClass
 import scalaz.ct.BifunctorClass

--- a/base/shared/src/main/scala/scalaz/data/Maybe2.scala
+++ b/base/shared/src/main/scala/scalaz/data/Maybe2.scala
@@ -1,6 +1,8 @@
 package scalaz
 package data
 
+import scala.{ AnyVal, Nothing, sys }
+
 import scalaz.core.EqClass
 import scalaz.ct.BifunctorClass
 import scalaz.debug.DebugClass

--- a/base/shared/src/main/scala/scalaz/data/MaybeSyntax.scala
+++ b/base/shared/src/main/scala/scalaz/data/MaybeSyntax.scala
@@ -1,6 +1,8 @@
 package scalaz
 package data
 
+import scala.Option
+
 trait MaybeSyntax {
   implicit final class OptionAsMaybe[A](oa: Option[A]) { def asMaybe: Maybe[A] = Maybe.fromOption(oa) }
 

--- a/base/shared/src/main/scala/scalaz/data/UpStar.scala
+++ b/base/shared/src/main/scala/scalaz/data/UpStar.scala
@@ -1,4 +1,6 @@
 package scalaz
 package data
 
+import scala.AnyVal
+
 final case class UpStar[F[_], A, B](run: A => F[B]) extends AnyVal

--- a/base/shared/src/main/scala/scalaz/data/balanced.scala
+++ b/base/shared/src/main/scala/scalaz/data/balanced.scala
@@ -1,6 +1,8 @@
 package scalaz
 package data
 
+import scala.AnyVal
+
 import Prelude._
 import AList.aListOps
 import scalaz.ct.ComposeClass
@@ -29,7 +31,8 @@ final class PreComposeBalancer[F[_, _], A, B] private (count: Int, stack: AList1
       val h1count = hcount * 2
       t.tail.uncons match {
         case ev @ AEmpty2() =>
-          assert(tfactor == 1)
+          // FIXME: Throw exception?
+          // assert(tfactor == 1)
           new PreComposeBalancer(h1count, h1 +: ev.unsubst[AList[F, ?, B]](AList.empty[F, B]))
         case AJust2(f, fs) =>
           add(h1, f +: fs, h1count, tfactor / 2)

--- a/base/shared/src/main/scala/scalaz/data/package.scala
+++ b/base/shared/src/main/scala/scalaz/data/package.scala
@@ -1,5 +1,7 @@
 package scalaz
 
+import scala.{ Any, AnyVal, Option, Some }
+
 package object data {
   val Forall: ForallModule = ForallImpl
   val ∀ : Forall.type      = Forall

--- a/base/shared/src/main/scala/scalaz/debug/DebugInterpolator.scala
+++ b/base/shared/src/main/scala/scalaz/debug/DebugInterpolator.scala
@@ -1,7 +1,7 @@
 package scalaz
 package debug
 
-import scala.{ AnyVal, StringContext, sys }
+import scala.{ sys, AnyVal, StringContext }
 
 import scala.annotation.implicitAmbiguous
 import scala.language.experimental.macros

--- a/base/shared/src/main/scala/scalaz/debug/DebugInterpolator.scala
+++ b/base/shared/src/main/scala/scalaz/debug/DebugInterpolator.scala
@@ -1,8 +1,11 @@
 package scalaz
 package debug
 
-import language.experimental.macros
-import language.implicitConversions
+import scala.{ AnyVal, StringContext, sys }
+
+import scala.annotation.implicitAmbiguous
+import scala.language.experimental.macros
+import scala.language.implicitConversions
 
 trait DebugSyntax {
   implicit final class ToDebugOps[A](self: A) {
@@ -21,7 +24,7 @@ object DebugInterpolator {
   }
 
   sealed abstract class HasDebug0 {
-    @annotation.implicitAmbiguous(
+    @implicitAmbiguous(
       "Cannot use the `z` interpolator to interpolate a value of type ${A}, as no implicit Show[${A}] instance is in scope."
     )
     implicit def ambiguousDebug1[A](a: A): HasDebug =

--- a/base/shared/src/main/scala/scalaz/package.scala
+++ b/base/shared/src/main/scala/scalaz/package.scala
@@ -5,4 +5,30 @@ package object scalaz
     with BaseTypes
     with BaseCt
     with BaseAlgebra
-    with BaseCore
+    with BaseCore {
+
+  // Types
+  type Boolean = scala.Boolean
+  type Byte = scala.Byte
+  type Double = scala.Double
+  type Float = scala.Float
+  type Function[-A, +B] = (A) ⇒ B
+  type Int = scala.Int
+  type Long = scala.Long
+  type Short = scala.Short
+  type Singleton = scala.Singleton
+  type String = java.lang.String
+  type Unit = scala.Unit
+
+  type <:<[-A, +B] = scala.Predef.<:<[A, B]
+  type =:=[A, B] = scala.Predef.=:=[A, B]
+
+  type inline = scala.inline
+
+  // Objects
+  val StringContext = scala.StringContext
+
+  // Functions
+  def identity[T](t: T) = scala.Predef.identity[T](t)
+  def implicitly[T](implicit t: T) = scala.Predef.implicitly[T](t)
+}

--- a/base/shared/src/main/scala/scalaz/package.scala
+++ b/base/shared/src/main/scala/scalaz/package.scala
@@ -8,20 +8,20 @@ package object scalaz
     with BaseCore {
 
   // Types
-  type Boolean = scala.Boolean
-  type Byte = scala.Byte
-  type Double = scala.Double
-  type Float = scala.Float
+  type Boolean          = scala.Boolean
+  type Byte             = scala.Byte
+  type Double           = scala.Double
+  type Float            = scala.Float
   type Function[-A, +B] = (A) ⇒ B
-  type Int = scala.Int
-  type Long = scala.Long
-  type Short = scala.Short
-  type Singleton = scala.Singleton
-  type String = java.lang.String
-  type Unit = scala.Unit
+  type Int              = scala.Int
+  type Long             = scala.Long
+  type Short            = scala.Short
+  type Singleton        = scala.Singleton
+  type String           = java.lang.String
+  type Unit             = scala.Unit
 
   type <:<[-A, +B] = scala.Predef.<:<[A, B]
-  type =:=[A, B] = scala.Predef.=:=[A, B]
+  type =:=[A, B]   = scala.Predef.=:=[A, B]
 
   type inline = scala.inline
 
@@ -29,6 +29,6 @@ package object scalaz
   val StringContext = scala.StringContext
 
   // Functions
-  def identity[T](t: T) = scala.Predef.identity[T](t)
+  def identity[T](t: T)            = scala.Predef.identity[T](t)
   def implicitly[T](implicit t: T) = scala.Predef.implicitly[T](t)
 }

--- a/base/shared/src/main/scala/scalaz/types/As.scala
+++ b/base/shared/src/main/scala/scalaz/types/As.scala
@@ -1,6 +1,8 @@
 package scalaz
 package types
 
+import scala.{ Any, AnyVal }
+
 /**
  * Liskov substitutability: A better `<:<`.
  *

--- a/base/shared/src/main/scala/scalaz/types/Is.scala
+++ b/base/shared/src/main/scala/scalaz/types/Is.scala
@@ -1,6 +1,8 @@
 package scalaz
 package types
 
+import scala.{ Any, AnyVal }
+
 /**
  * The data type `Is` is the encoding of Leibnitz’ law which states that
  * if `a` and `b` are identical then they must have identical properties.

--- a/base/shared/src/main/scala/scalaz/types/Leibniz.scala
+++ b/base/shared/src/main/scala/scalaz/types/Leibniz.scala
@@ -1,6 +1,8 @@
 package scalaz
 package types
 
+import scala.Any
+
 /**
  * This particular version of Leibniz’ equality has been generalized to
  * handle subtyping so that it can be used with constrained type constructors,

--- a/base/shared/src/main/scala/scalaz/types/Liskov.scala
+++ b/base/shared/src/main/scala/scalaz/types/Liskov.scala
@@ -1,6 +1,8 @@
 package scalaz
 package types
 
+import scala.{ Any, AnyVal }
+
 /**
  * Liskov substitutability: A better `<:<`.
  *

--- a/base/shared/src/main/scala/scalaz/types/NotIs.scala
+++ b/base/shared/src/main/scala/scalaz/types/NotIs.scala
@@ -1,6 +1,8 @@
 package scalaz
 package types
 
+import scala.AnyVal
+
 /**
  * The denial inequality is a symmetric irreflexive binary relation with
  * the additional condition that if two elements are apart, then any other

--- a/meta/shared/src/main/scala/scalaz/meta/Ops.scala
+++ b/meta/shared/src/main/scala/scalaz/meta/Ops.scala
@@ -1,6 +1,7 @@
 package scalaz
 package meta
 
+import scala.{ List, StringContext }
 import scala.reflect.macros.blackbox
 
 // Originally inspired by http://typelevel.org/blog/2013/10/13/spires-ops-macros.html

--- a/std/shared/src/main/scala/Either.scala
+++ b/std/shared/src/main/scala/Either.scala
@@ -1,6 +1,8 @@
 package scalaz
 package std
 
+import scala.{ Either, Left, Right }
+
 import core.EqClass
 import ct.{ BifunctorClass, MonadClass }
 import debug.DebugClass

--- a/std/shared/src/main/scala/Option.scala
+++ b/std/shared/src/main/scala/Option.scala
@@ -1,6 +1,8 @@
 package scalaz
 package std
 
+import scala.{ None, Option, Some }
+
 import scalaz.core.EqClass
 import scalaz.debug.DebugClass
 import scalaz.ct.MonadClass

--- a/std/shared/src/main/scala/Tuple.scala
+++ b/std/shared/src/main/scala/Tuple.scala
@@ -1,6 +1,8 @@
 package scalaz
 package std
 
+import scala.{ Tuple1, Tuple2 }
+
 import scalaz.core.EqClass
 
 trait TupleInstances {

--- a/std/shared/src/main/scala/collection/List.scala
+++ b/std/shared/src/main/scala/collection/List.scala
@@ -1,6 +1,10 @@
 package scalaz
 package std
 
+import scala.List
+
+import scala.Predef.$conforms
+
 import scalaz.core.EqClass
 import ct.MonadClass
 

--- a/std/shared/src/main/scala/collection/Set.scala
+++ b/std/shared/src/main/scala/collection/Set.scala
@@ -1,6 +1,8 @@
 package scalaz
 package std
 
+import scala.collection.immutable.Set
+
 import scalaz.core.EqClass
 
 trait SetInstances {

--- a/std/shared/src/main/scala/collection/Vector.scala
+++ b/std/shared/src/main/scala/collection/Vector.scala
@@ -1,6 +1,9 @@
 package scalaz
 package std
 
+import scala.Vector
+import scala.Predef.$conforms
+
 import core.EqClass
 import ct.MonadClass
 


### PR DESCRIPTION
Closed #1821 

- No default imports
- Added primitives and frequently used type aliases/vals into `scalaz._` package object
- There is an `assert` I did not know what to do with
- I hate `scala.Predef.$conforms` 