### PR TITLE
Free Monads

### DIFF
--- a/core/src/main/scala/scalaz/MonadError.scala
+++ b/core/src/main/scala/scalaz/MonadError.scala
@@ -36,6 +36,7 @@ object MonadError {
       override def iso: F <~> G = D
     }
 
+  ////
   /** The Free instruction set for MonadError */
   sealed abstract class Ast[E, A]
   final case class RaiseError[E, A](e: E) extends Ast[E, A]
@@ -55,7 +56,5 @@ object MonadError {
       def raiseError[A](e: E): Free[F, A] = Free.liftF(I.inj(RaiseError[E, A](e)))
       def handleError[A](fa: Free[F, A])(f: E => Free[F, A]): Free[F, A] = Free.liftF(I.inj(HandleError[F, E, A](fa, f)))
     }
-
-  ////
   ////
 }

--- a/core/src/main/scala/scalaz/MonadError.scala
+++ b/core/src/main/scala/scalaz/MonadError.scala
@@ -36,6 +36,26 @@ object MonadError {
       override def iso: F <~> G = D
     }
 
+  /** The Free instruction set for MonadError */
+  sealed abstract class Ast[E, A]
+  final case class RaiseError[E, A](e: E) extends Ast[E, A]
+  final case class HandleError[F[_], E, A](fa: Free[F, A], f: E => Free[F, A]) extends Ast[E, A]
+
+  /** Extensible Effect */
+  def liftF[F[_], E](
+    implicit I: Ast[E, ?] :<: F
+  ): MonadError[Free[F, ?], E] with BindRec[Free[F, ?]] =
+    new MonadError[Free[F, ?], E] with BindRec[Free[F, ?]] {
+      val delegate = Free.freeMonad[F]
+      def point[A](a: =>A): Free[F, A] = delegate.point(a)
+      def bind[A, B](fa: Free[F, A])(f: A => Free[F, B]) = delegate.bind(fa)(f)
+      override def map[A, B](fa: Free[F, A])(f: A => B) = delegate.map(fa)(f)
+      override def tailrecM[A, B](f: A => Free[F, A \/ B])(a: A) = delegate.tailrecM(f)(a)
+
+      def raiseError[A](e: E): Free[F, A] = Free.liftF(I.inj(RaiseError[E, A](e)))
+      def handleError[A](fa: Free[F, A])(f: E => Free[F, A]): Free[F, A] = Free.liftF(I.inj(HandleError[F, E, A](fa, f)))
+    }
+
   ////
   ////
 }

