### PR TITLE
Backport of scalaz-deriving core typeclasses

### DIFF
--- a/core/src/main/scala/scalaz/APair.scala
+++ b/core/src/main/scala/scalaz/APair.scala
@@ -1,0 +1,39 @@
+// Copyright: 2017 - 2018 Sam Halliday
+// License: https://opensource.org/licenses/BSD-3-Clause
+
+package scalaz
+
+import scala.inline
+import scala.Some
+
+/**
+ * Type-aligned pair. Isomorphic to
+ *
+ * {{{
+ * (F[A], G[A]) forSome { type A }
+ * }}}
+ *
+ * but more robust with respect to type inference.
+ *
+ * Notation is conjunction `/\` blended with `~`, which is often used to
+ * indicate higher kindedness.
+ */
+sealed abstract class /~\[A[_], B[_]] {
+  type T
+  def a: A[T]
+  def b: B[T]
+}
+object /~\ {
+  type APair[A[_], B[_]] = A /~\ B
+  type Aux[A[_], B[_], Z] = /~\[A, B] { type T = Z }
+
+  @inline final def unapply[A[_], B[_]](p: A /~\ B): Some[(A[p.T], B[p.T])] =
+    Some((p.a, p.b))
+
+  @inline final def apply[A[_], B[_], Z](az: =>A[Z], bz: =>B[Z]): A /~\ B =
+    new /~\[A, B] {
+      type T = Z
+      def a: A[Z] = az
+      def b: B[Z] = bz
+    }
+}

--- a/core/src/main/scala/scalaz/Alt.scala
+++ b/core/src/main/scala/scalaz/Alt.scala
@@ -1,0 +1,157 @@
+package scalaz
+
+////
+// Copyright: 2018 Sam Halliday
+// License: https://opensource.org/licenses/BSD-3-Clause
+
+/**
+ * https://hackage.haskell.org/package/semigroupoids-5.2.2/docs/Data-Functor-Alt.html
+ */
+////
+trait Alt[F[_]] extends Applicative[F] with InvariantAlt[F] { self =>
+  ////
+
+  def alt[A](a1: =>F[A], a2: =>F[A]): F[A]
+
+  /** One or none */
+  def optional[A](fa: F[A]): F[Maybe[A]] = alt(map(fa)(Maybe.just(_)), pure(Maybe.empty))
+
+  def altly1[Z, A1](a1: =>F[A1])(f: A1 => Z): F[Z] = map(a1)(f)
+  def altly2[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(f: A1 \/ A2 => Z): F[Z] =
+    map(alt(map(a1)(\/.left[A1, A2](_)), map(a2)(\/.right[A1, A2](_))))(f)
+
+  def altly3[Z, A1, A2, A3](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3])(
+    f: A1 \/ (A2 \/ A3) => Z
+  ): F[Z] = altly2(a1, altly2(a2, a3)(identity))(f)
+  def altly4[Z, A1, A2, A3, A4](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3], a4: =>F[A4])(
+    f: A1 \/ (A2 \/ (A3 \/ A4)) => Z
+  ): F[Z] = altly2(a1, altly3(a2, a3, a4)(identity))(f)
+  // ... altlyN
+
+  // equivalent of tupleN
+  def either2[A1, A2](a1: =>F[A1], a2: =>F[A2]): F[A1 \/ A2] =
+    altly2(a1, a2)(identity)
+  // ... eitherN
+
+  final def altlying1[Z, A1](
+    f: A1 => Z
+  )(implicit a1: F[A1]): F[Z] =
+    altly1(a1)(f)
+  final def altlying2[Z, A1, A2](
+    f: A1 \/ A2 => Z
+  )(implicit a1: F[A1], a2: F[A2]): F[Z] =
+    altly2(a1, a2)(f)
+  final def altlying3[Z, A1, A2, A3](
+    f: A1 \/ (A2 \/ A3) => Z
+  )(implicit a1: F[A1], a2: F[A2], a3: F[A3]): F[Z] =
+    altly3(a1, a2, a3)(f)
+  final def altlying4[Z, A1, A2, A3, A4](
+    f: A1 \/ (A2 \/ (A3 \/ A4)) => Z
+  )(implicit a1: F[A1], a2: F[A2], a3: F[A3], a4: F[A4]): F[Z] =
+    altly4(a1, a2, a3, a4)(f)
+  // ... altlyingX
+
+  override def xcoproduct1[Z, A1](a1: =>F[A1])(
+    f: A1 => Z,
+    g: Z => A1
+  ): F[Z] = altly1(a1)(f)
+  override def xcoproduct2[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(
+    f: (A1 \/ A2) => Z,
+    g: Z => (A1 \/ A2)
+  ): F[Z] = altly2(a1, a2)(f)
+  override def xcoproduct3[Z, A1, A2, A3](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3])(
+    f: (A1 \/ (A2 \/ A3)) => Z,
+    g: Z => (A1 \/ (A2 \/ A3))
+  ): F[Z] = altly3(a1, a2, a3)(f)
+  override def xcoproduct4[Z, A1, A2, A3, A4](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3], a4: =>F[A4])(
+    f: (A1 \/ (A2 \/ (A3 \/ A4))) => Z,
+    g: Z => (A1 \/ (A2 \/ (A3 \/ A4)))
+  ): F[Z] = altly4(a1, a2, a3, a4)(f)
+
+  // from Apply in scalaz 7.3
+  final def applying1[Z, A1](f: A1 => Z)(
+    implicit a1: F[A1]
+  ): F[Z] = map(a1)(f)
+  final def applying2[Z, A1, A2](
+    f: (A1, A2) => Z
+  )(implicit a1: F[A1], a2: F[A2]): F[Z] =
+    apply2(a1, a2)(f)
+  final def applying3[Z, A1, A2, A3](
+    f: (A1, A2, A3) => Z
+  )(implicit a1: F[A1], a2: F[A2], a3: F[A3]): F[Z] =
+    apply3(a1, a2, a3)(f)
+  final def applying4[Z, A1, A2, A3, A4](
+    f: (A1, A2, A3, A4) => Z
+  )(implicit a1: F[A1], a2: F[A2], a3: F[A3], a4: F[A4]): F[Z] =
+    apply4(a1, a2, a3, a4)(f)
+  //
+
+  override def xproduct0[Z](z: =>Z): F[Z] = pure(z)
+  override def xproduct1[Z, A1](a1: =>F[A1])(f: A1 => Z, g: Z => A1): F[Z] =
+    xmap(a1, f, g)
+  override def xproduct2[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(
+    f: (A1, A2) => Z,
+    g: Z => (A1, A2)
+  ): F[Z] = apply2(a1, a2)(f)
+  override def xproduct3[Z, A1, A2, A3](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3])(
+    f: (A1, A2, A3) => Z,
+    g: Z => (A1, A2, A3)
+  ): F[Z] = apply3(a1, a2, a3)(f)
+  override def xproduct4[Z, A1, A2, A3, A4](
+    a1: =>F[A1],
+    a2: =>F[A2],
+    a3: =>F[A3],
+    a4: =>F[A4]
+  )(
+    f: (A1, A2, A3, A4) => Z,
+    g: Z => (A1, A2, A3, A4)
+  ): F[Z] = apply4(a1, a2, a3, a4)(f)
+
+  trait AltLaw extends ApplicativeLaw {
+    // TODO: laws
+
+    // <!> is associative:             (a <!> b) <!> c = a <!> (b <!> c)
+    // <$> left-distributes over <!>:  f <$> (a <!> b) = (f <$> a) <!> (f <$> b)
+  }
+  def altLaw = new AltLaw {}
+
+  ////
+  val altSyntax = new scalaz.syntax.AltSyntax[F] { def F = Alt.this }
+}
+
+object Alt {
+  @inline def apply[F[_]](implicit F: Alt[F]): Alt[F] = F
+
+  import Isomorphism._
+
+  def fromIso[F[_], G[_]](D: F <~> G)(implicit E: Alt[G]): Alt[F] =
+    new IsomorphismAlt[F, G] {
+      override def G: Alt[G] = E
+      override def iso: F <~> G = D
+    }
+
+  ////
+
+  ////
+}
+
+trait IsomorphismAlt[F[_], G[_]] extends Alt[F] with IsomorphismApplicative[F, G] with IsomorphismInvariantAlt[F, G]{
+  implicit def G: Alt[G]
+
+  override def alt[A](a1: =>F[A], a2: =>F[A]): F[A] = iso.from(G.alt(iso.to(a1), iso.to(a2)))
+
+  override def xproduct0[Z](z: =>Z): F[Z] = super[Alt].xproduct0(z)
+  override def xproduct1[Z, A1](a1: =>F[A1])(f: A1 => Z, g: Z => A1): F[Z] = super[Alt].xproduct1(a1)(f, g)
+  override def xproduct2[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(f: (A1, A2) => Z, g: Z => (A1, A2)): F[Z] = super[Alt].xproduct2(a1, a2)(f, g)
+  override def xproduct3[Z, A1, A2, A3](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3])(f: (A1, A2, A3) => Z, g: Z => (A1, A2, A3)): F[Z] = super[Alt].xproduct3(a1, a2, a3)(f, g)
+  override def xproduct4[Z, A1, A2, A3, A4](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3], a4: =>F[A4])(f: (A1, A2, A3, A4) => Z, g: Z => (A1, A2, A3, A4)): F[Z] = super[Alt].xproduct4(a1, a2, a3, a4)(f, g)
+
+  override def xcoproduct1[Z, A1](a1: => F[A1])(f: A1 => Z, g: Z => A1): F[Z] =
+    super[Alt].xcoproduct1(a1)(f, g)
+  override def xcoproduct2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: A1 \/ A2 => Z, g: Z => A1 \/ A2): F[Z] =
+    super[Alt].xcoproduct2(a1, a2)(f, g)
+  override def xcoproduct3[Z, A1, A2, A3](a1: => F[A1], a2: => F[A2], a3: => F[A3])(f: A1 \/ (A2 \/ A3) => Z, g: Z => A1 \/ (A2 \/ A3)): F[Z] =
+    super[Alt].xcoproduct3(a1, a2, a3)(f, g)
+  override def xcoproduct4[Z, A1, A2, A3, A4](a1: => F[A1], a2: => F[A2], a3: => F[A3], a4: => F[A4])(f: A1 \/ (A2 \/ (A3 \/ A4)) => Z, g: Z => A1 \/ (A2 \/ (A3 \/ A4))): F[Z] =
+    super[Alt].xcoproduct4(a1, a2, a3, a4)(f, g)
+}

