### PR TITLE
convenient methods and type aliases for parallelism

### DIFF
--- a/core/src/main/scala-2.12+/scalaz/ApplicativeParent.scala
+++ b/core/src/main/scala-2.12+/scalaz/ApplicativeParent.scala
@@ -13,7 +13,7 @@ trait ApplicativeParent[F[_]] { self: Applicative[F] =>
    * defined on Applicative allowing for optimised parallel implementations that
    * would otherwise violate laws of more specific typeclasses (e.g. Monad).
    */
-  def par: Applicative[λ[α => F[α] @@ Parallel]] =
+  def par: Applicative.Par[F] =
     Applicative.fromIso[λ[α => F[α] @@ Parallel], F](
       new IsoFunctorTemplate[λ[α => F[α] @@ Parallel], F] {
         override def from[A](ga: F[A]): F[A] @@ Parallel = Parallel(ga)

--- a/core/src/main/scala-2.12+/scalaz/ApplicativeParent.scala
+++ b/core/src/main/scala-2.12+/scalaz/ApplicativeParent.scala
@@ -1,9 +1,25 @@
 package scalaz
 
 ////
+import Isomorphism.{ <~>, IsoFunctorTemplate }
+import Tags.Parallel
+
 ////
 trait ApplicativeParent[F[_]] { self: Applicative[F] =>
   ////
+
+  /**
+   * A lawful implementation of this that is isomorphic up to the methods
+   * defined on Applicative allowing for optimised parallel implementations that
+   * would otherwise violate laws of more specific typeclasses (e.g. Monad).
+   */
+  def par: Applicative[λ[α => F[α] @@ Parallel]] =
+    Applicative.fromIso[λ[α => F[α] @@ Parallel], F](
+      new IsoFunctorTemplate[λ[α => F[α] @@ Parallel], F] {
+        override def from[A](ga: F[A]): F[A] @@ Parallel = Parallel(ga)
+        override def to[A](fa: F[A] @@ Parallel): F[A] = Parallel.unwrap(fa)
+      }
+    )(self)
 
   ////
 }

--- a/core/src/main/scala-2.12+/scalaz/ApplicativeParent.scala
+++ b/core/src/main/scala-2.12+/scalaz/ApplicativeParent.scala
@@ -13,13 +13,7 @@ trait ApplicativeParent[F[_]] { self: Applicative[F] =>
    * defined on Applicative allowing for optimised parallel implementations that
    * would otherwise violate laws of more specific typeclasses (e.g. Monad).
    */
-  def par: Applicative.Par[F] =
-    Applicative.fromIso[λ[α => F[α] @@ Parallel], F](
-      new IsoFunctorTemplate[λ[α => F[α] @@ Parallel], F] {
-        override def from[A](ga: F[A]): F[A] @@ Parallel = Parallel(ga)
-        override def to[A](fa: F[A] @@ Parallel): F[A] = Parallel.unwrap(fa)
-      }
-    )(self)
+  def par: Applicative.Par[F] = Tags.Parallel.subst1[Applicative, F](self)
 
   ////
 }

--- a/core/src/main/scala/scalaz/Applicative.scala
+++ b/core/src/main/scala/scalaz/Applicative.scala
@@ -127,6 +127,7 @@ object Applicative {
     }
 
   ////
+  type Par[F[_]] = Applicative[λ[α => F[α] @@ Tags.Parallel]]
 
   implicit def monoidApplicative[M:Monoid]: Applicative[λ[α => M]] = Monoid[M].applicative
 

--- a/core/src/main/scala/scalaz/Apply.scala
+++ b/core/src/main/scala/scalaz/Apply.scala
@@ -159,6 +159,7 @@ object Apply {
     }
 
   ////
+  type Par[F[_]] = Apply[λ[α => F[α] @@ Tags.Parallel]]
 
   ////
 }

--- a/core/src/main/scala/scalaz/Isomorphism.scala
+++ b/core/src/main/scala/scalaz/Isomorphism.scala
@@ -315,6 +315,8 @@ trait IsomorphismApplicative[F[_], G[_]] extends Applicative[F] with Isomorphism
   def point[A](a: => A): F[A] = iso.from(G.point(a))
 
   override def ap[A, B](fa: => F[A])(f: => F[A => B]): F[B] = iso.from(G.ap(iso.to(fa))(iso.to(f)))
+
+  override def apply2[A, B, C](fa: => F[A], fb: => F[B])(f: (A, B) => C): F[C] = iso.from(G.apply2(iso.to(fa), iso.to(fb))(f))
 }
 
 trait IsomorphismBind[F[_], G[_]] extends Bind[F] with IsomorphismApply[F, G] {

--- a/core/src/main/scala/scalaz/Validation.scala
+++ b/core/src/main/scala/scalaz/Validation.scala
@@ -340,6 +340,8 @@ sealed abstract class Validation[+E, +A] extends Product with Serializable {
     }
   }
 
+  def andThen[EE >: E, B](f: A => Validation[EE, B]): Validation[EE, B] = fold(Failure(_), f)
+
 }
 
 final case class Success[A](a: A) extends Validation[Nothing, A]

