### PR TITLE
revert self-referential Monad Asts

### DIFF
--- a/core/src/main/scala/scalaz/MonadError.scala
+++ b/core/src/main/scala/scalaz/MonadError.scala
@@ -37,24 +37,5 @@ object MonadError {
     }
 
   ////
-  /** The Free instruction set for MonadError */
-  sealed abstract class Ast[F[_], E, A]
-  final case class RaiseError[F[_], E, A](e: E) extends Ast[F, E, A]
-  final case class HandleError[F[_], E, A](fa: F[A], f: E => F[A]) extends Ast[F, E, A]
-
-  /** Extensible Effect */
-  def liftF[F[_], E](
-    implicit I: Ast[Free[F, ?], E, ?] :<: F
-  ): MonadError[Free[F, ?], E] with BindRec[Free[F, ?]] =
-    new MonadError[Free[F, ?], E] with BindRec[Free[F, ?]] {
-      val delegate = Free.freeMonad[F]
-      def point[A](a: =>A): Free[F, A] = delegate.point(a)
-      def bind[A, B](fa: Free[F, A])(f: A => Free[F, B]) = delegate.bind(fa)(f)
-      override def map[A, B](fa: Free[F, A])(f: A => B) = delegate.map(fa)(f)
-      override def tailrecM[A, B](f: A => Free[F, A \/ B])(a: A) = delegate.tailrecM(f)(a)
-
-      def raiseError[A](e: E): Free[F, A] = Free.liftF(I.inj(RaiseError[Free[F, ?], E, A](e)))
-      def handleError[A](fa: Free[F, A])(f: E => Free[F, A]): Free[F, A] = Free.liftF(I.inj(HandleError[Free[F, ?], E, A](fa, f)))
-    }
   ////
 }

