### PR TITLE
Invariant parent of Applicative and Divisible

### DIFF
--- a/core/src/main/scala/scalaz/Alt.scala
+++ b/core/src/main/scala/scalaz/Alt.scala
@@ -51,20 +51,6 @@ trait Alt[F[_]] extends Applicative[F] with InvariantAlt[F] { self =>
     altly4(a1, a2, a3, a4)(f)
   // ... altlyingX
 
-  override def xproduct0[Z](z: =>Z): F[Z] = pure(z)
-  override def xproduct1[Z, A1](a1: =>F[A1])(f: A1 => Z, g: Z => A1): F[Z] = xmap(a1, f, g)
-  override def xproduct2[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(
-    f: (A1, A2) => Z, g: Z => (A1, A2)
-  ): F[Z] = apply2(a1, a2)(f)
-  override def xproduct3[Z, A1, A2, A3](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3])(
-    f: (A1, A2, A3) => Z,
-    g: Z => (A1, A2, A3)
-  ): F[Z] = apply3(a1, a2, a3)(f)
-  override def xproduct4[Z, A1, A2, A3, A4](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3], a4: =>F[A4])(
-    f: (A1, A2, A3, A4) => Z,
-    g: Z => (A1, A2, A3, A4)
-  ): F[Z] = apply4(a1, a2, a3, a4)(f)
-
   override def xcoproduct1[Z, A1](a1: =>F[A1])(
     f: A1 => Z,
     g: Z => A1
@@ -114,18 +100,6 @@ trait IsomorphismAlt[F[_], G[_]] extends Alt[F] with IsomorphismApplicative[F, G
   implicit def G: Alt[G]
   ////
   override def alt[A](a1: =>F[A], a2: =>F[A]): F[A] = iso.from(G.alt(iso.to(a1), iso.to(a2)))
-
-  override def xproduct0[Z](z: => Z): F[Z] =
-    super[Alt].xproduct0(z)
-
-  override def xproduct1[Z, A1](a1: =>F[A1])(f: A1 => Z, g: Z => A1): F[Z] =
-    super[Alt].xproduct1(a1)(f, g)
-  override def xproduct2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: (A1, A2) => Z, g: Z => (A1, A2)): F[Z] =
-    super[Alt].xproduct2(a1, a2)(f, g)
-  override def xproduct3[Z, A1, A2, A3](a1: => F[A1], a2: => F[A2], a3: => F[A3])(f: (A1, A2, A3) => Z, g: Z => (A1, A2, A3)): F[Z] =
-    super[Alt].xproduct3(a1, a2, a3)(f, g)
-  override def xproduct4[Z, A1, A2, A3, A4](a1: => F[A1], a2: => F[A2], a3: => F[A3], a4: => F[A4])(f: (A1, A2, A3, A4) => Z, g: Z => (A1, A2, A3, A4)): F[Z] =
-    super[Alt].xproduct4(a1, a2, a3, a4)(f, g)
 
   override def xcoproduct1[Z, A1](a1: => F[A1])(f: A1 => Z, g: Z => A1): F[Z] =
     super[Alt].xcoproduct1(a1)(f, g)

--- a/core/src/main/scala/scalaz/Applicative.scala
+++ b/core/src/main/scala/scalaz/Applicative.scala
@@ -17,7 +17,7 @@ package scalaz
  *  @see [[scalaz.Applicative.ApplicativeLaw]]
  */
 ////
-trait Applicative[F[_]] extends Apply[F] { self =>
+trait Applicative[F[_]] extends Apply[F] with InvariantApplicative[F] { self =>
   ////
   def point[A](a: => A): F[A]
 
@@ -40,6 +40,20 @@ trait Applicative[F[_]] extends Apply[F] { self =>
     traverse(as)(a => a)
 
   import std.list._
+
+  override def xproduct0[Z](z: =>Z): F[Z] = point(z)
+  override def xproduct1[Z, A1](a1: =>F[A1])(f: A1 => Z, g: Z => A1): F[Z] = xmap(a1, f, g)
+  override def xproduct2[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(
+    f: (A1, A2) => Z, g: Z => (A1, A2)
+  ): F[Z] = apply2(a1, a2)(f)
+  override def xproduct3[Z, A1, A2, A3](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3])(
+    f: (A1, A2, A3) => Z,
+    g: Z => (A1, A2, A3)
+  ): F[Z] = apply3(a1, a2, a3)(f)
+  override def xproduct4[Z, A1, A2, A3, A4](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3], a4: =>F[A4])(
+    f: (A1, A2, A3, A4) => Z,
+    g: Z => (A1, A2, A3, A4)
+  ): F[Z] = apply4(a1, a2, a3, a4)(f)
 
   /** Performs the action `n` times, returning the list of results. */
   def replicateM[A](n: Int, fa: F[A]): F[IList[A]] =
@@ -128,7 +142,7 @@ object Applicative {
   ////
 }
 
-trait IsomorphismApplicative[F[_], G[_]] extends Applicative[F] with IsomorphismApply[F, G]{
+trait IsomorphismApplicative[F[_], G[_]] extends Applicative[F] with IsomorphismApply[F, G] with IsomorphismInvariantApplicative[F, G]{
   implicit def G: Applicative[G]
   ////
 
@@ -137,5 +151,16 @@ trait IsomorphismApplicative[F[_], G[_]] extends Applicative[F] with Isomorphism
 
   override def ap[A, B](fa: => F[A])(f: => F[A => B]): F[B] =
     iso.from(G.ap(iso.to(fa))(iso.to(f)))
+
+  override def xproduct0[Z](z: => Z): F[Z] =
+    super[Applicative].xproduct0(z)
+  override def xproduct1[Z, A1](a1: =>F[A1])(f: A1 => Z, g: Z => A1): F[Z] =
+    super[Applicative].xproduct1(a1)(f, g)
+  override def xproduct2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: (A1, A2) => Z, g: Z => (A1, A2)): F[Z] =
+    super[Applicative].xproduct2(a1, a2)(f, g)
+  override def xproduct3[Z, A1, A2, A3](a1: => F[A1], a2: => F[A2], a3: => F[A3])(f: (A1, A2, A3) => Z, g: Z => (A1, A2, A3)): F[Z] =
+    super[Applicative].xproduct3(a1, a2, a3)(f, g)
+  override def xproduct4[Z, A1, A2, A3, A4](a1: => F[A1], a2: => F[A2], a3: => F[A3], a4: => F[A4])(f: (A1, A2, A3, A4) => Z, g: Z => (A1, A2, A3, A4)): F[Z] =
+    super[Applicative].xproduct4(a1, a2, a3, a4)(f, g)
   ////
 }

--- a/core/src/main/scala/scalaz/Applicative.scala
+++ b/core/src/main/scala/scalaz/Applicative.scala
@@ -151,6 +151,8 @@ trait IsomorphismApplicative[F[_], G[_]] extends Applicative[F] with Isomorphism
 
   override def ap[A, B](fa: => F[A])(f: => F[A => B]): F[B] =
     iso.from(G.ap(iso.to(fa))(iso.to(f)))
+  override def apply2[A, B, C](fa: => F[A], fb: => F[B])(f: (A, B) => C): F[C] =
+    iso.from(G.apply2(iso.to(fa), iso.to(fb))(f))
 
   override def xproduct0[Z](z: => Z): F[Z] =
     super[Applicative].xproduct0(z)

--- a/core/src/main/scala/scalaz/Decidable.scala
+++ b/core/src/main/scala/scalaz/Decidable.scala
@@ -45,21 +45,6 @@ trait Decidable[F[_]] extends Divisible[F] with InvariantAlt[F] { self =>
     choose4(fa1, fa2, fa3, fa4)(f)
   // ... choosingX
 
-  override def xproduct0[Z](z: =>Z): F[Z] = conquer
-  override def xproduct1[Z, A1](a1: =>F[A1])(f: A1 => Z, g: Z => A1): F[Z] = xmap(a1, f, g)
-  override def xproduct2[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(
-    f: (A1, A2) => Z,
-    g: Z => (A1, A2)
-  ): F[Z] = divide2(a1, a2)(g)
-  override def xproduct3[Z, A1, A2, A3](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3])(
-    f: (A1, A2, A3) => Z,
-    g: Z => (A1, A2, A3)
-  ): F[Z] = divide3(a1, a2, a3)(g)
-  override def xproduct4[Z, A1, A2, A3, A4](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3], a4: =>F[A4])(
-    f: (A1, A2, A3, A4) => Z,
-    g: Z => (A1, A2, A3, A4)
-  ): F[Z] = divide4(a1, a2, a3, a4)(g)
-
   override def xcoproduct1[Z, A1](a1: =>F[A1])(
     f: A1 => Z,
     g: Z => A1
@@ -114,9 +99,6 @@ trait IsomorphismDecidable[F[_], G[_]] extends Decidable[F] with IsomorphismDivi
   def choose2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: Z => A1 \/ A2): F[Z] =
     iso.from(G.choose2(iso.to(a1), iso.to(a2))(f))
 
-  override def xproduct0[Z](z: => Z): F[Z] =
-    super[Decidable].xproduct0(z)
-
   override def xcoproduct1[Z, A1](a1: => F[A1])(f: A1 => Z, g: Z => A1): F[Z] =
     super[Decidable].xcoproduct1(a1)(f, g)
   override def xcoproduct2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: A1 \/ A2 => Z, g: Z => A1 \/ A2): F[Z] =
@@ -125,15 +107,6 @@ trait IsomorphismDecidable[F[_], G[_]] extends Decidable[F] with IsomorphismDivi
     super[Decidable].xcoproduct3(a1, a2, a3)(f, g)
   override def xcoproduct4[Z, A1, A2, A3, A4](a1: => F[A1], a2: => F[A2], a3: => F[A3], a4: => F[A4])(f: A1 \/ (A2 \/ (A3 \/ A4)) => Z, g: Z => A1 \/ (A2 \/ (A3 \/ A4))): F[Z] =
     super[Decidable].xcoproduct4(a1, a2, a3, a4)(f, g)
-
-  override def xproduct1[Z, A1](a1: =>F[A1])(f: A1 => Z, g: Z => A1): F[Z] =
-    super[Decidable].xproduct1(a1)(f, g)
-  override def xproduct2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: (A1, A2) => Z, g: Z => (A1, A2)): F[Z] =
-    super[Decidable].xproduct2(a1, a2)(f, g)
-  override def xproduct3[Z, A1, A2, A3](a1: => F[A1], a2: => F[A2], a3: => F[A3])(f: (A1, A2, A3) => Z, g: Z => (A1, A2, A3)): F[Z] =
-    super[Decidable].xproduct3(a1, a2, a3)(f, g)
-  override def xproduct4[Z, A1, A2, A3, A4](a1: => F[A1], a2: => F[A2], a3: => F[A3], a4: => F[A4])(f: (A1, A2, A3, A4) => Z, g: Z => (A1, A2, A3, A4)): F[Z] =
-    super[Decidable].xproduct4(a1, a2, a3, a4)(f, g)
 
   ////
 }

