### PR TITLE
WIP - Enforce acyclic package dependencies

### DIFF
--- a/base/shared/src/main/scala/scalaz/algebra/monoid.scala
+++ b/base/shared/src/main/scala/scalaz/algebra/monoid.scala
@@ -1,6 +1,8 @@
 package scalaz
 package algebra
 
+import kernel.instanceOf
+
 trait MonoidClass[A] extends SemigroupClass[A] {
   def mempty: A
 }

--- a/base/shared/src/main/scala/scalaz/basehierarchy.scala
+++ b/base/shared/src/main/scala/scalaz/basehierarchy.scala
@@ -1,6 +1,7 @@
 package scalaz
 
-import scalaz.ct.FunctorClass
+import kernel.instanceOf
+import ct.FunctorClass
 
 trait BaseHierarchy extends BaseHierarchy.BH0
 

--- a/base/shared/src/main/scala/scalaz/core/eq.scala
+++ b/base/shared/src/main/scala/scalaz/core/eq.scala
@@ -3,6 +3,8 @@ package core
 
 import scala.language.experimental.macros
 
+import kernel.instanceOf
+
 trait EqClass[A] {
   def equal(first: A, second: A): Boolean
 }

--- a/base/shared/src/main/scala/scalaz/core/package.scala
+++ b/base/shared/src/main/scala/scalaz/core/package.scala
@@ -1,7 +1,5 @@
 package scalaz
 
 package object core {
-
   val Void: VoidModule = VoidImpl
-
 }

--- a/base/shared/src/main/scala/scalaz/core/void.scala
+++ b/base/shared/src/main/scala/scalaz/core/void.scala
@@ -7,6 +7,7 @@ import scala.{ inline, Nothing }
 
 import com.github.ghik.silencer.silent
 
+import kernel.instanceOf
 import algebra.SemigroupClass
 import debug.DebugClass
 import types.{ As, Is }

--- a/base/shared/src/main/scala/scalaz/ct/bifunctor.scala
+++ b/base/shared/src/main/scala/scalaz/ct/bifunctor.scala
@@ -5,6 +5,8 @@ import scala.Tuple2
 
 import scala.language.experimental.macros
 
