### PR TITLE
new data structure: IStream

### DIFF
--- a/core/src/main/scala/scalaz/IStream.scala
+++ b/core/src/main/scala/scalaz/IStream.scala
@@ -6,8 +6,8 @@ package scalaz
 import scala.annotation.tailrec
 
 /**
- * A linked list with by-name tail, allowing some control over memory usage and
- * evaluation of contents.
+ * A linked list with by-name head and tail, allowing some control over memory
+ * usage and evaluation of contents.
  *
  * This structure is a good choice when the contents are expensive to calculate
  * and may not all need to be evaluated, at the cost of an overhead when the
@@ -19,16 +19,27 @@ sealed abstract class IStream[A] { self =>
   import IStream._
 
   /** Strict concatenation */
-  final def !:(a: A): IStream[A]     = Cons(a, Value(self))
+  final def !:(a: A): IStream[A]     = Cons(Value(a), Value(self))
   final def :!(other: A): IStream[A] = !!(Strict(other))
   final def !!(other: IStream[A]): IStream[A] =
     instances.foldRight(self, other)((a, as) => Strict.cons(a, as))
+
+  /** prepend lazily (by-name parameters do not work here) */
+  final def #:(a: Name[A]): IStream[A] = Cons(a, Value(self))
+
+  // not stack safe. We could have an infinite stream so would we want to
+  // sacrifice stack safety for non-terminating programs instead? That's what
+  // foldLeft is for. Life is meaningless, etc, etc.
+  final def foldRightByName[B](z: =>B)(f: (=>A, =>B) => B): B = self match {
+    case _: Nil[_]        => z
+    case Cons(head, tail) => f(head.value, tail.value.foldRightByName(z)(f))
+  }
 
   // Stack safe, but can't exit early. You may never escape.
   final def foldLeftByName[B](z: B)(f: (=>B, =>A) => B): B = {
     @tailrec def loop(t: IStream[A], acc: B): B = t match {
       case _: Nil[_]        => acc
-      case Cons(head, tail) => loop(tail.value, f(acc, head))
+      case Cons(head, tail) => loop(tail.value, f(acc, head.value))
     }
     loop(self, z)
   }