--- a/core/src/main/scala/scalaz/Alt.scala
+++ b/core/src/main/scala/scalaz/Alt.scala
@@ -134,24 +134,3 @@ object Alt {
 
   ////
 }
-
-trait IsomorphismAlt[F[_], G[_]] extends Alt[F] with IsomorphismApplicative[F, G] with IsomorphismInvariantAlt[F, G]{
-  implicit def G: Alt[G]
-
-  override def alt[A](a1: =>F[A], a2: =>F[A]): F[A] = iso.from(G.alt(iso.to(a1), iso.to(a2)))
-
-  override def xproduct0[Z](z: =>Z): F[Z] = super[Alt].xproduct0(z)
-  override def xproduct1[Z, A1](a1: =>F[A1])(f: A1 => Z, g: Z => A1): F[Z] = super[Alt].xproduct1(a1)(f, g)
-  override def xproduct2[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(f: (A1, A2) => Z, g: Z => (A1, A2)): F[Z] = super[Alt].xproduct2(a1, a2)(f, g)
-  override def xproduct3[Z, A1, A2, A3](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3])(f: (A1, A2, A3) => Z, g: Z => (A1, A2, A3)): F[Z] = super[Alt].xproduct3(a1, a2, a3)(f, g)
-  override def xproduct4[Z, A1, A2, A3, A4](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3], a4: =>F[A4])(f: (A1, A2, A3, A4) => Z, g: Z => (A1, A2, A3, A4)): F[Z] = super[Alt].xproduct4(a1, a2, a3, a4)(f, g)
-
-  override def xcoproduct1[Z, A1](a1: => F[A1])(f: A1 => Z, g: Z => A1): F[Z] =
-    super[Alt].xcoproduct1(a1)(f, g)
-  override def xcoproduct2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: A1 \/ A2 => Z, g: Z => A1 \/ A2): F[Z] =
-    super[Alt].xcoproduct2(a1, a2)(f, g)
-  override def xcoproduct3[Z, A1, A2, A3](a1: => F[A1], a2: => F[A2], a3: => F[A3])(f: A1 \/ (A2 \/ A3) => Z, g: Z => A1 \/ (A2 \/ A3)): F[Z] =
-    super[Alt].xcoproduct3(a1, a2, a3)(f, g)
-  override def xcoproduct4[Z, A1, A2, A3, A4](a1: => F[A1], a2: => F[A2], a3: => F[A3], a4: => F[A4])(f: A1 \/ (A2 \/ (A3 \/ A4)) => Z, g: Z => A1 \/ (A2 \/ (A3 \/ A4))): F[Z] =
-    super[Alt].xcoproduct4(a1, a2, a3, a4)(f, g)
-}

--- a/core/src/main/scala/scalaz/Decidable.scala
+++ b/core/src/main/scala/scalaz/Decidable.scala
@@ -1,0 +1,142 @@
+package scalaz
+
+////
+// Copyright: 2017 Sam Halliday
+// License: https://opensource.org/licenses/BSD-3-Clause
+
+/**
+ * Coproduct analogue of Divide
+ *
+ * https://hackage.haskell.org/package/contravariant-1.4.1/docs/Data-Functor-Contravariant-Divisible.html#t:Decidable
+ */
+////
+trait Decidable[F[_]] extends Divisible[F] with InvariantAlt[F] { self =>
+  ////
+
+  // backport from 7.3's Divisible
+  override def contramap[A, B](fa: F[A])(f: B => A): F[B] =
+    divide2(conquer[Unit], fa)(c => ((), f(c)))
+
+  final def choose[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(f: Z => A1 \/ A2): F[Z] = choose2(a1, a2)(f)
+
+  def choose1[Z, A1](a1: =>F[A1])(f: Z => A1): F[Z] = contramap(a1)(f)
+  def choose2[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(f: Z => A1 \/ A2): F[Z]
+  def choose3[Z, A1, A2, A3](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3])(
+    f: Z => A1 \/ (A2 \/ A3)
+  ): F[Z] = {
+    val a23: F[A2 \/ A3] = choose2(a2, a3)(identity)
+    choose2(a1, a23)(f)
+  }
+  def choose4[Z, A1, A2, A3, A4](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3], a4: =>F[A4])(
+    f: Z => A1 \/ (A2 \/ (A3 \/ A4))
+  ): F[Z] = {
+    val a234: F[A2 \/ (A3 \/ A4)] = choose3(a2, a3, a4)(identity)
+    choose2(a1, a234)(f)
+  }
+  // ... chooseN
+
+  final def choosing2[Z, A1, A2](
+    f: Z => A1 \/ A2
+  )(implicit fa1: F[A1], fa2: F[A2]): F[Z] =
+    choose2(fa1, fa2)(f)
+  final def choosing3[Z, A1, A2, A3](
+    f: Z => A1 \/ (A2 \/ A3)
+  )(implicit fa1: F[A1], fa2: F[A2], fa3: F[A3]): F[Z] =
+    choose3(fa1, fa2, fa3)(f)
+  final def choosing4[Z, A1, A2, A3, A4](
+    f: Z => A1 \/ (A2 \/ (A3 \/ A4))
+  )(implicit fa1: F[A1], fa2: F[A2], fa3: F[A3], fa4: F[A4]): F[Z] =
+    choose4(fa1, fa2, fa3, fa4)(f)
+  // ... choosingX
+
+  override def xcoproduct1[Z, A1](a1: =>F[A1])(
+    f: A1 => Z,
+    g: Z => A1
+  ): F[Z] = choose1(a1)(g)
+  override def xcoproduct2[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(
+    f: (A1 \/ A2) => Z,
+    g: Z => (A1 \/ A2)
+  ): F[Z] = choose2(a1, a2)(g)
+  override def xcoproduct3[Z, A1, A2, A3](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3])(
+    f: (A1 \/ (A2 \/ A3)) => Z,
+    g: Z => (A1 \/ (A2 \/ A3))
+  ): F[Z] = choose3(a1, a2, a3)(g)
+  override def xcoproduct4[Z, A1, A2, A3, A4](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3], a4: =>F[A4])(
+    f: (A1 \/ (A2 \/ (A3 \/ A4))) => Z,
+    g: Z => (A1 \/ (A2 \/ (A3 \/ A4)))
+  ): F[Z] = choose4(a1, a2, a3, a4)(g)
+
+  // from 7.3's Divide
+  override def xproduct0[Z](z: =>Z): F[Z] = conquer
+  override def xproduct1[Z, A1](a1: =>F[A1])(f: A1 => Z, g: Z => A1): F[Z] =
+    xmap(a1, f, g)
+  override def xproduct2[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(
+    f: (A1, A2) => Z,
+    g: Z => (A1, A2)
+  ): F[Z] = divide2(a1, a2)(g)
+  override def xproduct3[Z, A1, A2, A3](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3])(
+    f: (A1, A2, A3) => Z,
+    g: Z => (A1, A2, A3)
+  ): F[Z] = divide3(a1, a2, a3)(g)
+  override def xproduct4[Z, A1, A2, A3, A4](
+    a1: =>F[A1],
+    a2: =>F[A2],
+    a3: =>F[A3],
+    a4: =>F[A4]
+  )(
+    f: (A1, A2, A3, A4) => Z,
+    g: Z => (A1, A2, A3, A4)
+  ): F[Z] = divide4(a1, a2, a3, a4)(g)
+
+  trait DecidableLaw extends DivisibleLaw {
+    // distribution law blocked on https://github.com/ekmett/contravariant/issues/53
+
+    // TODO: translate this
+    // choose f (choose g m n) o = divide f' m (divide id n o) where
+    //   f' bcd = either (either id (Right . Left) . g) (Right . Right) . f
+  }
+  def decidableLaw = new DecidableLaw {}
+
+  ////
+  val decidableSyntax = new scalaz.syntax.DecidableSyntax[F] { def F = Decidable.this }
+}
+
+object Decidable {
+  @inline def apply[F[_]](implicit F: Decidable[F]): Decidable[F] = F
+
+  import Isomorphism._
+
+  def fromIso[F[_], G[_]](D: F <~> G)(implicit E: Decidable[G]): Decidable[F] =
+    new IsomorphismDecidable[F, G] {
+      override def G: Decidable[G] = E
+      override def iso: F <~> G = D
+    }
+
+  ////
+
+  ////
+}
+
+
+trait IsomorphismDecidable[F[_], G[_]] extends Decidable[F] with IsomorphismDivisible[F, G] with IsomorphismInvariantAlt[F, G]{
+  implicit def G: Decidable[G]
+
+  def choose2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: Z => A1 \/ A2): F[Z] =
+    iso.from(G.choose2(iso.to(a1), iso.to(a2))(f))
+
+  override def xproduct0[Z](z: =>Z): F[Z] = super[Decidable].xproduct0(z)
+  override def xproduct1[Z, A1](a1: =>F[A1])(f: A1 => Z, g: Z => A1): F[Z] = super[Decidable].xproduct1(a1)(f, g)
+  override def xproduct2[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(f: (A1, A2) => Z, g: Z => (A1, A2)): F[Z] = super[Decidable].xproduct2(a1, a2)(f, g)
+  override def xproduct3[Z, A1, A2, A3](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3])(f: (A1, A2, A3) => Z, g: Z => (A1, A2, A3)): F[Z] = super[Decidable].xproduct3(a1, a2, a3)(f, g)
+  override def xproduct4[Z, A1, A2, A3, A4](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3], a4: =>F[A4])(f: (A1, A2, A3, A4) => Z, g: Z => (A1, A2, A3, A4)): F[Z] = super[Decidable].xproduct4(a1, a2, a3, a4)(f, g)
+
+  override def xcoproduct1[Z, A1](a1: => F[A1])(f: A1 => Z, g: Z => A1): F[Z] =
+    super[Decidable].xcoproduct1(a1)(f, g)
+  override def xcoproduct2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: A1 \/ A2 => Z, g: Z => A1 \/ A2): F[Z] =
+    super[Decidable].xcoproduct2(a1, a2)(f, g)
+  override def xcoproduct3[Z, A1, A2, A3](a1: => F[A1], a2: => F[A2], a3: => F[A3])(f: A1 \/ (A2 \/ A3) => Z, g: Z => A1 \/ (A2 \/ A3)): F[Z] =
+    super[Decidable].xcoproduct3(a1, a2, a3)(f, g)
+  override def xcoproduct4[Z, A1, A2, A3, A4](a1: => F[A1], a2: => F[A2], a3: => F[A3], a4: => F[A4])(f: A1 \/ (A2 \/ (A3 \/ A4)) => Z, g: Z => A1 \/ (A2 \/ (A3 \/ A4))): F[Z] =
+    super[Decidable].xcoproduct4(a1, a2, a3, a4)(f, g)
+
+}