--- a/core/src/main/scala/scalaz/MonadListen.scala
+++ b/core/src/main/scala/scalaz/MonadListen.scala
@@ -11,4 +11,26 @@ trait MonadListen[F[_], W] extends MonadTell[F, W] {
 
 object MonadListen {
   def apply[F[_], W](implicit ML: MonadListen[F, W]) = ML
+
+  /** The Free instruction set for MonadListen */
+  sealed abstract class Ast[S, A]
+  final case class Listen[F[_], S, A](ma: Free[F, A]) extends Ast[S, (A, S)]
+
+  /** Extensible Effect */
+  def liftF[F[_], S](
+    implicit
+      T: MonadTell.Ast[S, ?] :<: F,
+      L: Ast[S, ?] :<: F
+  ): MonadListen[Free[F, ?], S] with BindRec[Free[F, ?]] =
+    new MonadListen[Free[F, ?], S] with BindRec[Free[F, ?]] {
+      val delegate = Free.freeMonad[F]
+      def point[A](a: =>A): Free[F, A] = delegate.point(a)
+      def bind[A, B](fa: Free[F, A])(f: A => Free[F, B]) = delegate.bind(fa)(f)
+      override def map[A, B](fa: Free[F, A])(f: A => B) = delegate.map(fa)(f)
+      override def tailrecM[A, B](f: A => Free[F, A \/ B])(a: A) = delegate.tailrecM(f)(a)
+
+      def writer[A](w: S, v: A): Free[F, A] = Free.liftF(T.inj(MonadTell.Writer[S, A](w, v)))
+
+      def listen[A](ma: Free[F, A]): Free[F, (A, S)] = Free.liftF(L.inj(Listen[F, S, A](ma)))
+    }
 }

--- a/core/src/main/scala/scalaz/MonadPlus.scala
+++ b/core/src/main/scala/scalaz/MonadPlus.scala
@@ -72,13 +72,6 @@ object MonadPlus {
     }
 
   ////
-  import Isomorphism.<~>
-  def fromIso[F[_], G[_]](D: F <~> G)(implicit MP: MonadPlus[G]): MonadPlus[F] =
-    new IsomorphismMonadPlus[F, G] {
-      override implicit def G: MonadPlus[G] = MP
-      override def iso: F <~> G = D
-    }
-
   /** The Free instruction set for MonadPlus */
   sealed abstract class Ast[A]
   final case class Plus[F[_], A](a: Free[F, A], b: () => Free[F, A]) extends Ast[A]

--- a/core/src/main/scala/scalaz/MonadPlus.scala
+++ b/core/src/main/scala/scalaz/MonadPlus.scala
@@ -72,6 +72,32 @@ object MonadPlus {
     }
 
   ////
+  import Isomorphism.<~>
+  def fromIso[F[_], G[_]](D: F <~> G)(implicit MP: MonadPlus[G]): MonadPlus[F] =
+    new IsomorphismMonadPlus[F, G] {
+      override implicit def G: MonadPlus[G] = MP
+      override def iso: F <~> G = D
+    }
+
+  /** The Free instruction set for MonadPlus */
+  sealed abstract class Ast[A]
+  final case class Plus[F[_], A](a: Free[F, A], b: () => Free[F, A]) extends Ast[A]
+  final case class Empty[F[_], A]() extends Ast[A]
+
+  /** Extensible Effect */
+  def liftF[F[_]](
+    implicit I: Ast :<: F
+  ): MonadPlus[Free[F, ?]] with BindRec[Free[F, ?]] =
+    new MonadPlus[Free[F, ?]] with BindRec[Free[F, ?]] {
+      val delegate = Free.freeMonad[F]
+      def point[A](a: =>A): Free[F, A] = delegate.point(a)
+      def bind[A, B](fa: Free[F, A])(f: A => Free[F, B]) = delegate.bind(fa)(f)
+      override def map[A, B](fa: Free[F, A])(f: A => B) = delegate.map(fa)(f)
+      override def tailrecM[A, B](f: A => Free[F, A \/ B])(a: A) = delegate.tailrecM(f)(a)
+
+      def plus[A](a: Free[F, A], b: =>Free[F, A]): Free[F, A] = Free.liftF(I.inj(Plus[F, A](a, () => b)))
+      def empty[A]: Free[F, A] = Free.liftF(I.inj(Empty[F, A]()))
+    }
 
   ////
 }

--- a/core/src/main/scala/scalaz/MonadReader.scala
+++ b/core/src/main/scala/scalaz/MonadReader.scala
@@ -29,6 +29,32 @@ object MonadReader {
     }
 
   ////
+  import Isomorphism.<~>
+  def fromIso[F[_], G[_], S](D: F <~> G)(implicit MR: MonadReader[G, S]): MonadReader[F, S] =
+    new IsomorphismMonadReader[F, G, S] {
+      override implicit def G: MonadReader[G, S] = MR
+      override def iso: F <~> G = D
+    }
+
+  /** The Free instruction set for MonadReader */
+  sealed abstract class Ast[S, A]
+  final case class Ask[S]() extends Ast[S, S]
+  final case class Local[F[_], S, A](f: S => S, fa: Free[F, A]) extends Ast[S, A]
+
+  /** Extensible Effect */
+  def liftF[F[_], S](
+    implicit I: Ast[S, ?] :<: F
+  ): MonadReader[Free[F, ?], S] with BindRec[Free[F, ?]] =
+    new MonadReader[Free[F, ?], S] with BindRec[Free[F, ?]] {
+      val delegate = Free.freeMonad[F]
+      def point[A](a: =>A): Free[F, A] = delegate.point(a)
+      def bind[A, B](fa: Free[F, A])(f: A => Free[F, B]) = delegate.bind(fa)(f)
+      override def map[A, B](fa: Free[F, A])(f: A => B) = delegate.map(fa)(f)
+      override def tailrecM[A, B](f: A => Free[F, A \/ B])(a: A) = delegate.tailrecM(f)(a)
+
+      def ask: Free[F, S] = Free.liftF(I.inj(Ask[S]()))
+      def local[A](f: S => S)(fa: Free[F, A]): Free[F, A] = Free.liftF(I.inj(Local[F, S, A](f, fa)))
+    }
 
   ////
 }

