### PR TITLE
[WIP] Add IO Monoid instance

### DIFF
--- a/base/shared/src/main/scala/scalaz/tc/monoid.scala
+++ b/base/shared/src/main/scala/scalaz/tc/monoid.scala
@@ -37,4 +37,10 @@ object MonoidClass {
         def interrupt0(ts: List[Throwable]): IO[Nothing, Unit] = IO.unit
       }
     })
+
+  implicit def ioMonoid[E, A](implicit A: Monoid[A]): Monoid[IO[E, A]] =
+    instanceOf(new MonoidClass[IO[E, A]] {
+      def mappend(a1: IO[E, A], a2: => IO[E, A]): IO[E, A] = a1.zipWith(a2)(A.mappend(_, _))
+      def mempty: IO[E, A]                                 = IO.now(A.mempty)
+    })
 }


### PR DESCRIPTION
This relates to #1940 .
I've added just ioMonoid instance, since:

-  ~~`Retry` is still wip (https://github.com/scalaz/scalaz-zio/pull/141)~~

- `Alternative` and `MonadPlus` have not been defined yet ( see https://github.com/scalaz/scalaz/issues/1882 and https://github.com/scalaz/scalaz/pull/1941 )