--- a/core/src/main/scala/scalaz/Decidable.scala
+++ b/core/src/main/scala/scalaz/Decidable.scala
@@ -116,27 +116,3 @@ object Decidable {
 
   ////
 }
-
-
-trait IsomorphismDecidable[F[_], G[_]] extends Decidable[F] with IsomorphismDivisible[F, G] with IsomorphismInvariantAlt[F, G]{
-  implicit def G: Decidable[G]
-
-  def choose2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: Z => A1 \/ A2): F[Z] =
-    iso.from(G.choose2(iso.to(a1), iso.to(a2))(f))
-
-  override def xproduct0[Z](z: =>Z): F[Z] = super[Decidable].xproduct0(z)
-  override def xproduct1[Z, A1](a1: =>F[A1])(f: A1 => Z, g: Z => A1): F[Z] = super[Decidable].xproduct1(a1)(f, g)
-  override def xproduct2[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(f: (A1, A2) => Z, g: Z => (A1, A2)): F[Z] = super[Decidable].xproduct2(a1, a2)(f, g)
-  override def xproduct3[Z, A1, A2, A3](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3])(f: (A1, A2, A3) => Z, g: Z => (A1, A2, A3)): F[Z] = super[Decidable].xproduct3(a1, a2, a3)(f, g)
-  override def xproduct4[Z, A1, A2, A3, A4](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3], a4: =>F[A4])(f: (A1, A2, A3, A4) => Z, g: Z => (A1, A2, A3, A4)): F[Z] = super[Decidable].xproduct4(a1, a2, a3, a4)(f, g)
-
-  override def xcoproduct1[Z, A1](a1: => F[A1])(f: A1 => Z, g: Z => A1): F[Z] =
-    super[Decidable].xcoproduct1(a1)(f, g)
-  override def xcoproduct2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: A1 \/ A2 => Z, g: Z => A1 \/ A2): F[Z] =
-    super[Decidable].xcoproduct2(a1, a2)(f, g)
-  override def xcoproduct3[Z, A1, A2, A3](a1: => F[A1], a2: => F[A2], a3: => F[A3])(f: A1 \/ (A2 \/ A3) => Z, g: Z => A1 \/ (A2 \/ A3)): F[Z] =
-    super[Decidable].xcoproduct3(a1, a2, a3)(f, g)
-  override def xcoproduct4[Z, A1, A2, A3, A4](a1: => F[A1], a2: => F[A2], a3: => F[A3], a4: => F[A4])(f: A1 \/ (A2 \/ (A3 \/ A4)) => Z, g: Z => A1 \/ (A2 \/ (A3 \/ A4))): F[Z] =
-    super[Decidable].xcoproduct4(a1, a2, a3, a4)(f, g)
-
-}

