### PR TITLE
Backport 1397 (mapF for monad transformers)

### DIFF
--- a/core/src/main/scala/scalaz/EitherT.scala
+++ b/core/src/main/scala/scalaz/EitherT.scala
@@ -74,6 +74,11 @@ final case class EitherT[F[_], A, B](run: F[A \/ B]) {
   def map[C](f: B => C)(implicit F: Functor[F]): EitherT[F, A, C] =
     EitherT(F.map(run)(_.map(f)))
 
+  def mapF[C](f: B => F[C])(implicit M: Monad[F]): EitherT[F, A, C] =
+    flatMapF {
+      f andThen (mb => M.map(mb)(b => \/-(b)))
+    }
+
   def mapT[G[_], C, D](f: F[A \/ B] => G[C \/ D]): EitherT[G, C, D] =
     EitherT(f(run))
 

--- a/core/src/main/scala/scalaz/ListT.scala
+++ b/core/src/main/scala/scalaz/ListT.scala
@@ -51,6 +51,11 @@ final case class ListT[M[_], A](run: M[List[A]]){
 
   def map[B](f: A => B)(implicit M: Functor[M]) : ListT[M, B] = new ListT(M.map(run)(_.map(f)))
 
+	def mapF[B](f: A => M[B])(implicit M: Monad[M]): ListT[M, B] =
+		flatMapF {
+			f andThen (mb => M.map(mb)(b => List(b)))
+		}
+
   def mapT[F[_], B](f: M[List[A]] => F[List[B]]): ListT[F, B] =
     ListT(f(run))
 

--- a/core/src/main/scala/scalaz/ListT.scala
+++ b/core/src/main/scala/scalaz/ListT.scala
@@ -51,10 +51,10 @@ final case class ListT[M[_], A](run: M[List[A]]){
 
   def map[B](f: A => B)(implicit M: Functor[M]) : ListT[M, B] = new ListT(M.map(run)(_.map(f)))
 
-	def mapF[B](f: A => M[B])(implicit M: Monad[M]): ListT[M, B] =
-		flatMapF {
-			f andThen (mb => M.map(mb)(b => List(b)))
-		}
+  def mapF[B](f: A => M[B])(implicit M: Monad[M]): ListT[M, B] =
+    flatMapF {
+      f andThen (mb => M.map(mb)(b => List(b)))
+    }
 
   def mapT[F[_], B](f: M[List[A]] => F[List[B]]): ListT[F, B] =
     ListT(f(run))

--- a/core/src/main/scala/scalaz/MaybeT.scala
+++ b/core/src/main/scala/scalaz/MaybeT.scala
@@ -9,12 +9,12 @@ final case class MaybeT[F[_], A](run: F[Maybe[A]]) {
 
   def map[B](f: A => B)(implicit F: Functor[F]): MaybeT[F, B] = new MaybeT[F, B](mapO(_ map f))
 
-	def mapF[B](f: A => F[B])(implicit F: Monad[F]): MaybeT[F, B] = new MaybeT[F, B](
-		F.bind(self.run) {
-				case Empty() => F.point(empty[B])
-				case Just(z) => F.map(f(z))(b => just(b))
-			}
-		)
+  def mapF[B](f: A => F[B])(implicit F: Monad[F]): MaybeT[F, B] = new MaybeT[F, B](
+    F.bind(self.run) {
+        case Empty() => F.point(empty[B])
+        case Just(z) => F.map(f(z))(b => just(b))
+      }
+    )
 
   def mapT[G[_], B](f: F[Maybe[A]] => G[Maybe[B]]): MaybeT[G, B] =
     MaybeT(f(run))
@@ -23,8 +23,11 @@ final case class MaybeT[F[_], A](run: F[Maybe[A]]) {
     F.bind(self.run)(_.cata(f(_).run, F.point(empty)))
   )
 
-  def flatMapF[B](f: A => F[B])(implicit F: Monad[F]): MaybeT[F, B] = new MaybeT[F, B](
-    F.bind(self.run)(_.cata((a => F.map(f(a))(just)), F.point(empty)))
+  def flatMapF[B](f: A => F[Maybe[B]])(implicit F: Monad[F]): MaybeT[F, B] = new MaybeT[F, B](
+    F.bind(self.run) {
+      case Empty() => F.point(empty[B])
+      case Just(z) => f(z)
+    }
   )
 
   def foldRight[Z](z: => Z)(f: (A, => Z) => Z)(implicit F: Foldable[F]): Z = {
@@ -159,7 +162,7 @@ object MaybeT extends MaybeTInstances {
     }
 
   implicit def maybeTShow[F[_], A](implicit F0: Show[F[Maybe[A]]]): Show[MaybeT[F, A]] =
-		Contravariant[Show].contramap(F0)(_.run)
+    Contravariant[Show].contramap(F0)(_.run)
 }
 
 //

--- a/core/src/main/scala/scalaz/MonadTrans.scala
+++ b/core/src/main/scala/scalaz/MonadTrans.scala
@@ -11,6 +11,9 @@ trait MonadTrans[F[_[_], _]] {
 
   /** The [[scalaz.Monad]] implied by this transformer. */
   implicit def apply[G[_] : Monad]: Monad[F[G, ?]]
+
+	def mapF[G[_], A, B](fa: F[G, A])(f: A => G[B])(implicit M: Monad[G]): F[G, B] =
+		Monad[F[G, ?]].bind(fa)(a => liftM(f(a)))
 }
 
 object MonadTrans {

--- a/core/src/main/scala/scalaz/MonadTrans.scala
+++ b/core/src/main/scala/scalaz/MonadTrans.scala
@@ -12,8 +12,8 @@ trait MonadTrans[F[_[_], _]] {
   /** The [[scalaz.Monad]] implied by this transformer. */
   implicit def apply[G[_] : Monad]: Monad[F[G, ?]]
 
-	def mapF[G[_], A, B](fa: F[G, A])(f: A => G[B])(implicit M: Monad[G]): F[G, B] =
-		Monad[F[G, ?]].bind(fa)(a => liftM(f(a)))
+  def mapF[G[_], A, B](fa: F[G, A])(f: A => G[B])(implicit M: Monad[G]): F[G, B] =
+    Monad[F[G, ?]].bind(fa)(a => liftM(f(a)))
 }
 
 object MonadTrans {

--- a/core/src/main/scala/scalaz/OptionT.scala
+++ b/core/src/main/scala/scalaz/OptionT.scala
@@ -10,6 +10,13 @@ final case class OptionT[F[_], A](run: F[Option[A]]) {
 
   def map[B](f: A => B)(implicit F: Functor[F]): OptionT[F, B] = new OptionT[F, B](mapO(_ map f))
 
+  def mapF[B](f: A => F[B])(implicit F: Monad[F]): OptionT[F, B] = new OptionT[F, B](
+    F.bind(self.run) {
+      case None    => F.point(none[B])
+      case Some(z) => F.map(f(z))(b => some(b))
+    }
+  )
+
   def mapT[G[_], B](f: F[Option[A]] => G[Option[B]]): OptionT[G, B] =
     OptionT(f(run))
 

--- a/core/src/main/scala/scalaz/OptionT.scala
+++ b/core/src/main/scala/scalaz/OptionT.scala
@@ -27,10 +27,10 @@ final case class OptionT[F[_], A](run: F[Option[A]]) {
     }
   )
 
-  def flatMapF[B](f: A => F[B])(implicit F: Monad[F]): OptionT[F, B] = new OptionT[F, B](
+  def flatMapF[B](f: A => F[Option[B]])(implicit F: Monad[F]): OptionT[F, B] = new OptionT[F, B](
     F.bind(self.run) {
-      case None    => F.point(none[B])
-      case Some(z) => F.map(f(z))(b => some(b))
+      case None => F.point(None)
+      case Some(z) => f(z)
     }
   )
 

--- a/core/src/main/scala/scalaz/WriterT.scala
+++ b/core/src/main/scala/scalaz/WriterT.scala
@@ -48,9 +48,9 @@ final case class WriterT[F[_], W, A](run: F[(W, A)]) { self =>
   def map[B](f: A => B)(implicit F: Functor[F]): WriterT[F, W, B] =
     writerT(F.map(run)(wa => (wa._1, f(wa._2))))
 
-	def mapF[B](f: A => F[B])(implicit F: Bind[F], s: Semigroup[W]): WriterT[F, W, B] = writerT {
-		F.bind(run)(wa => F.map(f(wa._2))(a => (wa._1, a)))
-	}
+  def mapF[B](f: A => F[B])(implicit F: Bind[F], s: Semigroup[W]): WriterT[F, W, B] = writerT {
+    F.bind(run)(wa => F.map(f(wa._2))(a => (wa._1, a)))
+  }
 
 
   def ap[B](f: => WriterT[F, W, A => B])(implicit F: Apply[F], W: Semigroup[W]): WriterT[F, W, B] = writerT {

--- a/core/src/main/scala/scalaz/WriterT.scala
+++ b/core/src/main/scala/scalaz/WriterT.scala
@@ -48,6 +48,11 @@ final case class WriterT[F[_], W, A](run: F[(W, A)]) { self =>
   def map[B](f: A => B)(implicit F: Functor[F]): WriterT[F, W, B] =
     writerT(F.map(run)(wa => (wa._1, f(wa._2))))
 
+	def mapF[B](f: A => F[B])(implicit F: Bind[F], s: Semigroup[W]): WriterT[F, W, B] = writerT {
+		F.bind(run)(wa => F.map(f(wa._2))(a => (wa._1, a)))
+	}
+
+
   def ap[B](f: => WriterT[F, W, A => B])(implicit F: Apply[F], W: Semigroup[W]): WriterT[F, W, B] = writerT {
     F.apply2(f.run, run) {
       case ((w1, fab), (w2, a)) => (W.append(w1, w2), fab(a))

--- a/tests/src/test/scala/scalaz/EitherTTest.scala
+++ b/tests/src/test/scala/scalaz/EitherTTest.scala
@@ -76,6 +76,10 @@ object EitherTTest extends SpecLite {
     a.flatMap(f andThen EitherT.apply) must_=== a.flatMapF(f)
   }
 
+	"mapF consistent with map" ! forAll { (a: EitherTList[Int, Int], f: Int => String) =>
+		a.map(f) must_=== a.mapF(f andThen (s => Applicative[List].point(s)))
+	}
+
   "orElse only executes the left hand monad once" should {
     val counter = new AtomicInteger(0)
     val inc: EitherTComputation[Int] = EitherT.rightT(() => counter.incrementAndGet())

--- a/tests/src/test/scala/scalaz/ListTTest.scala
+++ b/tests/src/test/scala/scalaz/ListTTest.scala
@@ -69,6 +69,14 @@ object ListTTest extends SpecLite {
       ListT.listT(ass).run == ass
   }
 
+	"mapF consistent with map" ! forAll { (fa: ListTOpt[Int], f: Int => Int) =>
+		fa.map(f) must_=== fa.mapF(f andThen (i => Applicative[Option].point(i)))
+	}
+
+	"flatMapF consistent with flatMap" ! forAll { (fa: ListTOpt[Int], f: Int => Option[List[String]]) =>
+		fa.flatMap(f andThen ListT.apply) must_=== fa.flatMapF(f)
+	}
+
   checkAll(equal.laws[ListTOpt[Int]])
   checkAll(monoid.laws[ListTOpt[Int]])
   checkAll(plusEmpty.laws[ListTOpt])

--- a/tests/src/test/scala/scalaz/ListTTest.scala
+++ b/tests/src/test/scala/scalaz/ListTTest.scala
@@ -54,7 +54,7 @@ object ListTTest extends SpecLite {
   "flatMap" ! forAll {
     (ass: List[List[Int]]) =>
       (ListT.fromList(ass).flatMap(number => ListT.fromList(List(List(number.toFloat)))).toList
-      must_===(ass.map(_.flatMap(number => List(number.toFloat)))))
+        must_===(ass.map(_.flatMap(number => List(number.toFloat)))))
   }
 
   // Exists to ensure that fromList and map don't stack overflow.
@@ -69,13 +69,13 @@ object ListTTest extends SpecLite {
       ListT.listT(ass).run == ass
   }
 
-	"mapF consistent with map" ! forAll { (fa: ListTOpt[Int], f: Int => Int) =>
-		fa.map(f) must_=== fa.mapF(f andThen (i => Applicative[Option].point(i)))
-	}
+  "mapF consistent with map" ! forAll { (fa: ListTOpt[Int], f: Int => Int) =>
+    fa.map(f) must_=== fa.mapF(f andThen (i => Applicative[Option].point(i)))
+  }
 
-	"flatMapF consistent with flatMap" ! forAll { (fa: ListTOpt[Int], f: Int => Option[List[String]]) =>
-		fa.flatMap(f andThen ListT.apply) must_=== fa.flatMapF(f)
-	}
+  "flatMapF consistent with flatMap" ! forAll { (fa: ListTOpt[Int], f: Int => Option[List[String]]) =>
+    fa.flatMap(f andThen ListT.apply) must_=== fa.flatMapF(f)
+  }
 
   checkAll(equal.laws[ListTOpt[Int]])
   checkAll(monoid.laws[ListTOpt[Int]])

--- a/tests/src/test/scala/scalaz/MaybeTTest.scala
+++ b/tests/src/test/scala/scalaz/MaybeTTest.scala
@@ -8,21 +8,21 @@ import std.AllInstances._
 
 object MaybeTTest extends SpecLite {
 
-	type MaybeTList[A] = MaybeT[List, A]
-	type IntOr[A] = Int \/ A
-	type MaybeTEither[A] = MaybeT[IntOr, A]
+  type MaybeTList[A] = MaybeT[List, A]
+  type IntOr[A] = Int \/ A
+  type MaybeTEither[A] = MaybeT[IntOr, A]
 
-	"show" ! forAll { a: MaybeTList[Int] =>
-		Show[MaybeTList[Int]].show(a) must_=== Show[List[Maybe[Int]]].show(a.run)
-	}
+  "show" ! forAll { a: MaybeTList[Int] =>
+    Show[MaybeTList[Int]].show(a) must_=== Show[List[Maybe[Int]]].show(a.run)
+  }
 
-	"flatMapF consistent with flatMap" ! forAll { (fa: MaybeTList[Int], f: Int => List[Maybe[Int]]) =>
-		fa.flatMap(f andThen MaybeT.apply) must_=== fa.flatMapF(f)
-	}
+  "flatMapF consistent with flatMap" ! forAll { (fa: MaybeTList[Int], f: Int => List[Maybe[Int]]) =>
+    fa.flatMap(f andThen MaybeT.apply) must_=== fa.flatMapF(f)
+  }
 
-	"mapF consistent with map" ! forAll { (fa: MaybeTList[Int], f: Int => Int) =>
-		fa.map(f) must_=== fa.mapF(f andThen (i => Applicative[List].point(i)))
-	}
+  "mapF consistent with map" ! forAll { (fa: MaybeTList[Int], f: Int => Int) =>
+    fa.map(f) must_=== fa.mapF(f andThen (i => Applicative[List].point(i)))
+  }
 
 
   checkAll(equal.laws[MaybeTList[Int]])

--- a/tests/src/test/scala/scalaz/MaybeTTest.scala
+++ b/tests/src/test/scala/scalaz/MaybeTTest.scala
@@ -1,14 +1,29 @@
 package scalaz
 
+import org.scalacheck.Prop._
+
 import scalaz.scalacheck.ScalazProperties._
 import scalaz.scalacheck.ScalazArbitrary._
 import std.AllInstances._
 
 object MaybeTTest extends SpecLite {
 
-  type MaybeTList[A] = MaybeT[List, A]
-  type IntOr[A] = Int \/ A
-  type MaybeTEither[A] = MaybeT[IntOr, A]
+	type MaybeTList[A] = MaybeT[List, A]
+	type IntOr[A] = Int \/ A
+	type MaybeTEither[A] = MaybeT[IntOr, A]
+
+	"show" ! forAll { a: MaybeTList[Int] =>
+		Show[MaybeTList[Int]].show(a) must_=== Show[List[Maybe[Int]]].show(a.run)
+	}
+
+	"flatMapF consistent with flatMap" ! forAll { (fa: MaybeTList[Int], f: Int => List[Maybe[Int]]) =>
+		fa.flatMap(f andThen MaybeT.apply) must_=== fa.flatMapF(f)
+	}
+
+	"mapF consistent with map" ! forAll { (fa: MaybeTList[Int], f: Int => Int) =>
+		fa.map(f) must_=== fa.mapF(f andThen (i => Applicative[List].point(i)))
+	}
+
 
   checkAll(equal.laws[MaybeTList[Int]])
   checkAll(bindRec.laws[MaybeTList])

--- a/tests/src/test/scala/scalaz/OptionTTest.scala
+++ b/tests/src/test/scala/scalaz/OptionTTest.scala
@@ -23,18 +23,18 @@ object OptionTTest extends SpecLite {
   }
 
   "optionT" ! forAll { ass: List[Option[Int]] =>
-      OptionT.optionT(ass).run == ass
+    OptionT.optionT(ass).run == ass
   }
 
   "listT" ! forAll { a: OptionTList[Int] => a.toListT.run must_=== a.run.map(_.toList)}
 
-	"flatMapF consistent with flatMap" ! forAll { (fa: OptionTList[Int], f: Int => List[Option[Int]]) =>
-		fa.flatMap(f andThen OptionT.apply) must_=== fa.flatMapF(f)
-	}
+  "flatMapF consistent with flatMap" ! forAll { (fa: OptionTList[Int], f: Int => List[Option[Int]]) =>
+    fa.flatMap(f andThen OptionT.apply) must_=== fa.flatMapF(f)
+  }
 
-	"mapF consistent with map" ! forAll { (fa: OptionTList[Int], f: Int => Int) =>
-		fa.map(f) must_=== fa.mapF(f andThen (i => Applicative[List].point(i)))
-	}
+  "mapF consistent with map" ! forAll { (fa: OptionTList[Int], f: Int => Int) =>
+    fa.map(f) must_=== fa.mapF(f andThen (i => Applicative[List].point(i)))
+  }
 
   object instances {
     def functor[F[_] : Functor] = Functor[OptionT[F, ?]]

--- a/tests/src/test/scala/scalaz/OptionTTest.scala
+++ b/tests/src/test/scala/scalaz/OptionTTest.scala
@@ -28,6 +28,14 @@ object OptionTTest extends SpecLite {
 
   "listT" ! forAll { a: OptionTList[Int] => a.toListT.run must_=== a.run.map(_.toList)}
 
+	"flatMapF consistent with flatMap" ! forAll { (fa: OptionTList[Int], f: Int => List[Option[Int]]) =>
+		fa.flatMap(f andThen OptionT.apply) must_=== fa.flatMapF(f)
+	}
+
+	"mapF consistent with map" ! forAll { (fa: OptionTList[Int], f: Int => Int) =>
+		fa.map(f) must_=== fa.mapF(f andThen (i => Applicative[List].point(i)))
+	}
+
   object instances {
     def functor[F[_] : Functor] = Functor[OptionT[F, ?]]
     def bindRec[F[_] : Monad: BindRec] = BindRec[OptionT[F, ?]]

--- a/tests/src/test/scala/scalaz/WriterTTest.scala
+++ b/tests/src/test/scala/scalaz/WriterTTest.scala
@@ -38,10 +38,10 @@ object WriterTTest extends SpecLite {
       fa.flatMapF(f) must_=== fa.flatMap(f andThen WriterT.writerT)
   }
 
-	"mapF consistent with map" ! forAll {
-		(fa: WriterTOptInt[Int], f: Int => String) =>
-				fa.mapF(f andThen (s => Applicative[Option].point(s))) must_=== fa.map(f)
-	}
+  "mapF consistent with map" ! forAll {
+    (fa: WriterTOptInt[Int], f: Int => String) =>
+        fa.mapF(f andThen (s => Applicative[Option].point(s))) must_=== fa.map(f)
+  }
 
   private def writerTUcompilationTest: Unit = {
     import syntax.either._

--- a/tests/src/test/scala/scalaz/WriterTTest.scala
+++ b/tests/src/test/scala/scalaz/WriterTTest.scala
@@ -38,6 +38,11 @@ object WriterTTest extends SpecLite {
       fa.flatMapF(f) must_=== fa.flatMap(f andThen WriterT.writerT)
   }
 
+	"mapF consistent with map" ! forAll {
+		(fa: WriterTOptInt[Int], f: Int => String) =>
+				fa.mapF(f andThen (s => Applicative[Option].point(s))) must_=== fa.map(f)
+	}
+
   private def writerTUcompilationTest: Unit = {
     import syntax.either._
     val a: String \/ (Int, Boolean) = (1, true).right[String]


### PR DESCRIPTION
There is definitely some weirdness in here, but I figure this should be backported. It's a useful function.

Weirdness:
  * ~MaybeT and OptionT's implementation of `mapF` === `flatMapF`~ I'm an idiot
  * `flatMapF` is probably a better name for `mapF`, and `flatMapF` should be renamed (pointed out by @TomasMikula in #1397 