--- a/core/src/main/scala/scalaz/MonadReader.scala
+++ b/core/src/main/scala/scalaz/MonadReader.scala
@@ -29,13 +29,6 @@ object MonadReader {
     }
 
   ////
-  import Isomorphism.<~>
-  def fromIso[F[_], G[_], S](D: F <~> G)(implicit MR: MonadReader[G, S]): MonadReader[F, S] =
-    new IsomorphismMonadReader[F, G, S] {
-      override implicit def G: MonadReader[G, S] = MR
-      override def iso: F <~> G = D
-    }
-
   /** The Free instruction set for MonadReader */
   sealed abstract class Ast[S, A]
   final case class Ask[S]() extends Ast[S, S]

--- a/core/src/main/scala/scalaz/MonadState.scala
+++ b/core/src/main/scala/scalaz/MonadState.scala
@@ -33,6 +33,23 @@ object MonadState {
     }
 
   ////
+  sealed abstract class Ast[S, A]
+  final case class Get[S]()     extends Ast[S, S]
+  final case class Put[S](s: S) extends Ast[S, Unit]
 
+  def liftF[F[_], S](
+    implicit I: Ast[S, ?] :<: F
+  ): MonadState[Free[F, ?], S] with BindRec[Free[F, ?]] =
+    new MonadState[Free[F, ?], S] with BindRec[Free[F, ?]] {
+      val delegate = Free.freeMonad[F]
+      def point[A](a: =>A): Free[F, A] = delegate.point(a)
+      def bind[A, B](fa: Free[F, A])(f: A => Free[F, B]) = delegate.bind(fa)(f)
+      override def map[A, B](fa: Free[F, A])(f: A => B) = delegate.map(fa)(f)
+      override def tailrecM[A, B](f: A => Free[F, A \/ B])(a: A) = delegate.tailrecM(f)(a)
+
+      def init: Free[F, S] = get
+      def get: Free[F, S] = Free.liftF(I.inj(Get[S]()))
+      def put(s: S): Free[F, Unit] = Free.liftF(I.inj(Put[S](s)))
+    }
   ////
 }

--- a/core/src/main/scala/scalaz/MonadState.scala
+++ b/core/src/main/scala/scalaz/MonadState.scala
@@ -33,13 +33,6 @@ object MonadState {
     }
 
   ////
-  import Isomorphism.<~>
-  def fromIso[F[_], G[_], S](I: F <~> G)(implicit M: MonadState[G, S]): MonadState[F, S] =
-    new IsomorphismMonadState[F, G, S] {
-      override implicit def G: MonadState[G, S] = M
-      override def iso: F <~> G = I
-    }
-
   /** The Free instruction set for MonadState */
   sealed abstract class Ast[S, A]
   final case class Get[S]()     extends Ast[S, S]

--- a/core/src/main/scala/scalaz/MonadState.scala
+++ b/core/src/main/scala/scalaz/MonadState.scala
@@ -33,10 +33,19 @@ object MonadState {
     }
 
   ////
+  import Isomorphism.<~>
+  def fromIso[F[_], G[_], S](I: F <~> G)(implicit M: MonadState[G, S]): MonadState[F, S] =
+    new IsomorphismMonadState[F, G, S] {
+      override implicit def G: MonadState[G, S] = M
+      override def iso: F <~> G = I
+    }
+
+  /** The Free instruction set for MonadState */
   sealed abstract class Ast[S, A]
   final case class Get[S]()     extends Ast[S, S]
   final case class Put[S](s: S) extends Ast[S, Unit]
 
+  /** Extensible Effect */
   def liftF[F[_], S](
     implicit I: Ast[S, ?] :<: F
   ): MonadState[Free[F, ?], S] with BindRec[Free[F, ?]] =