--- a/core/src/main/scala/scalaz/IStream.scala
+++ b/core/src/main/scala/scalaz/IStream.scala
@@ -1,0 +1,155 @@
+// Copyright: 2017 - 2018 Sam Halliday
+// License: https://opensource.org/licenses/BSD-3-Clause
+
+package scalaz
+
+import scala.annotation.tailrec
+
+/**
+ * A linked list with by-name head and tail, allowing some control over memory
+ * usage and evaluation of contents.
+ *
+ * This structure is a good choice when the contents are expensive to calculate
+ * and may not all need to be evaluated, at the cost of an overhead when the
+ * contents are calculated. Typeclass instances try to defer evaluation of
+ * contents, unless it would require a full traversal of the spine, preferring
+ * lazy semantics when an evaluation choice is to be made.
+ */
+sealed abstract class IStream[A] { self =>
+  import IStream._
+
+  /** Strict concatenation */
+  final def !:(a: A): IStream[A]     = Cons(Value(a), Value(self))
+  final def :!(other: A): IStream[A] = !!(Strict(other))
+  final def !!(other: IStream[A]): IStream[A] =
+    instances.foldRight(self, other)((a, as) => Strict.cons(a, as))
+
+  /** prepend lazily (by-name parameters do not work here) */
+  final def #:(a: Name[A]): IStream[A] = Cons(a, Value(self))
+
+  // not stack safe. We could have an infinite stream so would we want to
+  // sacrifice stack safety for non-terminating programs instead? That's what
+  // foldLeft is for. Life is meaningless, etc, etc.
+  final def foldRightByName[B](z: =>B)(f: (=>A, =>B) => B): B = self match {
+    case _: Nil[_]        => z
+    case Cons(head, tail) => f(head.value, tail.value.foldRightByName(z)(f))
+  }
+
+  // Stack safe, but can't exit early. You may never escape.
+  final def foldLeftByName[B](z: B)(f: (=>B, =>A) => B): B = {
+    @tailrec def loop(t: IStream[A], acc: B): B = t match {
+      case _: Nil[_]        => acc
+      case Cons(head, tail) => loop(tail.value, f(acc, head.value))
+    }
+    loop(self, z)
+  }
+
+  def reverse: IStream[A] =
+    foldLeftByName(empty[A])((xs, x) => Lazy.cons(x, xs))
+
+  def headMaybe: Maybe[A] = self match {
+    case IStream.Nil()         => Maybe.empty
+    case IStream.Cons(head, _) => Maybe.just(head.value)
+  }
+
+}
+object IStream {
+
+  private final case class Nil[A]() extends IStream[A]
+  private final case class Cons[A](
+    head: Name[A],
+    tail: Name[IStream[A]]
+  ) extends IStream[A]
+  // it is very tempting to add a third case that concatenates two streams...
+  // but it would break the stack safety of foldLeft.
+
+  def empty[A]: IStream[A]       = _empty.asInstanceOf[IStream[A]]
+  private[this] final val _empty = Nil[Nothing]()
+
+  object ByName {
+    def apply[A](a: =>A): IStream[A] = Cons(Name(a), nil[A])
+    def cons[A](head: =>A, tail: =>IStream[A]): IStream[A] =
+      Cons(Name(head), Name(tail))
+    def infinite[A](el: A): IStream[A] = cons(el, infinite(el))
+  }
+  object Lazy {
+    def apply[A](a: =>A): IStream[A] = Cons(Need(a), nil[A])
+    def cons[A](head: =>A, tail: =>IStream[A]): IStream[A] =
+      Cons(Need(head), Need(tail))
+    def infinite[A](el: A): IStream[A] = cons(el, infinite(el))
+  }
+  object Strict {
+    def apply[A](a: A): IStream[A]                     = Cons(Value(a), nil[A])
+    def cons[A](head: A, tail: IStream[A]): IStream[A] = head !: tail
+  }
+
+  def fromStream[A](sa: Stream[A]): IStream[A] = sa match {
+    case Stream() => empty[A]
+    case h #:: t  => Lazy.cons(h, fromStream(t))
+  }
+
+  def fromFoldable[F[_]: Foldable, A](fa: F[A]): IStream[A] =
+    Foldable[F].foldRight(fa, empty[A])((h, t) => Lazy.cons(h, t))
+
+  // more efficient allocations
+  private[this] final val __empty = Value(_empty)
+  private[this] final def nil[A]  = __empty.asInstanceOf[Name[IStream[A]]]
+
+  implicit val instances
+    : MonadPlus[IStream] with IsEmpty[IStream] with Traverse[IStream] =
+    new MonadPlus[IStream] with IsEmpty[IStream] with Traverse[IStream] {
+
+      override def map[A, B](fa: IStream[A])(f: A => B): IStream[B] =
+        fa.foldRightByName(empty[B])((h, t) => Lazy.cons(f(h), t))
+
+      def point[A](a: =>A): IStream[A] = Lazy(a)
+      def bind[A, B](fa: IStream[A])(f: A => IStream[B]): IStream[B] =
+        foldRight(fa, empty[B])((h, t) => plus(f(h), t))
+
+      def plus[A](a: IStream[A], b: =>IStream[A]): IStream[A] =
+        a.foldRightByName(b)(Lazy.cons)
+      def empty[A]: IStream[A] = IStream.empty[A]
+
+      def isEmpty[A](fa: IStream[A]): Boolean = fa.isInstanceOf[Nil[_]]
+
+      override def foldMap[A, B](
+        fa: IStream[A]
+      )(f: A => B)(implicit F: Monoid[B]): B =
+        foldRight(fa, F.zero)((a, b) => F.append(f(a), b))
+
+      override def foldRight[A, B](fa: IStream[A], z: =>B)(
+        f: (A, =>B) => B
+      ): B =
+        fa match {
+          case _: Nil[_]        => z
+          case Cons(head, tail) => f(head.value, foldRight(tail.value, z)(f))
+        }
+
+      override def foldLeft[A, B](fa: IStream[A], z: B)(f: (B, A) => B): B = {
+        @tailrec def loop(t: IStream[A], acc: B): B = t match {
+          case _: Nil[_]        => acc
+          case Cons(head, tail) => loop(tail.value, f(acc, head.value))
+        }
+        loop(fa, z)
+      }
+
+      def traverseImpl[G[_], A, B](
+        fa: IStream[A]
+      )(f: A => G[B])(implicit G: Applicative[G]): G[IStream[B]] =
+        fa.foldRightByName(G.point(empty[B]))(
+          (x, ys) => G.apply2(f(x), ys)(_ !: _)
+        )
+
+      // wtf is traversal all about?
+      override def traverse[G[_]: Applicative, A, B](fa: IStream[A])(
+        f: A => G[B]
+      ): G[IStream[B]] = traverseImpl(fa)(f)
+
+    }
+
+  // it would be more in keeping with the data structure's objectives to
+  // Align.align and compare elements, to avoid a full traversal...
+  implicit def equal[A: Equal]: Equal[IStream[A]] =
+    Equal[IList[A]].contramap(instances.toIList(_))
+
+}

--- a/core/src/main/scala/scalaz/InvariantAlt.scala
+++ b/core/src/main/scala/scalaz/InvariantAlt.scala
@@ -72,15 +72,3 @@ object InvariantAlt {
 
   ////
 }
-
-trait IsomorphismInvariantAlt[F[_], G[_]] extends InvariantAlt[F] with IsomorphismInvariantApplicative[F, G]{
-  implicit def G: InvariantAlt[G]
-
-  import Isomorphism._
-
-  def iso: F <~> G
-
-  def xcoproduct2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: A1 \/ A2 => Z, g: Z => A1 \/ A2): F[Z] =
-    iso.from(G.xcoproduct2(iso.to(a1), iso.to(a2))(f, g))
-
-}

--- a/core/src/main/scala/scalaz/InvariantAlt.scala
+++ b/core/src/main/scala/scalaz/InvariantAlt.scala
@@ -1,0 +1,86 @@
+package scalaz
+
+////
+// Copyright: 2017 Sam Halliday
+// License: https://opensource.org/licenses/BSD-3-Clause
+
+/**
+ * Invariant parent of Decidable and Alternative.
+ *
+ * Used for typeclass derivation of products, coproducts and value types.
+ */
+////
+trait InvariantAlt[F[_]] extends InvariantApplicative[F] { self =>
+  ////
+
+  def xcoproduct1[Z, A1](a1: =>F[A1])(f: A1 => Z, g: Z => A1): F[Z] =
+    xmap(a1, f, g)
+  def xcoproduct2[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(
+    f: A1 \/ A2 => Z,
+    g: Z => A1 \/ A2
+  ): F[Z]
+  def xcoproduct3[Z, A1, A2, A3](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3])(
+    f: A1 \/ (A2 \/ A3) => Z,
+    g: Z => A1 \/ (A2 \/ A3)
+  ): F[Z] = {
+    val a23: F[A2 \/ A3] = xcoproduct2(a2, a3)(identity, identity)
+    xcoproduct2(a1, a23)(f, g)
+  }
+  def xcoproduct4[Z, A1, A2, A3, A4](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3], a4: =>F[A4])(
+    f: A1 \/ (A2 \/ (A3 \/ A4)) => Z,
+    g: Z => A1 \/ (A2 \/ (A3 \/ A4))
+  ): F[Z] = {
+    val a234: F[A2 \/ (A3 \/ A4)] = xcoproduct3(a2, a3, a4)(identity, identity)
+    xcoproduct2(a1, a234)(f, g)
+  }
+
+  // these methods fail for recursive ADTs, fixed in
+  // https://github.com/scala/scala/pull/6050
+  final def xcoderiving1[Z, A1](
+    f: A1 => Z,
+    g: Z => A1
+  )(implicit a1: F[A1]): F[Z] = xcoproduct1(a1)(f, g)
+  final def xcoderiving2[Z, A1, A2](
+    f: (A1 \/ A2) => Z,
+    g: Z => (A1 \/ A2)
+  )(implicit a1: F[A1], a2: F[A2]): F[Z] = xcoproduct2(a1, a2)(f, g)
+  final def xcoderiving3[Z, A1, A2, A3](
+    f: (A1 \/ (A2 \/ A3)) => Z,
+    g: Z => (A1 \/ (A2 \/ A3))
+  )(implicit a1: F[A1], a2: F[A2], a3: F[A3]): F[Z] = xcoproduct3(a1, a2, a3)(f, g)
+  final def xcoderiving4[Z, A1, A2, A3, A4](
+    f: (A1 \/ (A2 \/ (A3 \/ A4))) => Z,
+    g: Z => (A1 \/ (A2 \/ (A3 \/ A4)))
+  )(implicit a1: F[A1], a2: F[A2], a3: F[A3], a4: F[A4]): F[Z] = xcoproduct4(a1, a2, a3, a4)(f, g)
+
+  ////
+  val invariantAltSyntax = new scalaz.syntax.InvariantAltSyntax[F] { def F = InvariantAlt.this }
+}
+
+object InvariantAlt {
+  @inline def apply[F[_]](implicit F: InvariantAlt[F]): InvariantAlt[F] = F
+
+  import Isomorphism._
+
+  def fromIso[F[_], G[_]](D: F <~> G)(implicit E: InvariantAlt[G]): InvariantAlt[F] =
+    new IsomorphismInvariantAlt[F, G] {
+      override def G: InvariantAlt[G] = E
+      override def iso: F <~> G = D
+    }
+
+  ////
+
+  ////
+}
+
+trait IsomorphismInvariantAlt[F[_], G[_]] extends InvariantAlt[F] with IsomorphismInvariantApplicative[F, G]{
+  implicit def G: InvariantAlt[G]
+
+  import Isomorphism._
+
+  def iso: F <~> G
+
+  def xcoproduct2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: A1 \/ A2 => Z, g: Z => A1 \/ A2): F[Z] =
+    iso.from(G.xcoproduct2(iso.to(a1), iso.to(a2))(f, g))
+
+}

