### PR TITLE
[WIP] MonadPlus hierarchy

### DIFF
--- a/base/shared/src/main/scala/scalaz/tc/alt.scala
+++ b/base/shared/src/main/scala/scalaz/tc/alt.scala
@@ -1,0 +1,5 @@
+package scalaz.tc
+
+trait AltClass[F[_]] extends FunctorClass[F] {
+  def alt[A](fa1: => F[A], fa2: => F[A]): F[A]
+}

--- a/base/shared/src/main/scala/scalaz/tc/alternative.scala
+++ b/base/shared/src/main/scala/scalaz/tc/alternative.scala
@@ -1,0 +1,3 @@
+package scalaz.tc
+
+trait AlternativeClass[F[_]] extends ApplicativeClass[F] with PlusClass[F] {}

--- a/base/shared/src/main/scala/scalaz/tc/monadplus.scala
+++ b/base/shared/src/main/scala/scalaz/tc/monadplus.scala
@@ -1,0 +1,3 @@
+package scalaz.tc
+
+trait MonadPlusClass[F[_]] extends MonadZeroClass[F] {}

--- a/base/shared/src/main/scala/scalaz/tc/monadzero.scala
+++ b/base/shared/src/main/scala/scalaz/tc/monadzero.scala
@@ -1,0 +1,3 @@
+package scalaz.tc
+
+trait MonadZeroClass[F[_]] extends MonadClass[F] with AlternativeClass[F] {}

--- a/base/shared/src/main/scala/scalaz/tc/plus.scala
+++ b/base/shared/src/main/scala/scalaz/tc/plus.scala
@@ -1,0 +1,5 @@
+package scalaz.tc
+
+trait PlusClass[F[_]] extends AltClass[F] {
+  def empty[A]: F[A]
+}


### PR DESCRIPTION
This is just a draft proposal for #1882  opened by @fommil .
This is totally inspired from https://github.com/purescript/purescript-control .

Laws that justify each typeclass are reported here: https://pursuit.purescript.org/packages/purescript-control/4.1.0/docs/Control.MonadPlus

I add other references on this topic:

- https://stackoverflow.com/questions/10167879/distinction-between-typeclasses-monadplus-alternative-and-monoid

- https://stackoverflow.com/questions/13122489/what-s-an-example-of-a-monad-which-is-an-alternative-but-not-a-monadplus

- https://en.wikibooks.org/wiki/Haskell/Alternative_and_MonadPlus

I'd like to have some feedback on this topic and if it make sense having such hierarchy organization 