### PR TITLE
Optimise Apply[{ Either, \/ }].apply2

### DIFF
--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -109,8 +109,8 @@ sealed abstract class \/[+A, +B] extends Product with Serializable {
   /** Map on the right of this disjunction. */
   def map[D](g: B => D): (A \/ D) =
     this match {
-      case \/-(a)     => \/-(g(a))
-      case b @ -\/(_) => b
+      case b: \/-[_] => \/-(g(b.b))
+      case a => a.asInstanceOf[A \/ D]
     }
 
   /** Traverse on the right of this disjunction. */
@@ -131,8 +131,8 @@ sealed abstract class \/[+A, +B] extends Product with Serializable {
   /** Bind through the right of this disjunction. */
   def flatMap[AA >: A, D](g: B => (AA \/ D)): (AA \/ D) =
     this match {
-      case a @ -\/(_) => a
-      case \/-(b) => g(b)
+      case b : \/-[_] => g(b.b)
+      case a => a.asInstanceOf[AA \/ D]
     }
 
   /** Fold on the right of this disjunction. */

--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -474,6 +474,18 @@ sealed abstract class DisjunctionInstances1 extends DisjunctionInstances2 {
       override def map[A, B](fa: L \/ A)(f: A => B) =
         fa map f
 
+      override def ap[A,B](fa: => L \/ A)(f: => L \/ (A => B)): L \/ B = fa.ap(f)
+
+      override def apply2[A, B, C](fa: => L \/ A, fb: => L \/ B)(f: (A, B) => C): L \/ C =
+        fa match {
+          case a: \/-[_] =>
+            fb match {
+              case b: \/-[_] => \/-(f(a.b, b.b))
+              case e => e.asInstanceOf[L \/ C]
+            }
+          case e => e.asInstanceOf[L \/ C]
+        }
+
       @scala.annotation.tailrec
       def tailrecM[A, B](f: A => L \/ (A \/ B))(a: A): L \/ B =
         f(a) match {

--- a/core/src/main/scala/scalaz/Either.scala
+++ b/core/src/main/scala/scalaz/Either.scala
@@ -109,7 +109,7 @@ sealed abstract class \/[+A, +B] extends Product with Serializable {
   /** Map on the right of this disjunction. */
   def map[D](g: B => D): (A \/ D) =
     this match {
-      case b: \/-[_] => \/-(g(b.b))
+      case \/-(b) => \/-(g(b))
       case a => a.asInstanceOf[A \/ D]
     }
 
@@ -131,7 +131,7 @@ sealed abstract class \/[+A, +B] extends Product with Serializable {
   /** Bind through the right of this disjunction. */
   def flatMap[AA >: A, D](g: B => (AA \/ D)): (AA \/ D) =
     this match {
-      case b : \/-[_] => g(b.b)
+      case \/-(b) => g(b)
       case a => a.asInstanceOf[AA \/ D]
     }
 
@@ -478,9 +478,9 @@ sealed abstract class DisjunctionInstances1 extends DisjunctionInstances2 {
 
       override def apply2[A, B, C](fa: => L \/ A, fb: => L \/ B)(f: (A, B) => C): L \/ C =
         fa match {
-          case a: \/-[_] =>
+          case \/-(a) =>
             fb match {
-              case b: \/-[_] => \/-(f(a.b, b.b))
+              case \/-(b) => \/-(f(a, b))
               case e => e.asInstanceOf[L \/ C]
             }
           case e => e.asInstanceOf[L \/ C]

--- a/core/src/main/scala/scalaz/IList.scala
+++ b/core/src/main/scala/scalaz/IList.scala
@@ -434,17 +434,21 @@ sealed abstract class IList[A] extends Product with Serializable {
   def toZipper: Option[Zipper[A]] =
     sToZipper(toStream)
 
-  // optimised specialisation of Traverse.traverse for disjunction, avoiding
-  // allocations for each element, approximately 20% faster than the default
-  // implementation.
-  def traverseDisjunction[E, B](f: A => E \/ B): E \/ IList[B] = \/-(
-    map { a =>
-      f(a) match {
-        case -\/(err) => return -\/(err)
-        case \/-(j)   => j
-      }
+  /**
+   * Referentially transparent replacement for traverse, specialised to
+   * disjunction.
+   */
+  def traverseDisjunction[E, B](f: A => E \/ B): E \/ IList[B] = {
+    @tailrec def go(lst: IList[A], acc: IList[B]): E \/ IList[B] = lst match {
+      case INil() => \/-(acc)
+      case ICons(head, tail) =>
+        f(head) match {
+          case \/-(b)       => go(tail, b :: acc)
+          case err @ -\/(_) => err
+        }
     }
-  )
+    go(this, IList.empty).map(_.reverse)
+  }
 
   def uncons[B](n: => B, c: (A, IList[A]) => B): B =
     this match {

--- a/core/src/main/scala/scalaz/std/Either.scala
+++ b/core/src/main/scala/scalaz/std/Either.scala
@@ -66,20 +66,20 @@ trait EitherInstances extends EitherInstances0 {
   implicit def eitherMonad[L]: Traverse[Either[L, ?]] with MonadError[Either[L, ?], L] with BindRec[Either[L, ?]] with Cozip[Either[L, ?]] =
     new Traverse[Either[L, ?]] with MonadError[Either[L, ?], L] with BindRec[Either[L, ?]] with Cozip[Either[L, ?]] {
       def bind[A, B](fa: Either[L, A])(f: A => Either[L, B]) = fa match {
-        case b: Right[_, _] => f(b.value)
+        case Right(b) => f(b)
         case a => a.asInstanceOf[Either[L, B]]
       }
 
       override def map[A, B](fa: Either[L, A])(f: A => B) = fa match {
-        case b: Right[_, _] => Right(f(b.value))
+        case Right(b) => Right(f(b))
         case a => a.asInstanceOf[Either[L, B]]
       }
 
       override def apply2[A, B, C](fa: => Either[L, A], fb: => Either[L, B])(f: (A, B) => C): Either[L, C] =
         fa match {
-          case a: Right[_, _] =>
+          case Right(a) =>
             fb match {
-              case b: Right[_, _] => Right(f(a.value, b.value))
+              case Right(b) => Right(f(a, b))
               case e => e.asInstanceOf[Either[L, C]]
             }
           case e => e.asInstanceOf[Either[L, C]]

--- a/core/src/main/scala/scalaz/std/Either.scala
+++ b/core/src/main/scala/scalaz/std/Either.scala
@@ -70,7 +70,10 @@ trait EitherInstances extends EitherInstances0 {
         case a => a.asInstanceOf[Either[L, B]]
       }
 
-      override def map[A, B](fa: Either[L, A])(f: A => B) = fa.map(f)
+      override def map[A, B](fa: Either[L, A])(f: A => B) = fa match {
+        case b: Right[_, _] => Right(f(b.value))
+        case a => a.asInstanceOf[Either[L, B]]
+      }
 
       override def apply2[A, B, C](fa: => Either[L, A], fb: => Either[L, B])(f: (A, B) => C): Either[L, C] =
         fa match {

--- a/core/src/main/scala/scalaz/std/Either.scala
+++ b/core/src/main/scala/scalaz/std/Either.scala
@@ -66,9 +66,11 @@ trait EitherInstances extends EitherInstances0 {
   implicit def eitherMonad[L]: Traverse[Either[L, ?]] with MonadError[Either[L, ?], L] with BindRec[Either[L, ?]] with Cozip[Either[L, ?]] =
     new Traverse[Either[L, ?]] with MonadError[Either[L, ?], L] with BindRec[Either[L, ?]] with Cozip[Either[L, ?]] {
       def bind[A, B](fa: Either[L, A])(f: A => Either[L, B]) = fa match {
-        case Left(a)  => Left(a)
-        case Right(b) => f(b)
+        case b: Right[_, _] => f(b.value)
+        case a => a.asInstanceOf[Either[L, B]]
       }
+
+      override def map[A, B](fa: Either[L, A])(f: A => B) = fa.map(f)
 
       override def apply2[A, B, C](fa: => Either[L, A], fb: => Either[L, B])(f: (A, B) => C): Either[L, C] =
         fa match {

--- a/core/src/main/scala/scalaz/std/Either.scala
+++ b/core/src/main/scala/scalaz/std/Either.scala
@@ -70,6 +70,16 @@ trait EitherInstances extends EitherInstances0 {
         case Right(b) => f(b)
       }
 
+      override def apply2[A, B, C](fa: => Either[L, A], fb: => Either[L, B])(f: (A, B) => C): Either[L, C] =
+        fa match {
+          case a: Right[_, _] =>
+            fb match {
+              case b: Right[_, _] => Right(f(a.value, b.value))
+              case e => e.asInstanceOf[Either[L, C]]
+            }
+          case e => e.asInstanceOf[Either[L, C]]
+        }
+
       def handleError[A](fa: Either[L, A])(f: L => Either[L, A]) =
         fa match {
           case a @ Right(_) => a

--- a/tests/src/test/scala/scalaz/IListTest.scala
+++ b/tests/src/test/scala/scalaz/IListTest.scala
@@ -296,6 +296,14 @@ object IListTest extends SpecLite {
     (ns reverse_::: ms).toList must_=== (ns.toList reverse_::: ms.toList)
   }
 
+  "traverseDisjunction" ! forAll { (is: IList[Int]) =>
+    import syntax.traverse._
+
+    def f(i: Int): String \/ Int = if (i % 2 == 0) -\/(i.toString) else \/-(i)
+
+    is.traverseDisjunction(f).must_===(is.traverse[String \/ ?, Int](f))
+  }
+
   "scanLeft" ! forAll { (ss: IList[String], f: (Int, String) => Int) =>
     ss.scanLeft(0)(f).toList must_=== ss.toList.scanLeft(0)(f)
     ss.scanLeft("z")(_ + _).toList must_=== ss.toList.scanLeft("z")(_ + _)


### PR DESCRIPTION
close #1956 

Running this perf test

```scala
jsonformat/jmh:run -i 5 -wi 5 -f1 -t1 -w1 -r1 .*Geo.*decodeManual*
```

from https://gitlab.com/fommil/scalaz-deriving

BEFORE this change

```
Benchmark                               Mode  Cnt      Score     Error  Units
GeoJSONBenchmarks.decodeManualError    thrpt    5  25727.854 ± 263.755  ops/s
GeoJSONBenchmarks.decodeManualSuccess  thrpt    5  26943.126 ± 230.573  ops/s
```

AFTER this change

```
GeoJSONBenchmarks.decodeManualError    thrpt    5  70845.254 ± 890.444  ops/s
GeoJSONBenchmarks.decodeManualSuccess  thrpt    5  84736.783 ± 473.980  ops/s
```

and WITH custom short circution impl of traverseDisjunction from #1956 (which is used in the repo's master... back out that change to run the above tests)

```
GeoJSONBenchmarks.decodeManualError    thrpt    5  586733.762 ±  6389.296  ops/s
GeoJSONBenchmarks.decodeManualSuccess  thrpt    5  110961.246 ±  468.384  ops/s
```

async-profiler alloc tracing shows that the `\/-` allocations are quite heavy. I guess that's to be expected.