### PR TITLE
Add convenience functions for IO

### DIFF
--- a/base/shared/src/main/scala/scalaz/data/io.scala
+++ b/base/shared/src/main/scala/scalaz/data/io.scala
@@ -1,0 +1,96 @@
+package scalaz
+package data
+
+import scalaz.zio.{ ExitResult, Fiber, IO }
+import scalaz.tc.{ Foldable, Unfoldable }
+
+import scala.{ AnyVal, Nothing, Throwable, Unit }
+
+object io {
+
+  implicit class IOObjOps(private val ioObj: IO.type) extends AnyVal {
+
+    final def absolvez[E, A](v: IO[E, E \/ A]): IO[E, A] =
+      v.flatMap(fromDisjunction)
+
+    final def fromDisjunction[E, A](v: E \/ A): IO[E, A] =
+      v.fold(IO.fail, IO.now)
+
+    final def fromMaybe[A](v: Maybe[A]): IO[Unit, A] =
+      Maybe.fold(v)(IO.now, IO.fail(()))
+
+    final def requirez[E, A](error: E): IO[E, Maybe[A]] => IO[E, A] =
+      (io: IO[E, Maybe[A]]) =>
+        io.flatMap { maybe =>
+          Maybe.fold[A, IO[E, A]](maybe)(IO.now[A], IO.fail[E](error))
+      }
+
+    final def forkAllz[E, A, F[_]](
+      as: F[IO[E, A]]
+    )(implicit f: Foldable[F], u: Unfoldable[F]): IO[Nothing, Fiber[E, F[A]]] =
+      f.foldRight(as, IO.point(Fiber.point[E, IList[A]](IList.empty))) { (aIO, asFiberIO) =>
+          asFiberIO.par(aIO.fork).map {
+            case (asFiber, aFiber) =>
+              asFiber.zipWith(aFiber)((as, a) => a :: as)
+          }
+        }
+        .map(
+          fas =>
+            fas.zipWith(Fiber.point(())) { (res, _) =>
+              u.fromList(res)
+          }
+        )
+
+    final def raceAllz[E, A, F[_]](io: IO[E, A], ios: F[IO[E, A]])(implicit f: Foldable[F]): IO[E, A] =
+      f.foldLeft[IO[E, A], IO[E, A]](ios, io)(_ race _)
+
+    final def reduceAllz[E, A, F[_]](a: IO[E, A], as: F[IO[E, A]])(f: (A, A) => A)(implicit fd: Foldable[F]): IO[E, A] =
+      fd.foldLeft(as, a) { (l, r) =>
+        l.par(r).map(f.tupled)
+      }
+
+    final def mergeAllz[E, A, B, F[_]](in: F[IO[E, A]])(zero: B, f: (B, A) => B)(implicit fd: Foldable[F]): IO[E, B] =
+      fd.foldLeft[IO[E, A], IO[E, B]](in, IO.point[B](zero))((acc, a) => acc.par(a).map(f.tupled))
+
+    final def terminate0z[F[_]](ts: F[Throwable])(implicit f: Foldable[F]): IO[Nothing, Nothing] =
+      IO.terminate0(f.toList(ts))
+
+    final def unsandboxz[E, A, F[_]](v: IO[F[Throwable] \/ E, A])(implicit f: Foldable[F]): IO[E, A] =
+      v.catchAll[E, A] {
+        case \/-(e)  => IO.fail(e)
+        case -\/(ts) => IO.terminate0z(ts)
+      }
+
+  }
+
+  implicit class IOOps[E, A](private val io: IO[E, A]) extends AnyVal {
+    final def attemptz: IO[Nothing, E \/ A] =
+      io.redeem[Nothing, E \/ A](e => IO.now(-\/(e)), a => IO.now(\/-(a)))
+
+    final def raceBothz[E1 >: E, B](that: IO[E1, B]): IO[E1, A \/ B] =
+      io.raceWith(that)((a, fiber) => fiber.interrupt.const(-\/(a)), (b, fiber) => fiber.interrupt.const(\/-(b)))
+
+    final def or[E2, B](that: => IO[E2, B]): IO[E2, A \/ B] =
+      io.redeem(_ => that.map(\/-(_)), e => IO.now(-\/(e)))
+
+    final def sandboxedz[F[_]: Foldable](implicit u: Unfoldable[F]): IO[\/[F[Throwable], E], A] =
+      io.run.flatMap[\/[F[Throwable], E], A](_ match {
+        case ExitResult.Completed(value) =>
+          IO.now(value)
+        case ExitResult.Failed(error, _) =>
+          IO.fail(\/-[F[Throwable], E](error))
+        case ExitResult.Terminated(ts) =>
+          IO.fail(-\/[F[Throwable], E](u.fromList(IList(ts: _*))))
+      })
+
+    final def sandboxWithz[E2, B, F[_]: Foldable](
+      f: IO[\/[F[Throwable], E], A] => IO[\/[F[Throwable], E2], B]
+    )(implicit u: Unfoldable[F]): IO[E2, B] =
+      f(io.sandboxedz).catchAll[E2, B] {
+        case \/-(e)  => IO.fail(e)
+        case -\/(ts) => IO.terminate0z(ts)
+      }
+
+  }
+
+}