--- a/core/src/main/scala/scalaz/package.scala
+++ b/core/src/main/scala/scalaz/package.scala
@@ -149,9 +149,15 @@ package object scalaz {
 
   object StateT extends StateTInstances with StateTFunctions {
     def apply[F[_], S, A](f: S => F[(S, A)])(implicit F: Monad[F]): StateT[F, S, A] = IndexedStateT[F, S, S, A](f)
+    def liftM[F[_]: Monad, S, A](fa: F[A]): StateT[F, S, A] = MonadTrans[StateT[?[_], S, ?]].liftM(fa)
 
     def hoist[F[_]: Monad, G[_]: Monad, S, A](nat: F ~> G): StateT[F, S, ?] ~> StateT[G, S, ?] =
       λ[StateT[F, S, ?] ~> StateT[G, S, ?]](st => StateT((s: S) => nat(st.run(s))))
+
+    def get[F[_]: Monad, S]: StateT[F, S, S] = MonadState[StateT[F, S, ?], S].get
+    def gets[F[_]: Monad, S, A](f: S => A): StateT[F, S, A] = MonadState[StateT[F, S, ?], S].gets(f)
+    def put[F[_]: Monad, S](s: S): StateT[F, S, Unit] = MonadState[StateT[F, S, ?], S].put(s)
+    def modify[F[_]: Monad, S](f: S => S): StateT[F, S, Unit] = MonadState[StateT[F, S, ?], S].modify(f)
   }
   object IndexedState extends StateFunctions {
     def apply[S1, S2, A](f: S1 => (S2, A)): IndexedState[S1, S2, A] = IndexedStateT[Id, S1, S2, A](f)

--- a/core/src/main/scala/scalaz/syntax/ApplicativeBuilder.scala
+++ b/core/src/main/scala/scalaz/syntax/ApplicativeBuilder.scala
@@ -177,9 +177,9 @@ private[scalaz] trait ApplicativeBuilder[M[_], A, B] {
 }
 
 // outside of ApplicativeBuilder for bincompat
-abstract class ApplicativeBuilderSyntax {
+object ApplicativeBuilder {
   implicit final class ApplicativeBuilderOps2[M[_], A, B](
-    private val self: ApplicativeBuilder[M, A, B]) {
+      val self: ApplicativeBuilder[M, A, B]) extends AnyVal {
     def parApply[C](f: (A, B) => C)(implicit ap: Apply.Par[M]): M[C] =
       Tag.unwrap(ap.apply2(Tag[M[A], Parallel](self.a), Tag[M[B], Parallel](self.b))(f))
 

--- a/core/src/main/scala/scalaz/syntax/ApplicativeBuilder.scala
+++ b/core/src/main/scala/scalaz/syntax/ApplicativeBuilder.scala
@@ -1,6 +1,8 @@
 package scalaz
 package syntax
 
+import Tags.Parallel
+
 /** @see [[scalaz.syntax.ApplyOps]]`#|@|` */
 private[scalaz] trait ApplicativeBuilder[M[_], A, B] {
   val a: M[A]
@@ -9,6 +11,12 @@ private[scalaz] trait ApplicativeBuilder[M[_], A, B] {
   def apply[C](f: (A, B) => C)(implicit ap: Apply[M]): M[C] = ap.apply2(a, b)(f)
 
   def tupled(implicit ap: Apply[M]): M[(A, B)] = apply(Tuple2.apply)
+
+  def parApply[C](f: (A, B) => C)(implicit ap: Apply[λ[α => M[α] @@ Parallel]]): M[C] =
+    Parallel.unwrap(ap.apply2(Parallel(a), Parallel(b))(f))
+
+  def parTupled(implicit ap: Apply[λ[α => M[α] @@ Parallel]]): M[(A, B)] =
+    parApply(Tuple2.apply)
 
   def ⊛[C](cc: M[C]) = new ApplicativeBuilder3[C] {
     val c = cc

--- a/core/src/main/scala/scalaz/syntax/ApplicativeBuilder.scala
+++ b/core/src/main/scala/scalaz/syntax/ApplicativeBuilder.scala
@@ -25,6 +25,12 @@ private[scalaz] trait ApplicativeBuilder[M[_], A, B] {
 
     def tupled(implicit ap: Apply[M]): M[(A, B, C)] = apply(Tuple3.apply)
 
+    def ⊛[D](dd: M[D]) = new ApplicativeBuilder4[D] {
+      val d = dd
+    }
+
+    def |@|[D](dd: M[D]): ApplicativeBuilder4[D] = ⊛(dd)
+
     def parApply[Z](f: (A, B, C) => Z)(implicit ap: Apply.Par[M]): M[Z] =
       Tag.unwrap(ap.apply3(
                    Tag[M[A], Parallel](a),
@@ -34,13 +40,6 @@ private[scalaz] trait ApplicativeBuilder[M[_], A, B] {
 
     def parTupled(implicit ap: Apply.Par[M]): M[(A, B, C)] =
       parApply(Tuple3.apply)
-
-
-    def ⊛[D](dd: M[D]) = new ApplicativeBuilder4[D] {
-      val d = dd
-    }
-
-    def |@|[D](dd: M[D]): ApplicativeBuilder4[D] = ⊛(dd)
 
     sealed abstract class ApplicativeBuilder4[D] {
       val d: M[D]
@@ -55,6 +54,17 @@ private[scalaz] trait ApplicativeBuilder[M[_], A, B] {
 
       def |@|[E](ee: M[E]): ApplicativeBuilder5[E] = ⊛(ee)
 
+    def parApply[Z](f: (A, B, C, D) => Z)(implicit ap: Apply.Par[M]): M[Z] =
+      Tag.unwrap(ap.apply4(
+                   Tag[M[A], Parallel](a),
+                   Tag[M[B], Parallel](b),
+                   Tag[M[C], Parallel](c),
+                   Tag[M[D], Parallel](d)
+                 )(f))
+
+    def parTupled(implicit ap: Apply.Par[M]): M[(A, B, C, D)] =
+      parApply(Tuple4.apply)
+
       sealed abstract class ApplicativeBuilder5[E] {
         val e: M[E]
 
@@ -67,6 +77,18 @@ private[scalaz] trait ApplicativeBuilder[M[_], A, B] {
         }
 
         def |@|[F](f: M[F]): ApplicativeBuilder6[F] = ⊛(f)
+
+        def parApply[Z](f: (A, B, C, D, E) => Z)(implicit ap: Apply.Par[M]): M[Z] =
+          Tag.unwrap(ap.apply5(
+                       Tag[M[A], Parallel](a),
+                       Tag[M[B], Parallel](b),
+                       Tag[M[C], Parallel](c),
+                       Tag[M[D], Parallel](d),
+                       Tag[M[E], Parallel](e)
+                     )(f))
+
+        def parTupled(implicit ap: Apply.Par[M]): M[(A, B, C, D, E)] =
+          parApply(Tuple5.apply)
 
         sealed abstract class ApplicativeBuilder6[F] {
           val ff: M[F]
@@ -81,6 +103,19 @@ private[scalaz] trait ApplicativeBuilder[M[_], A, B] {
 
           def |@|[G](gg: M[G]): ApplicativeBuilder7[G] = ⊛(gg)
 
+          def parApply[Z](f: (A, B, C, D, E, F) => Z)(implicit ap: Apply.Par[M]): M[Z] =
+            Tag.unwrap(ap.apply6(
+                         Tag[M[A], Parallel](a),
+                         Tag[M[B], Parallel](b),
+                         Tag[M[C], Parallel](c),
+                         Tag[M[D], Parallel](d),
+                         Tag[M[E], Parallel](e),
+                         Tag[M[F], Parallel](ff)
+                       )(f))
+
+          def parTupled(implicit ap: Apply.Par[M]): M[(A, B, C, D, E, F)] =
+            parApply(Tuple6.apply)
+
           sealed abstract class ApplicativeBuilder7[G] {
             val g: M[G]
 
@@ -93,6 +128,20 @@ private[scalaz] trait ApplicativeBuilder[M[_], A, B] {
             }
 
             def |@|[H](hh: M[H]): ApplicativeBuilder8[H] = ⊛(hh)
+
+            def parApply[Z](f: (A, B, C, D, E, F, G) => Z)(implicit ap: Apply.Par[M]): M[Z] =
+              Tag.unwrap(ap.apply7(
+                           Tag[M[A], Parallel](a),
+                           Tag[M[B], Parallel](b),
+                           Tag[M[C], Parallel](c),
+                           Tag[M[D], Parallel](d),
+                           Tag[M[E], Parallel](e),
+                           Tag[M[F], Parallel](ff),
+                           Tag[M[G], Parallel](g)
+                         )(f))
+
+            def parTupled(implicit ap: Apply.Par[M]): M[(A, B, C, D, E, F, G)] =
+              parApply(Tuple7.apply)
 
             sealed abstract class ApplicativeBuilder8[H] {
               val h: M[H]
@@ -107,6 +156,21 @@ private[scalaz] trait ApplicativeBuilder[M[_], A, B] {
 
               def |@|[I](ii: M[I]): ApplicativeBuilder9[I] = ⊛(ii)
 
+              def parApply[Z](f: (A, B, C, D, E, F, G, H) => Z)(implicit ap: Apply.Par[M]): M[Z] =
+                Tag.unwrap(ap.apply8(
+                             Tag[M[A], Parallel](a),
+                             Tag[M[B], Parallel](b),
+                             Tag[M[C], Parallel](c),
+                             Tag[M[D], Parallel](d),
+                             Tag[M[E], Parallel](e),
+                             Tag[M[F], Parallel](ff),
+                             Tag[M[G], Parallel](g),
+                             Tag[M[H], Parallel](h)
+                           )(f))
+
+              def parTupled(implicit ap: Apply.Par[M]): M[(A, B, C, D, E, F, G, H)] =
+                parApply(Tuple8.apply)
+
               sealed abstract class ApplicativeBuilder9[I] {
                 val i: M[I]
 
@@ -120,6 +184,22 @@ private[scalaz] trait ApplicativeBuilder[M[_], A, B] {
 
                 def |@|[J](jj: M[J]): ApplicativeBuilder10[J] = ⊛(jj)
 
+                def parApply[Z](f: (A, B, C, D, E, F, G, H, I) => Z)(implicit ap: Apply.Par[M]): M[Z] =
+                  Tag.unwrap(ap.apply9(
+                               Tag[M[A], Parallel](a),
+                               Tag[M[B], Parallel](b),
+                               Tag[M[C], Parallel](c),
+                               Tag[M[D], Parallel](d),
+                               Tag[M[E], Parallel](e),
+                               Tag[M[F], Parallel](ff),
+                               Tag[M[G], Parallel](g),
+                               Tag[M[H], Parallel](h),
+                               Tag[M[I], Parallel](i)
+                             )(f))
+
+                def parTupled(implicit ap: Apply.Par[M]): M[(A, B, C, D, E, F, G, H, I)] =
+                  parApply(Tuple9.apply)
+
                 sealed abstract class ApplicativeBuilder10[J] {
                   val j: M[J]
 
@@ -132,6 +212,23 @@ private[scalaz] trait ApplicativeBuilder[M[_], A, B] {
                   }
 
                   def |@|[K](kk: M[K]): ApplicativeBuilder11[K] = ⊛(kk)
+
+                  def parApply[Z](f: (A, B, C, D, E, F, G, H, I, J) => Z)(implicit ap: Apply.Par[M]): M[Z] =
+                    Tag.unwrap(ap.apply10(
+                                 Tag[M[A], Parallel](a),
+                                 Tag[M[B], Parallel](b),
+                                 Tag[M[C], Parallel](c),
+                                 Tag[M[D], Parallel](d),
+                                 Tag[M[E], Parallel](e),
+                                 Tag[M[F], Parallel](ff),
+                                 Tag[M[G], Parallel](g),
+                                 Tag[M[H], Parallel](h),
+                                 Tag[M[I], Parallel](i),
+                                 Tag[M[J], Parallel](j)
+                               )(f))
+
+                  def parTupled(implicit ap: Apply.Par[M]): M[(A, B, C, D, E, F, G, H, I, J)] =
+                    parApply(Tuple10.apply)
 
                   sealed abstract class ApplicativeBuilder11[K] {
                     val k: M[K]
@@ -147,6 +244,24 @@ private[scalaz] trait ApplicativeBuilder[M[_], A, B] {
 
                     def |@|[L](ll: M[L]): ApplicativeBuilder12[L] = ⊛(ll)
 
+                    def parApply[Z](f: (A, B, C, D, E, F, G, H, I, J, K) => Z)(implicit ap: Apply.Par[M]): M[Z] =
+                      Tag.unwrap(ap.apply11(
+                                   Tag[M[A], Parallel](a),
+                                   Tag[M[B], Parallel](b),
+                                   Tag[M[C], Parallel](c),
+                                   Tag[M[D], Parallel](d),
+                                   Tag[M[E], Parallel](e),
+                                   Tag[M[F], Parallel](ff),
+                                   Tag[M[G], Parallel](g),
+                                   Tag[M[H], Parallel](h),
+                                   Tag[M[I], Parallel](i),
+                                   Tag[M[J], Parallel](j),
+                                   Tag[M[K], Parallel](k)
+                                 )(f))
+
+                    def parTupled(implicit ap: Apply.Par[M]): M[(A, B, C, D, E, F, G, H, I, J, K)] =
+                      parApply(Tuple11.apply)
+
                     sealed abstract class ApplicativeBuilder12[L] {
                       val l: M[L]
 
@@ -154,6 +269,26 @@ private[scalaz] trait ApplicativeBuilder[M[_], A, B] {
                         ap.apply12(a, b, c, d, e, ff, g, h, i, j, k, l)(f)
 
                       def tupled(implicit ap: Apply[M]): M[(A, B, C, D, E, F, G, H, I, J, K, L)] = apply(Tuple12.apply)
+
+                      def parApply[Z](f: (A, B, C, D, E, F, G, H, I, J, K, L) => Z)(implicit ap: Apply.Par[M]): M[Z] =
+                        Tag.unwrap(ap.apply12(
+                                     Tag[M[A], Parallel](a),
+                                     Tag[M[B], Parallel](b),
+                                     Tag[M[C], Parallel](c),
+                                     Tag[M[D], Parallel](d),
+                                     Tag[M[E], Parallel](e),
+                                     Tag[M[F], Parallel](ff),
+                                     Tag[M[G], Parallel](g),
+                                     Tag[M[H], Parallel](h),
+                                     Tag[M[I], Parallel](i),
+                                     Tag[M[J], Parallel](j),
+                                     Tag[M[K], Parallel](k),
+                                     Tag[M[L], Parallel](l)
+                                   )(f))
+
+                      def parTupled(implicit ap: Apply.Par[M]): M[(A, B, C, D, E, F, G, H, I, J, K, L)] =
+                        parApply(Tuple12.apply)
+
                     }
 
                   }

--- a/core/src/main/scala/scalaz/syntax/ApplicativeBuilder.scala
+++ b/core/src/main/scala/scalaz/syntax/ApplicativeBuilder.scala
@@ -12,11 +12,11 @@ private[scalaz] trait ApplicativeBuilder[M[_], A, B] {
 
   def tupled(implicit ap: Apply[M]): M[(A, B)] = apply(Tuple2.apply)
 
-  def parApply[C](f: (A, B) => C)(implicit ap: Apply[λ[α => M[α] @@ Parallel]]): M[C] =
-    Parallel.unwrap(ap.apply2(Parallel(a), Parallel(b))(f))
-
-  def parTupled(implicit ap: Apply[λ[α => M[α] @@ Parallel]]): M[(A, B)] =
-    parApply(Tuple2.apply)
+  // bincompat :-(
+  //def parApply[C](f: (A, B) => C)(implicit ap: Apply[λ[α => M[α] @@ Parallel]]): M[C] =
+  //  Parallel.unwrap(ap.apply2(Parallel(a), Parallel(b))(f))
+  //def parTupled(implicit ap: Apply[λ[α => M[α] @@ Parallel]]): M[(A, B)] =
+  //  parApply(Tuple2.apply)
 
   def ⊛[C](cc: M[C]) = new ApplicativeBuilder3[C] {
     val c = cc

--- a/core/src/main/scala/scalaz/syntax/ApplicativeBuilder.scala
+++ b/core/src/main/scala/scalaz/syntax/ApplicativeBuilder.scala
@@ -170,7 +170,7 @@ abstract class ApplicativeBuilderSyntax {
   implicit final class ApplicativeBuilderOps2[M[_], A, B](
     private val self: ApplicativeBuilder[M, A, B]) {
     def parApply[C](f: (A, B) => C)(implicit ap: Apply[λ[α => M[α] @@ Parallel]]): M[C] =
-      Parallel.unwrap(ap.apply2(Parallel(self.a), Parallel(self.b))(f))
+      Tag.unwrap(ap.apply2(Tag[M[A], Parallel](self.a), Tag[M[B], Parallel](self.b))(f))
 
     def parTupled(implicit ap: Apply[λ[α => M[α] @@ Parallel]]): M[(A, B)] =
       parApply(Tuple2.apply)

--- a/core/src/main/scala/scalaz/syntax/ApplicativeBuilder.scala
+++ b/core/src/main/scala/scalaz/syntax/ApplicativeBuilder.scala
@@ -169,10 +169,10 @@ abstract class ApplicativeBuilderSyntax {
 
   implicit final class ApplicativeBuilderOps2[M[_], A, B](
     private val self: ApplicativeBuilder[M, A, B]) {
-    def parApply[C](f: (A, B) => C)(implicit ap: Apply[λ[α => M[α] @@ Parallel]]): M[C] =
+    def parApply[C](f: (A, B) => C)(implicit ap: Apply.Par[M]): M[C] =
       Tag.unwrap(ap.apply2(Tag[M[A], Parallel](self.a), Tag[M[B], Parallel](self.b))(f))
 
-    def parTupled(implicit ap: Apply[λ[α => M[α] @@ Parallel]]): M[(A, B)] =
+    def parTupled(implicit ap: Apply.Par[M]): M[(A, B)] =
       parApply(Tuple2.apply)
   }
 }

--- a/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/MonadErrorSyntax.scala
@@ -10,6 +10,12 @@ final class MonadErrorOps[F[_], S, A] private[syntax](self: F[A])(implicit val F
   final def emap[B](f: A => S \/ B): F[B] =
     F.bind(self)(a => f(a).fold(F.raiseError(_), F.pure(_)))
 
+  final def recover(f: S => A): F[A] =
+    F.handleError(self)(s => F.point(f(s)))
+
+  final def attempt: F[S \/ A] =
+    F.handleError(F.map(self)(a => \/.right[S, A](a)))(e => F.point(-\/(e)))
+
   ////
 }
 

--- a/core/src/main/scala/scalaz/syntax/TraverseSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/TraverseSyntax.scala
@@ -65,6 +65,15 @@ final class TraverseOps[F[_],A] private[syntax](val self: F[A])(implicit val F: 
     F.mapAccumL(self, z)(f)
   final def mapAccumR[S,B](z: S)(f: (S,A) => (S,B)): (S, F[B]) =
     F.mapAccumR(self, z)(f)
+
+  import Tags.Parallel
+  final def parTraverse[G[_], B](f: A => G[B])(
+    implicit F: Traverse[F], G: Applicative[λ[α => G[α] @@ Parallel]]
+  ): G[F[B]] = {
+    type ParG[C] = G[C] @@ Parallel
+    Parallel.unwrap(F.traverse(self)(a => Parallel(f(a)): ParG[B]))
+  }
+
   ////
 }
 

--- a/core/src/main/scala/scalaz/syntax/TraverseSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/TraverseSyntax.scala
@@ -68,10 +68,10 @@ final class TraverseOps[F[_],A] private[syntax](val self: F[A])(implicit val F: 
 
   import Tags.Parallel
   final def parTraverse[G[_], B](f: A => G[B])(
-    implicit F: Traverse[F], G: Applicative[λ[α => G[α] @@ Parallel]]
+    implicit F: Traverse[F], G: Applicative.Par[G]
   ): G[F[B]] = {
-    type ParG[C] = G[C] @@ Parallel
-    Parallel.unwrap(F.traverse(self)(a => Parallel(f(a)): ParG[B]))
+    type ParG[a] = G[a] @@ Parallel
+    Tag.unwrap(F.traverse[ParG, A, B](self)(a => Tag(f(a))))
   }
 
   ////

--- a/core/src/main/scala/scalaz/syntax/package.scala
+++ b/core/src/main/scala/scalaz/syntax/package.scala
@@ -12,5 +12,4 @@ package object syntax extends Syntaxes {
   object contT extends ToContTOps
   object monadTrans extends ToMonadTransOps
   object eithert extends ToEitherTOps
-  object parallel extends ApplicativeBuilderSyntax
 }

--- a/core/src/main/scala/scalaz/syntax/package.scala
+++ b/core/src/main/scala/scalaz/syntax/package.scala
@@ -12,4 +12,5 @@ package object syntax extends Syntaxes {
   object contT extends ToContTOps
   object monadTrans extends ToMonadTransOps
   object eithert extends ToEitherTOps
+  object parallel extends ApplicativeBuilderSyntax
 }

--- a/example/src/main/scala/scalaz/example/ApplyUsage.scala
+++ b/example/src/main/scala/scalaz/example/ApplyUsage.scala
@@ -162,8 +162,9 @@ object ApplyUsage extends App {
   (fa |@| fb).tupled: Task[(String, String)]
 
   // parallel
-  import scalaz.syntax.parallel._
+  //import scalaz.syntax.parallel._
 
+  (fa |@| fb).parApply(_ ++ _): Task[String]
   (fa |@| fb).parTupled: Task[(String, String)]
 
   // yuck

--- a/example/src/main/scala/scalaz/example/ApplyUsage.scala
+++ b/example/src/main/scala/scalaz/example/ApplyUsage.scala
@@ -162,18 +162,17 @@ object ApplyUsage extends App {
   import Task.taskParallelApplicativeInstance
 
   // sequential
-  (fa |@| fb) {
-    case (a, b) => a + b
-  }
+  (fa |@| fb).tupled: Task[(String, String)]
 
   // parallel
   import scalaz.syntax.parallel._
-  (fa |@| fb).parApply {
-    case (a, b) => a + b
-  }
 
-  // (fa |@| fb |@| fc).parApply {
-  //   case (a, b, c) => a + b + c
-  // }
+  (fa |@| fb).parTupled: Task[(String, String)]
+
+  // can't add syntax until 7.3 where we can break bincompat...
+  // (fa |@| fb |@| fc).parTupled: Task[(String, String, String)]
+
+  // yuck
+  (fa |@| (fb |@| fc).parTupled).parTupled: Task[(String, (String, String))]
 
 }

--- a/example/src/main/scala/scalaz/example/ApplyUsage.scala
+++ b/example/src/main/scala/scalaz/example/ApplyUsage.scala
@@ -162,12 +162,8 @@ object ApplyUsage extends App {
   (fa |@| fb).tupled: Task[(String, String)]
 
   // parallel
-  //import scalaz.syntax.parallel._
-
   (fa |@| fb).parApply(_ ++ _): Task[String]
   (fa |@| fb).parTupled: Task[(String, String)]
-
-  // yuck
   (fa |@| fb |@| fc).parTupled: Task[(String, String, String)]
 
 }

--- a/example/src/main/scala/scalaz/example/ApplyUsage.scala
+++ b/example/src/main/scala/scalaz/example/ApplyUsage.scala
@@ -156,19 +156,24 @@ object ApplyUsage extends App {
   // imagine these were effectful, like hitting disk or network...
   val fa: Task[String] = Task.delay("hello")
   val fb: Task[String] = Task.delay("world")
+  val fc: Task[String] = Task.delay("!")
 
   // WORKAROUND https://github.com/scala/bug/issues/10954
   import Task.taskParallelApplicativeInstance
 
   // sequential
   (fa |@| fb) {
-    case (a, b) => b + a
+    case (a, b) => a + b
   }
 
   // parallel
   import scalaz.syntax.parallel._
   (fa |@| fb).parApply {
-    case (a, b) => b + a
+    case (a, b) => a + b
   }
+
+  // (fa |@| fb |@| fc).parApply {
+  //   case (a, b, c) => a + b + c
+  // }
 
 }

--- a/example/src/main/scala/scalaz/example/ApplyUsage.scala
+++ b/example/src/main/scala/scalaz/example/ApplyUsage.scala
@@ -146,4 +146,29 @@ object ApplyUsage extends App {
 
   assert(deepResult === expectedDeep)
 
+  ///////////////////////////////////
+  // PARALLELISM
+  import scalaz.Tags.Parallel
+  import scalaz.{ @@, Applicative }
+  import scalaz.Isomorphism.IsoFunctorTemplate
+  import scalaz.concurrent.Task
+
+  // imagine these were effectful, like hitting disk or network...
+  val fa: Task[String] = Task.delay("hello")
+  val fb: Task[String] = Task.delay("world")
+
+  // WORKAROUND https://github.com/scala/bug/issues/10954
+  import Task.taskParallelApplicativeInstance
+
+  // sequential
+  (fa |@| fb) {
+    case (a, b) => b + a
+  }
+
+  // parallel
+  import scalaz.syntax.parallel._
+  (fa |@| fb).parApply {
+    case (a, b) => b + a
+  }
+
 }

--- a/example/src/main/scala/scalaz/example/ApplyUsage.scala
+++ b/example/src/main/scala/scalaz/example/ApplyUsage.scala
@@ -148,9 +148,6 @@ object ApplyUsage extends App {
 
   ///////////////////////////////////
   // PARALLELISM
-  import scalaz.Tags.Parallel
-  import scalaz.{ @@, Applicative }
-  import scalaz.Isomorphism.IsoFunctorTemplate
   import scalaz.concurrent.Task
 
   // imagine these were effectful, like hitting disk or network...

--- a/example/src/main/scala/scalaz/example/ApplyUsage.scala
+++ b/example/src/main/scala/scalaz/example/ApplyUsage.scala
@@ -166,10 +166,7 @@ object ApplyUsage extends App {
 
   (fa |@| fb).parTupled: Task[(String, String)]
 
-  // can't add syntax until 7.3 where we can break bincompat...
-  // (fa |@| fb |@| fc).parTupled: Task[(String, String, String)]
-
   // yuck
-  (fa |@| (fb |@| fc).parTupled).parTupled: Task[(String, (String, String))]
+  (fa |@| fb |@| fc).parTupled: Task[(String, String, String)]
 
 }


### PR DESCRIPTION
This PR does not add any features but instead makes it easier to use existing features.

Subject to binary compatibility, of course. In 7.3 we can apply the obvious changes to `Applicative` and if bincompat holds up, we can add `parApply` / `parTuple` to all the `ApplicativeBuilder`s.

I am particularly interested to hear @xuwei-k's thoughts on this! Seems we had similar ideas around `def parallel`, but I think we should delete `NonDeterminism`.
