### PR TITLE
Decidable[MaybeT]

### DIFF
--- a/tests/src/test/scala/scalaz/MaybeTTest.scala
+++ b/tests/src/test/scala/scalaz/MaybeTTest.scala
@@ -11,6 +11,7 @@ object MaybeTTest extends SpecLite {
   type MaybeTList[A] = MaybeT[List, A]
   type IntOr[A] = Int \/ A
   type MaybeTEither[A] = MaybeT[IntOr, A]
+  type ConstInt[A] = Const[Int, A]
 
   checkAll(equal.laws[MaybeTList[Int]])
   checkAll(bindRec.laws[MaybeTList])
@@ -18,6 +19,7 @@ object MaybeTTest extends SpecLite {
   checkAll(traverse.laws[MaybeTList])
   checkAll(monadError.laws[MaybeTEither, Int])
   checkAll(monadTrans.laws[MaybeT, List])
+  checkAll(decidable.laws[MaybeT[ConstInt, ?]])
 
   "show" ! forAll { a: MaybeTList[Int] =>
     Show[MaybeTList[Int]].show(a) must_=== Show[List[Maybe[Int]]].show(a.run)
@@ -38,6 +40,7 @@ object MaybeTTest extends SpecLite {
     def monadError[F[_], E](implicit F: MonadError[F, E]) = MonadError[MaybeT[F, ?], E]
     def foldable[F[_] : Foldable] = Foldable[MaybeT[F, ?]]
     def traverse[F[_] : Traverse] = Traverse[MaybeT[F, ?]]
+    def decidable[F[_] : Divisible] = Decidable[MaybeT[F, ?]]
 
     // checking absence of ambiguity
     def functor[F[_] : Monad] = Functor[MaybeT[F, ?]]


### PR DESCRIPTION
This is related to #1885 by @fommil .
I've implementeted `Decidable `instance for `MaybeT`.

I noticed that is possible to provide instances through `Decidable.fromIso`.
Anyway for `Decidable[MaybeT[F, ?]]` we require an instance of `Divisable[F]`.
Right now `Decidable.fromIso` requires an `implicit Decidable[F]`, so in this case we could have a problem. Any suggestion on this?

Furthermore, I could also refactor in this PR the provisioning of the other instances through `fromIso `as well if you prefer.