--- a/tests/src/main/scala/scalaz/tests/IOTests.scala
+++ b/tests/src/main/scala/scalaz/tests/IOTests.scala
@@ -1,15 +1,18 @@
 package scalaz
 package tests
 
-import scala.{ List, Range, StringContext }
+import scala.{ Exception, Int, List, Nothing, Range, StringContext, Throwable, Unit }
 import scala.Predef.String
-
 import Scalaz._
-
-import testz._, z._
-import laws._, FunctorLaws._
-
+import testz._
+import z._
+import laws._
+import FunctorLaws._
+import scalaz.data._
+import scalaz.data.io._
 import zio._
+import scala.concurrent.duration._
+import Result._
 
 object IOTests {
 
@@ -41,10 +44,12 @@ object IOTests {
     seeds.flatMap(s => endos.map(_(s)))
   }
 
-  object RTS extends RTS
+  val exampleError    = new Exception("Oh noes!")
+  val interruptCause1 = new Exception("Oh noes 1!")
 
-  def ioEql[E, A](l: IO[E, A], r: IO[E, A]): Result =
-    assert(RTS.unsafeRunSync(l.attempt) == RTS.unsafeRunSync(r.attempt))
+  object RTS extends RTS {
+    override def defaultHandler: List[Throwable] => IO[Nothing, Unit] = i => IO.traverse(i)(_ => IO.unit) *> IO.unit
+  }
 
   object fns {
     val s1 = (s: String) => IO.point(s"foo$s")
@@ -52,59 +57,203 @@ object IOTests {
     val f  = (s: String) => IO.fail(Error(s))
   }
 
-  def tests[T](harness: Harness[T]): T = {
+  def tests[T](harness: Harness[T], rts: RTS): T = {
     import harness._
-    namedSection("zio.IO instances")(
-      namedSection("bifunctor")(
-        test("identityToIdentity") { () =>
-          ios.foldMap(Bifunctor.identityToIdentity(_)(ioEql))
-        },
-      ),
-      namedSection("functor")(
-        test("identity") { () =>
-          ios.foldMap(Functor.identityToIdentity(_)(ioEql))
-        },
-      ),
-      namedSection("applicative")(
-        test("applyIdentity") { () =>
-          ios.foldMap(ApplicativeLaws.applyIdentity(_)(ioEql))
-        },
-      ),
-      namedSection("bind")(
-        namedSection("bindAssoc")(
-          test("success/success") { () =>
-            ios.foldMap(BindLaws.bindAssoc(_)(fns.s1, fns.s2)(ioEql))
+
+    def ioEql[E, A](l: IO[E, A], r: IO[E, A]): Result =
+      assert(rts.unsafeRunSync(l.attempt) == rts.unsafeRunSync(r.attempt))
+
+    namedSection("zio")(
+      namedSection("zio.IO instances")(
+        namedSection("bifunctor")(
+          test("identityToIdentity") { () =>
+            ios.foldMap(Bifunctor.identityToIdentity(_)(ioEql))
           },
-          test("failure/success") { () =>
-            ios.foldMap(BindLaws.bindAssoc(_)(fns.f, fns.s2)(ioEql))
+        ),
+        namedSection("functor")(
+          test("identity") { () =>
+            ios.foldMap(Functor.identityToIdentity(_)(ioEql))
           },
-          test("failure/failure") { () =>
-            ios.foldMap(BindLaws.bindAssoc(_)(fns.f, fns.f)(ioEql))
+        ),
+        namedSection("applicative")(
+          test("applyIdentity") { () =>
+            ios.foldMap(ApplicativeLaws.applyIdentity(_)(ioEql))
           },
-          test("success/failure") { () =>
-            ios.foldMap(BindLaws.bindAssoc(_)(fns.s1, fns.f)(ioEql))
-          },
+        ),
+        namedSection("bind")(
+          namedSection("bindAssoc")(
+            test("success/success") { () =>
+              ios.foldMap(BindLaws.bindAssoc(_)(fns.s1, fns.s2)(ioEql))
+            },
+            test("failure/success") { () =>
+              ios.foldMap(BindLaws.bindAssoc(_)(fns.f, fns.s2)(ioEql))
+            },
+            test("failure/failure") { () =>
+              ios.foldMap(BindLaws.bindAssoc(_)(fns.f, fns.f)(ioEql))
+            },
+            test("success/failure") { () =>
+              ios.foldMap(BindLaws.bindAssoc(_)(fns.s1, fns.f)(ioEql))
+            },
+          )
+        ),
+        namedSection("monad")(
+          namedSection("bindLeftIdentity")(
+            test("success") { () =>
+              MonadLaws.bindLeftIdentity("mxyzptlk")(fns.s1)(ioEql)
+            },
+            test("failure") { () =>
+              MonadLaws.bindLeftIdentity("mxyzptlk")(fns.f)(ioEql)
+            },
+          ),
+          namedSection("bindRightIdentity")(
+            test("success") { () =>
+              ios.foldMap(MonadLaws.bindRightIdentity(_)(ioEql))
+            },
+            test("failure") { () =>
+              ios.foldMap(MonadLaws.bindRightIdentity(_)(ioEql))
+            },
+          ),
         )
       ),
-      namedSection("monad")(
-        namedSection("bindLeftIdentity")(
-          test("success") { () =>
-            MonadLaws.bindLeftIdentity("mxyzptlk")(fns.s1)(ioEql)
-          },
-          test("failure") { () =>
-            MonadLaws.bindLeftIdentity("mxyzptlk")(fns.f)(ioEql)
-          },
-        ),
-        namedSection("bindRightIdentity")(
-          test("success") { () =>
-            ios.foldMap(MonadLaws.bindRightIdentity(_)(ioEql))
-          },
-          test("failure") { () =>
-            ios.foldMap(MonadLaws.bindRightIdentity(_)(ioEql))
-          },
-        ),
+      namedSection("zio.IO.type ops")(
+        test("absolve") { () =>
+          val res1 = IO.absolvez(IO.point(\/-(1)))
+          val res2 = IO.absolvez(IO.point(-\/("fail")))
+
+          combine(
+            assertEqual(rts.unsafeRun(res1), 1),
+            assertEqual[String \/ Int](rts.unsafeRun(res2.attemptz), -\/("fail"))
+          )
+        },
+        test("fromDisjunction") { () =>
+          val res1 = IO.fromDisjunction(\/-(1))
+          val res2 = IO.fromDisjunction(-\/("fail"))
+
+          combine(
+            assertEqual(rts.unsafeRun(res1), 1),
+            assertEqual[String \/ Int](rts.unsafeRun(res2.attemptz), -\/("fail"))
+          )
+        },
+        test("fromMaybe") { () =>
+          val res1 = IO.fromMaybe(Maybe.just(1))
+          val res2 = IO.fromMaybe(Maybe.empty)
+
+          combine(
+            assertEqual(rts.unsafeRun(res1), 1),
+            assertEqual[Unit \/ Int](rts.unsafeRun(res2.attemptz), -\/(()))
+          )
+        },
+        test("require") { () =>
+          val res1 = IO.requirez("fail")(IO.point(Maybe.just(1)))
+          val res2 = IO.requirez("fail")(IO.point(Maybe.empty))
+
+          combine(
+            assertEqual(rts.unsafeRun(res1), 1),
+            assertEqual[String \/ Int](rts.unsafeRun(res2.attemptz), -\/("fail"))
+          )
+        },
+        test("forkAll") { () =>
+          val list = IList(IO.point(1), IO.point(2))
+          val res  = rts.unsafeRun(IO.forkAllz(list).flatMap(_.join))
+          assertEqual(res, IList(1, 2))
+        },
+        test("raceAll") { () =>
+          val list   = IList(IO.sleep(1.millisecond) *> IO.point(1))
+          val slower = IO.sleep(1.second) *> IO.point(2)
+          assertEqual(rts.unsafeRun(IO.raceAllz(slower, list)), 1)
+        },
+        test("reduceAll") { () =>
+          val list: IList[IO[Nothing, Int]] = IList(IO.point(1), IO.point(2))
+          assertEqual(rts.unsafeRun(IO.reduceAllz(IO.point(3), list)(_ + _)), 6)
+        },
+        test("mergeAll") { () =>
+          val list: IList[IO[Nothing, Int]] = IList(IO.point(1), IO.point(2))
+          assertEqual(rts.unsafeRun(IO.mergeAllz[Nothing, Int, Int, IList](list)(0, _ + _)), 3)
+        },
+        test("terminate0") { () =>
+          val comp = IO.terminate0z[IList](IList(exampleError)).ensuring(IO.sync(throw interruptCause1))
+          assert(rts.unsafeRun(comp.run) == ExitResult.Terminated(List(exampleError, interruptCause1)))
+        },
+        test("unsandbox") { () =>
+          val defect = IO.unsandboxz[String, Int, IList](IO.fail(-\/(IList(exampleError)))).run
+          val err    = IO.unsandboxz[String, Int, IList](IO.fail(\/-("fail"))).run
+          val succ   = IO.unsandboxz[String, Int, IList](IO.point[Int](1)).run
+
+          combine(
+            assert(rts.unsafeRun(defect) == ExitResult.Terminated(List(exampleError))),
+            combine(
+              assert(rts.unsafeRun(err) == ExitResult.Failed("fail")),
+              assert(rts.unsafeRun(succ) == ExitResult.Completed(1))
+            )
+          )
+        }
+      ),
+      namedSection("zio.IO ops")(
+        test("attempt") { () =>
+          val succ: String \/ Int = rts.unsafeRun(IO.point[Int](1).attemptz)
+          val fail: String \/ Int = rts.unsafeRun(IO.fail[String]("fail").attemptz)
+          combine(
+            assertEqual(succ, \/-[String, Int](1)),
+            assertEqual(fail, -\/[String, Int]("fail"))
+          )
+        },
+        test("raceBoth") { () =>
+          val faster: IO[Int, String] = IO.sleep(1.millisecond) *> IO.point("1")
+          val slower: IO[Int, String] = IO.sleep(1.second) *> IO.point("2")
+          assertEqual(rts.unsafeRun(slower.raceBothz[Int, String](faster)), \/-[String, String]("1"))
+        },
+        test("or") { () =>
+          val err  = IO.fail("fail")
+          val succ = IO.point[Int](1)
+
+          val error: String \/ (Int \/ Int) = rts.unsafeRun(err.or(err).attemptz)
+          val succ1: String \/ Int          = rts.unsafeRun(err.or(succ))
+          val succ2: Int \/ String          = rts.unsafeRun(succ.or(err))
+
+          combine(
+            assertEqual(error, -\/[String, Int \/ Int]("fail")),
+            combine(
+              assertEqual(succ1, \/-[String, Int](1)),
+              assertEqual(succ2, -\/[Int, String](1))
+            )
+          )
+        },
+        test("sandboxed") { () =>
+          val defect: IO[IList[Throwable] \/ String, Int] = IO.sync(throw exampleError).sandboxedz[IList]
+          val err: IO[IList[Throwable] \/ String, Int]    = IO.fail("fail").sandboxedz[IList]
+          val succ: IO[IList[Throwable] \/ String, Int]   = IO.point[Int](1).sandboxedz[IList]
+
+          combine(
+            assert(rts.unsafeRun(defect.attemptz) == -\/[IList[Throwable] \/ String, Int](-\/(IList(exampleError)))),
+            combine(
+              assert(rts.unsafeRun(err.attemptz) == -\/[IList[Throwable] \/ String, Int](\/-("fail"))),
+              assertEqual(rts.unsafeRun(succ), 1)
+            )
+          )
+        },
+        test("sandboxWith") { () =>
+          val defect =
+            IO.sync(throw exampleError)
+              .sandboxWithz[Nothing, Int, IList](
+                (_: IO[IList[Throwable] \/ String, Int]) =>
+                  IO.fail[IList[Throwable] \/ Nothing](-\/(IList(interruptCause1)))
+              )
+          val err =
+            IO.fail("fail").sandboxWithz[Int, Unit, IList]((_: IO[IList[Throwable] \/ String, Int]) => IO.fail(\/-(-1)))
+          val succ =
+            IO.point[Int](1).sandboxWithz[Nothing, Int, IList]((_: IO[IList[Throwable] \/ String, Int]) => IO.point(1))
+
+          combine(
+            assert(rts.unsafeRun(defect.run) == ExitResult.Terminated(List(interruptCause1))),
+            combine(
+              assert(rts.unsafeRun(err.run) == ExitResult.Failed(-1)),
+              assert(rts.unsafeRun(succ.run) == ExitResult.Completed(1))
+            )
+          )
+        }
       )
     )
+
   }
 
 }

--- a/tests/src/main/scala/scalaz/tests/TestMain.scala
+++ b/tests/src/main/scala/scalaz/tests/TestMain.scala
@@ -2,17 +2,19 @@ package scalaz
 package tests
 
 import java.util.concurrent.Executors
+
 import scala.{ inline, Array, Char, Int, List, Unit }
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
-
 import java.lang.String
 
 import testz._
 import runner.TestOutput
 import extras.DocHarness
+import scalaz.tests.IOTests.RTS
 
 object TestMain {
   def main(args: Array[String]): Unit = {
@@ -40,7 +42,9 @@ object TestMain {
         Future(run("Double Tests", DoubleTests.tests(harness)))(ec),
         Future(run("IList Tests", IListTests.tests(harness)))(ec),
         Future(run("Maybe Tests", MaybeTests.tests(harness)))(ec),
-        Future(run("IO Tests", IOTests.tests(harness)))(ec),
+        Future(run("IO Tests", IOTests.tests(harness, RTS)))(ec).andThen[Unit] {
+          case _ => RTS.unsafeShutdownAndWait(1.nano)
+        }(ec),
         Future(run("Ordering Tests", OrderingTests.tests(harness)))(ec),
         Future(run("Scala Map Tests", SMapTests.tests(harness)))(ec),
       )


### PR DESCRIPTION
This PR is related to https://github.com/scalaz/scalaz/issues/1886.
Basically, it's just porting some convenience functions using scalaz adts (Either => \\/, Option => Maybe, etc..).

My remaining concerns are about:
 - implementing `traverse`, `sequence`, `parTraverse` and `parAll` or not, since we may just use traversable syntax and get them for free

Thanks guys, coding under scalaz compiler restrictions is a really nice experience :)