--- a/core/src/main/scala/scalaz/MonadTell.scala
+++ b/core/src/main/scala/scalaz/MonadTell.scala
@@ -27,13 +27,6 @@ object MonadTell {
     }
 
   ////
-  import Isomorphism.<~>
-  def fromIso[F[_], G[_], S](I: F <~> G)(implicit M: MonadTell[G, S]): MonadTell[F, S] =
-    new IsomorphismMonadTell[F, G, S] {
-      override implicit def G: MonadTell[G, S] = M
-      override def iso: F <~> G = I
-    }
-
   /** The Free instruction set for MonadTell */
   sealed abstract class Ast[S, A]
   final case class Writer[S, A](s: S, a: A) extends Ast[S, A]

--- a/example/src/main/scala/scalaz/example/FreeMonadsUsage.scala
+++ b/example/src/main/scala/scalaz/example/FreeMonadsUsage.scala
@@ -1,0 +1,134 @@
+package scalaz.example
+
+import scalaz._, Scalaz._
+
+// example of using the Monad extensions in a Free program.
+// For an example of Free on its own, see FreeUsage.
+object FreeMonadsUsage {
+
+  // a test algebra...
+  trait Console[F[_]] {
+    def read: F[String]
+    def write(s: String): F[Unit]
+  }
+  object Console {
+    // with a data type instruction set
+    sealed abstract class Ast[A]
+    final case class Read() extends Ast[String]
+    final case class Write(s: String) extends Ast[Unit]
+
+    // and an implementation of the trait for any Free algebra
+    def liftF[F[_]](implicit I: Ast :<: F): Console[Free[F, ?]] =
+      new Console[Free[F, ?]] {
+        def read: Free[F, String] = Free.liftF(I.inj(Read()))
+        def write(s: String): Free[F, Unit] = Free.liftF(I.inj(Write(s)))
+      }
+  }
+
+  // "business logic" that uses the MTL typeclasses. The utility of what these
+  // methods are doing is irrelevant, the only important thing is that it uses
+  // methods from both the specialised Monad and the Console algebra.
+  def withState[F[_]](C: Console[F])(implicit F: MonadState[F, String]): F[String] =
+    for {
+      was <- F.get
+      in  <- C.read
+      update = was + in
+      _   <- F.put(update)
+    } yield update
+
+  def withError[F[_]](C: Console[F])(implicit F: MonadError[F, String]): F[Int] =
+    for {
+      in <- C.read
+      parsed = in.parseInt
+      i <- parsed.fold(_ => F.raiseError(s"bad input '$in'"), F.pure(_))
+    } yield i
+
+  def withReader[F[_]](C: Console[F])(implicit F: MonadReader[F, String]): F[String] =
+    for {
+      in <- C.read
+      path <- F.local(p => s"$p/$in")(F.ask)
+    } yield path
+
+  def withPlus[F[_]](C: Console[F])(implicit F: MonadPlus[F]): F[Int] =
+    for {
+     in <- C.read
+     parsed = in.parseInt
+     i <- parsed.fold(_ => F.empty, F.pure(_))
+   } yield i
+
+  def withWriter[F[_]](C: Console[F])(implicit F: MonadListen[F, String]): F[String] =
+   for {
+     in <- C.read
+     _ <- F.tell(in)
+     out <- F.listen(F.pure(()))
+   } yield out._2
+
+  // now show that each can be converted into a Free program. Implementing the
+  // interpreters is left as an exercise to the reader. Unfortunately there is a
+  // lot of boilerplate here because implicit search tends to fail without the
+  // SI-2712 fix.
+
+  def freeState = {
+    type StateAst[a] = MonadState.Ast[String, a]
+    type Ast[a] = Coproduct[StateAst, Console.Ast, a]
+
+    // scala implicit search fail... needs a helping hand without SI-2712
+    implicit val injecter: StateAst :<: Ast = Inject.leftInjectInstance
+
+    type F[a] = Free[Ast, a]
+    // these generators are not implicit by default for compile perf
+    implicit val monad: MonadState[F, String] = MonadState.liftF
+
+    withState[F](Console.liftF)
+  }
+
+  def freeError = {
+    type ErrorAst[a] = MonadError.Ast[String, a]
+    type Ast[a] = Coproduct[ErrorAst, Console.Ast, a]
+    implicit val injecter: ErrorAst :<: Ast = Inject.leftInjectInstance
+
+    type F[a] = Free[Ast, a]
+    implicit val monad: MonadError[F, String] = MonadError.liftF
+
+    withError[F](Console.liftF)
+  }
+
+  def freeReader = {
+    type ReaderAst[a] = MonadReader.Ast[String, a]
+    type Ast[a] = Coproduct[ReaderAst, Console.Ast, a]
+    implicit val injecter: ReaderAst :<: Ast = Inject.leftInjectInstance
+
+    type F[a] = Free[Ast, a]
+    implicit val monad: MonadReader[F, String] = MonadReader.liftF
+
+    withReader[F](Console.liftF)
+  }
+
+  def freePlus = {
+    type Ast[a] = Coproduct[MonadPlus.Ast, Console.Ast, a]
+    implicit val injecter: MonadPlus.Ast :<: Ast = Inject.leftInjectInstance
+
+    type F[a] = Free[Ast, a]
+    implicit val monad: MonadPlus[F] = MonadPlus.liftF
+
+    withPlus[F](Console.liftF)
+  }
+
+  def freeWriter = {
+    type TellAst[a] = MonadTell.Ast[String, a]
+    type PartialAst[a] = Coproduct[TellAst, Console.Ast, a]
+    type ListenAst[a] = MonadListen.Ast[String, a]
+    type Ast[a] = Coproduct[ListenAst, PartialAst, a]
+
+    // omg SI-2712...
+    implicit val injector0: Console.Ast :<: PartialAst = Inject.rightInjectInstance
+    implicit val injecter1: ListenAst :<: Ast = Inject.leftInjectInstance
+    implicit val injecter2: TellAst :<: Ast = Inject.rightInjectInstance
+
+    type F[a] = Free[Ast, a]
+    implicit val monadL: MonadListen[F, String] = MonadListen.liftF
+
+    withWriter[F](Console.liftF)
+  }
+
+}