--- a/core/src/main/scala/scalaz/InvariantApplicative.scala
+++ b/core/src/main/scala/scalaz/InvariantApplicative.scala
@@ -1,0 +1,103 @@
+package scalaz
+
+////
+/**
+ * Should be an invariant parent of Divisible and Applicative (changed in 7.3).
+ *
+ * Used for typeclass derivation of products and value types.
+ */
+////
+trait InvariantApplicative[F[_]] extends InvariantFunctor[F] { self =>
+  ////
+
+  def xproduct0[Z](f: =>Z): F[Z]
+  def xproduct1[Z, A1](a1: =>F[A1])(f: A1 => Z, g: Z => A1): F[Z] =
+    xmap(a1, f, g)
+
+  def xproduct2[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(
+    f: (A1, A2) => Z,
+    g: Z => (A1, A2)
+  ): F[Z]
+  def xproduct3[Z, A1, A2, A3](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3])(
+    f: (A1, A2, A3) => Z,
+    g: Z => (A1, A2, A3)
+  ): F[Z] = {
+    val a23: F[(A2, A3)] = xproduct2(a2, a3)(
+      (a, b) => (a, b),
+      v => v
+    )
+    val a123: F[(A1, A2, A3)] = xproduct2(a1, a23)(
+      (a, b) => (a, b._1, b._2),
+      v => (v._1, (v._2, v._3))
+    )
+    xmap(a123, f.tupled, g)
+  }
+
+  def xproduct4[Z, A1, A2, A3, A4](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3], a4: =>F[A4])(
+    f: (A1, A2, A3, A4) => Z,
+    g: Z => (A1, A2, A3, A4)
+  ): F[Z] = {
+    val a12: F[(A1, A2)] = xproduct2(a1, a2)(
+      (a, b) => (a, b),
+      v => v
+    )
+    val a34: F[(A3, A4)] = xproduct2(a3, a4)(
+      (a, b) => (a, b),
+      v => v
+    )
+    val a1234: F[(A1, A2, A3, A4)] = xproduct2(a12, a34)(
+      (a, b) => (a._1, a._2, b._1, b._2),
+      v => ((v._1, v._2), (v._3, v._4))
+    )
+    xmap(a1234, f.tupled, g)
+  }
+
+  // these methods fail for recursive ADTs, fixed in
+  // https://github.com/scala/scala/pull/6050
+  final def xderiving0[Z](z: =>Z): F[Z] = xproduct0(z)
+  final def xderiving1[Z, A1](
+    f: A1 => Z,
+    g: Z => A1
+  )(implicit a1: F[A1]): F[Z] = xproduct1(a1)(f, g)
+  final def xderiving2[Z, A1, A2](
+    f: (A1, A2) => Z,
+    g: Z => (A1, A2)
+  )(implicit a1: F[A1], a2: F[A2]): F[Z] = xproduct2(a1, a2)(f, g)
+  final def xderiving3[Z, A1, A2, A3](
+    f: (A1, A2, A3) => Z,
+    g: Z => (A1, A2, A3)
+  )(implicit a1: F[A1], a2: F[A2], a3: F[A3]): F[Z] = xproduct3(a1, a2, a3)(f, g)
+  final def xderiving4[Z, A1, A2, A3, A4](
+    f: (A1, A2, A3, A4) => Z,
+    g: Z => (A1, A2, A3, A4)
+  )(implicit a1: F[A1], a2: F[A2], a3: F[A3], a4: F[A4]): F[Z] = xproduct4(a1, a2, a3, a4)(f, g)
+
+  ////
+  val invariantApplicativeSyntax = new scalaz.syntax.InvariantApplicativeSyntax[F] { def F = InvariantApplicative.this }
+}
+
+object InvariantApplicative {
+  @inline def apply[F[_]](implicit F: InvariantApplicative[F]): InvariantApplicative[F] = F
+
+  import Isomorphism._
+
+  def fromIso[F[_], G[_]](D: F <~> G)(implicit E: InvariantApplicative[G]): InvariantApplicative[F] =
+    new IsomorphismInvariantApplicative[F, G] {
+      override def G: InvariantApplicative[G] = E
+      override def iso: F <~> G = D
+    }
+
+  ////
+
+  ////
+}
+
+trait IsomorphismInvariantApplicative[F[_], G[_]] extends InvariantApplicative[F] with IsomorphismInvariantFunctor[F, G]{
+  implicit def G: InvariantApplicative[G]
+
+  def xproduct0[Z](f: => Z): F[Z] =
+    iso.from(G.xproduct0(f))
+  def xproduct2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: (A1, A2) => Z, g: Z => (A1, A2)): F[Z] =
+    iso.from(G.xproduct2(iso.to(a1), iso.to(a2))(f, g))
+
+}

--- a/core/src/main/scala/scalaz/InvariantApplicative.scala
+++ b/core/src/main/scala/scalaz/InvariantApplicative.scala
@@ -91,13 +91,3 @@ object InvariantApplicative {
 
   ////
 }
-
-trait IsomorphismInvariantApplicative[F[_], G[_]] extends InvariantApplicative[F] with IsomorphismInvariantFunctor[F, G]{
-  implicit def G: InvariantApplicative[G]
-
-  def xproduct0[Z](f: => Z): F[Z] =
-    iso.from(G.xproduct0(f))
-  def xproduct2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: (A1, A2) => Z, g: Z => (A1, A2)): F[Z] =
-    iso.from(G.xproduct2(iso.to(a1), iso.to(a2))(f, g))
-
-}

--- a/core/src/main/scala/scalaz/Isomorphism.scala
+++ b/core/src/main/scala/scalaz/Isomorphism.scala
@@ -641,3 +641,42 @@ trait IsomorphismBitraverse[F[_, _], G[_, _]] extends Bitraverse[F] with Isomorp
   def bitraverseImpl[H[_]: Applicative, A, B, C, D](fab: F[A, B])(f: A => H[C], g: B => H[D]): H[F[C, D]] =
     Applicative[H].map(G.bitraverseImpl(iso.to(fab))(f, g))(iso.from.apply)
 }
