### PR TITLE
Tests for ACatenable1

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,1 +1,2 @@
 -XX:+UseCodeCacheFlushing
+-XX:+UseConcMarkSweepGC

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 - gem install sass
 - gem install jekyll -v 3.8.2
 script:
-- sbt ++$TRAVIS_SCALA_VERSION scalafmtCheck test:scalafmtCheck scalafmtSbtCheck test microsite/makeMicrosite
+- sbt ++$TRAVIS_SCALA_VERSION scalafmtCheck test:scalafmtCheck scalafmtSbtCheck tests/run microsite/makeMicrosite
 - if [[ "$TRAVIS_PULL_REQUEST" = "false" && "$TRAVIS_BRANCH" = "series/8.0.x" ]]; then sbt publish; fi
 env:
   global:

--- a/base/shared/src/main/scala/scalaz/data/acatenable1.scala
+++ b/base/shared/src/main/scala/scalaz/data/acatenable1.scala
@@ -3,7 +3,7 @@ package data
 
 import scala.annotation.tailrec
 
-import tc.{instanceOf, Semicategory, SemicategoryClass}
+import tc.{ instanceOf, Semicategory, SemicategoryClass }
 
 /**
  * Non-empty type-aligned sequence represented as a (non-balanced) binary tree,
@@ -77,7 +77,7 @@ object ACatenable1 {
   // (depending on user code) and never asymptotically slower.
   implicit def acatenable1FreeSemicategory[=>:[_, _]]: Semicategory[ACatenable1[=>:, ?, ?]] =
     instanceOf(new SemicategoryClass[ACatenable1[=>:, ?, ?]] {
-      def compose[A, B, C](f: ACatenable1[=>:,B,C], g: ACatenable1[=>:,A,B]): ACatenable1[=>:,A,C] =
+      def compose[A, B, C](f: ACatenable1[=>:, B, C], g: ACatenable1[=>:, A, B]): ACatenable1[=>:, A, C] =
         f.compose(g)
     })
 }

--- a/base/shared/src/main/scala/scalaz/data/biconst.scala
+++ b/base/shared/src/main/scala/scalaz/data/biconst.scala
@@ -1,0 +1,125 @@
+package scalaz
+package data
+
+import tc._
+
+abstract class BiconstModule {
+  type Biconst[A, B, C]
+
+  def apply[A, B, C](a: A): Biconst[A, B, C]
+  def run[A, B, C](const: Biconst[A, B, C]): A
+
+  def biconstSemicategory[A: Semigroup]: Semicategory[Biconst[A, ?, ?]]
+  def biconstCategory[A: Monoid]: Category[Biconst[A, ?, ?]]
+  def biconstApply[A: Semigroup, B]: Apply[Biconst[A, B, ?]]
+  def biconstApplicative[A: Monoid, B]: Applicative[Biconst[A, B, ?]]
+  def biconstTraversable[A, B]: Traversable[Biconst[A, B, ?]]
+  def biconstBifunctor[A]: Bifunctor[Biconst[A, ?, ?]]
+  def biconstPhantom[A, B]: Phantom[Biconst[A, B, ?]]
+
+  def biconstSemigroup[A: Semigroup, B, C]: Semigroup[Biconst[A, B, C]]
+  def biconstMonoid[A: Monoid, B, C]: Monoid[Biconst[A, B, C]]
+  def biconstEq[A: Eq, B, C]: Eq[Biconst[A, B, C]]
+  def biconstDebug[A: Debug, B, C]: Debug[Biconst[A, B, C]]
+}
+
+object BiconstModule {
+  implicit def biconstSemicategory[A: Semigroup]: Semicategory[Biconst[A, ?, ?]] =
+    Biconst.biconstSemicategory[A]
+  implicit def biconstCategory[A: Monoid]: Category[Biconst[A, ?, ?]]            =
+    Biconst.biconstCategory[A]
+  implicit def biconstApply[A: Semigroup, B]: Apply[Biconst[A, B, ?]]            =
+    Biconst.biconstApply[A, B]
+  implicit def biconstApplicative[A: Monoid, B]: Applicative[Biconst[A, B, ?]]   =
+    Biconst.biconstApplicative[A, B]
+  implicit def biconstTraversable[A, B]: Traversable[Biconst[A, B, ?]]              =
+    Biconst.biconstTraversable[A, B]
+  implicit def biconstPhantom[A, B]: Phantom[Biconst[A, B, ?]]                   =
+    Biconst.biconstPhantom[A, B]
+
+  implicit def biconstSemigroup[A: Semigroup, B, C]: Semigroup[Biconst[A, B, C]] =
+    Biconst.biconstSemigroup[A, B, C]
+  implicit def biconstMonoid[A: Monoid, B, C]: Monoid[Biconst[A, B, C]]          =
+    Biconst.biconstMonoid[A, B, C]
+  implicit def biconstEq[A: Eq, B, C]: Eq[Biconst[A, B, C]]                =
+    Biconst.biconstEq[A, B, C]
+  implicit def biconstDebug[A: Debug, B, C]: Debug[Biconst[A, B, C]]             =
+    Biconst.biconstDebug[A, B, C]
+}
+
+private[data] object BiconstImpl extends BiconstModule {
+  type Biconst[A, B, C] = A
+
+  def apply[A, B, C](a: A): A = a
+  def run[A, B, C](biconst: A): A = biconst
+
+  private trait BiconstSemicategory[A] extends SemicategoryClass[Biconst[A, ?, ?]] {
+    def A: SemigroupClass[A]
+    def compose[B, C, D](f: A, g: A): A = A.mappend(f, g)
+  }
+
+  private trait BiconstPhantom[R, A] extends PhantomClass[Biconst[R, A, ?]] with PhantomClass.DeriveMapContramap[Biconst[R, A, ?]] {
+    def pmap[B, C](ma: Biconst[R, A, B]): Biconst[R, A, C] = ma
+  }
+
+  private trait BiconstApply[R, A] extends ApplyClass[Biconst[R, A, ?]] with BiconstPhantom[R, A] {
+    def R: SemigroupClass[R]
+
+    final override def ap[B, C](fa: Biconst[R, A, B])(f: Biconst[R, A, B => C]): Biconst[R, A, C] =
+      R.mappend(fa, f)
+  }
+
+  private trait BiconstApplicative[R, A] extends ApplicativeClass[Biconst[R, A, ?]] with BiconstApply[R, A] {
+    override def R: MonoidClass[R]
+    final override def pure[B](b: B): Biconst[R, A, B] = R.mempty
+  }
+
+  def biconstSemicategory[A](implicit A0: Semigroup[A]): Semicategory[Biconst[A, ?, ?]] =
+    instanceOf(new BiconstSemicategory[A] { def A = A0 })
+  def biconstCategory[A](implicit A0: Monoid[A]): Category[Biconst[A, ?, ?]] =
+    instanceOf(new BiconstSemicategory[A] with CategoryClass[Biconst[A, ?, ?]] {
+       def A = A0
+       def id[X]: A = A0.mempty
+    })
+  def biconstApply[A: Semigroup, B]: Apply[Biconst[A, B, ?]] =
+    instanceOf(new BiconstApply[A, B] {
+      val R = Semigroup[A]
+    })
+  def biconstApplicative[A: Monoid, B]: Applicative[Biconst[A, B, ?]] =
+    instanceOf(new BiconstApplicative[A, B] {
+      val R = Monoid[A]
+    })
+
+  def biconstTraversable[C, D]: Traversable[Biconst[C, D, ?]] =
+    instanceOf(new TraversableClass[Biconst[C, D, ?]] with BiconstPhantom[C, D] {
+      def foldLeft[A, B](fa: C, z: B)(f: (B, A) => B): B = z
+      def foldMap[A, B](fa: C)(f: A => B)(implicit B: Monoid[B]): B = B.mempty
+      def foldRight[A, B](fa: C, z: => B)(f: (A, => B) => B): B = z
+      def msuml[A](fa: C)(implicit A: Monoid[A]): A = A.mempty
+      def toList[A](fa: C): scala.List[A] = scala.Nil
+      def sequence[F[_], A](ta: C)(implicit F: scalaz.tc.Applicative[F]): F[C] = F.pure(ta)
+      def traverse[F[_], A, B](ta: C)(f: A => F[B])(implicit F: scalaz.tc.Applicative[F]): F[C] = F.pure(ta)
+    })
+
+  def biconstBifunctor[A]: Bifunctor[Biconst[A, ?, ?]] =
+    instanceOf(new BifunctorClass[Biconst[A, ?, ?]] {
+      def bimap[B, C, S, T](fab: A)(as: B => S, bt: C => T): A = fab
+      def lmap[B, C, S](fab: A)(as: B => S): A = fab
+      def rmap[B, C, T](fab: A)(bt: C => T): A = fab
+    })
+
+  def biconstPhantom[A, B]: Phantom[Biconst[A, B, ?]] =
+    instanceOf(new BiconstPhantom[A, B] {})
+
+  def biconstSemigroup[A, B, C](implicit A: Semigroup[A]): Semigroup[Biconst[A, B, C]] =
+    A
+  def biconstMonoid[A, B, C](implicit A: Monoid[A]): Monoid[Biconst[A, B, C]] =
+    A
+  def biconstEq[A, B, C](implicit A: Eq[A]): Eq[Biconst[A, B, C]] =
+    A
+  def biconstDebug[A, B, C](implicit A: Debug[A]): Debug[Biconst[A, B, C]] =
+    A
+}
+
+
+

--- a/base/shared/src/main/scala/scalaz/data/biconst.scala
+++ b/base/shared/src/main/scala/scalaz/data/biconst.scala
@@ -26,31 +26,31 @@ abstract class BiconstModule {
 object BiconstModule {
   implicit def biconstSemicategory[A: Semigroup]: Semicategory[Biconst[A, ?, ?]] =
     Biconst.biconstSemicategory[A]
-  implicit def biconstCategory[A: Monoid]: Category[Biconst[A, ?, ?]]            =
+  implicit def biconstCategory[A: Monoid]: Category[Biconst[A, ?, ?]] =
     Biconst.biconstCategory[A]
-  implicit def biconstApply[A: Semigroup, B]: Apply[Biconst[A, B, ?]]            =
+  implicit def biconstApply[A: Semigroup, B]: Apply[Biconst[A, B, ?]] =
     Biconst.biconstApply[A, B]
-  implicit def biconstApplicative[A: Monoid, B]: Applicative[Biconst[A, B, ?]]   =
+  implicit def biconstApplicative[A: Monoid, B]: Applicative[Biconst[A, B, ?]] =
     Biconst.biconstApplicative[A, B]
-  implicit def biconstTraversable[A, B]: Traversable[Biconst[A, B, ?]]              =
+  implicit def biconstTraversable[A, B]: Traversable[Biconst[A, B, ?]] =
     Biconst.biconstTraversable[A, B]
-  implicit def biconstPhantom[A, B]: Phantom[Biconst[A, B, ?]]                   =
+  implicit def biconstPhantom[A, B]: Phantom[Biconst[A, B, ?]] =
     Biconst.biconstPhantom[A, B]
 
   implicit def biconstSemigroup[A: Semigroup, B, C]: Semigroup[Biconst[A, B, C]] =
     Biconst.biconstSemigroup[A, B, C]
-  implicit def biconstMonoid[A: Monoid, B, C]: Monoid[Biconst[A, B, C]]          =
+  implicit def biconstMonoid[A: Monoid, B, C]: Monoid[Biconst[A, B, C]] =
     Biconst.biconstMonoid[A, B, C]
-  implicit def biconstEq[A: Eq, B, C]: Eq[Biconst[A, B, C]]                =
+  implicit def biconstEq[A: Eq, B, C]: Eq[Biconst[A, B, C]] =
     Biconst.biconstEq[A, B, C]
-  implicit def biconstDebug[A: Debug, B, C]: Debug[Biconst[A, B, C]]             =
+  implicit def biconstDebug[A: Debug, B, C]: Debug[Biconst[A, B, C]] =
     Biconst.biconstDebug[A, B, C]
 }
 
 private[data] object BiconstImpl extends BiconstModule {
   type Biconst[A, B, C] = A
 
-  def apply[A, B, C](a: A): A = a
+  def apply[A, B, C](a: A): A     = a
   def run[A, B, C](biconst: A): A = biconst
 
   private trait BiconstSemicategory[A] extends SemicategoryClass[Biconst[A, ?, ?]] {
@@ -58,7 +58,9 @@ private[data] object BiconstImpl extends BiconstModule {
     def compose[B, C, D](f: A, g: A): A = A.mappend(f, g)
   }
 
-  private trait BiconstPhantom[R, A] extends PhantomClass[Biconst[R, A, ?]] with PhantomClass.DeriveMapContramap[Biconst[R, A, ?]] {
+  private trait BiconstPhantom[R, A]
+      extends PhantomClass[Biconst[R, A, ?]]
+      with PhantomClass.DeriveMapContramap[Biconst[R, A, ?]] {
     def pmap[B, C](ma: Biconst[R, A, B]): Biconst[R, A, C] = ma
   }
 
@@ -78,8 +80,8 @@ private[data] object BiconstImpl extends BiconstModule {
     instanceOf(new BiconstSemicategory[A] { def A = A0 })
   def biconstCategory[A](implicit A0: Monoid[A]): Category[Biconst[A, ?, ?]] =
     instanceOf(new BiconstSemicategory[A] with CategoryClass[Biconst[A, ?, ?]] {
-       def A = A0
-       def id[X]: A = A0.mempty
+      def A        = A0
+      def id[X]: A = A0.mempty
     })
   def biconstApply[A: Semigroup, B]: Apply[Biconst[A, B, ?]] =
     instanceOf(new BiconstApply[A, B] {
@@ -92,20 +94,20 @@ private[data] object BiconstImpl extends BiconstModule {
 
   def biconstTraversable[C, D]: Traversable[Biconst[C, D, ?]] =
     instanceOf(new TraversableClass[Biconst[C, D, ?]] with BiconstPhantom[C, D] {
-      def foldLeft[A, B](fa: C, z: B)(f: (B, A) => B): B = z
-      def foldMap[A, B](fa: C)(f: A => B)(implicit B: Monoid[B]): B = B.mempty
-      def foldRight[A, B](fa: C, z: => B)(f: (A, => B) => B): B = z
-      def msuml[A](fa: C)(implicit A: Monoid[A]): A = A.mempty
-      def toList[A](fa: C): scala.List[A] = scala.Nil
-      def sequence[F[_], A](ta: C)(implicit F: scalaz.tc.Applicative[F]): F[C] = F.pure(ta)
+      def foldLeft[A, B](fa: C, z: B)(f: (B, A) => B): B                                        = z
+      def foldMap[A, B](fa: C)(f: A => B)(implicit B: Monoid[B]): B                             = B.mempty
+      def foldRight[A, B](fa: C, z: => B)(f: (A, => B) => B): B                                 = z
+      def msuml[A](fa: C)(implicit A: Monoid[A]): A                                             = A.mempty
+      def toList[A](fa: C): scala.List[A]                                                       = scala.Nil
+      def sequence[F[_], A](ta: C)(implicit F: scalaz.tc.Applicative[F]): F[C]                  = F.pure(ta)
       def traverse[F[_], A, B](ta: C)(f: A => F[B])(implicit F: scalaz.tc.Applicative[F]): F[C] = F.pure(ta)
     })
 
   def biconstBifunctor[A]: Bifunctor[Biconst[A, ?, ?]] =
     instanceOf(new BifunctorClass[Biconst[A, ?, ?]] {
       def bimap[B, C, S, T](fab: A)(as: B => S, bt: C => T): A = fab
-      def lmap[B, C, S](fab: A)(as: B => S): A = fab
-      def rmap[B, C, T](fab: A)(bt: C => T): A = fab
+      def lmap[B, C, S](fab: A)(as: B => S): A                 = fab
+      def rmap[B, C, T](fab: A)(bt: C => T): A                 = fab
     })
 
   def biconstPhantom[A, B]: Phantom[Biconst[A, B, ?]] =
@@ -120,6 +122,3 @@ private[data] object BiconstImpl extends BiconstModule {
   def biconstDebug[A, B, C](implicit A: Debug[A]): Debug[Biconst[A, B, C]] =
     A
 }
-
-
-

--- a/base/shared/src/main/scala/scalaz/data/package.scala
+++ b/base/shared/src/main/scala/scalaz/data/package.scala
@@ -88,6 +88,9 @@ package object data {
   val AList: AListModule = AListImpl
   type AList[F[_, _], A, B] = AList.AList[F, A, B]
 
+  val Biconst: BiconstModule = BiconstImpl
+  type Biconst[A, B, C] = Biconst.Biconst[A, B, C]
+
   val Compose: ComposeModule = ComposeImpl
   type Compose[F[_], G[_], X] = Compose.Compose[F, G, X]
 

--- a/base/shared/src/main/scala/scalaz/tc/category.scala
+++ b/base/shared/src/main/scala/scalaz/tc/category.scala
@@ -6,8 +6,9 @@ trait CategoryClass[=>:[_, _]] extends SemicategoryClass[=>:] {
 }
 
 object CategoryClass {
-  implicit def function1Category: Category[? => ?] = instanceOf(new CategoryClass[? => ?] {
-    def id[A]: A => A = scala.Predef.identity[A]
-    def compose[A, B, C](f: B => C, g: A => B): A => C = f.compose(g)
-  })
+  implicit def function1Category: Category[? => ?] =
+    instanceOf(new CategoryClass[? => ?] {
+      def id[A]: A => A                                  = scala.Predef.identity[A]
+      def compose[A, B, C](f: B => C, g: A => B): A => C = f.compose(g)
+    })
 }

--- a/base/shared/src/main/scala/scalaz/tc/category.scala
+++ b/base/shared/src/main/scala/scalaz/tc/category.scala
@@ -4,3 +4,10 @@ package tc
 trait CategoryClass[=>:[_, _]] extends SemicategoryClass[=>:] {
   def id[A]: A =>: A
 }
+
+object CategoryClass {
+  implicit def function1Category: Category[? => ?] = instanceOf(new CategoryClass[? => ?] {
+    def id[A]: A => A = scala.Predef.identity[A]
+    def compose[A, B, C](f: B => C, g: A => B): A => C = f.compose(g)
+  })
+}

--- a/base/shared/src/main/scala/scalaz/tc/semicategory.scala
+++ b/base/shared/src/main/scala/scalaz/tc/semicategory.scala
@@ -1,7 +1,7 @@
 package scalaz
 package tc
 
-import scala.Predef.{Map => SMap}
+import scala.Predef.{ Map => SMap }
 import scala.language.experimental.macros
 
 trait SemicategoryClass[=>:[_, _]] {
@@ -21,10 +21,11 @@ trait SemicategorySyntax {
 }
 
 object SemicategoryClass {
-  implicit def mapSemicategory: Semicategory[SMap] = instanceOf(new SemicategoryClass[SMap] {
-    def compose[A, B, C](f: B SMap C, g: A SMap B): A SMap C =
-      g.flatMap {
-        case (a, b) => f.get(b).map(c => (a, c))
-      }
-  })
+  implicit def mapSemicategory: Semicategory[SMap] =
+    instanceOf(new SemicategoryClass[SMap] {
+      def compose[A, B, C](f: B SMap C, g: A SMap B): A SMap C =
+        g.flatMap {
+          case (a, b) => f.get(b).map(c => (a, c))
+        }
+    })
 }

--- a/base/shared/src/main/scala/scalaz/tc/semicategory.scala
+++ b/base/shared/src/main/scala/scalaz/tc/semicategory.scala
@@ -1,14 +1,30 @@
 package scalaz
 package tc
 
+import scala.Predef.{Map => SMap}
 import scala.language.experimental.macros
 
 trait SemicategoryClass[=>:[_, _]] {
   def compose[A, B, C](f: B =>: C, g: A =>: B): (A =>: C)
+  final def andThen[A, B, C](g: A =>: B, f: B =>: C): (A =>: C) = compose(f, g)
 }
 
 trait SemicategorySyntax {
   implicit final class ToSemicategoryOps[=>:[_, _], B, C](self: B =>: C) {
     def compose[A](f: A =>: B)(implicit ev: Semicategory[=>:]): A =>: C = macro meta.Ops.ia_1
+    def andThen[D](f: C =>: D)(implicit ev: Semicategory[=>:]): B =>: D = macro meta.Ops.ia_1
+    type compose
+    type andThen
+    def <<<[A](f: A =>: B)(implicit ev: Semicategory[=>:]): A =>: C = macro meta.Ops.nia_1[compose]
+    def >>>[D](f: C =>: D)(implicit ev: Semicategory[=>:]): B =>: D = macro meta.Ops.nia_1[andThen]
   }
+}
+
+object SemicategoryClass {
+  implicit def mapSemicategory: Semicategory[SMap] = instanceOf(new SemicategoryClass[SMap] {
+    def compose[A, B, C](f: B SMap C, g: A SMap B): A SMap C =
+      g.flatMap {
+        case (a, b) => f.get(b).map(c => (a, c))
+      }
+  })
 }

--- a/base/shared/src/main/scala/scalaz/tc/semigroup.scala
+++ b/base/shared/src/main/scala/scalaz/tc/semigroup.scala
@@ -17,5 +17,7 @@ object SemigroupClass {
 trait SemigroupSyntax {
   implicit final class ToSemigroupOps[A](a: A) {
     def mappend(f: => A)(implicit ev: Semigroup[A]): A = macro meta.Ops.ia_1
+    type mappend
+    def |+|(f: => A)(implicit ev: Semigroup[A]): A = macro meta.Ops.nia_1[mappend]
   }
 }

--- a/tests/src/main/scala/scalaz/tests/ACatenable1Tests.scala
+++ b/tests/src/main/scala/scalaz/tests/ACatenable1Tests.scala
@@ -1,0 +1,139 @@
+package scalaz
+package tests
+
+import scala.Int
+import scala.Predef.{ Map, String}
+
+import data._
+import tc._
+import Scalaz._
+
+import laws._
+
+import testz._
+import z._
+
+import ACatenable1.lift
+
+object ACatenable1Tests {
+  // these type aliases unnerve me with their presence
+  type R[A, B] = ACatenable1[Map, A, B] => Map[A, B]
+  type L[A, B] = Map[A, B] => ACatenable1[Map, A, B]
+  val foldF: ACatenable1[Map, ?, ?] ~~> Map = Forall2.of[R](_.fold)
+  val liftF: Map ~~> ACatenable1[Map, ?, ?] = Forall2.of[L](ACatenable1.lift(_))
+
+  // specified in `compose`-order
+  val fst = Map(
+    (6, 9),
+    (7, 10),
+    (8, 11)
+  )
+  val snd = Map(
+    (3, 6),
+    (4, 7),
+    (5, 8),
+  )
+  val thd = Map(
+    (0, 3),
+    (1, 4),
+    (2, 5),
+  )
+
+  def const(s: String): ACatenable1[Biconst[String, ?, ?], Int, Int] = lift(Biconst(s))
+
+  def tests[T](harness: Harness[T], sequence: (T, T) => T): T = {
+    import harness._
+
+    sequence(
+      section("laws")(
+        section("lawful semicategory")(
+          test("associativity") { () =>
+            SemicategoryLaws.composeAssoc(fst, snd, thd)(assertEqualNonEmptyMaps)
+          },
+        ),
+        section("free semicategory")(
+          test("foldMap") { () =>
+            HomomorphismLaws.semicategoryCompose(foldF)(
+              lift(fst) <<< lift(snd), lift(thd)
+            )(assertEqualNonEmptyMaps) |+|
+            HomomorphismLaws.semicategoryCompose(foldF)(
+              lift(fst), lift(snd) <<< lift(thd)
+            )(assertEqualNonEmptyMaps)
+          },
+          test("lift") { () =>
+            HomomorphismLaws.semicategoryCompose(liftF)(
+              fst, snd
+            )((f, s) => assertEqualNonEmptyMaps(f.fold, s.fold))
+          },
+        ),
+      ),
+      section("tests")(
+        // tests that order is correct.
+        test("compose") { () =>
+          assertEqual(
+            const("hello").compose(const("world")).fold,
+            Biconst[String, Int, Int]("helloworld")
+          )
+        },
+        // also tests that order is correct.
+        test("andThen") { () =>
+          assertEqual(
+            const("world").andThen(const("hello")).fold,
+            Biconst[String, Int, Int]("helloworld")
+          )
+        },
+        // tests that order is correct.
+        test(":+") { () =>
+          assertEqual(
+            (const("hello") :+ Biconst[String, Int, Int]("world")).fold,
+            Biconst[String, Int, Int]("helloworld")
+          )
+        },
+        // also tests that order is correct.
+        test("+:") { () =>
+          assertEqual(
+            (Biconst[String, Int, Int]("hello") +: const("world")).fold,
+            Biconst[String, Int, Int]("helloworld")
+          )
+        },
+
+        test("foldLeft") { () =>
+         assertEqual(
+            (const("hello") >>> const("world") >>> const("foobar")).foldLeft(Const[String, Int](""))(
+              ν[RightAction[Const[String, ?], Biconst[String, ?, ?]]][α, β] {
+                (ga, fab) => Const("(" + Const.run(ga) + "|" + Biconst.run(fab) + ")")
+              }
+            ),
+            Const[String, Int]("(((|hello)|world)|foobar)")
+          )
+        },
+
+        test("foldRight") { () =>
+          assertEqual(
+            (const("hello") >>> const("world") >>> const("foobar")).foldRight(Const[String, Int](""))(
+              ν[LeftAction[Const[String, ?], Biconst[String, ?, ?]]][α, β] {
+                (fab, gb) => Const[String, α]("(" + Biconst.run(fab) + "|" + Const.run(gb) + ")")
+              }
+            ),
+            Const[String, Int]("(hello|(world|(foobar|)))")
+          )
+        },
+        test("fold") { () =>
+          final class Fake[A, B](val str: String)
+          // not lawful, used to observe internal behavior of `fold`.
+          implicit val fakeSemicategory: Semicategory[Fake] = instanceOf(new SemicategoryClass[Fake] {
+            def compose[A, B, C](fst: Fake[B, C], snd: Fake[A, B]): Fake[A, C] =
+              new Fake("(" + fst.str + "|" + snd.str + ")")
+          })
+          assertEqual(
+            (lift(new Fake[Int, Int]("hello")) :+ new Fake[Int, Int]("world") :+ new Fake[Int, Int]("foo") :+ new Fake[Int, Int]("bar")).fold.str,
+            "((hello|world)|(foo|bar))"
+          ) |+| assertEqual(
+            (new Fake[Int, Int]("hello") +: new Fake[Int, Int]("world") +: new Fake[Int, Int]("foo") +: lift(new Fake[Int, Int]("bar"))).fold.str,
+            "((hello|world)|(foo|bar))"
+          )
+        }
+      )
+    )
+  }
+}

--- a/tests/src/main/scala/scalaz/tests/ACatenable1Tests.scala
+++ b/tests/src/main/scala/scalaz/tests/ACatenable1Tests.scala
@@ -132,9 +132,8 @@ object ACatenable1Tests {
           def fake(str: String): Fake[Int, Int] = new Fake(str)
           IList(
             ((lift(fake("hello")) :+ fake("world") :+ fake("foo") :+ fake("bar")).fold.str,
-              "((hello|world)|(foo|bar))"),
-            ((fake("hello") +: fake("world") +: fake("foo") +: lift(fake("bar"))).fold.str,
-              "((hello|world)|(foo|bar))")
+             "((hello|world)|(foo|bar))"),
+            ((fake("hello") +: fake("world") +: fake("foo") +: lift(fake("bar"))).fold.str, "((hello|world)|(foo|bar))")
           ).foldMap(assertEqualTupled)
         }
       )

--- a/tests/src/main/scala/scalaz/tests/ACatenable1Tests.scala
+++ b/tests/src/main/scala/scalaz/tests/ACatenable1Tests.scala
@@ -118,9 +118,11 @@ object ACatenable1Tests {
             Const[String, Int]("(hello|(world|(foobar|)))")
           )
         },
+
         test("fold") { () =>
           final class Fake[A, B](val str: String)
-          // not lawful, used to observe internal behavior of `fold`.
+          // not lawful, used to observe balanced binary tree shape of `fold`.
+          // not associative.
           implicit val fakeSemicategory: Semicategory[Fake] = instanceOf(new SemicategoryClass[Fake] {
             def compose[A, B, C](fst: Fake[B, C], snd: Fake[A, B]): Fake[A, C] =
               new Fake("(" + fst.str + "|" + snd.str + ")")
@@ -128,7 +130,8 @@ object ACatenable1Tests {
           assertEqual(
             (lift(new Fake[Int, Int]("hello")) :+ new Fake[Int, Int]("world") :+ new Fake[Int, Int]("foo") :+ new Fake[Int, Int]("bar")).fold.str,
             "((hello|world)|(foo|bar))"
-          ) |+| assertEqual(
+          ) |+|
+          assertEqual(
             (new Fake[Int, Int]("hello") +: new Fake[Int, Int]("world") +: new Fake[Int, Int]("foo") +: lift(new Fake[Int, Int]("bar"))).fold.str,
             "((hello|world)|(foo|bar))"
           )

--- a/tests/src/main/scala/scalaz/tests/ACatenable1Tests.scala
+++ b/tests/src/main/scala/scalaz/tests/ACatenable1Tests.scala
@@ -20,9 +20,11 @@ object ACatenable1Tests {
   type R[A, B] = ACatenable1[Map, A, B] => Map[A, B]
   type L[A, B] = Map[A, B] => ACatenable1[Map, A, B]
   val foldF: ACatenable1[Map, ?, ?] ~~> Map = Forall2.of[R](_.fold)
-  val liftF: Map ~~> ACatenable1[Map, ?, ?] = Forall2.of[L](ACatenable1.lift(_))
+  val liftF: Map ~~> ACatenable1[Map, ?, ?] = Forall2.of[L](lift(_))
 
   // specified in `compose`-order
+  // while these are each similar to `(+) 3`,
+  // they are not commutative.
   val fst = Map(
     (6, 9),
     (7, 10),

--- a/tests/src/main/scala/scalaz/tests/ACatenable1Tests.scala
+++ b/tests/src/main/scala/scalaz/tests/ACatenable1Tests.scala
@@ -127,19 +127,13 @@ object ACatenable1Tests {
             def compose[A, B, C](fst: Fake[B, C], snd: Fake[A, B]): Fake[A, C] =
               new Fake("(" + fst.str + "|" + snd.str + ")")
           })
-          assertEqual(
-            (lift(new Fake[Int, Int]("hello")) :+ new Fake[Int, Int]("world") :+ new Fake[Int, Int]("foo") :+ new Fake[
-              Int,
-              Int
-            ]("bar")).fold.str,
-            "((hello|world)|(foo|bar))"
-          ) |+|
-            assertEqual(
-              (new Fake[Int, Int]("hello") +: new Fake[Int, Int]("world") +: new Fake[Int, Int]("foo") +: lift(
-                new Fake[Int, Int]("bar")
-              )).fold.str,
-              "((hello|world)|(foo|bar))"
-            )
+          def fake(str: String): Fake[Int, Int] = new Fake(str)
+          IList(
+            ((lift(fake("hello")) :+ fake("world") :+ fake("foo") :+ fake("bar")).fold.str,
+              "((hello|world)|(foo|bar))"),
+            ((fake("hello") +: fake("world") +: fake("foo") +: lift(fake("bar"))).fold.str,
+              "((hello|world)|(foo|bar))")
+          ).foldMap(assertEqualTupled)
         }
       )
     )

--- a/tests/src/main/scala/scalaz/tests/ACatenable1Tests.scala
+++ b/tests/src/main/scala/scalaz/tests/ACatenable1Tests.scala
@@ -2,7 +2,7 @@ package scalaz
 package tests
 
 import scala.Int
-import scala.Predef.{ Map, String}
+import scala.Predef.{ Map, String }
 
 import data._
 import tc._
@@ -54,15 +54,18 @@ object ACatenable1Tests {
         section("free semicategory")(
           test("foldMap") { () =>
             HomomorphismLaws.semicategoryCompose(foldF)(
-              lift(fst) <<< lift(snd), lift(thd)
+              lift(fst) <<< lift(snd),
+              lift(thd)
             )(assertEqualNonEmptyMaps) |+|
-            HomomorphismLaws.semicategoryCompose(foldF)(
-              lift(fst), lift(snd) <<< lift(thd)
-            )(assertEqualNonEmptyMaps)
+              HomomorphismLaws.semicategoryCompose(foldF)(
+                lift(fst),
+                lift(snd) <<< lift(thd)
+              )(assertEqualNonEmptyMaps)
           },
           test("lift") { () =>
             HomomorphismLaws.semicategoryCompose(liftF)(
-              fst, snd
+              fst,
+              snd
             )((f, s) => assertEqualNonEmptyMaps(f.fold, s.fold))
           },
         ),
@@ -96,29 +99,26 @@ object ACatenable1Tests {
             Biconst[String, Int, Int]("helloworld")
           )
         },
-
         test("foldLeft") { () =>
-         assertEqual(
+          assertEqual(
             (const("hello") >>> const("world") >>> const("foobar")).foldLeft(Const[String, Int](""))(
-              ν[RightAction[Const[String, ?], Biconst[String, ?, ?]]][α, β] {
-                (ga, fab) => Const("(" + Const.run(ga) + "|" + Biconst.run(fab) + ")")
+              ν[RightAction[Const[String, ?], Biconst[String, ?, ?]]][α, β] { (ga, fab) =>
+                Const("(" + Const.run(ga) + "|" + Biconst.run(fab) + ")")
               }
             ),
             Const[String, Int]("(((|hello)|world)|foobar)")
           )
         },
-
         test("foldRight") { () =>
           assertEqual(
             (const("hello") >>> const("world") >>> const("foobar")).foldRight(Const[String, Int](""))(
-              ν[LeftAction[Const[String, ?], Biconst[String, ?, ?]]][α, β] {
-                (fab, gb) => Const[String, α]("(" + Biconst.run(fab) + "|" + Const.run(gb) + ")")
+              ν[LeftAction[Const[String, ?], Biconst[String, ?, ?]]][α, β] { (fab, gb) =>
+                Const[String, α]("(" + Biconst.run(fab) + "|" + Const.run(gb) + ")")
               }
             ),
             Const[String, Int]("(hello|(world|(foobar|)))")
           )
         },
-
         test("fold") { () =>
           final class Fake[A, B](val str: String)
           // not lawful, used to observe balanced binary tree shape of `fold`.
@@ -128,13 +128,18 @@ object ACatenable1Tests {
               new Fake("(" + fst.str + "|" + snd.str + ")")
           })
           assertEqual(
-            (lift(new Fake[Int, Int]("hello")) :+ new Fake[Int, Int]("world") :+ new Fake[Int, Int]("foo") :+ new Fake[Int, Int]("bar")).fold.str,
+            (lift(new Fake[Int, Int]("hello")) :+ new Fake[Int, Int]("world") :+ new Fake[Int, Int]("foo") :+ new Fake[
+              Int,
+              Int
+            ]("bar")).fold.str,
             "((hello|world)|(foo|bar))"
           ) |+|
-          assertEqual(
-            (new Fake[Int, Int]("hello") +: new Fake[Int, Int]("world") +: new Fake[Int, Int]("foo") +: lift(new Fake[Int, Int]("bar"))).fold.str,
-            "((hello|world)|(foo|bar))"
-          )
+            assertEqual(
+              (new Fake[Int, Int]("hello") +: new Fake[Int, Int]("world") +: new Fake[Int, Int]("foo") +: lift(
+                new Fake[Int, Int]("bar")
+              )).fold.str,
+              "((hello|world)|(foo|bar))"
+            )
         }
       )
     )

--- a/tests/src/main/scala/scalaz/tests/IListTests.scala
+++ b/tests/src/main/scala/scalaz/tests/IListTests.scala
@@ -24,10 +24,10 @@ final class IListTests {
 
   def testAppend(append: (IList[Int], IList[Int]) => IList[Int]): Result =
     List(
-      assertEqual(append(IList(1, 2, 3), IList(4, 5, 6)), IList(1, 2, 3, 4, 5, 6)),
-      assertEqual(append(IList.empty, IList(4, 5, 6)), IList(4, 5, 6)),
-      assertEqual(append(IList(1, 2, 3), IList.empty), IList(1, 2, 3)),
-    ).msuml
+      (append(IList(1, 2, 3), IList(4, 5, 6)), IList(1, 2, 3, 4, 5, 6)),
+      (append(IList.empty, IList(4, 5, 6)), IList(4, 5, 6)),
+      (append(IList(1, 2, 3), IList.empty), IList(1, 2, 3)),
+    ).foldMap(assertEqualTupled)
 
   def tests[T](harness: Harness[T], sequence: (T, T) => T): T = {
     import harness._
@@ -54,17 +54,16 @@ final class IListTests {
           )
         },
         test("uncons") { () =>
-          val assertion = assertEqual[Maybe2[Int, IList[Int]]] _
           List(
-            assertion(IList.uncons(IList.cons(1, IList.empty)), Maybe2.just2(1, IList.empty)),
-            assertion(IList.uncons(IList.empty), Maybe2.empty2),
-          ).msuml
+            (IList.uncons(IList.cons(1, IList.empty)), Maybe2.just2(1, IList.empty[Int])),
+            (IList.uncons(IList.empty[Int]), Maybe2.empty2[Int, IList[Int]]),
+          ).foldMap(assertEqualTupled)
         },
         test("reverse") { () =>
           List(
-            assertEqual(IList.reverse(IList(1, 2, 3)), IList(3, 2, 1)),
-            assertEqual(IList.reverse(IList.empty[Int]), IList.empty[Int]),
-          ).msuml
+            (IList.reverse(IList(1, 2, 3)), IList(3, 2, 1)),
+            (IList.reverse(IList.empty[Int]), IList.empty[Int]),
+          ).foldMap(assertEqualTupled)
         },
         test("unfoldRight") { () =>
           def keepLess5(i: Int): Maybe2[Int, Int] =
@@ -72,9 +71,9 @@ final class IListTests {
             else Maybe2.empty2
 
           List(
-            assertEqual(IList.unfoldRight[Int, Int](_ => Maybe2.empty2)(0), IList.empty[Int]),
-            assertEqual(IList.unfoldRight[Int, Int](keepLess5)(0), IList(0, 1, 2, 3, 4)),
-          ).msuml
+            (IList.unfoldRight[Int, Int](_ => Maybe2.empty2)(0), IList.empty[Int]),
+            (IList.unfoldRight[Int, Int](keepLess5)(0), IList(0, 1, 2, 3, 4)),
+          ).foldMap(assertEqualTupled)
         },
         test("foldLeft") { () =>
           assertEqual(
@@ -84,130 +83,129 @@ final class IListTests {
         },
         test("head") { () =>
           List(
-            assertEqual(IList.empty[Int].head, Maybe.empty[Int]),
-            assertEqual(IList(1).head, Maybe.just(1)),
-            assertEqual(IList(1, 2).head, Maybe.just(1)),
-          ).msuml
+            (IList.empty[Int].head, Maybe.empty[Int]),
+            (IList(1).head, Maybe.just(1)),
+            (IList(1, 2).head, Maybe.just(1)),
+          ).foldMap(assertEqualTupled)
         },
         test("tail") { () =>
-          val assertion = assertEqual[Maybe[IList[Int]]] _
           List(
-            assertion(IList.empty.tail, Maybe.empty[IList[Int]]),
-            assertion(IList(1).tail, Maybe.just(IList.empty[Int])),
-            assertion(IList(1, 2).tail, Maybe.just(IList(2))),
-          ).msuml
+            (IList.empty[Int].tail, Maybe.empty[IList[Int]]),
+            (IList(1).tail, Maybe.just(IList.empty[Int])),
+            (IList(1, 2).tail, Maybe.just(IList(2))),
+          ).foldMap(assertEqualTupled)
         },
         test("isEmpty") { () =>
           List(
-            assert(IList.empty[Int].isEmpty),
-            assert(!IList(1).isEmpty),
-          ).msuml
+            IList.empty[Int].isEmpty,
+            !IList(1).isEmpty,
+          ).foldMap(assert)
         },
         test("nonEmpty") { () =>
           List(
-            assert(!IList.empty[Int].nonEmpty),
-            assert(IList(1).nonEmpty),
-          ).msuml
+            !IList.empty[Int].nonEmpty,
+            IList(1).nonEmpty,
+          ).foldMap(assert)
         },
         test("reverse_:::") { () =>
           List(
-            assertEqual(IList.empty[Int] reverse_::: IList.empty, IList.empty[Int]),
-            assertEqual(IList(1, 2, 3) reverse_::: IList.empty, IList(3, 2, 1)),
-            assertEqual(IList.empty[Int] reverse_::: IList(1, 2, 3), IList(1, 2, 3)),
-            assertEqual(IList(1, 2, 3) reverse_::: IList(4, 5, 6), IList(3, 2, 1, 4, 5, 6)),
-          ).msuml
+            (IList.empty[Int] reverse_::: IList.empty, IList.empty[Int]),
+            (IList(1, 2, 3) reverse_::: IList.empty, IList(3, 2, 1)),
+            (IList.empty[Int] reverse_::: IList(1, 2, 3), IList(1, 2, 3)),
+            (IList(1, 2, 3) reverse_::: IList(4, 5, 6), IList(3, 2, 1, 4, 5, 6)),
+          ).foldMap(assertEqualTupled)
         },
         test("filter") { () =>
           List(
-            assertEqual(IList.empty[Int].filter(_ => false), IList.empty[Int]),
-            assertEqual(IList(1, 2, 3).filter(_ => true), IList(1, 2, 3)),
-            assertEqual(IList(1, 2, 3).filter(_ => false), IList.empty[Int]),
-            assertEqual(IList(1, 2, 3).filter(i => i % 2 != 0), IList(1, 3)),
-          ).msuml
+            (IList.empty[Int].filter(_ => false), IList.empty[Int]),
+            (IList(1, 2, 3).filter(_ => true), IList(1, 2, 3)),
+            (IList(1, 2, 3).filter(_ => false), IList.empty[Int]),
+            (IList(1, 2, 3).filter(i => i % 2 != 0), IList(1, 3)),
+          ).foldMap(assertEqualTupled)
         },
         test("exists") { () =>
           List(
-            assert(!IList.empty[Int].exists(_ == 1)),
-            assert(IList(1).exists(_ == 1)),
-            assert(IList(1, 2).exists(_ == 2)),
-          ).msuml
+            (!IList.empty[Int].exists(_ == 1)),
+            (IList(1).exists(_ == 1)),
+            (IList(1, 2).exists(_ == 2)),
+          ).foldMap(assert)
         },
         test("forall") { () =>
           List(
-            assert(IList.empty[Int].forall(_ == 1)),
-            assert(IList(1).forall(_ == 1)),
-            assert(!IList(1, 2).forall(_ == 2)),
-          ).msuml
+            IList.empty[Int].forall(_ == 1),
+            IList(1).forall(_ == 1),
+            !IList(1, 2).forall(_ == 2),
+          ).foldMap(assert)
         },
         test("find") { () =>
           List(
-            assertEqual(IList.empty[Int].find(_ == 1), Maybe.empty[Int]),
-            assertEqual(IList(1).find(_ == 1), Maybe.just(1)),
-            assertEqual(IList(1, 2, 3).find(_ > 1), Maybe.just(2)),
-          ).msuml
+            (IList.empty[Int].find(_ == 1), Maybe.empty[Int]),
+            (IList(1).find(_ == 1), Maybe.just(1)),
+            (IList(1, 2, 3).find(_ > 1), Maybe.just(2)),
+          ).foldMap(assertEqualTupled)
         },
         test("index") { () =>
           List(
-            assertEqual(IList.empty[Int].index(0), Maybe.empty[Int]),
-            assertEqual(IList(0, 1).index(0), Maybe.just(0)),
-            assertEqual(IList(0, 1).index(1), Maybe.just(1)),
-          ).msuml
+            (IList.empty[Int].index(0), Maybe.empty[Int]),
+            (IList(0, 1).index(0), Maybe.just(0)),
+            (IList(0, 1).index(1), Maybe.just(1)),
+          ).foldMap(assertEqualTupled)
         },
         test("zip") { () =>
           List(
-            assertEqual(IList.empty[Int].zip[Int](IList.empty), IList.empty[(Int, Int)]),
-            assertEqual(IList(1, 2).zip[Int](IList.empty), IList.empty[(Int, Int)]),
-            assertEqual(IList(1, 2).zip[Int](IList(1)), IList((1, 1))),
-            assertEqual(IList(1).zip[Int](IList(1, 2)), IList((1, 1))),
-            assertEqual(IList(1, 2).zip[Int](IList(1, 2)), IList((1, 1), (2, 2))),
-          ).msuml
+            (IList.empty[Int].zip[Int](IList.empty), IList.empty[(Int, Int)]),
+            (IList(1, 2).zip[Int](IList.empty), IList.empty[(Int, Int)]),
+            (IList(1, 2).zip[Int](IList(1)), IList((1, 1))),
+            (IList(1).zip[Int](IList(1, 2)), IList((1, 1))),
+            (IList(1, 2).zip[Int](IList(1, 2)), IList((1, 1), (2, 2))),
+          ).foldMap(assertEqualTupled)
         },
         test("zipWithIndex") { () =>
           List(
-            assertEqual(IList.empty[Int].zipWithIndex, IList.empty[(Int, Int)]),
-            assertEqual(IList(1, 2, 3).zipWithIndex, IList((0, 1), (1, 2), (2, 3))),
-          ).msuml
+            (IList.empty[Int].zipWithIndex, IList.empty[(Int, Int)]),
+            (IList(1, 2, 3).zipWithIndex, IList((0, 1), (1, 2), (2, 3))),
+          ).foldMap(assertEqualTupled)
         },
         test("take") { () =>
           List(
-            assertEqual(IList.empty[Int].take(1), IList.empty[Int]),
-            assertEqual(IList(1).take(0), IList.empty[Int]),
-            assertEqual(IList(1, 2).take(2), IList(1, 2)),
-            assertEqual(IList(1, 2).take(3), IList(1, 2)),
-          ).msuml
+            (IList.empty[Int].take(1), IList.empty[Int]),
+            (IList(1).take(0), IList.empty[Int]),
+            (IList(1, 2).take(2), IList(1, 2)),
+            (IList(1, 2).take(3), IList(1, 2)),
+          ).foldMap(assertEqualTupled)
         },
         test("drop") { () =>
           List(
-            assertEqual(IList.empty[Int].drop(1), IList.empty[Int]),
-            assertEqual(IList(1).drop(0), IList(1)),
-            assertEqual(IList(1, 2).drop(2), IList.empty[Int]),
-            assertEqual(IList(1, 2, 3).drop(1), IList(2, 3)),
-          ).msuml
+            (IList.empty[Int].drop(1), IList.empty[Int]),
+            (IList(1).drop(0), IList(1)),
+            (IList(1, 2).drop(2), IList.empty[Int]),
+            (IList(1, 2, 3).drop(1), IList(2, 3)),
+          ).foldMap(assertEqualTupled)
         },
         test("takeWhile") { () =>
           List(
-            assertEqual(IList.empty[Int].takeWhile(_ => true), IList.empty[Int]),
-            assertEqual(IList.empty[Int].takeWhile(_ => false), IList.empty[Int]),
-            assertEqual(IList(1, 2).takeWhile(_ => true), IList(1, 2)),
-            assertEqual(IList(1, 2).takeWhile(_ => false), IList.empty[Int]),
-            assertEqual(IList(1, 2).takeWhile(_ === 1), IList(1)),
-          ).msuml
+            (IList.empty[Int].takeWhile(_ => true), IList.empty[Int]),
+            (IList.empty[Int].takeWhile(_ => false), IList.empty[Int]),
+            (IList(1, 2).takeWhile(_ => true), IList(1, 2)),
+            (IList(1, 2).takeWhile(_ => false), IList.empty[Int]),
+            (IList(1, 2).takeWhile(_ === 1), IList(1)),
+          ).foldMap(assertEqualTupled)
         },
         test("dropWhile") { () =>
           List(
-            assertEqual(IList.empty[Int].dropWhile(_ => true), IList.empty[Int]),
-            assertEqual(IList.empty[Int].dropWhile(_ => false), IList.empty[Int]),
-            assertEqual(IList(1, 2).dropWhile(_ => true), IList.empty[Int]),
-            assertEqual(IList(1, 2).dropWhile(_ => false), IList(1, 2)),
-            assertEqual(IList(1, 2).dropWhile(_ === 1), IList(2)),
-          ).msuml
+            (IList.empty[Int].dropWhile(_ => true), IList.empty[Int]),
+            (IList.empty[Int].dropWhile(_ => false), IList.empty[Int]),
+            (IList(1, 2).dropWhile(_ => true), IList.empty[Int]),
+            (IList(1, 2).dropWhile(_ => false), IList(1, 2)),
+            (IList(1, 2).dropWhile(_ === 1), IList(2)),
+          ).foldMap(assertEqualTupled)
         },
         test("size") { () =>
           List(
-            assertEqual(IList.empty.size, 0),
-            assertEqual(IList(1).size, 1),
-            assertEqual(IList(1, 2).size, 2),
-          ).msuml
+            (IList.empty.size, 0),
+            (IList(1).size, 1),
+            (IList(1, 2).size, 2),
+          ).foldMap(assertEqualTupled)
         },
       ),
       section("laws")(

--- a/tests/src/main/scala/scalaz/tests/SMapTests.scala
+++ b/tests/src/main/scala/scalaz/tests/SMapTests.scala
@@ -1,0 +1,35 @@
+package scalaz
+package tests
+
+import scala.Int
+import scala.Predef.Map
+
+import data._
+import laws._
+import Scalaz._
+
+import testz._
+import z._
+
+object SMapTests {
+  def tests[T](harness: Harness[T]): T = {
+    import harness._
+
+    section("laws")(
+      section("semicategory laws")(
+        test("compose associativity") { () =>
+          IList(
+            (Map((2, 3)), Map((1, 2)), Map((0, 1))),
+            (Map((3, 6), (1, 5)), Map((2, 3)), Map((0, 1), (1, 2))),
+            (Map((0, 1)), Map.empty[Int, Int], Map.empty[Int, Int]),
+            (Map.empty[Int, Int], Map((0, 1)), Map.empty[Int, Int]),
+            (Map.empty[Int, Int], Map.empty[Int, Int], Map((0, 1))),
+          ).foldMap {
+            case (fst, snd, thd) =>
+              SemicategoryLaws.composeAssoc(fst, snd, thd)(assertEqualMaps)
+          }
+        },
+      ),
+    ),
+  }
+}

--- a/tests/src/main/scala/scalaz/tests/TestMain.scala
+++ b/tests/src/main/scala/scalaz/tests/TestMain.scala
@@ -15,7 +15,7 @@ object TestMain {
   def main(args: Array[String]): Unit = {
 
     val executor = Executors.newFixedThreadPool(2)
-    val ec = ExecutionContext.fromExecutor(executor)
+    val ec       = ExecutionContext.fromExecutor(executor)
 
     val harness: Harness[PureHarness.Uses[Unit]] =
       PureHarness.toHarness(

--- a/tests/src/main/scala/scalaz/tests/TestMain.scala
+++ b/tests/src/main/scala/scalaz/tests/TestMain.scala
@@ -14,7 +14,13 @@ import testz.runner.Runner
 object TestMain {
   def main(args: Array[String]): Unit = {
 
-    val executor = Executors.newFixedThreadPool(2)
+    val isCI = try {
+      scala.sys.env("CI") == "true"
+    } catch {
+      case _: java.util.NoSuchElementException => false
+    }
+
+    val executor = Executors.newFixedThreadPool(if (isCI) 1 else 2)
     val ec       = ExecutionContext.fromExecutor(executor)
 
     val harness: Harness[PureHarness.Uses[Unit]] =

--- a/tests/src/main/scala/scalaz/tests/z.scala
+++ b/tests/src/main/scala/scalaz/tests/z.scala
@@ -1,6 +1,8 @@
 package scalaz
 package tests
 
+import scala.Predef.Map
+
 import tc._, Scalaz._
 
 import testz._
@@ -14,4 +16,14 @@ object z {
 
   def assertEqual[A: Eq](a1: A, a2: A): Result =
     assert(a1 === a2)
+
+  def assertEqualTupled[A: Eq]: ((A, A)) => Result =
+    t => assertEqual(t._1, t._2)
+
+  def assertEqualMaps[K, V](fst: Map[K, V], snd: Map[K, V]): Result =
+    assert(fst == snd)
+
+  def assertEqualNonEmptyMaps[K, V](fst: Map[K, V], snd: Map[K, V]): Result =
+    assert(fst.nonEmpty) |+| assertEqualMaps(fst, snd)
+
 }


### PR DESCRIPTION
Also added a `Category[Function1]` (untested) and found a `Semicategory[Map]` (tested), added the `|+|` alias for `mappend`, the `<<<` and `>>>` aliases for `compose` and `andThen` respectively.

P.S.: Removed unnecessary indirection in `Const` instances.

P.P.S: Started running tests in parallel, just at the suite-level. Gives me almost a 2x speedup on my machine, 80 ms to 40 ms 😝 