+import kernel.instanceOf
+
 /** A typeclass for types which are (covariant) [[Functor]]s in both type parameters.
  *
  * Minimal definition:

--- a/base/shared/src/main/scala/scalaz/ct/choice.scala
+++ b/base/shared/src/main/scala/scalaz/ct/choice.scala
@@ -7,6 +7,8 @@ import data.Disjunction.swap
 
 import scala.language.experimental.macros
 
+import kernel.instanceOf
+
 trait ChoiceClass[P[_, _]] extends ProfunctorClass[P] {
 
   def leftchoice[A, B, C](pab: P[A, B]): P[A \/ C, B \/ C]

--- a/base/shared/src/main/scala/scalaz/ct/cobind.scala
+++ b/base/shared/src/main/scala/scalaz/ct/cobind.scala
@@ -5,6 +5,8 @@ import scala.{ List, Option, Some }
 
 import scala.language.experimental.macros
 
+import kernel.instanceOf
+
 trait CobindClass[F[_]] extends FunctorClass[F] {
 
   def cobind[A, B](fa: F[A])(f: F[A] => B): F[B]

--- a/base/shared/src/main/scala/scalaz/ct/comonad.scala
+++ b/base/shared/src/main/scala/scalaz/ct/comonad.scala
@@ -5,6 +5,8 @@ import scala.{ Function0, Tuple2 }
 
 import scala.language.experimental.macros
 
+import kernel.instanceOf
+
 trait ComonadClass[F[_]] extends CobindClass[F] {
   def copoint[A](fa: F[A]): A
 }

--- a/base/shared/src/main/scala/scalaz/ct/compose.scala
+++ b/base/shared/src/main/scala/scalaz/ct/compose.scala
@@ -3,6 +3,8 @@ package ct
 
 import scala.{ Option, Some }
 
+import kernel.instanceOf
+
 sealed abstract class ComposeModule {
   type Compose[F[_], G[_], X]
 

--- a/base/shared/src/main/scala/scalaz/ct/endo.scala
+++ b/base/shared/src/main/scala/scalaz/ct/endo.scala
@@ -1,6 +1,7 @@
 package scalaz
 package ct
 
+import kernel.instanceOf
 import algebra.{ MonoidClass, SemigroupClass }
 
 sealed abstract class EndoModule {

--- a/base/shared/src/main/scala/scalaz/ct/kleisli.scala
+++ b/base/shared/src/main/scala/scalaz/ct/kleisli.scala
@@ -3,6 +3,7 @@ package ct
 
 import scala.inline
 
+import kernel.instanceOf
 import algebra.MonoidClass
 import data.~>
 

--- a/base/shared/src/main/scala/scalaz/ct/monad.scala
+++ b/base/shared/src/main/scala/scalaz/ct/monad.scala
@@ -3,6 +3,8 @@ package ct
 
 import scala.{ Function0, Function1, List, Option }
 
+import kernel.instanceOf
+
 trait MonadClass[M[_]] extends ApplicativeClass[M] with BindClass[M]
 
 object MonadClass {

--- a/base/shared/src/main/scala/scalaz/ct/strong.scala
+++ b/base/shared/src/main/scala/scalaz/ct/strong.scala
@@ -3,6 +3,8 @@ package ct
 
 import scala.language.experimental.macros
 
+import kernel.instanceOf
+
 trait StrongClass[P[_, _]] extends ProfunctorClass[P] {
   def first[A, B, C](pab: P[A, B]): P[(A, C), (B, C)]
   def second[A, B, C](pab: P[A, B]): P[(C, A), (C, B)]

--- a/base/shared/src/main/scala/scalaz/ct/traversable.scala
+++ b/base/shared/src/main/scala/scalaz/ct/traversable.scala
@@ -5,6 +5,8 @@ import scala.{ List, Tuple2 }
 
 import scala.language.experimental.macros
 
+import kernel.instanceOf
+
 trait TraversableClass[T[_]] extends FunctorClass[T] with FoldableClass[T] {
 
   def traverse[F[_]: Applicative, A, B](ta: T[A])(f: A => F[B]): F[T[B]]

--- a/base/shared/src/main/scala/scalaz/data/Cord.scala
+++ b/base/shared/src/main/scala/scalaz/data/Cord.scala
@@ -5,6 +5,7 @@ import java.lang.Math
 import scala.{ AnyRef, Array, Char, Null }
 import scala.Predef.{ classOf, String }
 
+import kernel.instanceOf
 import algebra.MonoidClass
 import debug.DebugClass
 

--- a/base/shared/src/main/scala/scalaz/data/balanced.scala
+++ b/base/shared/src/main/scala/scalaz/data/balanced.scala
@@ -3,6 +3,7 @@ package data
 
 import scala.AnyVal
 
+import kernel.instanceOf
 import Prelude._
 import AList.aListOps
 import ct.SemicategoryClass

--- a/base/shared/src/main/scala/scalaz/data/const.scala
+++ b/base/shared/src/main/scala/scalaz/data/const.scala
@@ -3,6 +3,7 @@ package data
 
 import scala.{ List, Nil }
 
+import kernel.instanceOf
 import scalaz.algebra._
 import scalaz.core.EqClass
 import scalaz.ct._

--- a/base/shared/src/main/scala/scalaz/data/disjunction.scala
+++ b/base/shared/src/main/scala/scalaz/data/disjunction.scala
@@ -3,6 +3,7 @@ package data
 
 import scala.{ inline, Either }
 
+import kernel.instanceOf
 import core.EqClass
 import ct._
 import debug.DebugClass

--- a/base/shared/src/main/scala/scalaz/data/downstar.scala
+++ b/base/shared/src/main/scala/scalaz/data/downstar.scala
@@ -3,6 +3,7 @@ package data
 
 import scala.AnyVal
 
+import kernel.instanceOf
 import scalaz.ct.ProfunctorClass
 
 final case class DownStar[F[_], A, B](run: F[A] => B) extends AnyVal

--- a/base/shared/src/main/scala/scalaz/data/forget.scala
+++ b/base/shared/src/main/scala/scalaz/data/forget.scala
@@ -1,6 +1,7 @@
 package scalaz
 package data
 
+import kernel.instanceOf
 import ct.StrongClass
 
 final case class Forget[A, B, C](forget: B => A) {

--- a/base/shared/src/main/scala/scalaz/data/identity.scala
+++ b/base/shared/src/main/scala/scalaz/data/identity.scala
@@ -1,6 +1,7 @@
 package scalaz
 package data
 
+import kernel.instanceOf
 import core.EqClass
 import ct.MonadClass
 import debug.DebugClass

--- a/base/shared/src/main/scala/scalaz/data/ilist.scala
+++ b/base/shared/src/main/scala/scalaz/data/ilist.scala
@@ -1,6 +1,7 @@
 package scalaz
 package data
 
+import kernel.instanceOf
 import core.EqClass
 import debug.DebugClass
 import types.IsCovariantClass

--- a/base/shared/src/main/scala/scalaz/data/maybe.scala
+++ b/base/shared/src/main/scala/scalaz/data/maybe.scala
@@ -3,6 +3,7 @@ package data
 
 import scala.{ List, None, Option, Some }
 
+import kernel.instanceOf
 import scalaz.core.EqClass
 import scalaz.ct._
 import scalaz.debug.DebugClass

--- a/base/shared/src/main/scala/scalaz/data/maybe2.scala
+++ b/base/shared/src/main/scala/scalaz/data/maybe2.scala
@@ -3,6 +3,7 @@ package data
 
 import scala.{ sys, AnyVal, Nothing }
 
+import kernel.instanceOf
 import scalaz.core.EqClass
 import scalaz.ct.BifunctorClass
 import scalaz.debug.DebugClass

--- a/base/shared/src/main/scala/scalaz/data/these.scala
+++ b/base/shared/src/main/scala/scalaz/data/these.scala
@@ -3,6 +3,7 @@ package data
 
 import scala.inline
 
+import kernel.instanceOf
 import algebra.SemigroupClass
 import core.EqClass
 import ct._

--- a/base/shared/src/main/scala/scalaz/data/upstar.scala
+++ b/base/shared/src/main/scala/scalaz/data/upstar.scala
@@ -3,7 +3,8 @@ package data
 
 import scala.AnyVal
 
-import scalaz.ct.ProfunctorClass
+import kernel.instanceOf
+import ct.ProfunctorClass
 
 final case class UpStar[F[_], A, B](run: A => F[B]) extends AnyVal
 

--- a/base/shared/src/main/scala/scalaz/debug/debug.scala
+++ b/base/shared/src/main/scala/scalaz/debug/debug.scala
@@ -7,6 +7,7 @@ import scala.annotation.implicitAmbiguous
 import scala.language.experimental.macros
 import scala.language.implicitConversions
 
+import kernel.instanceOf
 import ct.ContravariantClass
 import data.Cord
 

--- a/base/shared/src/main/scala/scalaz/external/io.scala
+++ b/base/shared/src/main/scala/scalaz/external/io.scala
@@ -1,8 +1,9 @@
 package scalaz
-package core
+package external
 
 import java.lang.Throwable
 
+import kernel.instanceOf
 import algebra.MonoidClass
 import ct._
 import types.IsCovariantClass
@@ -62,3 +63,4 @@ trait FiberInstances {
       }
     })
 }
+

--- a/base/shared/src/main/scala/scalaz/external/io.scala
+++ b/base/shared/src/main/scala/scalaz/external/io.scala
@@ -63,4 +63,3 @@ trait FiberInstances {
       }
     })
 }
-

--- a/base/shared/src/main/scala/scalaz/external/package.scala
+++ b/base/shared/src/main/scala/scalaz/external/package.scala
@@ -1,0 +1,5 @@
+package scalaz
+
+package object external {
+  import acyclic.pkg
+}

--- a/base/shared/src/main/scala/scalaz/kernel/instanceof.scala
+++ b/base/shared/src/main/scala/scalaz/kernel/instanceof.scala
@@ -1,4 +1,5 @@
 package scalaz
+package kernel
 
 sealed abstract class InstanceOfModule {
   type InstanceOf[T] <: T

--- a/base/shared/src/main/scala/scalaz/kernel/package.scala
+++ b/base/shared/src/main/scala/scalaz/kernel/package.scala
@@ -1,0 +1,12 @@
+package scalaz
+
+import scala.inline
+
+package object kernel {
+
+  type InstanceOf[T] = InstanceOfModule.impl.InstanceOf[T]
+
+  @inline
+  private[scalaz] final def instanceOf[T]: T => InstanceOf[T] =
+    InstanceOfModule.impl.instanceOf
+}

--- a/base/shared/src/main/scala/scalaz/prelude.scala
+++ b/base/shared/src/main/scala/scalaz/prelude.scala
@@ -1,7 +1,6 @@
 package scalaz
 
-import scala.inline
-
+import kernel._
 import algebra._
 import core._
 import ct._
@@ -9,10 +8,6 @@ import debug._
 import types._
 
 trait BaseTypeclasses {
-  type InstanceOf[T] = InstanceOfModule.impl.InstanceOf[T]
-
-  @inline
-  final def instanceOf[T](t: T): InstanceOf[T] = InstanceOfModule.impl.instanceOf(t)
 
   type Applicative[F[_]]      = InstanceOf[ApplicativeClass[F]]
   type Apply[F[_]]            = InstanceOf[ApplyClass[F]]
@@ -66,11 +61,14 @@ trait BaseTypeclasses {
   final def Traversable[T[_]](implicit T: Traversable[T]): Traversable[T]                = T
 }
 
+trait BaseKernel {
+  type InstanceOf[T] = kernel.InstanceOf[T]
+  final def instanceOf[T](t: T): InstanceOf[T] = kernel.instanceOf(t)
+}
+
 trait BaseCore {
   type Void = core.Void.Void
-
   val Void: core.Void.type = core.Void
-
 }
 
 trait BaseTypes {
@@ -91,7 +89,6 @@ trait BaseCt {
   val Iso = ct.Iso
 
   val Kleisli: ct.Kleisli.type = ct.Kleisli
-
 }
 
 trait BaseAlgebra {
@@ -179,8 +176,8 @@ trait AllInstances
     with ct.TraversableInstances
     with debug.DebugInstances
     with core.EqInstances
-    with core.IOInstances
-    with core.FiberInstances
+    with external.IOInstances
+    with external.FiberInstances
     with types.AsInstances
     with types.IsContravariantInstances
     with types.IsCovariantInstances
@@ -226,5 +223,6 @@ trait LowPriority
     with BaseTypes
     with BaseCt
     with BaseAlgebra
+    with BaseKernel
 
 object Scalaz extends LowPriority with AllFunctions with AllSyntax with AllInstances

--- a/base/shared/src/main/scala/scalaz/std/boolean.scala
+++ b/base/shared/src/main/scala/scalaz/std/boolean.scala
@@ -1,6 +1,7 @@
 package scalaz
 package std
 
+import kernel.instanceOf
 import algebra.OrdClass
 import utils._
 

--- a/base/shared/src/main/scala/scalaz/std/byte.scala
+++ b/base/shared/src/main/scala/scalaz/std/byte.scala
@@ -1,6 +1,7 @@
 package scalaz
 package std
 
+import kernel.instanceOf
 import algebra.OrdClass
 import utils._
 

--- a/base/shared/src/main/scala/scalaz/std/double.scala
+++ b/base/shared/src/main/scala/scalaz/std/double.scala
@@ -3,8 +3,9 @@ package std
 
 import java.lang.Double.doubleToRawLongBits
 
-import algebra.OrdClass
+import kernel.instanceOf
 import core.EqClass
+import algebra.OrdClass
 import utils._
 
 trait DoubleInstances {

--- a/base/shared/src/main/scala/scalaz/std/float.scala
+++ b/base/shared/src/main/scala/scalaz/std/float.scala
@@ -2,7 +2,10 @@ package scalaz
 package std
 
 import java.lang.Float.floatToRawIntBits
+
+import kernel.instanceOf
 import core.EqClass
+
 import utils._
 
 trait FloatInstances {

--- a/base/shared/src/main/scala/scalaz/std/int.scala
+++ b/base/shared/src/main/scala/scalaz/std/int.scala
@@ -1,6 +1,7 @@
 package scalaz
 package std
 
+import kernel.instanceOf
 import algebra.OrdClass
 import utils._
 

--- a/base/shared/src/main/scala/scalaz/std/long.scala
+++ b/base/shared/src/main/scala/scalaz/std/long.scala
@@ -1,6 +1,7 @@
 package scalaz
 package std
 
+import kernel.instanceOf
 import algebra.OrdClass
 import utils._
 

--- a/base/shared/src/main/scala/scalaz/std/utils.scala
+++ b/base/shared/src/main/scala/scalaz/std/utils.scala
@@ -1,6 +1,7 @@
 package scalaz
 package std
 
+import kernel.instanceOf
 import core.EqClass
 import data.Cord
 import debug.DebugClass

--- a/base/shared/src/main/scala/scalaz/types/iscontravariant.scala
+++ b/base/shared/src/main/scala/scalaz/types/iscontravariant.scala
@@ -1,6 +1,8 @@
 package scalaz
 package types
 
+import kernel.instanceOf
+
 /**
  * Witnesses that the type constructor `F[_]` is contravariant,
  * even though the variance annotation of its type parameter has been forgotten.

--- a/base/shared/src/main/scala/scalaz/types/iscovariant.scala
+++ b/base/shared/src/main/scala/scalaz/types/iscovariant.scala
@@ -1,6 +1,8 @@
 package scalaz
 package types
 
+import kernel.instanceOf
+
 /**
  * Witnesses that the type constructor `F[_]` is covariant,
  * even though the variance annotation of its type parameter has been forgotten.

--- a/project/ScalazBuild.scala
+++ b/project/ScalazBuild.scala
@@ -45,8 +45,11 @@ object Scalaz {
       libraryDependencies ++= compileOnlyDeps ++ testDeps ++ Seq(
         compilerPlugin("org.spire-math"         %% "kind-projector"  % "0.9.7"),
         compilerPlugin("com.github.tomasmikula" %% "pascal"          % "0.2.1"),
-        compilerPlugin("com.github.ghik"        %% "silencer-plugin" % "1.0")
+        compilerPlugin("com.github.ghik"        %% "silencer-plugin" % "1.0"),
+        compilerPlugin("com.lihaoyi"            %% "acyclic"         % "0.1.7"),
+        "com.lihaoyi" %% "acyclic" % "0.1.7" % "provided"
       ),
+      autoCompilerPlugins := true,
       incOptions ~= (_.withLogRecompileOnMacro(false))
     ) ++ {
       Seq(packageBin, packageDoc, packageSrc).flatMap {

--- a/std/shared/src/main/scala/collection/list.scala
+++ b/std/shared/src/main/scala/collection/list.scala
@@ -5,6 +5,7 @@ import scala.{ ::, List, Nil }
 
 import scala.Predef.$conforms
 
+import scalaz.kernel.instanceOf
 import core.EqClass
 import ct.MonadClass
 import data.Cord

--- a/std/shared/src/main/scala/collection/set.scala
+++ b/std/shared/src/main/scala/collection/set.scala
@@ -3,7 +3,8 @@ package std
 
 import scala.collection.immutable.Set
 
-import scalaz.core.EqClass
+import scalaz.kernel.instanceOf
+import core.EqClass
 
 trait SetInstances {
   implicit def setEq[A: Eq]: Eq[Set[A]] =

--- a/std/shared/src/main/scala/collection/vector.scala
+++ b/std/shared/src/main/scala/collection/vector.scala
@@ -4,6 +4,7 @@ package std
 import scala.Vector
 import scala.Predef.$conforms
 
+import scalaz.kernel.instanceOf
 import core.EqClass
 import ct.MonadClass
 

--- a/std/shared/src/main/scala/either.scala
+++ b/std/shared/src/main/scala/either.scala
@@ -3,6 +3,7 @@ package std
 
 import scala.{ Either, Left, Right }
 
+import scalaz.kernel.instanceOf
 import core.EqClass
 import ct.{ BifunctorClass, MonadClass }
 import debug.DebugClass

--- a/std/shared/src/main/scala/option.scala
+++ b/std/shared/src/main/scala/option.scala
@@ -3,6 +3,7 @@ package std
 
 import scala.{ None, Option, Some }
 
+import scalaz.kernel.instanceOf
 import core.EqClass
 import data.Cord
 import debug.DebugClass

--- a/std/shared/src/main/scala/tuple.scala
+++ b/std/shared/src/main/scala/tuple.scala
@@ -3,6 +3,7 @@ package std
 
 import scala.{ Tuple1, Tuple2 }
 
+import scalaz.kernel.instanceOf
 import scalaz.core.EqClass
 
 trait TupleInstances {


### PR DESCRIPTION
This is a WIP for issue https://github.com/scalaz/scalaz/issues/1826. At the moment I just moved the machinery for the `InstanceOf` of the typeclasses to a package that's supposed to be very high if not the root of the hierarchy (almost everything depends on it). I called it `kernel`. I also moved `io` to another package (`external`, but the names are ugly and can be changed) as it should be pretty low level and only the prelude should depend on it. 
While doing that though I noticed that the prelude is tricky. The aliases in `BaseTypeclasses` in fact make it depend on most of the other packages but, if I'm not mistaken, a lot of those packages also depend on it as they use the aliases themselves.
If I run the plugin placing for instance `import acyclic.pkg` in the `external` package object I get something like 

```
[error] Unwanted cyclic dependency
[info] /Users/fmariotti/open-src/scalaz/base/shared/src/main/scala/scalaz/package.scala:8:10:
[info]     with BaseCore {
[info]          ^
[info] symbol: trait BaseCore
[info] More dependencies at lines 3 2 5 2 6 2 2 2 2 2 2 7 4
[info] /Users/fmariotti/open-src/scalaz/base/shared/src/main/scala/scalaz/prelude.scala:179:19:
[info]     with external.IOInstances
[info]                   ^
[info] symbol: trait IOInstances
[info] More dependencies at lines 180 150 150
[info] package scalaz.external
[warn] Choosing Sonatype OSS Snapshots for org.scalaz#scalaz-zio_2.12;0.1-SNAPSHOT
[info] /Users/fmariotti/open-src/scalaz/base/shared/src/main/scala/scalaz/external/io.scala:33:34:
[info]   implicit def ioIsCovariant[E]: IsCovariant[IO[E, ?]] = IsCovariantClass.unsafeForce[IO[E, ?]]
[info]                                  ^
[info] symbol: type InstanceOf
[info] More dependencies at lines 13 38 47 57 43 51 27 62 38
```

any thoughts ? I will keep experimenting, but before touching many files (and changing the way the aliases are used) I wanted to ask for opinions and suggestions here. Thanks a lot.