+
+trait IsomorphismInvariantApplicative[F[_], G[_]] extends InvariantApplicative[F] with IsomorphismInvariantFunctor[F, G]{
+  implicit def G: InvariantApplicative[G]
+  def xproduct0[Z](f: => Z): F[Z] = iso.from(G.xproduct0(f))
+  def xproduct2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: (A1, A2) => Z, g: Z => (A1, A2)): F[Z] = iso.from(G.xproduct2(iso.to(a1), iso.to(a2))(f, g))
+}
+
+trait IsomorphismInvariantAlt[F[_], G[_]] extends InvariantAlt[F] with IsomorphismInvariantApplicative[F, G]{
+  implicit def G: InvariantAlt[G]
+  def xcoproduct2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: A1 \/ A2 => Z, g: Z => A1 \/ A2): F[Z] = iso.from(G.xcoproduct2(iso.to(a1), iso.to(a2))(f, g))
+}
+
+trait IsomorphismAlt[F[_], G[_]] extends Alt[F] with IsomorphismApplicative[F, G] with IsomorphismInvariantAlt[F, G]{
+  implicit def G: Alt[G]
+  override def alt[A](a1: =>F[A], a2: =>F[A]): F[A] = iso.from(G.alt(iso.to(a1), iso.to(a2)))
+  override def xproduct0[Z](z: =>Z): F[Z] = super[Alt].xproduct0(z)
+  override def xproduct1[Z, A1](a1: =>F[A1])(f: A1 => Z, g: Z => A1): F[Z] = super[Alt].xproduct1(a1)(f, g)
+  override def xproduct2[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(f: (A1, A2) => Z, g: Z => (A1, A2)): F[Z] = super[Alt].xproduct2(a1, a2)(f, g)
+  override def xproduct3[Z, A1, A2, A3](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3])(f: (A1, A2, A3) => Z, g: Z => (A1, A2, A3)): F[Z] = super[Alt].xproduct3(a1, a2, a3)(f, g)
+  override def xproduct4[Z, A1, A2, A3, A4](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3], a4: =>F[A4])(f: (A1, A2, A3, A4) => Z, g: Z => (A1, A2, A3, A4)): F[Z] = super[Alt].xproduct4(a1, a2, a3, a4)(f, g)
+  override def xcoproduct1[Z, A1](a1: => F[A1])(f: A1 => Z, g: Z => A1): F[Z] = super[Alt].xcoproduct1(a1)(f, g)
+  override def xcoproduct2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: A1 \/ A2 => Z, g: Z => A1 \/ A2): F[Z] = super[Alt].xcoproduct2(a1, a2)(f, g)
+  override def xcoproduct3[Z, A1, A2, A3](a1: => F[A1], a2: => F[A2], a3: => F[A3])(f: A1 \/ (A2 \/ A3) => Z, g: Z => A1 \/ (A2 \/ A3)): F[Z] = super[Alt].xcoproduct3(a1, a2, a3)(f, g)
+  override def xcoproduct4[Z, A1, A2, A3, A4](a1: => F[A1], a2: => F[A2], a3: => F[A3], a4: => F[A4])(f: A1 \/ (A2 \/ (A3 \/ A4)) => Z, g: Z => A1 \/ (A2 \/ (A3 \/ A4))): F[Z] = super[Alt].xcoproduct4(a1, a2, a3, a4)(f, g)
+}
+
+trait IsomorphismDecidable[F[_], G[_]] extends Decidable[F] with IsomorphismDivisible[F, G] with IsomorphismInvariantAlt[F, G]{
+  implicit def G: Decidable[G]
+  def choose2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: Z => A1 \/ A2): F[Z] = iso.from(G.choose2(iso.to(a1), iso.to(a2))(f))
+  override def xproduct0[Z](z: =>Z): F[Z] = super[Decidable].xproduct0(z)
+  override def xproduct1[Z, A1](a1: =>F[A1])(f: A1 => Z, g: Z => A1): F[Z] = super[Decidable].xproduct1(a1)(f, g)
+  override def xproduct2[Z, A1, A2](a1: =>F[A1], a2: =>F[A2])(f: (A1, A2) => Z, g: Z => (A1, A2)): F[Z] = super[Decidable].xproduct2(a1, a2)(f, g)
+  override def xproduct3[Z, A1, A2, A3](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3])(f: (A1, A2, A3) => Z, g: Z => (A1, A2, A3)): F[Z] = super[Decidable].xproduct3(a1, a2, a3)(f, g)
+  override def xproduct4[Z, A1, A2, A3, A4](a1: =>F[A1], a2: =>F[A2], a3: =>F[A3], a4: =>F[A4])(f: (A1, A2, A3, A4) => Z, g: Z => (A1, A2, A3, A4)): F[Z] = super[Decidable].xproduct4(a1, a2, a3, a4)(f, g)
+  override def xcoproduct1[Z, A1](a1: => F[A1])(f: A1 => Z, g: Z => A1): F[Z] = super[Decidable].xcoproduct1(a1)(f, g)
+  override def xcoproduct2[Z, A1, A2](a1: => F[A1], a2: => F[A2])(f: A1 \/ A2 => Z, g: Z => A1 \/ A2): F[Z] = super[Decidable].xcoproduct2(a1, a2)(f, g)
+  override def xcoproduct3[Z, A1, A2, A3](a1: => F[A1], a2: => F[A2], a3: => F[A3])(f: A1 \/ (A2 \/ A3) => Z, g: Z => A1 \/ (A2 \/ A3)): F[Z] = super[Decidable].xcoproduct3(a1, a2, a3)(f, g)
+  override def xcoproduct4[Z, A1, A2, A3, A4](a1: => F[A1], a2: => F[A2], a3: => F[A3], a4: => F[A4])(f: A1 \/ (A2 \/ (A3 \/ A4)) => Z, g: Z => A1 \/ (A2 \/ (A3 \/ A4))): F[Z] = super[Decidable].xcoproduct4(a1, a2, a3, a4)(f, g)
+}

--- a/core/src/main/scala/scalaz/syntax/AltSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/AltSyntax.scala
@@ -1,0 +1,33 @@
+package scalaz
+package syntax
+
+/** Wraps a value `self` and provides methods related to `Alt` */
+final class AltOps[F[_],A] private[syntax](val self: F[A])(implicit val F: Alt[F]) extends Ops[F[A]] {
+  ////
+
+  ////
+}
+
+sealed trait ToAltOps0 {
+  implicit def ToAltOpsUnapply[FA](v: FA)(implicit F0: Unapply[Alt, FA]) =
+    new AltOps[F0.M,F0.A](F0(v))(F0.TC)
+
+}
+
+trait ToAltOps extends ToAltOps0 with ToApplicativeOps with ToInvariantAltOps {
+  implicit def ToAltOps[F[_],A](v: F[A])(implicit F0: Alt[F]) =
+    new AltOps[F,A](v)
+
+  ////
+
+  ////
+}
+
+trait AltSyntax[F[_]] extends ApplicativeSyntax[F] with InvariantAltSyntax[F] {
+  implicit def ToAltOps[A](v: F[A]): AltOps[F, A] = new AltOps[F,A](v)(AltSyntax.this.F)
+
+  def F: Alt[F]
+  ////
+
+  ////
+}

--- a/core/src/main/scala/scalaz/syntax/DecidableSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/DecidableSyntax.scala
@@ -1,0 +1,33 @@
+package scalaz
+package syntax
+
+/** Wraps a value `self` and provides methods related to `Decidable` */
+final class DecidableOps[F[_],A] private[syntax](val self: F[A])(implicit val F: Decidable[F]) extends Ops[F[A]] {
+  ////
+
+  ////
+}
+
+sealed trait ToDecidableOps0 {
+  implicit def ToDecidableOpsUnapply[FA](v: FA)(implicit F0: Unapply[Decidable, FA]) =
+    new DecidableOps[F0.M,F0.A](F0(v))(F0.TC)
+
+}
+
+trait ToDecidableOps extends ToDecidableOps0 with ToDivisibleOps with ToInvariantAltOps {
+  implicit def ToDecidableOps[F[_],A](v: F[A])(implicit F0: Decidable[F]) =
+    new DecidableOps[F,A](v)
+
+  ////
+
+  ////
+}
+
+trait DecidableSyntax[F[_]] extends DivisibleSyntax[F] with InvariantAltSyntax[F] {
+  implicit def ToDecidableOps[A](v: F[A]): DecidableOps[F, A] = new DecidableOps[F,A](v)(DecidableSyntax.this.F)
+
+  def F: Decidable[F]
+  ////
+
+  ////
+}

--- a/core/src/main/scala/scalaz/syntax/InvariantAltSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/InvariantAltSyntax.scala
@@ -1,0 +1,33 @@
+package scalaz
+package syntax
+
+/** Wraps a value `self` and provides methods related to `InvariantAlt` */
+final class InvariantAltOps[F[_],A] private[syntax](val self: F[A])(implicit val F: InvariantAlt[F]) extends Ops[F[A]] {
+  ////
+
+  ////
+}
+
+sealed trait ToInvariantAltOps0 {
+  implicit def ToInvariantAltOpsUnapply[FA](v: FA)(implicit F0: Unapply[InvariantAlt, FA]) =
+    new InvariantAltOps[F0.M,F0.A](F0(v))(F0.TC)
+
+}
+
+trait ToInvariantAltOps extends ToInvariantAltOps0 with ToInvariantApplicativeOps {
+  implicit def ToInvariantAltOps[F[_],A](v: F[A])(implicit F0: InvariantAlt[F]) =
+    new InvariantAltOps[F,A](v)
+
+  ////
+
+  ////
+}
+
+trait InvariantAltSyntax[F[_]] extends InvariantApplicativeSyntax[F] {
+  implicit def ToInvariantAltOps[A](v: F[A]): InvariantAltOps[F, A] = new InvariantAltOps[F,A](v)(InvariantAltSyntax.this.F)
+
+  def F: InvariantAlt[F]
+  ////
+
+  ////
+}

--- a/core/src/main/scala/scalaz/syntax/InvariantApplicativeSyntax.scala
+++ b/core/src/main/scala/scalaz/syntax/InvariantApplicativeSyntax.scala
@@ -1,0 +1,33 @@
+package scalaz
+package syntax
+
+/** Wraps a value `self` and provides methods related to `InvariantApplicative` */
+final class InvariantApplicativeOps[F[_],A] private[syntax](val self: F[A])(implicit val F: InvariantApplicative[F]) extends Ops[F[A]] {
+  ////
+
+  ////
+}
+
+sealed trait ToInvariantApplicativeOps0 {
+  implicit def ToInvariantApplicativeOpsUnapply[FA](v: FA)(implicit F0: Unapply[InvariantApplicative, FA]) =
+    new InvariantApplicativeOps[F0.M,F0.A](F0(v))(F0.TC)
+
+}
+
+trait ToInvariantApplicativeOps extends ToInvariantApplicativeOps0 with ToInvariantFunctorOps {
+  implicit def ToInvariantApplicativeOps[F[_],A](v: F[A])(implicit F0: InvariantApplicative[F]) =
+    new InvariantApplicativeOps[F,A](v)
+
+  ////
+
+  ////
+}
+
+trait InvariantApplicativeSyntax[F[_]] extends InvariantFunctorSyntax[F] {
+  implicit def ToInvariantApplicativeOps[A](v: F[A]): InvariantApplicativeOps[F, A] = new InvariantApplicativeOps[F,A](v)(InvariantApplicativeSyntax.this.F)
+
+  def F: InvariantApplicative[F]
+  ////
+
+  ////
+}

