### PR TITLE
Remove some dubious re-exports from the scalaz package object.

### DIFF
--- a/base/shared/src/main/scala/scalaz/core/void.scala
+++ b/base/shared/src/main/scala/scalaz/core/void.scala
@@ -3,7 +3,7 @@ package core
 
 import java.lang.RuntimeException
 
-import scala.Nothing
+import scala.{ inline, Nothing }
 
 import com.github.ghik.silencer.silent
 

--- a/base/shared/src/main/scala/scalaz/ct/choice.scala
+++ b/base/shared/src/main/scala/scalaz/ct/choice.scala
@@ -1,8 +1,6 @@
 package scalaz
 package ct
 
-import scala.Function
-
 import data.Disjunction
 
 import data.Disjunction.swap
@@ -33,13 +31,13 @@ object ChoiceClass {
 
 trait ChoiceInstances {
 
-  implicit val functionChoice: Choice[Function] = instanceOf(
-    new ChoiceClass[Function] with ProfunctorClass.DeriveDimap[Function] {
+  implicit val functionChoice: Choice[? => ?] = instanceOf(
+    new ChoiceClass[? => ?] with ProfunctorClass.DeriveDimap[? => ?] {
 
-      override def lmap[A, B, C](fab: Function[A, B])(ca: C => A): Function[C, B] =
+      override def lmap[A, B, C](fab: A => B)(ca: C => A): C => B =
         fab compose ca
 
-      override def rmap[A, B, C](fab: Function[A, B])(bc: B => C): Function[A, C] =
+      override def rmap[A, B, C](fab: A => B)(bc: B => C): A => C =
         fab andThen bc
 
       override def leftchoice[A, B, C](ab: A => B): A \/ C => B \/ C =

--- a/base/shared/src/main/scala/scalaz/ct/iso.scala
+++ b/base/shared/src/main/scala/scalaz/ct/iso.scala
@@ -1,6 +1,8 @@
 package scalaz
 package ct
 
+import scala.Singleton
+
 sealed abstract class Iso[A, B] { ab =>
   def to(a: A): B
   def from(b: B): A

--- a/base/shared/src/main/scala/scalaz/ct/kleisli.scala
+++ b/base/shared/src/main/scala/scalaz/ct/kleisli.scala
@@ -1,8 +1,10 @@
 package scalaz
 package ct
 
-import scalaz.data.~>
-import scalaz.algebra.MonoidClass
+import scala.inline
+
+import algebra.MonoidClass
+import data.~>
 
 sealed trait KleisliModule {
   type Kleisli[F[_], A, B]

--- a/base/shared/src/main/scala/scalaz/ct/strong.scala
+++ b/base/shared/src/main/scala/scalaz/ct/strong.scala
@@ -1,8 +1,6 @@
 package scalaz
 package ct
 
-import scala.Function
-
 import scala.language.experimental.macros
 
 trait StrongClass[P[_, _]] extends ProfunctorClass[P] {
@@ -27,8 +25,8 @@ object StrongClass {
 
 trait StrongInstances { instances =>
 
-  implicit val functionStrong: Strong[Function] = instanceOf(
-    new StrongClass[Function] with ProfunctorClass.DeriveDimap[Function] {
+  implicit val functionStrong: Strong[? => ?] = instanceOf(
+    new StrongClass[? => ?] with ProfunctorClass.DeriveDimap[? => ?] {
 
       override def lmap[A, B, C](fab: A => B)(ca: C => A): C => B =
         fab compose ca

--- a/base/shared/src/main/scala/scalaz/data/Cord.scala
+++ b/base/shared/src/main/scala/scalaz/data/Cord.scala
@@ -2,7 +2,7 @@ package scalaz
 package data
 
 import java.lang.Math
-import scala.{ AnyRef, Char, Null }
+import scala.{ AnyRef, Array, Char, Null }
 import scala.Predef.{ classOf, String }
 
 import algebra.MonoidClass

--- a/base/shared/src/main/scala/scalaz/data/disjunction.scala
+++ b/base/shared/src/main/scala/scalaz/data/disjunction.scala
@@ -1,11 +1,11 @@
 package scalaz
 package data
 
-import scala.Either
+import scala.{ inline, Either }
 
-import scalaz.core.EqClass
-import scalaz.ct._
-import scalaz.debug.DebugClass
+import core.EqClass
+import ct._
+import debug.DebugClass
 
 sealed trait Disjunction[L, R] {
   final def fold[A](la: L => A, ra: R => A): A = this match {

--- a/base/shared/src/main/scala/scalaz/data/these.scala
+++ b/base/shared/src/main/scala/scalaz/data/these.scala
@@ -1,10 +1,12 @@
 package scalaz
 package data
 
-import scalaz.algebra.SemigroupClass
-import scalaz.core.EqClass
-import scalaz.ct._
-import scalaz.debug.DebugClass
+import scala.inline
+
+import algebra.SemigroupClass
+import core.EqClass
+import ct._
+import debug.DebugClass
 
 sealed abstract class These[L, R] {
 

--- a/base/shared/src/main/scala/scalaz/package.scala
+++ b/base/shared/src/main/scala/scalaz/package.scala
@@ -8,29 +8,22 @@ package object scalaz
     with BaseCore {
 
   // Types
-  type Array[A]         = scala.Array[A]
-  type Boolean          = scala.Boolean
-  type Byte             = scala.Byte
-  type Double           = scala.Double
-  type Float            = scala.Float
-  type Function[-A, +B] = (A) ⇒ B
-  type Int              = scala.Int
-  type Long             = scala.Long
-  type Short            = scala.Short
-  type Singleton        = scala.Singleton
-  type String           = java.lang.String
-  type Throwable        = java.lang.Throwable
-  type Unit             = scala.Unit
+  type Boolean = scala.Boolean
+  type Byte    = scala.Byte
+  type Double  = scala.Double
+  type Float   = scala.Float
+  type Int     = scala.Int
+  type Long    = scala.Long
+  type Short   = scala.Short
+  type String  = java.lang.String
+  type Unit    = scala.Unit
 
-  type <:<[-A, +B] = scala.Predef.<:<[A, B]
-  type =:=[A, B]   = scala.Predef.=:=[A, B]
-
-  type inline = scala.inline
-
-  // Objects
-  val StringContext = scala.StringContext
+  // don't export this, but scala needs `StringContext` to be in scope with this name
+  private[scalaz] val StringContext = scala.StringContext
 
   // Functions
-  def identity[T](t: T)            = scala.Predef.identity[T](t)
-  def implicitly[T](implicit t: T) = scala.Predef.implicitly[T](t)
+  @scala.inline
+  def identity[T](t: T): T = t
+  @scala.inline
+  def implicitly[T](implicit t: T) = t
 }

--- a/base/shared/src/main/scala/scalaz/prelude.scala
+++ b/base/shared/src/main/scala/scalaz/prelude.scala
@@ -1,10 +1,12 @@
 package scalaz
 
-import ct._
+import scala.inline
+
 import algebra._
-import scalaz.core._
-import scalaz.debug._
-import scalaz.types._
+import core._
+import ct._
+import debug._
+import types._
 
 trait BaseTypeclasses {
   type InstanceOf[T] = InstanceOfModule.impl.InstanceOf[T]

--- a/base/shared/src/main/scala/scalaz/types/as.scala
+++ b/base/shared/src/main/scala/scalaz/types/as.scala
@@ -1,7 +1,8 @@
 package scalaz
 package types
 
-import scala.{ Any, AnyVal }
+import scala.{ Any, AnyVal, Predef }
+import Predef.<:<
 
 import scala.language.implicitConversions
 

--- a/base/shared/src/main/scala/scalaz/types/is.scala
+++ b/base/shared/src/main/scala/scalaz/types/is.scala
@@ -1,7 +1,8 @@
 package scalaz
 package types
 
-import scala.{ Any, AnyVal }
+import scala.{ Any, AnyVal, Predef }
+import Predef.=:=
 
 /**
  * The data type `Is` is the encoding of Leibnitz’ law which states that

--- a/base/shared/src/main/scala/scalaz/types/leibniz.scala
+++ b/base/shared/src/main/scala/scalaz/types/leibniz.scala
@@ -1,7 +1,8 @@
 package scalaz
 package types
 
-import scala.Any
+import scala.{ Any, Predef }
+import Predef.=:=
 
 /**
  * This particular version of Leibniz’ equality has been generalized to

--- a/base/shared/src/main/scala/scalaz/types/liskov.scala
+++ b/base/shared/src/main/scala/scalaz/types/liskov.scala
@@ -1,7 +1,8 @@
 package scalaz
 package types
 
-import scala.{ Any, AnyVal }
+import scala.{ Any, AnyVal, Predef }
+import Predef.<:<
 
 /**
  * Liskov substitutability: A better `<:<`.

--- a/effect/jvm/src/main/scala/scalaz/effect/RTS.scala
+++ b/effect/jvm/src/main/scala/scalaz/effect/RTS.scala
@@ -2,7 +2,7 @@
 package scalaz
 package effect
 
-import scala.{ ::, Any, AnyRef, Array, List, Nil, None, Nothing, Option, Some }
+import scala.{ ::, inline, Any, AnyRef, Array, List, Nil, None, Nothing, Option, Some }
 import scala.annotation.{ switch, tailrec }
 import scala.concurrent.duration.Duration
 
@@ -150,15 +150,15 @@ private object RTS {
   final def nextInstr[E](value: Any, stack: Stack): IO[E, Any] =
     if (!stack.isEmpty) stack.pop()(value).asInstanceOf[IO[E, Any]] else null
 
-  object Catcher extends Function[Any, IO[Any, Any]] {
+  object Catcher extends (Any => IO[Any, Any]) {
     final def apply(v: Any): IO[Any, Any] = IO.now(\/-(v))
   }
 
-  object IdentityCont extends Function[Any, IO[Any, Any]] {
+  object IdentityCont extends (Any => IO[Any, Any]) {
     final def apply(v: Any): IO[Any, Any] = IO.now(v)
   }
 
-  final case class Finalizer[E](finalizer: ExitResult[E, Any] => IO[Void, Unit]) extends Function[Any, IO[E, Any]] {
+  final case class Finalizer[E](finalizer: ExitResult[E, Any] => IO[Void, Unit]) extends (Any => IO[E, Any]) {
     final def apply(v: Any): IO[E, Any] = IO.now(v)
   }
 

--- a/effect/jvm/src/main/scala/scalaz/effect/SafeApp.scala
+++ b/effect/jvm/src/main/scala/scalaz/effect/SafeApp.scala
@@ -2,7 +2,7 @@
 package scalaz
 package effect
 
-import scala.{ sys, List }
+import scala.{ sys, Array, List }
 import scala.concurrent.duration.Duration
 
 /**


### PR DESCRIPTION
I don't want to type `import scalaz._` and have trash like `Singleton`, `<:<`, `Array` just come popping out at me like that.

`StringContext` is evidently used by name so has to be kept here for `-Yno-imports`; I exported it `private[scalaz]` for laziness.