--- a/core/src/main/scala/scalaz/MonadError.scala
+++ b/core/src/main/scala/scalaz/MonadError.scala
@@ -40,7 +40,7 @@ object MonadError {
   /** The Free instruction set for MonadError */
   sealed abstract class Ast[E, A]
   final case class RaiseError[E, A](e: E) extends Ast[E, A]
-  final case class HandleError[F[_], E, A](fa: Free[F, A], f: E => Free[F, A]) extends Ast[E, A]
+  final case class HandleError[F[_], E, A](fa: F[A], f: E => F[A]) extends Ast[E, A]
 
   /** Extensible Effect */
   def liftF[F[_], E](
@@ -54,7 +54,7 @@ object MonadError {
       override def tailrecM[A, B](f: A => Free[F, A \/ B])(a: A) = delegate.tailrecM(f)(a)
 
       def raiseError[A](e: E): Free[F, A] = Free.liftF(I.inj(RaiseError[E, A](e)))
-      def handleError[A](fa: Free[F, A])(f: E => Free[F, A]): Free[F, A] = Free.liftF(I.inj(HandleError[F, E, A](fa, f)))
+      def handleError[A](fa: Free[F, A])(f: E => Free[F, A]): Free[F, A] = Free.liftF(I.inj(HandleError[Free[F, ?], E, A](fa, f)))
     }
   ////
 }

--- a/core/src/main/scala/scalaz/MonadListen.scala
+++ b/core/src/main/scala/scalaz/MonadListen.scala
@@ -14,7 +14,7 @@ object MonadListen {
 
   /** The Free instruction set for MonadListen */
   sealed abstract class Ast[S, A]
-  final case class Listen[F[_], S, A](ma: Free[F, A]) extends Ast[S, (A, S)]
+  final case class Listen[F[_], S, A](ma: F[A]) extends Ast[S, (A, S)]
 
   /** Extensible Effect */
   def liftF[F[_], S](
@@ -31,6 +31,6 @@ object MonadListen {
 
       def writer[A](w: S, v: A): Free[F, A] = Free.liftF(T.inj(MonadTell.Writer[S, A](w, v)))
 
-      def listen[A](ma: Free[F, A]): Free[F, (A, S)] = Free.liftF(L.inj(Listen[F, S, A](ma)))
+      def listen[A](ma: Free[F, A]): Free[F, (A, S)] = Free.liftF(L.inj(Listen[Free[F, ?], S, A](ma)))
     }
 }

--- a/core/src/main/scala/scalaz/MonadListen.scala
+++ b/core/src/main/scala/scalaz/MonadListen.scala
@@ -11,26 +11,4 @@ trait MonadListen[F[_], W] extends MonadTell[F, W] {
 
 object MonadListen {
   def apply[F[_], W](implicit ML: MonadListen[F, W]) = ML
-
-  /** The Free instruction set for MonadListen */
-  sealed abstract class Ast[S, A]
-  final case class Listen[F[_], S, A](ma: F[A]) extends Ast[S, (A, S)]
-
-  /** Extensible Effect */
-  def liftF[F[_], S](
-    implicit
-      T: MonadTell.Ast[S, ?] :<: F,
-      L: Ast[S, ?] :<: F
-  ): MonadListen[Free[F, ?], S] with BindRec[Free[F, ?]] =
-    new MonadListen[Free[F, ?], S] with BindRec[Free[F, ?]] {
-      val delegate = Free.freeMonad[F]
-      def point[A](a: =>A): Free[F, A] = delegate.point(a)
-      def bind[A, B](fa: Free[F, A])(f: A => Free[F, B]) = delegate.bind(fa)(f)
-      override def map[A, B](fa: Free[F, A])(f: A => B) = delegate.map(fa)(f)
-      override def tailrecM[A, B](f: A => Free[F, A \/ B])(a: A) = delegate.tailrecM(f)(a)
-
-      def writer[A](w: S, v: A): Free[F, A] = Free.liftF(T.inj(MonadTell.Writer[S, A](w, v)))
-
-      def listen[A](ma: Free[F, A]): Free[F, (A, S)] = Free.liftF(L.inj(Listen[Free[F, ?], S, A](ma)))
-    }
 }

--- a/core/src/main/scala/scalaz/MonadPlus.scala
+++ b/core/src/main/scala/scalaz/MonadPlus.scala
@@ -74,7 +74,7 @@ object MonadPlus {
   ////
   /** The Free instruction set for MonadPlus */
   sealed abstract class Ast[A]
-  final case class Plus[F[_], A](a: Free[F, A], b: () => Free[F, A]) extends Ast[A]
+  final case class Plus[F[_], A](a: F[A], b: () => F[A]) extends Ast[A]
   final case class Empty[F[_], A]() extends Ast[A]
 
   /** Extensible Effect */
@@ -88,7 +88,7 @@ object MonadPlus {
       override def map[A, B](fa: Free[F, A])(f: A => B) = delegate.map(fa)(f)
       override def tailrecM[A, B](f: A => Free[F, A \/ B])(a: A) = delegate.tailrecM(f)(a)
 
-      def plus[A](a: Free[F, A], b: =>Free[F, A]): Free[F, A] = Free.liftF(I.inj(Plus[F, A](a, () => b)))
+      def plus[A](a: Free[F, A], b: =>Free[F, A]): Free[F, A] = Free.liftF(I.inj(Plus[Free[F, ?], A](a, () => b)))
       def empty[A]: Free[F, A] = Free.liftF(I.inj(Empty[F, A]()))
     }
 

--- a/core/src/main/scala/scalaz/MonadPlus.scala
+++ b/core/src/main/scala/scalaz/MonadPlus.scala
@@ -72,25 +72,5 @@ object MonadPlus {
     }
 
   ////
-  /** The Free instruction set for MonadPlus */
-  sealed abstract class Ast[A]
-  final case class Plus[F[_], A](a: F[A], b: () => F[A]) extends Ast[A]
-  final case class Empty[F[_], A]() extends Ast[A]
-
-  /** Extensible Effect */
-  def liftF[F[_]](
-    implicit I: Ast :<: F
-  ): MonadPlus[Free[F, ?]] with BindRec[Free[F, ?]] =
-    new MonadPlus[Free[F, ?]] with BindRec[Free[F, ?]] {
-      val delegate = Free.freeMonad[F]
-      def point[A](a: =>A): Free[F, A] = delegate.point(a)
-      def bind[A, B](fa: Free[F, A])(f: A => Free[F, B]) = delegate.bind(fa)(f)
-      override def map[A, B](fa: Free[F, A])(f: A => B) = delegate.map(fa)(f)
-      override def tailrecM[A, B](f: A => Free[F, A \/ B])(a: A) = delegate.tailrecM(f)(a)
-
-      def plus[A](a: Free[F, A], b: =>Free[F, A]): Free[F, A] = Free.liftF(I.inj(Plus[Free[F, ?], A](a, () => b)))
-      def empty[A]: Free[F, A] = Free.liftF(I.inj(Empty[F, A]()))
-    }
-
   ////
 }

--- a/core/src/main/scala/scalaz/MonadReader.scala
+++ b/core/src/main/scala/scalaz/MonadReader.scala
@@ -29,25 +29,5 @@ object MonadReader {
     }
 
   ////
-  /** The Free instruction set for MonadReader */
-  sealed abstract class Ast[S, A]
-  final case class Ask[S]() extends Ast[S, S]
-  final case class Local[F[_], S, A](f: S => S, fa: F[A]) extends Ast[S, A]
-
-  /** Extensible Effect */
-  def liftF[F[_], S](
-    implicit I: Ast[S, ?] :<: F
-  ): MonadReader[Free[F, ?], S] with BindRec[Free[F, ?]] =
-    new MonadReader[Free[F, ?], S] with BindRec[Free[F, ?]] {
-      val delegate = Free.freeMonad[F]
-      def point[A](a: =>A): Free[F, A] = delegate.point(a)
-      def bind[A, B](fa: Free[F, A])(f: A => Free[F, B]) = delegate.bind(fa)(f)
-      override def map[A, B](fa: Free[F, A])(f: A => B) = delegate.map(fa)(f)
-      override def tailrecM[A, B](f: A => Free[F, A \/ B])(a: A) = delegate.tailrecM(f)(a)
-
-      def ask: Free[F, S] = Free.liftF(I.inj(Ask[S]()))
-      def local[A](f: S => S)(fa: Free[F, A]): Free[F, A] = Free.liftF(I.inj(Local[Free[F, ?], S, A](f, fa)))
-    }
-
   ////
 }

--- a/core/src/main/scala/scalaz/MonadReader.scala
+++ b/core/src/main/scala/scalaz/MonadReader.scala
@@ -32,7 +32,7 @@ object MonadReader {
   /** The Free instruction set for MonadReader */
   sealed abstract class Ast[S, A]
   final case class Ask[S]() extends Ast[S, S]
-  final case class Local[F[_], S, A](f: S => S, fa: Free[F, A]) extends Ast[S, A]
+  final case class Local[F[_], S, A](f: S => S, fa: F[A]) extends Ast[S, A]
 
   /** Extensible Effect */
   def liftF[F[_], S](
@@ -46,7 +46,7 @@ object MonadReader {
       override def tailrecM[A, B](f: A => Free[F, A \/ B])(a: A) = delegate.tailrecM(f)(a)
 
       def ask: Free[F, S] = Free.liftF(I.inj(Ask[S]()))
-      def local[A](f: S => S)(fa: Free[F, A]): Free[F, A] = Free.liftF(I.inj(Local[F, S, A](f, fa)))
+      def local[A](f: S => S)(fa: Free[F, A]): Free[F, A] = Free.liftF(I.inj(Local[Free[F, ?], S, A](f, fa)))
     }
 
   ////


### PR DESCRIPTION
close #1887 ... it can't be done, Lord Tagless was right all along.

these encodings haven't been released yet, and even if they have been I doubt anybody is using them, so we should be fine to make this change.