### PR TITLE
IList append

### DIFF
--- a/base/shared/src/main/scala/scalaz/data/ilist.scala
+++ b/base/shared/src/main/scala/scalaz/data/ilist.scala
@@ -159,8 +159,11 @@ object IListModule {
     def uncons: Maybe2[A, IList[A]] =
       IList.uncons(self)
 
-    def append(that: IList[A]): IList[A] =
+    def prepend(that: IList[A]): IList[A] =
       IList.reverse(that).foldLeft(self)((b, a) => IList.cons(a, b))
+
+    def append(that: IList[A]): IList[A] =
+      that.prepend(self)
 
     def :::(that: IList[A]): IList[A] =
       self.append(that)


### PR DESCRIPTION
* Name change from `append` to `prepend`
* A proper `append` (defined in terms of `prepend` of `that`)

This commit closes #1950