### PR TITLE
Place microsite in folder

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -195,6 +195,7 @@ lazy val site = Project(
   micrositeGithubOwner := "scalaz",
   micrositeGithubRepo := "scalaz",
   micrositeFavicons := Seq(microsites.MicrositeFavicon("favicon.png", "512x512")),
+  micrositeBaseUrl := "/7",
   micrositePalette := Map(
     "brand-primary"   -> "#ED2124",
     "brand-secondary" -> "#251605",


### PR DESCRIPTION
In order to keep the repo `scalaz.github.io` a little more organized, place the 7.x microsite in a folder.