### PR TITLE
Fix typos detected by github.com/client9/misspell

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ def foo[M[_]: Monad] = bar[M] // Monad[M] is a subtype of Functor[M]
 * A single implicit can define a number of type class instances for a type.
 * A type class definition can override methods (including derived methods) for efficiency.
 
-Here is an instance definition for `Option`. Notice that the method `map` has been overriden.
+Here is an instance definition for `Option`. Notice that the method `map` has been overridden.
 
 ```scala
   implicit val option = new Traverse[Option] with MonadPlus[Option] {

--- a/example/src/main/scala/scalaz/example/ApplyUsage.scala
+++ b/example/src/main/scala/scalaz/example/ApplyUsage.scala
@@ -66,7 +66,7 @@ object ApplyUsage extends App {
   val plus2: Int => Int = _ + 2
   assert(List(1,2,3) <*> List(plus1, plus2) === List(2,3,4,3,4,5))
 
-  // |@| is refered to as "applicative builder", it allows you to
+  // |@| is referred to as "applicative builder", it allows you to
   // evaluate a function of multiple arguments in a context, similar
   // to apply2, apply3, apply4, etc:
   assert((some(1) |@| some(2) |@| some(3))(_ + _ + _) === Some(6))

--- a/example/src/main/scala/scalaz/example/WordCount.scala
+++ b/example/src/main/scala/scalaz/example/WordCount.scala
@@ -4,7 +4,7 @@ import scalaz.{Monoid, StateT}
 
 
 /**
- * Character/Line/Word Count from "The Essense of the Iterator Pattern".
+ * Character/Line/Word Count from "The Essence of the Iterator Pattern".
  *
  * @see [[http://www.comlab.ox.ac.uk/jeremy.gibbons/publications/iterator.pdf]]
  */

--- a/tests/jvm/src/test/scala/scalaz/concurrent/ConcurrentTest.scala
+++ b/tests/jvm/src/test/scala/scalaz/concurrent/ConcurrentTest.scala
@@ -56,7 +56,7 @@ object ConcurrentTest extends SpecLite{
         latch.countDown
       }
       if (latch.await(timeout, TimeUnit.MILLISECONDS)) result
-      else sys.error("Timeout occured, possible deadlock.")
+      else sys.error("Timeout occurred, possible deadlock.")
     }
   }
 


### PR DESCRIPTION
Fixing typos is sometimes very hard. It's not so easy to visually review them. Recently, I discovered a very useful tool for it, [misspell](https://github.com/client9/misspell). 

This pull request fixes minor typos detected by [misspell](https://github.com/client9/misspell) except for the false positives. If you would like me to work on other files as well, let me know. 

## before

```
$ misspell . | grep -v '/js/'
README.md:149:83: "overriden" is a misspelling of "overridden"
example/src/main/scala/scalaz/example/ApplyUsage.scala:69:12: "refered" is a misspelling of "referred"
example/src/main/scala/scalaz/example/WordCount.scala:7:39: "Essense" is a misspelling of "Essence"
example/src/main/scala/scalaz/example/transformers/typecheck/TypeCheckerWithExplicitTypesAST.scala:16:26: "thn" is a misspelling of "then"
tests/jvm/src/test/scala/scalaz/concurrent/ConcurrentTest.scala:59:30: "occured" is a misspelling of "occurred"
```

## after

```
$ misspell . | grep -v '/js/'
example/src/main/scala/scalaz/example/transformers/typecheck/TypeCheckerWithExplicitTypesAST.scala:16:26: "thn" is a misspelling of "then"
```