@@ -40,7 +51,7 @@ object IStream {
 
   private final case class Nil[A]() extends IStream
   private final case class Cons[A](
-    head: A,
+    head: Name[A],
     tail: Name[IStream[A]]
   ) extends IStream[A]
   // it is very tempting to add a third case that concatenates two streams...
@@ -50,17 +61,17 @@ object IStream {
   private[this] final val _empty = Nil[Nothing]()
 
   object ByName {
-    def apply[A](a: =>A): IStream[A] = Cons(a, nil[A])
-    def cons[A](head: A, tail: =>IStream[A]): IStream[A] = Cons(head, Name(tail))
+    def apply[A](a: =>A): IStream[A] = Cons(Name(a), nil[A])
+    def cons[A](head: =>A, tail: =>IStream[A]): IStream[A] = Cons(Name(head), Name(tail))
     def infinite[A](el: A): IStream[A] = cons(el, infinite(el))
   }
   object Lazy {
-    def apply[A](a: =>A): IStream[A] = Cons(a, nil[A])
-    def cons[A](head: A, tail: =>IStream[A]): IStream[A] = Cons(head, Need(tail))
+    def apply[A](a: =>A): IStream[A] = Cons(Need(a), nil[A])
+    def cons[A](head: =>A, tail: =>IStream[A]): IStream[A] = Cons(Need(head), Need(tail))
     def infinite[A](el: A): IStream[A] = cons(el, infinite(el))
   }
   object Strict {
-    def apply[A](a: A): IStream[A]                     = Cons(a, nil[A])
+    def apply[A](a: A): IStream[A]                     = Cons(Value(a), nil[A])
     def cons[A](head: A, tail: IStream[A]): IStream[A] = head !: tail
   }
 
@@ -80,14 +91,14 @@ object IStream {
     new MonadPlus[IStream] with IsEmpty[IStream] with Traverse[IStream] {
 
       override def map[A, B](fa: IStream[A])(f: A => B): IStream[B] =
-        foldRight(fa, empty[B])((h, t) => Lazy.cons(f(h), t))
+        fa.foldRightByName(empty[B])((h, t) => Lazy.cons(f(h), t))
 
       def point[A](a: =>A): IStream[A] = Lazy(a)
       def bind[A, B](fa: IStream[A])(f: A => IStream[B]): IStream[B] =
         foldRight(fa, empty[B])((h, t) => plus(f(h), t))
 
       def plus[A](a: IStream[A], b: =>IStream[A]): IStream[A] =
-        foldRight(a, b)(Lazy.cons)
+        a.foldRightByName(b)(Lazy.cons)
       def empty[A]: IStream[A] = IStream.empty[A]
 
       def isEmpty[A](fa: IStream[A]): Boolean = fa.isInstanceOf[Nil[_]]
@@ -100,13 +111,13 @@ object IStream {
       ): B =
         fa match {
           case _: Nil[_]        => z
-          case Cons(head, tail) => f(head, foldRight(tail.value, z)(f))
+          case Cons(head, tail) => f(head.value, foldRight(tail.value, z)(f))
         }
 
       override def foldLeft[A, B](fa: IStream[A], z: B)(f: (B, A) => B): B = {
         @tailrec def loop(t: IStream[A], acc: B): B = t match {
           case _: Nil[_]        => acc
-          case Cons(head, tail) => loop(tail.value, f(acc, head))
+          case Cons(head, tail) => loop(tail.value, f(acc, head.value))
         }
         loop(fa, z)
       }
@@ -114,7 +125,9 @@ object IStream {
       def traverseImpl[G[_], A, B](
         fa: IStream[A]
       )(f: A => G[B])(implicit G: Applicative[G]): G[IStream[B]] =
-        foldRight(fa, G.point(empty[B]))((x, ys) => G.apply2(f(x), ys)(_ !: _))
+        fa.foldRightByName(G.point(empty[B]))(
+          (x, ys) => G.apply2(f(x), ys)(_ !: _)
+        )
 
       // wtf is traversal all about?
       override def traverse[G[_]: Applicative, A, B](fa: IStream[A])(f: A => G[B]): G[IStream[B]] = traverseImpl(fa)(f)

--- a/core/src/main/scala/scalaz/IStream.scala
+++ b/core/src/main/scala/scalaz/IStream.scala
@@ -1,0 +1,141 @@
+// Copyright: 2017 - 2018 Sam Halliday
+// License: https://opensource.org/licenses/BSD-3-Clause
+
+package scalaz
+
+import scala.annotation.tailrec
+
+/**
+ * A linked list with by-name head and tail, allowing some control over memory
+ * usage and evaluation of contents.
+ *
+ * This structure is a good choice when the contents are expensive to calculate
+ * and may not all need to be evaluated, at the cost of an overhead when the
+ * contents are calculated. Typeclass instances try to defer evaluation of
+ * contents, unless it would require a full traversal of the spine, preferring
+ * lazy semantics when an evaluation choice is to be made.
+ */
+sealed abstract class IStream[A] { self =>
+  import IStream._
+
+  /** Strict concatenation */
+  final def !:(a: A): IStream[A]     = Cons(Value(a), Value(self))
+  final def :!(other: A): IStream[A] = !!(Strict(other))
+  final def !!(other: IStream[A]): IStream[A] =
+    instances.foldRight(self, other)((a, as) => Strict.cons(a, as))
+
+  /** prepend lazily (by-name parameters do not work here) */
+  final def #:(a: Name[A]): IStream[A] = Cons(a, Value(self))
+
+  // not stack safe. We could have an infinite stream so would we want to
+  // sacrifice stack safety for non-terminating programs instead? That's what
+  // foldLeft is for. Life is meaningless, etc, etc.
+  final def foldRightByName[B](z: =>B)(f: (=>A, =>B) => B): B = self match {
+    case _: Nil[_]        => z
+    case Cons(head, tail) => f(head.value, tail.value.foldRightByName(z)(f))
+  }
+
+  // Stack safe, but can't exit early. You may never escape.
+  final def foldLeftByName[B](z: B)(f: (=>B, =>A) => B): B = {
+    @tailrec def loop(t: IStream[A], acc: B): B = t match {
+      case _: Nil[_]        => acc
+      case Cons(head, tail) => loop(tail.value, f(acc, head.value))
+    }
+    loop(self, z)
+  }
+
+  def reverse: IStream[A] = foldLeftByName(empty[A])((xs, x) => Lazy.cons(x, xs))
+
+}
+object IStream {
+
+  private final case class Nil[A]() extends IStream
+  private final case class Cons[A](
+    head: Name[A],
+    tail: Name[IStream[A]]
+  ) extends IStream[A]
+  // it is very tempting to add a third case that concatenates two streams...
+  // but it would break the stack safety of foldLeft.
+
+  def empty[A]: IStream[A]       = _empty.asInstanceOf[IStream[A]]
+  private[this] final val _empty = Nil[Nothing]()
+
+  object ByName {
+    def apply[A](a: =>A): IStream[A] = Cons(Name(a), nil[A])
+    def cons[A](head: =>A, tail: =>IStream[A]): IStream[A] = Cons(Name(head), Name(tail))
+    def infinite[A](el: A): IStream[A] = cons(el, infinite(el))
+  }
+  object Lazy {
+    def apply[A](a: =>A): IStream[A] = Cons(Need(a), nil[A])
+    def cons[A](head: =>A, tail: =>IStream[A]): IStream[A] = Cons(Need(head), Need(tail))
+    def infinite[A](el: A): IStream[A] = cons(el, infinite(el))
+  }
+  object Strict {
+    def apply[A](a: A): IStream[A]                     = Cons(Value(a), nil[A])
+    def cons[A](head: A, tail: IStream[A]): IStream[A] = head !: tail
+  }
+
+  def fromStream[A](sa: Stream[A]): IStream[A] = sa match {
+    case Stream() => empty[A]
+    case h #:: t  => Lazy.cons(h, fromStream(t))
+  }
+
+  def fromFoldable[F[_]: Foldable, A](fa: F[A]): IStream[A] =
+    Foldable[F].foldRight(fa, empty[A])((h, t) => Lazy.cons(h, t))
+
+  // more efficient allocations
+  private[this] final val __empty = Value(_empty)
+  private[this] final def nil[A]  = __empty.asInstanceOf[Name[IStream[A]]]
+
+  implicit val instances: MonadPlus[IStream] with IsEmpty[IStream] with Traverse[IStream] =
+    new MonadPlus[IStream] with IsEmpty[IStream] with Traverse[IStream] {
+
+      override def map[A, B](fa: IStream[A])(f: A => B): IStream[B] =
+        fa.foldRightByName(empty[B])((h, t) => Lazy.cons(f(h), t))
+
+      def point[A](a: =>A): IStream[A] = Lazy(a)
+      def bind[A, B](fa: IStream[A])(f: A => IStream[B]): IStream[B] =
+        foldRight(fa, empty[B])((h, t) => plus(f(h), t))
+
+      def plus[A](a: IStream[A], b: =>IStream[A]): IStream[A] =
+        a.foldRightByName(b)(Lazy.cons)
+      def empty[A]: IStream[A] = IStream.empty[A]
+
+      def isEmpty[A](fa: IStream[A]): Boolean = fa.isInstanceOf[Nil[_]]
+
+      override def foldMap[A, B](fa: IStream[A])(f: A => B)(implicit F: Monoid[B]): B =
+        foldRight(fa, F.zero)((a, b) => F.append(f(a), b))
+
+      override def foldRight[A, B](fa: IStream[A], z: =>B)(
+        f: (A, =>B) => B
+      ): B =
+        fa match {
+          case _: Nil[_]        => z
+          case Cons(head, tail) => f(head.value, foldRight(tail.value, z)(f))
+        }
+
+      override def foldLeft[A, B](fa: IStream[A], z: B)(f: (B, A) => B): B = {
+        @tailrec def loop(t: IStream[A], acc: B): B = t match {
+          case _: Nil[_]        => acc
+          case Cons(head, tail) => loop(tail.value, f(acc, head.value))
+        }
+        loop(fa, z)
+      }
+
+      def traverseImpl[G[_], A, B](
+        fa: IStream[A]
+      )(f: A => G[B])(implicit G: Applicative[G]): G[IStream[B]] =
+        fa.foldRightByName(G.point(empty[B]))(
+          (x, ys) => G.apply2(f(x), ys)(_ !: _)
+        )
+
+      // wtf is traversal all about?
+      override def traverse[G[_]: Applicative, A, B](fa: IStream[A])(f: A => G[B]): G[IStream[B]] = traverseImpl(fa)(f)
+
+    }
+
+  // it would be more in keeping with the data structure's objectives to
+  // Align.align and compare elements, to avoid a full traversal...
+  implicit def equal[A: Equal]: Equal[IStream[A]] = Equal[IList[A]].contramap(instances.toIList(_))
+
+}

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
@@ -243,6 +243,9 @@ object ScalazArbitrary extends ScalazArbitraryPlatform {
   implicit def EphemeralStreamArbitrary[A : Arbitrary]: Arbitrary[EphemeralStream[A]] =
     Functor[Arbitrary].map(arb[Stream[A]])(EphemeralStream.fromStream[A](_))
 
+  implicit def IStreamArbitrary[A : Arbitrary]: Arbitrary[IStream[A]] =
+    Functor[Arbitrary].map(arb[Stream[A]])(IStream.fromStream[A](_))
+
   implicit def CorecursiveListArbitrary[A : Arbitrary]: Arbitrary[CorecursiveList[A]] =
     Functor[Arbitrary].map(arb[Stream[A]])(CorecursiveList.fromStream)
 

--- a/tests/src/test/scala/scalaz/IStreamTest.scala
+++ b/tests/src/test/scala/scalaz/IStreamTest.scala
@@ -1,0 +1,42 @@
+package scalaz
+
+import scalaz.scalacheck.ScalazProperties._
+import scalaz.scalacheck.ScalazArbitrary._
+import std.AllInstances._
+import syntax.contravariant._
+import syntax.foldable._
+import org.scalacheck.Prop.forAll
+
+object IStreamTest extends SpecLite {
+
+  checkAll(monadPlus.strongLaws[IStream])
+  checkAll(isEmpty.laws[IStream])
+  checkAll(traverse.laws[IStream])
+
+  implicit def iStreamShow[A: Show]: Show[IStream[A]] =
+    Show[List[A]].contramap(_.toList)
+
+  "reverse" ! forAll{ e: IStream[Int] =>
+    e.reverse.toList must_===(e.toList.reverse)
+    e.reverse.reverse must_===(e)
+  }
+
+  "Foldable.foldLeft" ! forAll{ xs: List[List[Int]] =>
+    Foldable[IStream].foldLeft(IStream.fromFoldable(xs), List[Int]())(_ ::: _) must_===(xs.foldLeft(List[Int]())(_ ::: _))
+  }
+
+  "foldMap evaluates lazily" in {
+    Foldable[IStream].foldMap(IStream.Lazy.infinite(false))(identity)(booleanInstance.conjunction) must_===(false)
+  }
+
+  // https://github.com/scalaz/scalaz/issues/1515
+  "traverse is curiously lazy over Id" ! {
+    import syntax.traverse._
+    import Scalaz.Id
+
+    val stream = IStream.Lazy.infinite(1)
+    val _ = stream.traverse[Id, Int](identity)
+    // got here without exception... that's good!
+  }
+
+}


### PR DESCRIPTION
A more flexible alternative to `EphemeralStream` that makes different implementation trade-offs. I'd appreciate feedback before I invest any more time into it. The by-name nature of `EphemeralStream` causes performance problems in `scalaz-deriving` where lazy semantics (not by-name) are very much preferred.

We could potentially change `EphemeralStream` to point here if we felt that the tradeoffs are strictly better.

One thing I don't like about this implementation, vs one where the head is always eager, is that a `OneAnd` with a lazy head will have a nested `Name[Name[A]]`. This suddenly becomes a usecase to reintroduce https://github.com/scalaz/scalaz/issues/1516 ... or to make `OneAnd` use `Name` for the head. I have the code sitting around somewhere.

@TomasMikula remember https://github.com/scalaz/scalaz/issues/1515 ? Well this seems to have better `traverse` behaviour. This has been driving me crazy.