### PR TITLE
Specialized EqClass/EqAnyRef

### DIFF
--- a/base/shared/src/main/scala/scalaz/algebra/ord.scala
+++ b/base/shared/src/main/scala/scalaz/algebra/ord.scala
@@ -3,9 +3,9 @@ package algebra
 
 import scala.language.experimental.macros
 
-import scala.{ Product, Serializable }
+import scala.{ AnyRef, Product, Serializable }
 
-import core.EqClass
+import core.{ EqAnyRef, EqClass }
 
 sealed abstract class Ordering extends Product with Serializable
 final case object LT           extends Ordering
@@ -15,11 +15,15 @@ final case object EQ           extends Ordering
 trait OrdClass[A] extends EqClass[A] {
   def comp(a: A, b: A): Ordering
 
-  def <(a: A, b: A): Boolean  = comp(a, b) eq LT
-  def <=(a: A, b: A): Boolean = comp(a, b) ne GT
-  def >(a: A, b: A): Boolean  = comp(a, b) eq GT
-  def >=(a: A, b: A): Boolean = comp(a, b) ne LT
-  def equal(a: A, b: A)       = comp(a, b) eq EQ
+  def <(a: A, b: A): Boolean     = comp(a, b) eq LT
+  def <=(a: A, b: A): Boolean    = comp(a, b) ne GT
+  def >(a: A, b: A): Boolean     = comp(a, b) eq GT
+  def >=(a: A, b: A): Boolean    = comp(a, b) ne LT
+  override def equal(a: A, b: A) = comp(a, b) eq EQ
+}
+
+trait OrdAnyRef[A <: AnyRef] extends OrdClass[A] with EqAnyRef[A] {
+  def valueEqual(a: A, b: A): Boolean = (comp(a, b) eq EQ)
 }
 
 trait OrdSyntax {

--- a/base/shared/src/main/scala/scalaz/core/eq.scala
+++ b/base/shared/src/main/scala/scalaz/core/eq.scala
@@ -1,14 +1,16 @@
 package scalaz
 package core
 
+import scala.AnyRef
 import scala.language.experimental.macros
 
 trait EqClass[A] {
   def equal(first: A, second: A): Boolean
 }
 
-trait EqInstances {
-  implicit final val voidEq: Eq[Void] = instanceOf[EqClass[Void]]((a, b) => a.absurd)
+trait EqAnyRef[A <: AnyRef] extends EqClass[A] {
+  final override def equal(first: A, second: A): Boolean = (first eq second) || valueEqual(first, second)
+  def valueEqual(first: A, second: A): Boolean
 }
 
 trait EqSyntax {

--- a/base/shared/src/main/scala/scalaz/core/void.scala
+++ b/base/shared/src/main/scala/scalaz/core/void.scala
@@ -44,7 +44,10 @@ trait VoidInstances {
     instanceOf(new SemigroupClass[Void] {
       override def mappend(a1: Void, a2: => Void): Void = a1
     })
+
   implicit val voidDebug: Debug[Void] = DebugClass.instance[Void](Void.absurd)
+
+  implicit final val voidEq: Eq[Void] = instanceOf[EqClass[Void]]((a, b) => a.absurd)
 }
 
 @silent

--- a/base/shared/src/main/scala/scalaz/data/disjunction.scala
+++ b/base/shared/src/main/scala/scalaz/data/disjunction.scala
@@ -3,9 +3,9 @@ package data
 
 import scala.{ inline, Either }
 
-import core.EqClass
-import ct._
-import debug.DebugClass
+import scalaz.core.EqAnyRef
+import scalaz.ct._
+import scalaz.debug.DebugClass
 
 sealed trait Disjunction[L, R] {
   final def fold[A](la: L => A, ra: R => A): A = this match {
@@ -71,11 +71,11 @@ trait DisjunctionInstances {
     })
 
   implicit def disjunctionEq[A, B](implicit A: Eq[A], B: Eq[B]): Eq[A \/ B] =
-    instanceOf[EqClass[A \/ B]] {
+    instanceOf({
       case (-\/(a1), -\/(a2)) => A.equal(a1, a2)
       case (\/-(b1), \/-(b2)) => B.equal(b1, b2)
       case _                  => false
-    }
+    }: EqAnyRef[A \/ B])
 }
 
 trait DisjunctionSyntax {

--- a/base/shared/src/main/scala/scalaz/data/ilist.scala
+++ b/base/shared/src/main/scala/scalaz/data/ilist.scala
@@ -1,12 +1,13 @@
 package scalaz
 package data
 
+import scala.annotation.tailrec
+import scala.AnyRef
+import scala.PartialFunction.{ cond, condOpt }
+
 import core.EqClass
 import debug.DebugClass
 import types.IsCovariantClass
-
-import scala.annotation.tailrec
-import scala.PartialFunction.{ cond, condOpt }
 
 trait IListModule {
   type IList[A]
@@ -49,7 +50,7 @@ trait IListInstances {
           case _ => false
         }
 
-      go(a1, a2)
+      (a1.asInstanceOf[AnyRef] eq a2.asInstanceOf[AnyRef]) || go(a1, a2)
     }
 
   implicit final def ilistDebug[A](implicit A: Debug[A]): Debug[IList[A]] =

--- a/base/shared/src/main/scala/scalaz/data/maybe.scala
+++ b/base/shared/src/main/scala/scalaz/data/maybe.scala
@@ -3,9 +3,9 @@ package data
 
 import scala.{ List, None, Option, Some }
 
-import scalaz.core.EqClass
-import scalaz.ct._
-import scalaz.debug.DebugClass
+import core.EqAnyRef
+import ct._
+import debug.DebugClass
 
 sealed trait MaybeModule {
   type Maybe[A]
@@ -66,11 +66,13 @@ private[scalaz] object MaybeImpl extends MaybeModule {
     }
   }
 
-  def eq[A](implicit A: Eq[A]): Eq[Maybe[A]] = instanceOf[EqClass[Maybe[A]]] {
-    case (Some(a), Some(b)) => A.equal(a, b)
-    case (None, None)       => true
-    case _                  => false
-  }
+  def eq[A](implicit A: Eq[A]): Eq[Maybe[A]] =
+    instanceOf({
+      case (Some(a), Some(b)) => A.equal(a, b)
+      case (None, None)       => true
+      case _                  => false
+
+    }: EqAnyRef[Maybe[A]])
 
   private val instance =
     new MonadClass[Maybe] with BindClass.DeriveFlatten[Maybe] with TraversableClass[Maybe]

--- a/base/shared/src/main/scala/scalaz/data/maybe2.scala
+++ b/base/shared/src/main/scala/scalaz/data/maybe2.scala
@@ -3,9 +3,9 @@ package data
 
 import scala.{ sys, AnyVal, Nothing }
 
-import scalaz.core.EqClass
-import scalaz.ct.BifunctorClass
-import scalaz.debug.DebugClass
+import ct.BifunctorClass
+import core.EqAnyRef
+import debug.DebugClass
 
 sealed trait Maybe2Module {
 
@@ -60,11 +60,11 @@ private[data] object Maybe2Impl extends Maybe2Module {
   }
 
   implicit def eq[A, B](implicit A: Eq[A], B: Eq[B]): Eq[Maybe2[A, B]] =
-    instanceOf[EqClass[Maybe2[A, B]]] {
+    instanceOf({
       case (Some2(a1, b1), Some2(a2, b2)) => A.equal(a1, a2) && B.equal(b1, b2)
       case (None2, None2)                 => true
       case _                              => false
-    }
+    }: EqAnyRef[Maybe2[A, B]])
 
   implicit def bifunctor: scalaz.Bifunctor[Maybe2] =
     instanceOf(new BifunctorClass[Maybe2] with BifunctorClass.DeriveLmapRmap[Maybe2] {

--- a/base/shared/src/main/scala/scalaz/data/these.scala
+++ b/base/shared/src/main/scala/scalaz/data/these.scala
@@ -1,10 +1,8 @@
 package scalaz
 package data
 
-import scala.inline
-
 import algebra.SemigroupClass
-import core.EqClass
+import core.EqAnyRef
 import ct._
 import debug.DebugClass
 
@@ -198,10 +196,10 @@ trait TheseInstances {
   }
 
   implicit final def theseEq[L, R](implicit L: Eq[L], R: Eq[R]): Eq[These[L, R]] =
-    instanceOf[EqClass[These[L, R]]] {
+    instanceOf({
       case (This(l1), This(l2))         => L.equal(l1, l2)
       case (That(r1), That(r2))         => R.equal(r1, r2)
       case (Both(l1, r1), Both(l2, r2)) => L.equal(l1, l2) && R.equal(r1, r2)
       case _                            => false
-    }
+    }: EqAnyRef[These[L, R]])
 }

--- a/base/shared/src/main/scala/scalaz/package.scala
+++ b/base/shared/src/main/scala/scalaz/package.scala
@@ -21,6 +21,11 @@ package object scalaz
   // don't export this, but scala needs `StringContext` to be in scope with this name
   private[scalaz] val StringContext = scala.StringContext
 
+  type <:<[-A, +B] = scala.Predef.<:<[A, B]
+  type =:=[A, B]   = scala.Predef.=:=[A, B]
+
+  type inline = scala.inline
+
   // Functions
   @scala.inline
   def identity[T](t: T): T = t

--- a/base/shared/src/main/scala/scalaz/prelude.scala
+++ b/base/shared/src/main/scala/scalaz/prelude.scala
@@ -1,7 +1,5 @@
 package scalaz
 
-import scala.inline
-
 import algebra._
 import core._
 import ct._
@@ -178,7 +176,6 @@ trait AllInstances
     with ct.StrongInstances
     with ct.TraversableInstances
     with debug.DebugInstances
-    with core.EqInstances
     with types.AsInstances
     with types.IsContravariantInstances
     with types.IsCovariantInstances

--- a/base/shared/src/main/scala/scalaz/std/boolean.scala
+++ b/base/shared/src/main/scala/scalaz/std/boolean.scala
@@ -6,13 +6,11 @@ import utils._
 
 trait BooleanInstances {
   implicit val booleanDebug: Debug[Boolean] = toStringDebug[Boolean]
-  implicit val booleanEq: Eq[Boolean]       = universalEq[Boolean]
+  implicit val booleanEq: Eq[Boolean]       = universalEqAnyVal[Boolean]
 
-  implicit val booleanOrd: Ord[Boolean] = instanceOf(new OrdClass[Boolean] {
-    def comp(a: Boolean, b: Boolean) = (a, b) match {
-      case (true, false) => GT
-      case (false, true) => LT
-      case _             => EQ
-    }
-  })
+  implicit val booleanOrd: Ord[Boolean] = instanceOf({
+    case (true, false) => GT
+    case (false, true) => LT
+    case _             => EQ
+  }: OrdClass[Boolean])
 }

--- a/base/shared/src/main/scala/scalaz/std/byte.scala
+++ b/base/shared/src/main/scala/scalaz/std/byte.scala
@@ -6,13 +6,15 @@ import utils._
 
 trait ByteInstances {
   implicit val byteDebug: Debug[Byte] = toStringDebug[Byte]
-  implicit val byteEq: Eq[Byte]       = universalEq[Byte]
+  implicit val byteEq: Eq[Byte]       = universalEqAnyVal[Byte]
 
-  implicit val byteOrd: Ord[Byte] = instanceOf(new OrdClass[Byte] {
-    def comp(a: Byte, b: Byte) = java.lang.Byte.compare(a, b) match {
-      case 0          => EQ
-      case x if x < 0 => LT
-      case _          => GT
-    }
-  })
+  implicit val byteOrd: Ord[Byte] = instanceOf(
+    ((a: Byte,
+      b: Byte) =>
+       java.lang.Byte.compare(a, b) match {
+         case 0          => EQ
+         case x if x < 0 => LT
+         case _          => GT
+       }): OrdClass[Byte]
+  )
 }

--- a/base/shared/src/main/scala/scalaz/std/double.scala
+++ b/base/shared/src/main/scala/scalaz/std/double.scala
@@ -13,19 +13,15 @@ trait DoubleInstances {
 
   implicit val doubleDebug: Debug[Double] = toStringDebug[Double]
   implicit val doubleEq: Eq[Double] =
-    instanceOf(new EqClass[Double] {
-      def equal(a: Double, b: Double) = (a, b) match {
-        case (NegZero, PosZero) => true
-        case (PosZero, NegZero) => true
-        case (x, y)             => doubleToRawLongBits(x) == doubleToRawLongBits(y)
-      }
-    })
+    instanceOf({
+      case (NegZero, PosZero) => true
+      case (PosZero, NegZero) => true
+      case (x, y)             => doubleToRawLongBits(x) == doubleToRawLongBits(y)
+    }: EqClass[Double])
 
-  implicit val doubleOrd: Ord[Double] = instanceOf(new OrdClass[Double] {
-    def comp(a: Double, b: Double): Ordering = (a, b) match {
-      case (a, b) if doubleEq.equal(a, b)                            => EQ
-      case (a, b) if doubleToRawLongBits(a) < doubleToRawLongBits(b) => LT
-      case _                                                         => GT
-    }
-  })
+  implicit val doubleOrd: Ord[Double] = instanceOf({
+    case (a, b) if doubleEq.equal(a, b)                            => EQ
+    case (a, b) if doubleToRawLongBits(a) < doubleToRawLongBits(b) => LT
+    case _                                                         => GT
+  }: OrdClass[Double])
 }

--- a/base/shared/src/main/scala/scalaz/std/float.scala
+++ b/base/shared/src/main/scala/scalaz/std/float.scala
@@ -7,5 +7,7 @@ import utils._
 
 trait FloatInstances {
   implicit val floatDebug: Debug[Float] = toStringDebug[Float]
-  implicit val floatEq: Eq[Float]       = instanceOf[EqClass[Float]]((a, b) => floatToRawIntBits(a) == floatToRawIntBits(b))
+  implicit val floatEq: Eq[Float] = instanceOf(
+    ((first, second) => floatToRawIntBits(first) == floatToRawIntBits(second)): EqClass[Float]
+  )
 }

--- a/base/shared/src/main/scala/scalaz/std/int.scala
+++ b/base/shared/src/main/scala/scalaz/std/int.scala
@@ -6,13 +6,15 @@ import utils._
 
 trait IntInstances {
   implicit val intDebug: Debug[Int] = toStringDebug[Int]
-  implicit val intEq: Eq[Int]       = universalEq[Int]
+  implicit val intEq: Eq[Int]       = universalEqAnyVal[Int]
 
-  implicit val intOrd: Ord[Int] = instanceOf(new OrdClass[Int] {
-    def comp(a: Int, b: Int) = java.lang.Integer.compare(a, b) match {
-      case 0          => EQ
-      case x if x < 0 => LT
-      case _          => GT
-    }
-  })
+  implicit val intOrd: Ord[Int] = instanceOf(
+    ((a: Int,
+      b: Int) =>
+       java.lang.Integer.compare(a, b) match {
+         case 0          => EQ
+         case x if x < 0 => LT
+         case _          => GT
+       }): OrdClass[Int]
+  )
 }

--- a/base/shared/src/main/scala/scalaz/std/long.scala
+++ b/base/shared/src/main/scala/scalaz/std/long.scala
@@ -6,13 +6,15 @@ import utils._
 
 trait LongInstances {
   implicit val longDebug: Debug[Long] = toStringDebug[Long]
-  implicit val longEq: Eq[Long]       = universalEq[Long]
+  implicit val longEq: Eq[Long]       = universalEqAnyVal[Long]
 
-  implicit val longOrd: Ord[Long] = instanceOf(new OrdClass[Long] {
-    def comp(a: Long, b: Long) = java.lang.Long.compare(a, b) match {
-      case 0          => EQ
-      case x if x < 0 => LT
-      case _          => GT
-    }
-  })
+  implicit val longOrd: Ord[Long] = instanceOf(
+    ((a: Long,
+      b: Long) =>
+       java.lang.Long.compare(a, b) match {
+         case 0          => EQ
+         case x if x < 0 => LT
+         case _          => GT
+       }): OrdClass[Long]
+  )
 }

--- a/base/shared/src/main/scala/scalaz/std/short.scala
+++ b/base/shared/src/main/scala/scalaz/std/short.scala
@@ -5,5 +5,5 @@ import utils._
 
 trait ShortInstances {
   implicit val shortDebug: Debug[Short] = toStringDebug[Short]
-  implicit val shortEq: Eq[Short]       = universalEq[Short]
+  implicit val shortEq: Eq[Short]       = universalEqAnyVal[Short]
 }

--- a/base/shared/src/main/scala/scalaz/std/string.scala
+++ b/base/shared/src/main/scala/scalaz/std/string.scala
@@ -5,5 +5,5 @@ import utils._
 
 trait StringInstances {
   implicit val stringDebug: Debug[String] = toStringDebug[String]
-  implicit val stringEq: Eq[String]       = universalEq[String]
+  implicit val stringEq: Eq[String]       = universalEqAnyRef[String]
 }

--- a/base/shared/src/main/scala/scalaz/std/utils.scala
+++ b/base/shared/src/main/scala/scalaz/std/utils.scala
@@ -1,12 +1,17 @@
 package scalaz
 package std
 
-import core.EqClass
+import scala.{ AnyRef, AnyVal }
+
+import core.{ EqAnyRef, EqClass }
 import data.Cord
 import debug.DebugClass
 
 private[std] object utils {
-  def singletonEq[A]: Eq[A]      = instanceOf[EqClass[A]]((a, b) => true)
-  def universalEq[A]: Eq[A]      = instanceOf[EqClass[A]]((a, b) => a == b)
+  def singletonEq[A]: Eq[A] = instanceOf(((a: A, b: A) => true): EqClass[A])
+
+  def universalEqAnyRef[A <: AnyRef]: Eq[A] = instanceOf(((a: A, b: A) => a == b): EqAnyRef[A])
+  def universalEqAnyVal[A <: AnyVal]: Eq[A] = instanceOf(((a, b) => a == b): EqClass[A])
+
   def toStringDebug[A]: Debug[A] = DebugClass.instance[A](a => Cord(a.toString))
 }

--- a/example/src/main/tut/core/Eq.md
+++ b/example/src/main/tut/core/Eq.md
@@ -28,12 +28,19 @@ These laws entail symmetry and transitivity, which should be easier to test, sin
 ## Instance declaration
 
 ```tut
-import scalaz._, Prelude._, core.EqClass
+import scalaz._, Prelude._, core.{ EqAnyRef, EqClass }
 
 implicit final def optionEq[A](implicit A: Eq[A]): Eq[Option[A]] =
-  instanceOf[EqClass[Option[A]]] {
+  instanceOf(new EqAnyRef[Option[A]] {
+    def valueEqual(first: Option[A], second: Option[A]) = (first, second) match {
     case (None, None)         => true
     case (Some(a1), Some(a2)) => A.equal(a1, a2)
     case _                    => false
-  }
+  }}: EqClass[Option[A]])
 ```
+
+### EqClass vs EqAnyRef
+
+Scalaz contains two possible traits to extend when declaring an `Eq` instance: `EqClass` and `EqAnyRef`.
+`EqAnyRef` is a specialization of `EqClass` that will always run a reference check before handing control to the user-supplied equality logic.
+`EqAnyRef` should be preferred in most cases except for `AnyVal` subtypes. In those cases, the `@specialized` annotation can be used to avoid boxing.

--- a/std/shared/src/main/scala/collection/list.scala
+++ b/std/shared/src/main/scala/collection/list.scala
@@ -5,8 +5,8 @@ import scala.{ ::, List, Nil }
 
 import scala.Predef.$conforms
 
-import core.EqClass
 import ct.MonadClass
+import core.EqAnyRef
 import data.Cord
 import debug.DebugClass
 
@@ -19,10 +19,9 @@ trait ListInstances {
     override def flatten[A](ma: List[List[A]]): List[A]               = ma.flatten
   })
 
-  implicit def listEq[A: Eq]: Eq[List[A]] =
-    instanceOf(new EqClass[List[A]] {
-      def equal(first: List[A], second: List[A]): Boolean = (first.corresponds(second)(Eq[A].equal))
-    })
+  implicit def listEq[A: Eq]: Eq[List[A]] = instanceOf(((a, b) => (a corresponds b)(Eq[A].equal)): EqAnyRef[List[A]])
+
+  //instanceOf((first, second) => (first.corresponds(second)(Eq[A].equal)): EqAnyRef[List[A]])
 
   implicit def listDebug[A: Debug]: Debug[List[A]] =
     DebugClass.instance(as => {

--- a/std/shared/src/main/scala/collection/set.scala
+++ b/std/shared/src/main/scala/collection/set.scala
@@ -3,11 +3,9 @@ package std
 
 import scala.collection.immutable.Set
 
-import scalaz.core.EqClass
+import core.EqAnyRef
 
 trait SetInstances {
   implicit def setEq[A: Eq]: Eq[Set[A]] =
-    instanceOf(new EqClass[Set[A]] {
-      def equal(first: Set[A], second: Set[A]): Boolean = (first.toStream.corresponds(second.toStream)(Eq[A].equal))
-    })
+    instanceOf(((a, b) => (a.toStream corresponds b.toStream)(Eq[A].equal)): EqAnyRef[Set[A]])
 }

--- a/std/shared/src/main/scala/collection/vector.scala
+++ b/std/shared/src/main/scala/collection/vector.scala
@@ -4,7 +4,7 @@ package std
 import scala.Vector
 import scala.Predef.$conforms
 
-import core.EqClass
+import core.EqAnyRef
 import ct.MonadClass
 
 trait VectorInstances {
@@ -17,9 +17,7 @@ trait VectorInstances {
   })
 
   implicit def vectorEq[A: Eq]: Eq[Vector[A]] =
-    instanceOf(new EqClass[Vector[A]] {
-      def equal(first: Vector[A], second: Vector[A]): Boolean = (first.corresponds(second)(Eq[A].equal))
-    })
+    instanceOf(((a, b) => (a corresponds b)(Eq[A].equal)): EqAnyRef[Vector[A]])
 
   /* https://github.com/scalaz/scalaz/pull/1633
   implicit def vectorDebug[A: Debug]: Debug[Vector[A]] = instanceOf(new DebugClass[Vector[A]] {

--- a/std/shared/src/main/scala/either.scala
+++ b/std/shared/src/main/scala/either.scala
@@ -3,7 +3,7 @@ package std
 
 import scala.{ Either, Left, Right }
 
-import core.EqClass
+import core.EqAnyRef
 import ct.{ BifunctorClass, MonadClass }
 import debug.DebugClass
 
@@ -33,13 +33,11 @@ trait EitherInstances {
   })
 
   implicit def eitherEq[L, R](implicit X: Eq[L], Y: Eq[R]): Eq[Either[L, R]] =
-    instanceOf(new EqClass[Either[L, R]] {
-      def equal(first: Either[L, R], second: Either[L, R]): Boolean = (first, second) match {
-        case (Left(x), Left(y))   => X.equal(x, y)
-        case (Right(x), Right(y)) => Y.equal(x, y)
-        case _                    => false
-      }
-    })
+    instanceOf({
+      case (Left(x), Left(y))   => X.equal(x, y)
+      case (Right(x), Right(y)) => Y.equal(x, y)
+      case _                    => false
+    }: EqAnyRef[Either[L, R]])
 
   implicit def eitherDebug[L, R](implicit L: Debug[L], R: Debug[R]): Debug[Either[L, R]] = {
     import Scalaz.debugInterpolator

--- a/std/shared/src/main/scala/option.scala
+++ b/std/shared/src/main/scala/option.scala
@@ -3,10 +3,10 @@ package std
 
 import scala.{ None, Option, Some }
 
-import core.EqClass
+import ct.MonadClass
+import core.EqAnyRef
 import data.Cord
 import debug.DebugClass
-import ct.MonadClass
 
 trait OptionInstances {
   implicit val optionMonad: Monad[Option] =
@@ -19,13 +19,11 @@ trait OptionInstances {
     })
 
   implicit def optionEq[A](implicit X: Eq[A]): Eq[Option[A]] =
-    instanceOf(new EqClass[Option[A]] {
-      def equal(first: Option[A], second: Option[A]): Boolean = (first, second) match {
-        case (None, None)       => true
-        case (Some(a), Some(b)) => X.equal(a, b)
-        case _                  => false
-      }
-    })
+    instanceOf({
+      case (None, None)       => true
+      case (Some(a), Some(b)) => X.equal(a, b)
+      case _                  => false
+    }: EqAnyRef[Option[A]])
 
   implicit def optionDebug[A](implicit X: Debug[A]): Debug[Option[A]] = {
     import Scalaz.debugInterpolator

--- a/std/shared/src/main/scala/tuple.scala
+++ b/std/shared/src/main/scala/tuple.scala
@@ -3,32 +3,32 @@ package std
 
 import scala.{ Tuple1, Tuple2 }
 
-import scalaz.core.EqClass
+import scalaz.core.EqAnyRef
 
 trait TupleInstances {
   implicit final def tuple1Eq[A](implicit A: Eq[A]): Eq[Tuple1[A]] =
-    instanceOf[EqClass[Tuple1[A]]] {
+    instanceOf({
       case (Tuple1(a1), Tuple1(a2)) => A.equal(a1, a2)
       case _                        => false
-    }
+    }: EqAnyRef[Tuple1[A]])
 
   implicit final def tuple2Eq[A, B](implicit A: Eq[A], B: Eq[B]): Eq[Tuple2[A, B]] =
-    instanceOf[EqClass[Tuple2[A, B]]] {
+    instanceOf({
       case ((a1, b1), (a2, b2)) => A.equal(a1, a2) && B.equal(b1, b2)
       case _                    => false
-    }
+    }: EqAnyRef[Tuple2[A, B]])
 
   implicit final def tuple3Eq[A, B, C](implicit A: Eq[A], B: Eq[B], C: Eq[C]): Eq[(A, B, C)] =
-    instanceOf[EqClass[(A, B, C)]] {
+    instanceOf({
       case ((a1, b1, c1), (a2, b2, c2)) =>
         A.equal(a1, a2) && B.equal(b1, b2) && C.equal(c1, c2)
       case _ => false
-    }
+    }: EqAnyRef[(A, B, C)])
 
   implicit final def tuple4Eq[A, B, C, D](implicit A: Eq[A], B: Eq[B], C: Eq[C], D: Eq[D]): Eq[(A, B, C, D)] =
-    instanceOf[EqClass[(A, B, C, D)]] {
+    instanceOf({
       case ((a1, b1, c1, d1), (a2, b2, c2, d2)) =>
         A.equal(a1, a2) && B.equal(b1, b2) && C.equal(c1, c2) && D.equal(d1, d2)
       case _ => false
-    }
+    }: EqAnyRef[(A, B, C, D)])
 }


### PR DESCRIPTION
Closes #1808 

Introduces `EqAnyRef`, a special case of `EqClass` that used reference equality before handing off to the actual equality logic.