--- a/core/src/main/scala/scalaz/Divisible.scala
+++ b/core/src/main/scala/scalaz/Divisible.scala
@@ -7,13 +7,28 @@ package scalaz
  * @see [[https://youtu.be/cB8DapKQz-I?t=20m35s ZuriHac 2015 - Discrimination is Wrong: Improving Productivity]]
  */
 ////
-trait Divisible[F[_]] extends Divide[F] { self =>
+trait Divisible[F[_]] extends Divide[F] with InvariantApplicative[F] { self =>
   ////
   /** Universally quantified instance of F[_] */
   def conquer[A]: F[A]
 
   override def contramap[A, B](fa: F[A])(f: B => A): F[B] =
     divide2(conquer[Unit], fa)(c => ((), f(c)))
+
+  override def xproduct0[Z](z: =>Z): F[Z] = conquer
+  override def xproduct1[Z, A1](a1: =>F[A1])(f: A1 => Z, g: Z => A1): F[Z] = xmap(a1, f, g)
+  override def xproduct2[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(
+    f: (A1, A2) => Z,
+    g: Z => (A1, A2)
+  ): F[Z] = divide2(a1, a2)(g)
+  override def xproduct3[Z, A1, A2, A3](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3])(
+    f: (A1, A2, A3) => Z,
+    g: Z => (A1, A2, A3)
+  ): F[Z] = divide3(a1, a2, a3)(g)
+  override def xproduct4[Z, A1, A2, A3, A4](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3], a4: =>F[A4])(
+    f: (A1, A2, A3, A4) => Z,
+    g: Z => (A1, A2, A3, A4)
+  ): F[Z] = divide4(a1, a2, a3, a4)(g)
 
   trait DivisibleLaw extends DivideLaw {
     def rightIdentity[A](fa: F[A])(implicit E: Equal[F[A]]): Boolean =
@@ -45,11 +60,23 @@ object Divisible {
   ////
 }
 
-trait IsomorphismDivisible[F[_], G[_]] extends Divisible[F] with IsomorphismDivide[F, G]{
+trait IsomorphismDivisible[F[_], G[_]] extends Divisible[F] with IsomorphismDivide[F, G] with IsomorphismInvariantApplicative[F, G]{
   implicit def G: Divisible[G]
   ////
 
   override def conquer[A]: F[A] =
     iso.from(G.conquer)
+
+  override def xproduct0[Z](z: => Z): F[Z] =
+    super[Divisible].xproduct0(z)
+  override def xproduct1[Z, A1](a1: =>F[A1])(f: A1 => Z, g: Z => A1): F[Z] =
+    super[Divisible].xproduct1(a1)(f, g)
+  override def xproduct2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: (A1, A2) => Z, g: Z => (A1, A2)): F[Z] =
+    super[Divisible].xproduct2(a1, a2)(f, g)
+  override def xproduct3[Z, A1, A2, A3](a1: => F[A1], a2: => F[A2], a3: => F[A3])(f: (A1, A2, A3) => Z, g: Z => (A1, A2, A3)): F[Z] =
+    super[Divisible].xproduct3(a1, a2, a3)(f, g)
+  override def xproduct4[Z, A1, A2, A3, A4](a1: => F[A1], a2: => F[A2], a3: => F[A3], a4: => F[A4])(f: (A1, A2, A3, A4) => Z, g: Z => (A1, A2, A3, A4)): F[Z] =
+    super[Divisible].xproduct4(a1, a2, a3, a4)(f, g)
+
   ////
 }

--- a/core/src/main/scala/scalaz/InvariantAlt.scala
+++ b/core/src/main/scala/scalaz/InvariantAlt.scala
@@ -10,23 +10,8 @@ package scalaz
  * Used for typeclass derivation of products, coproducts and value types.
  */
 ////
-trait InvariantAlt[F[_]] extends InvariantFunctor[F] { self =>
+trait InvariantAlt[F[_]] extends InvariantApplicative[F] { self =>
   ////
-
-  def xproduct0[Z](f: =>Z): F[Z]
-  def xproduct1[Z, A1](a1: =>F[A1])(f: A1 => Z, g: Z => A1): F[Z]
-  def xproduct2[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(
-    f: (A1, A2) => Z,
-    g: Z => (A1, A2)
-  ): F[Z]
-  def xproduct3[Z, A1, A2, A3](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3])(
-    f: (A1, A2, A3) => Z,
-    g: Z => (A1, A2, A3)
-  ): F[Z]
-  def xproduct4[Z, A1, A2, A3, A4](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3], a4: =>F[A4])(
-    f: (A1, A2, A3, A4) => Z,
-    g: Z => (A1, A2, A3, A4)
-  ): F[Z]
 
   def xcoproduct1[Z, A1](a1: =>F[A1])(f: A1 => Z, g: Z => A1): F[Z]
   def xcoproduct2[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(
@@ -44,23 +29,6 @@ trait InvariantAlt[F[_]] extends InvariantFunctor[F] { self =>
 
   // these methods fail for recursive ADTs, fixed in
   // https://github.com/scala/scala/pull/6050
-  final def xderiving0[Z](z: =>Z): F[Z] = xproduct0(z)
-  final def xderiving1[Z, A1](
-    f: A1 => Z,
-    g: Z => A1
-  )(implicit a1: F[A1]): F[Z] = xproduct1(a1)(f, g)
-  final def xderiving2[Z, A1, A2](
-    f: (A1, A2) => Z,
-    g: Z => (A1, A2)
-  )(implicit a1: F[A1], a2: F[A2]): F[Z] = xproduct2(a1, a2)(f, g)
-  final def xderiving3[Z, A1, A2, A3](
-    f: (A1, A2, A3) => Z,
-    g: Z => (A1, A2, A3)
-  )(implicit a1: F[A1], a2: F[A2], a3: F[A3]): F[Z] = xproduct3(a1, a2, a3)(f, g)
-  final def xderiving4[Z, A1, A2, A3, A4](
-    f: (A1, A2, A3, A4) => Z,
-    g: Z => (A1, A2, A3, A4)
-  )(implicit a1: F[A1], a2: F[A2], a3: F[A3], a4: F[A4]): F[Z] = xproduct4(a1, a2, a3, a4)(f, g)
   final def xcoderiving1[Z, A1](
     f: A1 => Z,
     g: Z => A1
@@ -98,7 +66,7 @@ object InvariantAlt {
   ////
 }
 
-trait IsomorphismInvariantAlt[F[_], G[_]] extends InvariantAlt[F] with IsomorphismInvariantFunctor[F, G]{
+trait IsomorphismInvariantAlt[F[_], G[_]] extends InvariantAlt[F] with IsomorphismInvariantApplicative[F, G]{
   implicit def G: InvariantAlt[G]
   ////
   import Isomorphism._
@@ -113,17 +81,6 @@ trait IsomorphismInvariantAlt[F[_], G[_]] extends InvariantAlt[F] with Isomorphi
     iso.from(G.xcoproduct3(iso.to(a1), iso.to(a2), iso.to(a3))(f, g))
   def xcoproduct4[Z, A1, A2, A3, A4](a1: => F[A1], a2: => F[A2], a3: => F[A3], a4: => F[A4])(f: A1 \/ (A2 \/ (A3 \/ A4)) => Z, g: Z => A1 \/ (A2 \/ (A3 \/ A4))): F[Z] =
     iso.from(G.xcoproduct4(iso.to(a1), iso.to(a2), iso.to(a3), iso.to(a4))(f, g))
-
-  def xproduct0[Z](f: => Z): F[Z] =
-    iso.from(G.xproduct0(f))
-  def xproduct1[Z, A1](a1: => F[A1])(f: A1 => Z, g: Z => A1): F[Z] =
-    iso.from(G.xproduct1(iso.to(a1))(f, g))
-  def xproduct2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: (A1, A2) => Z, g: Z => (A1, A2)): F[Z] =
-    iso.from(G.xproduct2(iso.to(a1), iso.to(a2))(f, g))
-  def xproduct3[Z, A1, A2, A3](a1: => F[A1], a2: => F[A2], a3: => F[A3])(f: (A1, A2, A3) => Z, g: Z => (A1, A2, A3)): F[Z] =
-    iso.from(G.xproduct3(iso.to(a1), iso.to(a2), iso.to(a3))(f, g))
-  def xproduct4[Z, A1, A2, A3, A4](a1: => F[A1], a2: => F[A2], a3: => F[A3], a4: => F[A4])(f: (A1, A2, A3, A4) => Z, g: Z => (A1, A2, A3, A4)): F[Z] =
-    iso.from(G.xproduct4(iso.to(a1), iso.to(a2), iso.to(a3), iso.to(a4))(f, g))
 
   ////
 }

--- a/core/src/main/scala/scalaz/InvariantApplicative.scala
+++ b/core/src/main/scala/scalaz/InvariantApplicative.scala
@@ -1,0 +1,109 @@
+package scalaz
+
+////
+/**
+ * Invariant parent of Divisible and Applicative.
+ *
+ * Used for typeclass derivation of products and value types.
+ */
+////
+trait InvariantApplicative[F[_]] extends InvariantFunctor[F] { self =>
+  ////
+
+  def xproduct0[Z](f: =>Z): F[Z]
+  def xproduct1[Z, A1](a1: =>F[A1])(f: A1 => Z, g: Z => A1): F[Z] =
+    xmap(a1, f, g)
+
+  def xproduct2[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(
+    f: (A1, A2) => Z,
+    g: Z => (A1, A2)
+  ): F[Z]
+  def xproduct3[Z, A1, A2, A3](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3])(
+    f: (A1, A2, A3) => Z,
+    g: Z => (A1, A2, A3)
+  ): F[Z] = {
+    val a23: F[(A2, A3)] = xproduct2(a2, a3)(
+      (a, b) => (a, b),
+      v => v
+    )
+    val a123: F[(A1, A2, A3)] = xproduct2(a1, a23)(
+      (a, b) => (a, b._1, b._2),
+      v => (v._1, (v._2, v._3))
+    )
+    xmap(a123, f.tupled, g)
+  }
+
+  def xproduct4[Z, A1, A2, A3, A4](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3], a4: =>F[A4])(
+    f: (A1, A2, A3, A4) => Z,
+    g: Z => (A1, A2, A3, A4)
+  ): F[Z] = {
+    val a12: F[(A1, A2)] = xproduct2(a1, a2)(
+      (a, b) => (a, b),
+      v => v
+    )
+    val a34: F[(A3, A4)] = xproduct2(a3, a4)(
+      (a, b) => (a, b),
+      v => v
+    )
+    val a1234: F[(A1, A2, A3, A4)] = xproduct2(a12, a34)(
+      (a, b) => (a._1, a._2, b._1, b._2),
+      v => ((v._1, v._2), (v._3, v._4))
+    )
+    xmap(a1234, f.tupled, g)
+  }
+
+  // these methods fail for recursive ADTs, fixed in
+  // https://github.com/scala/scala/pull/6050
+  final def xderiving0[Z](z: =>Z): F[Z] = xproduct0(z)
+  final def xderiving1[Z, A1](
+    f: A1 => Z,
+    g: Z => A1
+  )(implicit a1: F[A1]): F[Z] = xproduct1(a1)(f, g)
+  final def xderiving2[Z, A1, A2](
+    f: (A1, A2) => Z,
+    g: Z => (A1, A2)
+  )(implicit a1: F[A1], a2: F[A2]): F[Z] = xproduct2(a1, a2)(f, g)
+  final def xderiving3[Z, A1, A2, A3](
+    f: (A1, A2, A3) => Z,
+    g: Z => (A1, A2, A3)
+  )(implicit a1: F[A1], a2: F[A2], a3: F[A3]): F[Z] = xproduct3(a1, a2, a3)(f, g)
+  final def xderiving4[Z, A1, A2, A3, A4](
+    f: (A1, A2, A3, A4) => Z,
+    g: Z => (A1, A2, A3, A4)
+  )(implicit a1: F[A1], a2: F[A2], a3: F[A3], a4: F[A4]): F[Z] = xproduct4(a1, a2, a3, a4)(f, g)
+
+  ////
+  val invariantApplicativeSyntax = new scalaz.syntax.InvariantApplicativeSyntax[F] { def F = InvariantApplicative.this }
+}
+
+object InvariantApplicative {
+  @inline def apply[F[_]](implicit F: InvariantApplicative[F]): InvariantApplicative[F] = F
+
+  import Isomorphism._
+
+  def fromIso[F[_], G[_]](D: F <~> G)(implicit E: InvariantApplicative[G]): InvariantApplicative[F] =
+    new IsomorphismInvariantApplicative[F, G] {
+      override def G: InvariantApplicative[G] = E
+      override def iso: F <~> G = D
+    }
+
+  ////
+
+  ////
+}
+
+trait IsomorphismInvariantApplicative[F[_], G[_]] extends InvariantApplicative[F] with IsomorphismInvariantFunctor[F, G]{
+  implicit def G: InvariantApplicative[G]
+  ////
+  def xproduct0[Z](f: => Z): F[Z] =
+    iso.from(G.xproduct0(f))
+  override def xproduct1[Z, A1](a1: => F[A1])(f: A1 => Z, g: Z => A1): F[Z] =
+    iso.from(G.xproduct1(iso.to(a1))(f, g))
+  def xproduct2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: (A1, A2) => Z, g: Z => (A1, A2)): F[Z] =
+    iso.from(G.xproduct2(iso.to(a1), iso.to(a2))(f, g))
+  override def xproduct3[Z, A1, A2, A3](a1: => F[A1], a2: => F[A2], a3: => F[A3])(f: (A1, A2, A3) => Z, g: Z => (A1, A2, A3)): F[Z] =
+    iso.from(G.xproduct3(iso.to(a1), iso.to(a2), iso.to(a3))(f, g))
+  override def xproduct4[Z, A1, A2, A3, A4](a1: => F[A1], a2: => F[A2], a3: => F[A3], a4: => F[A4])(f: (A1, A2, A3, A4) => Z, g: Z => (A1, A2, A3, A4)): F[Z] =
+    iso.from(G.xproduct4(iso.to(a1), iso.to(a2), iso.to(a3), iso.to(a4))(f, g))
+  ////
+}

--- a/core/src/main/scala/scalaz/InvariantApplicative.scala
+++ b/core/src/main/scala/scalaz/InvariantApplicative.scala
@@ -97,13 +97,7 @@ trait IsomorphismInvariantApplicative[F[_], G[_]] extends InvariantApplicative[F
   ////
   def xproduct0[Z](f: => Z): F[Z] =
     iso.from(G.xproduct0(f))
-  override def xproduct1[Z, A1](a1: => F[A1])(f: A1 => Z, g: Z => A1): F[Z] =
-    iso.from(G.xproduct1(iso.to(a1))(f, g))
   def xproduct2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: (A1, A2) => Z, g: Z => (A1, A2)): F[Z] =
     iso.from(G.xproduct2(iso.to(a1), iso.to(a2))(f, g))
-  override def xproduct3[Z, A1, A2, A3](a1: => F[A1], a2: => F[A2], a3: => F[A3])(f: (A1, A2, A3) => Z, g: Z => (A1, A2, A3)): F[Z] =
-    iso.from(G.xproduct3(iso.to(a1), iso.to(a2), iso.to(a3))(f, g))
-  override def xproduct4[Z, A1, A2, A3, A4](a1: => F[A1], a2: => F[A2], a3: => F[A3], a4: => F[A4])(f: (A1, A2, A3, A4) => Z, g: Z => (A1, A2, A3, A4)): F[Z] =
-    iso.from(G.xproduct4(iso.to(a1), iso.to(a2), iso.to(a3), iso.to(a4))(f, g))
   ////
 }

--- a/core/src/main/scala/scalaz/syntax/ApplicativeSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/ApplicativeSyntax.scala
@@ -37,9 +37,9 @@ trait ToApplicativeOps0[TC[F[_]] <: Applicative[F]] extends ToApplicativeOpsU[TC
   }  ////
 }
 
-trait ToApplicativeOps[TC[F[_]] <: Applicative[F]] extends ToApplicativeOps0[TC] with ToApplyOps[TC]
+trait ToApplicativeOps[TC[F[_]] <: Applicative[F]] extends ToApplicativeOps0[TC] with ToApplyOps[TC] with ToInvariantApplicativeOps[TC]
 
-trait ApplicativeSyntax[F[_]] extends ApplySyntax[F] {
+trait ApplicativeSyntax[F[_]] extends ApplySyntax[F] with InvariantApplicativeSyntax[F] {
   implicit def ToApplicativeOps[A](v: F[A]): ApplicativeOps[F, A] = new ApplicativeOps[F,A](v)(ApplicativeSyntax.this.F)
 
   def F: Applicative[F]

--- a/core/src/main/scala/scalaz/syntax/DivisibleSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/DivisibleSyntax.scala
@@ -23,9 +23,9 @@ trait ToDivisibleOps0[TC[F[_]] <: Divisible[F]] extends ToDivisibleOpsU[TC] {
   ////
 }
 
-trait ToDivisibleOps[TC[F[_]] <: Divisible[F]] extends ToDivisibleOps0[TC] with ToDivideOps[TC]
+trait ToDivisibleOps[TC[F[_]] <: Divisible[F]] extends ToDivisibleOps0[TC] with ToDivideOps[TC] with ToInvariantApplicativeOps[TC]
 
-trait DivisibleSyntax[F[_]] extends DivideSyntax[F] {
+trait DivisibleSyntax[F[_]] extends DivideSyntax[F] with InvariantApplicativeSyntax[F] {
   implicit def ToDivisibleOps[A](v: F[A]): DivisibleOps[F, A] = new DivisibleOps[F,A](v)(DivisibleSyntax.this.F)
 
   def F: Divisible[F]

--- a/core/src/main/scala/scalaz/syntax/InvariantAltSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/InvariantAltSyntax.scala
@@ -23,9 +23,9 @@ trait ToInvariantAltOps0[TC[F[_]] <: InvariantAlt[F]] extends ToInvariantAltOpsU
   ////
 }
 
-trait ToInvariantAltOps[TC[F[_]] <: InvariantAlt[F]] extends ToInvariantAltOps0[TC] with ToInvariantFunctorOps[TC]
+trait ToInvariantAltOps[TC[F[_]] <: InvariantAlt[F]] extends ToInvariantAltOps0[TC] with ToInvariantApplicativeOps[TC]
 
-trait InvariantAltSyntax[F[_]] extends InvariantFunctorSyntax[F] {
+trait InvariantAltSyntax[F[_]] extends InvariantApplicativeSyntax[F] {
   implicit def ToInvariantAltOps[A](v: F[A]): InvariantAltOps[F, A] = new InvariantAltOps[F,A](v)(InvariantAltSyntax.this.F)
 
   def F: InvariantAlt[F]

--- a/core/src/main/scala/scalaz/syntax/InvariantApplicativeSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/InvariantApplicativeSyntax.scala
@@ -1,0 +1,35 @@
+package scalaz
+package syntax
+
+/** Wraps a value `self` and provides methods related to `InvariantApplicative` */
+final class InvariantApplicativeOps[F[_],A] private[syntax](val self: F[A])(implicit val F: InvariantApplicative[F]) extends Ops[F[A]] {
+  ////
+
+  ////
+}
+
+sealed trait ToInvariantApplicativeOpsU[TC[F[_]] <: InvariantApplicative[F]] {
+  implicit def ToInvariantApplicativeOpsUnapply[FA](v: FA)(implicit F0: Unapply[TC, FA]) =
+    new InvariantApplicativeOps[F0.M,F0.A](F0(v))(F0.TC)
+
+}
+
+trait ToInvariantApplicativeOps0[TC[F[_]] <: InvariantApplicative[F]] extends ToInvariantApplicativeOpsU[TC] {
+  implicit def ToInvariantApplicativeOps[F[_],A](v: F[A])(implicit F0: TC[F]) =
+    new InvariantApplicativeOps[F,A](v)
+
+  ////
+
+  ////
+}
+
+trait ToInvariantApplicativeOps[TC[F[_]] <: InvariantApplicative[F]] extends ToInvariantApplicativeOps0[TC] with ToInvariantFunctorOps[TC]
+
+trait InvariantApplicativeSyntax[F[_]] extends InvariantFunctorSyntax[F] {
+  implicit def ToInvariantApplicativeOps[A](v: F[A]): InvariantApplicativeOps[F, A] = new InvariantApplicativeOps[F,A](v)(InvariantApplicativeSyntax.this.F)
+
+  def F: InvariantApplicative[F]
+  ////
+
+  ////
+}

--- a/project/GenTypeClass.scala
+++ b/project/GenTypeClass.scala
@@ -35,11 +35,12 @@ object TypeClass {
 
   lazy val invariantFunctor = TypeClass("InvariantFunctor", *->*)
   lazy val functor = TypeClass("Functor", *->*, extendsList = Seq(invariantFunctor))
-  lazy val derives = TypeClass("InvariantAlt", *->*, extendsList = Seq(invariantFunctor))
-  lazy val decidable = TypeClass("Decidable", *->*, extendsList = Seq(divisible, derives))
-  lazy val alt = TypeClass("Alt", *->*, extendsList = Seq(applicative, derives))
+  lazy val invariantApplicative = TypeClass("InvariantApplicative", *->*, extendsList = Seq(invariantFunctor))
+  lazy val invariantAlt = TypeClass("InvariantAlt", *->*, extendsList = Seq(invariantApplicative))
+  lazy val decidable = TypeClass("Decidable", *->*, extendsList = Seq(divisible, invariantAlt))
+  lazy val alt = TypeClass("Alt", *->*, extendsList = Seq(applicative, invariantAlt))
   lazy val apply: TypeClass = TypeClass("Apply", *->*, extendsList = Seq(functor))
-  lazy val applicative = TypeClass("Applicative", *->*, extendsList = Seq(apply))
+  lazy val applicative = TypeClass("Applicative", *->*, extendsList = Seq(apply, invariantApplicative))
   lazy val align = TypeClass("Align", *->*, extendsList = Seq(functor))
   lazy val zip = TypeClass("Zip", *->*)
   lazy val unzip = TypeClass("Unzip", *->*)
@@ -52,7 +53,7 @@ object TypeClass {
 
   lazy val contravariant = TypeClass("Contravariant", *->*, extendsList = Seq(invariantFunctor))
   lazy val divide = TypeClass("Divide", *->*, extendsList = Seq(contravariant))
-  lazy val divisible = TypeClass("Divisible", *->*, extendsList = Seq(divide))
+  lazy val divisible = TypeClass("Divisible", *->*, extendsList = Seq(divide, invariantApplicative))
   lazy val cobind = TypeClass("Cobind", *->*, extendsList = Seq(functor))
   lazy val comonad = TypeClass("Comonad", *->*, extendsList = Seq(cobind))
   lazy val cozip = TypeClass("Cozip", *->*)
@@ -113,7 +114,8 @@ object TypeClass {
     divisible,
     apply,
     applicative,
-    derives,
+    invariantAlt,
+    invariantApplicative,
     decidable,
     alt,
     align,


### PR DESCRIPTION
Seems we've gone full circle... #1481 // @puffnfresh using an `Invariant` prefix naming convention (of the `Functor`, arguably arbitrarily) after discussing with Ed Kmett.

There is value in having this split from `InvariantAlt`, as it represents product and newtype derivation for lawful typeclasses, excluding coproducts.