--- a/tests/src/test/scala/scalaz/FreeTest.scala
+++ b/tests/src/test/scala/scalaz/FreeTest.scala
@@ -166,32 +166,6 @@ object FreeTest extends SpecLite {
     a != b
   }
 
-  "Free effects" should {
-    "exist for MonadState" in {
-      fail
-    }
-
-    "exist for MonadError" in {
-      fail
-    }
-
-    "exist for MonadReader" in {
-      fail
-    }
-
-    "exist for MonadPlus" in {
-      fail
-    }
-
-    "exist for MonadTell" in {
-      fail
-    }
-
-    "exist for MonadListen" in {
-      fail
-    }
-  }
-
   object instances {
     def bindRec[F[_]] = BindRec[Free[F, ?]]
     def monad[F[_]] = Monad[Free[F, ?]]

--- a/tests/src/test/scala/scalaz/FreeTest.scala
+++ b/tests/src/test/scala/scalaz/FreeTest.scala
@@ -166,6 +166,32 @@ object FreeTest extends SpecLite {
     a != b
   }
 
+  "Free effects" should {
+    "exist for MonadState" in {
+      fail
+    }
+
+    "exist for MonadError" in {
+      fail
+    }
+
+    "exist for MonadReader" in {
+      fail
+    }
+
+    "exist for MonadPlus" in {
+      fail
+    }
+
+    "exist for MonadTell" in {
+      fail
+    }
+
+    "exist for MonadListen" in {
+      fail
+    }
+  }
+
   object instances {
     def bindRec[F[_]] = BindRec[Free[F, ?]]
     def monad[F[_]] = Monad[Free[F, ?]]


### PR DESCRIPTION
Unless I am misunderstanding something, this seems to give us something like `Eff` out of the box for our MTL typeclasses.

It should be fairly easy to add something similar to `MonadError` and friends.

Thoughts?

If this is of interest, I could add some unit tests... I'm hoping people who review understand the concept, e.g. @edmundnoble 

Should these be `implicit`? They are creating coherent typeclasses, so could be. I'm willing to bet that it confuses the compiler more than helps.