--- a/project/GenTypeClass.scala
+++ b/project/GenTypeClass.scala
@@ -27,6 +27,10 @@ object TypeClass {
 
   lazy val invariantFunctor = TypeClass("InvariantFunctor", *->*)
   lazy val functor = TypeClass("Functor", *->*, extendsList = Seq(invariantFunctor))
+  lazy val invariantApplicative = TypeClass("InvariantApplicative", *->*, extendsList = Seq(invariantFunctor))
+  lazy val invariantAlt = TypeClass("InvariantAlt", *->*, extendsList = Seq(invariantApplicative))
+  lazy val decidable = TypeClass("Decidable", *->*, extendsList = Seq(divisible, invariantAlt))
+  lazy val alt = TypeClass("Alt", *->*, extendsList = Seq(applicative, invariantAlt))
   lazy val apply: TypeClass = TypeClass("Apply", *->*, extendsList = Seq(functor), parent = true)
   lazy val applicative = TypeClass("Applicative", *->*, extendsList = Seq(apply), parent = true)
   lazy val align = TypeClass("Align", *->*, extendsList = Seq(functor))
@@ -101,6 +105,10 @@ object TypeClass {
     divisible,
     apply,
     applicative,
+    invariantAlt,
+    invariantApplicative,
+    decidable,
+    alt,
     align,
     zip,
     unzip,

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
@@ -47,6 +47,9 @@ object ScalazArbitrary extends ScalazArbitraryPlatform {
   implicit def EphemeralStreamArbitrary[A : Arbitrary]: Arbitrary[EphemeralStream[A]] =
     Functor[Arbitrary].map(arb[Stream[A]])(EphemeralStream.fromStream[A](_))
 
+  implicit def IStreamArbitrary[A : Arbitrary]: Arbitrary[IStream[A]] =
+    Functor[Arbitrary].map(arb[Stream[A]])(IStream.fromStream[A](_))
+
   implicit def CorecursiveListArbitrary[A : Arbitrary]: Arbitrary[CorecursiveList[A]] =
     Functor[Arbitrary].map(arb[Stream[A]])(CorecursiveList.fromStream)
 

--- a/tests/src/test/scala/examples/examples.scala
+++ b/tests/src/test/scala/examples/examples.scala
@@ -1,0 +1,161 @@
+// Copyright: 2017 - 2018 Sam Halliday
+// License: https://opensource.org/licenses/BSD-3-Clause
+
+package examples
+
+import java.lang.String
+import scala.{ Boolean, Int }
+import scala.Predef.implicitly
+
+import scalaz._, Scalaz._
+import orphans._
+
+// a simple adt with typeclass derivations
+package adt {
+  sealed trait Foo
+  final case class Bar(s: String)          extends Foo
+  final case class Faz(b: Boolean, i: Int) extends Foo
+  final case object Baz extends Foo {
+    implicit val equal: Equal[Baz.type] =
+      InvariantAlt[Equal].xderiving0(Baz)
+    implicit val default: Default[Baz.type] =
+      InvariantAlt[Default].xderiving0(Baz)
+  }
+  object Bar {
+    implicit val equal: Equal[Bar] =
+      InvariantAlt[Equal].xderiving1((s: String) => Bar(s), _.s)
+    implicit val default: Default[Bar] =
+      InvariantAlt[Default].xderiving1((s: String) => Bar(s), _.s)
+  }
+  object Faz {
+    implicit val equal: Equal[Faz] =
+      InvariantAlt[Equal]
+        .xderiving2((b: Boolean, i: Int) => Faz(b, i), f => (f.b, f.i))
+    implicit val default: Default[Faz] =
+      InvariantAlt[Default]
+        .xderiving2((b: Boolean, i: Int) => Faz(b, i), f => (f.b, f.i))
+  }
+  object Foo {
+    private[this] val to: (Bar \/ (Baz.type \/ Faz)) => Foo = {
+      case -\/(bar)      => bar: Foo
+      case \/-(-\/(baz)) => baz: Foo
+      case \/-(\/-(faz)) => faz: Foo
+    }
+    private[this] val from: Foo => (Bar \/ (Baz.type \/ Faz)) = {
+      case bar: Bar      => -\/(bar)
+      case baz: Baz.type => \/-(-\/(baz))
+      case faz: Faz      => \/-(\/-(faz))
+    }
+
+    implicit val equal: Equal[Foo] =
+      InvariantAlt[Equal].xcoderiving3(to, from)
+    implicit val default: Default[Foo] =
+      InvariantAlt[Default].xcoderiving3(to, from)
+  }
+}
+
+// more complex recursive type example
+package recadt {
+  sealed trait ATree
+  final case class Leaf(value: String)               extends ATree
+  final case class Branch(left: ATree, right: ATree) extends ATree
+
+  object Leaf {
+    implicit val equal: Equal[Leaf] = {
+      InvariantAlt[Equal].xderiving1((v: String) => Leaf(v), _.value)
+    }
+    implicit val default: Default[Leaf] =
+      InvariantAlt[Default].xderiving1((v: String) => Leaf(v), _.value)
+  }
+  object Branch {
+    implicit val equal: Equal[Branch] =
+      InvariantAlt[Equal].xproduct2(
+        implicitly[Equal[ATree]],
+        implicitly[Equal[ATree]]
+      )(
+        (left: ATree, right: ATree) => Branch(left, right),
+        b => (b.left, b.right)
+      )
+    implicit val default: Default[Branch] =
+      InvariantAlt[Default].xproduct2(
+        implicitly[Default[ATree]],
+        implicitly[Default[ATree]]
+      )(
+        (left: ATree, right: ATree) => Branch(left, right),
+        b => (b.left, b.right)
+      )
+  }
+  object ATree {
+    private[this] val to: Leaf \/ Branch => ATree = {
+      case -\/(leaf)   => leaf
+      case \/-(branch) => branch
+    }
+    private[this] val from: ATree => Leaf \/ Branch = {
+      case leaf @ Leaf(_)        => -\/(leaf)
+      case branch @ Branch(_, _) => \/-(branch)
+    }
+
+    implicit val equal: Equal[ATree] =
+      InvariantAlt[Equal].xcoproduct2(
+        implicitly[Equal[Leaf]],
+        implicitly[Equal[Branch]]
+      )(to, from)
+    implicit val default: Default[ATree] =
+      InvariantAlt[Default].xcoderiving2(to, from)
+  }
+
+}
+
+// more complex recursive GADT type example
+package recgadt {
+  sealed trait GTree[A]
+  final case class GLeaf[A](value: A)                          extends GTree[A]
+  final case class GBranch[A](left: GTree[A], right: GTree[A]) extends GTree[A]
+
+  object GLeaf {
+    implicit def equal[A: Equal]: Equal[GLeaf[A]] =
+      InvariantAlt[Equal].xderiving1((v: A) => GLeaf(v), _.value)
+    implicit def default[A: Default]: Default[GLeaf[A]] =
+      InvariantAlt[Default].xderiving1((v: A) => GLeaf(v), _.value)
+  }
+  object GBranch {
+    implicit def equal[A: Equal]: Equal[GBranch[A]] =
+      InvariantAlt[Equal].xproduct2(
+        implicitly[Equal[GTree[A]]],
+        implicitly[Equal[GTree[A]]]
+      )(
+        (left: GTree[A], right: GTree[A]) => GBranch(left, right),
+        b => (b.left, b.right)
+      )
+    implicit def default[A: Default]: Default[GBranch[A]] =
+      InvariantAlt[Default].xproduct2(
+        implicitly[Default[GTree[A]]],
+        implicitly[Default[GTree[A]]]
+      )(
+        (left: GTree[A], right: GTree[A]) => GBranch(left, right),
+        b => (b.left, b.right)
+      )
+  }
+  object GTree {
+    private[this] def to[A]: GLeaf[A] \/ GBranch[A] => GTree[A] = {
+      case -\/(leaf)   => leaf
+      case \/-(branch) => branch
+    }
+    private[this] def from[A]: GTree[A] => GLeaf[A] \/ GBranch[A] = {
+      case leaf @ GLeaf(_)        => -\/(leaf)
+      case branch @ GBranch(_, _) => \/-(branch)
+    }
+
+    implicit def equal[A: Equal]: Equal[GTree[A]] =
+      InvariantAlt[Equal].xcoproduct2(
+        implicitly[Equal[GLeaf[A]]],
+        implicitly[Equal[GBranch[A]]]
+      )(to, from)
+    implicit def default[A: Default]: Default[GTree[A]] =
+      InvariantAlt[Default].xcoproduct2(
+        implicitly[Default[GLeaf[A]]],
+        implicitly[Default[GBranch[A]]]
+      )(to, from)
+  }
+
+}

--- a/tests/src/test/scala/scalaz/AltTest.scala
+++ b/tests/src/test/scala/scalaz/AltTest.scala
@@ -1,0 +1,52 @@
+// Copyright: 2017 Sam Halliday
+// License: https://opensource.org/licenses/BSD-3-Clause
+
+package scalaz
+
+import examples.adt._
+import examples.recadt._
+import examples.recgadt._
+
+class AltTest extends SpecLite {
+
+  "products" should {
+    "behave as expected" in {
+      Default[Faz].default must_==(Faz(false, 0))
+    }
+  }
+
+  "coproducts" should {
+    "behave as expected" in {
+      Default[Foo].default must_==(Bar(""))
+    }
+  }
+
+  // Default for a recursive ADT is a dumb idea. It only works by accident here
+  // because of the ordering of the source code case classes! Try using \/- as
+  // the choice, or swap the case classes around and watch the world explode
+  // with an infinite loop.
+  "recursive products" should {
+    "behave as expected" in {
+      Default[Leaf].default must_==(Leaf(""))
+    }
+  }
+
+  "recursive coproducts" should {
+    "behave as expected" in {
+      Default[ATree].default must_==(Leaf(""))
+    }
+  }
+
+  "recursive GADT products" should {
+    "behave as expected" in {
+      Default[GLeaf[String]].default must_==(GLeaf(""))
+    }
+  }
+
+  "recursive GADT coproducts" should {
+    "behave as expected" in {
+      Default[GTree[String]].default must_==(GLeaf(""))
+    }
+  }
+
+}

--- a/tests/src/test/scala/scalaz/DecidableTest.scala
+++ b/tests/src/test/scala/scalaz/DecidableTest.scala
@@ -1,0 +1,80 @@
+// Copyright: 2017 Sam Halliday
+// License: https://opensource.org/licenses/BSD-3-Clause
+
+package scalaz
+
+import examples.adt._
+import examples.recadt._
+import examples.recgadt._
+
+import Scalaz._
+
+class DecidableTest extends SpecLite {
+
+  val bar: Foo = Bar("hello")
+  val baz: Foo = Baz
+  val faz: Foo = Faz(true, 1)
+
+  "products" should {
+    "behave as expected" in {
+      assert(Bar("hello") === Bar("hello"))
+
+      assert(Bar("hello") /== Bar("goodbye"))
+    }
+  }
+
+  "coproducts" should {
+    "behave as expected" in {
+      assert(bar === bar)
+      assert(bar /== baz)
+      assert(baz /== bar)
+      assert(baz === baz)
+      assert(bar /== faz)
+      assert(baz /== faz)
+      assert(faz === faz)
+    }
+  }
+
+  val leaf1        = Leaf("hello")
+  val leaf2        = Leaf("goodbye")
+  val branch       = Branch(leaf1, leaf2)
+  val tree1: ATree = Branch(leaf1, branch)
+  val tree2: ATree = Branch(leaf2, branch)
+
+  "recursive products" should {
+    "behave as expected" in {
+      assert(leaf1 === leaf1)
+      assert(leaf2 === leaf2)
+      assert(leaf1 /== leaf2)
+    }
+  }
+
+  "recursive coproducts" should {
+    "behave as expected" in {
+      assert(tree1 === tree1)
+      assert(tree1 /== tree2)
+    }
+  }
+
+  val gleaf1: GLeaf[String]    = GLeaf("hello")
+  val gleaf2: GLeaf[String]    = GLeaf("goodbye")
+  val gbranch: GBranch[String] = GBranch(gleaf1, gleaf2)
+  val gtree1: GTree[String]    = GBranch(gleaf1, gbranch)
+  val gtree2: GTree[String]    = GBranch(gleaf2, gbranch)
+
+  "recursive GADT products" should {
+    "behave as expected" in {
+      assert(gleaf1 === gleaf1)
+      assert(gleaf2 === gleaf2)
+      assert(gleaf1 /== gleaf2)
+    }
+  }
+
+  "recursive GADT coproducts" should {
+    "behave as expected" in {
+      assert(gtree1 === gtree1)
+      assert(gtree1 /== gtree2)
+    }
+  }
+
+}

--- a/tests/src/test/scala/scalaz/Default.scala
+++ b/tests/src/test/scala/scalaz/Default.scala
@@ -1,0 +1,34 @@
+// Copyright: 2017 - 2018 Sam Halliday
+// License: https://opensource.org/licenses/BSD-3-Clause
+
+package scalaz
+
+import java.lang.String
+
+import scala.{ inline, Boolean, Int }
+
+// a simple covariant typeclass
+trait Default[A] {
+  def default: A
+}
+object Default {
+  @inline def apply[A](implicit i: Default[A]): Default[A] = i
+  @inline def instance[A](a: =>A): Default[A] = new Default[A] {
+    override def default: A = a
+  }
+
+  implicit val int: Default[Int]         = instance(0)
+  implicit val string: Default[String]   = instance("")
+  implicit val boolean: Default[Boolean] = instance(false)
+
+  implicit val default_alt: Alt[Default] =
+    new Alt[Default] {
+      override def point[A](a: =>A): Default[A] = instance(a)
+      override def ap[A, B](fa: =>Default[A])(
+        f: =>Default[A => B]
+      ): Default[B] = instance(f.default(fa.default))
+
+      override def alt[A](a: =>Default[A], b: =>Default[A]): Default[A] = a
+    }
+
+}

--- a/tests/src/test/scala/scalaz/IStreamTest.scala
+++ b/tests/src/test/scala/scalaz/IStreamTest.scala
@@ -1,0 +1,42 @@
+package scalaz
+
+import scalaz.scalacheck.ScalazProperties._
+import scalaz.scalacheck.ScalazArbitrary._
+import std.AllInstances._
+import syntax.contravariant._
+import syntax.foldable._
+import org.scalacheck.Prop.forAll
+
+object IStreamTest extends SpecLite {
+
+  checkAll(monadPlus.strongLaws[IStream])
+  checkAll(isEmpty.laws[IStream])
+  checkAll(traverse.laws[IStream])
+
+  implicit def iStreamShow[A: Show]: Show[IStream[A]] =
+    Show[List[A]].contramap(_.toList)
+
+  "reverse" ! forAll{ e: IStream[Int] =>
+    e.reverse.toList must_===(e.toList.reverse)
+    e.reverse.reverse must_===(e)
+  }
+
+  "Foldable.foldLeft" ! forAll{ xs: List[List[Int]] =>
+    Foldable[IStream].foldLeft(IStream.fromFoldable(xs), List[Int]())(_ ::: _) must_===(xs.foldLeft(List[Int]())(_ ::: _))
+  }
+
+  "foldMap evaluates lazily" in {
+    Foldable[IStream].foldMap(IStream.Lazy.infinite(false))(identity)(booleanInstance.conjunction) must_===(false)
+  }
+
+  // https://github.com/scalaz/scalaz/issues/1515
+  "traverse is curiously lazy over Id" ! {
+    import syntax.traverse._
+    import Scalaz.Id
+
+    val stream = IStream.Lazy.infinite(1)
+    val _ = stream.traverse[Id, Int](identity)
+    // got here without exception... that's good!
+  }
+
+}

--- a/tests/src/test/scala/scalaz/orphans.scala
+++ b/tests/src/test/scala/scalaz/orphans.scala
@@ -1,0 +1,37 @@
+// Copyright: 2017 - 2018 Sam Halliday
+// License: https://opensource.org/licenses/BSD-3-Clause
+
+package scalaz
+
+import scala.AnyRef
+
+/** instances that are defined in scalaz 7.3, but not 7.2 ... */
+object orphans {
+  // breaks typeclass coherence for everything above Divisible
+  implicit val _decidable_equal: Decidable[Equal] = new Decidable[Equal] {
+    override def divide[A1, A2, Z](a1: Equal[A1], a2: Equal[A2])(
+      f: Z => (A1, A2)
+    ): Equal[Z] = Equal.equal { (z1, z2) =>
+      val (s1, s2) = f(z1)
+      val (t1, t2) = f(z2)
+      ((s1.asInstanceOf[AnyRef].eq(t1.asInstanceOf[AnyRef])) || a1
+        .equal(s1, t1)) &&
+      ((s2.asInstanceOf[AnyRef].eq(t2.asInstanceOf[AnyRef])) || a2
+        .equal(s2, t2))
+    }
+    override def conquer[A]: Equal[A] = Equal.equal((_, _) => true)
+
+    override def choose2[Z, A1, A2](a1: =>Equal[A1], a2: =>Equal[A2])(
+      f: Z => A1 \/ A2
+    ): Equal[Z] = Equal.equal { (z1, z2) =>
+      (f(z1), f(z2)) match {
+        case (-\/(s), -\/(t)) =>
+          (s.asInstanceOf[AnyRef].eq(t.asInstanceOf[AnyRef])) || a1.equal(s, t)
+        case (\/-(s), \/-(t)) =>
+          (s.asInstanceOf[AnyRef].eq(t.asInstanceOf[AnyRef])) || a2.equal(s, t)
+        case _ => false
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
With some compromises to avoid breaking bincompat (e.g. can't add parents to Divide or Applicative) and no instances.

It **might** be possible to add instances. Which would be good.

Consider this a tech preview of 7.3.