### PR TITLE
Add Unfoldable

### DIFF
--- a/base/shared/src/main/scala/scalaz/tc/package.scala
+++ b/base/shared/src/main/scala/scalaz/tc/package.scala
@@ -31,6 +31,7 @@ package object tc {
   type Semigroup[T]           = InstanceOf[SemigroupClass[T]]
   type Strong[F[_, _]]        = InstanceOf[StrongClass[F]]
   type Traversable[T[_]]      = InstanceOf[TraversableClass[T]]
+  type Unfoldable[F[_]]       = InstanceOf[UnfoldableClass[F]]
 
   final def Applicative[F[_]](implicit F: Applicative[F]): Applicative[F]                = F
   final def Apply[F[_]](implicit F: Apply[F]): Apply[F]                                  = F
@@ -52,4 +53,5 @@ package object tc {
   final def Semigroup[T](implicit T: Semigroup[T]): Semigroup[T]                         = T
   final def Strong[P[_, _]](implicit P: Strong[P]): Strong[P]                            = P
   final def Traversable[T[_]](implicit T: Traversable[T]): Traversable[T]                = T
+  final def Unfoldable[F[_]](implicit F: Unfoldable[F]): Unfoldable[F]                   = F
 }

--- a/base/shared/src/main/scala/scalaz/tc/unfoldable.scala
+++ b/base/shared/src/main/scala/scalaz/tc/unfoldable.scala
@@ -1,0 +1,9 @@
+package scalaz
+package tc
+
+import scalaz.data.{ IList, Maybe, Maybe2 }
+
+trait UnfoldableClass[T[_]] {
+  def unfoldRight[A, B](f: B => Maybe2[A, B])(b: B): Maybe[T[A]]
+  def fromList[A](as: IList[A]): Maybe[T[A]] = unfoldRight(IList.uncons[A])(as)
+}

--- a/microsite/src/main/resources/microsite/data/menu.yml
+++ b/microsite/src/main/resources/microsite/data/menu.yml
@@ -37,6 +37,8 @@ options:
       url: tc/Semigroup.html
     - title: Strong
       url: tc/Strong.html
+    - title: Unfoldable
+      url: tc/Unfoldable.html
 
   - title: Data classes
     url: data/index.html

--- a/microsite/src/main/tut/typeclass/Unfoldable.md
+++ b/microsite/src/main/tut/typeclass/Unfoldable.md
@@ -1,0 +1,27 @@
+---
+layout: docs
+title:  "Unfoldable"
+---
+
+# Unfoldable [![GitHub](../img/github.png)](https://github.com/scalaz/scalaz/blob/series/8.0.x/base/shared/src/main/scala/scalaz/tc/unfoldable.scala)
+
+*Whereas a `Foldable` allows folding data structures to values, `Unfoldable` identifies data structures which can be unfolded.*
+
+The generating function `f` in `unfoldr(f)(b)` is understood as follows:
+
+- if `f(b)` is `Empty2`, then `unfoldr(f)(b)` should be empty.
+- if `f(b)` is `Just2(a, b1)`, then `unfoldr(f)(b)` should consist of an appended to the result of `unfoldr(f)(b1)`.
+
+**Typical imports**
+
+```tut:silent
+import scalaz.tc._
+import scalaz.data._
+import scalaz.Scalaz._
+```
+
+# Usage
+
+```tut
+Unfoldable[IList].unfoldRight[Int, Int](b => if (b == 0) empty2 else just2(b, b - 1))(10)
+```


### PR DESCRIPTION
Related to https://github.com/scalaz/scalaz/pull/1917 and https://github.com/scalaz/scalaz-zio/pull/147.
Scalaz 7: #1626 

This PR will add `Unfoldable`, so that we can unfold data structure without `CanBuildFrom` machinery or similar.

```scala
trait UnfoldableClass[T[_]] {
  def unfoldRight[A, B](f: B => Maybe2[A, B])(b: B): Maybe[T[A]]
  def fromList[A](as: IList[A]): Maybe[T[A]] = unfoldRight(IList.uncons[A])(as)
}
```
