### PR TITLE
Add Unfoldable1, update Unfoldable

### DIFF
--- a/base/shared/src/main/scala/scalaz/data/ilist.scala
+++ b/base/shared/src/main/scala/scalaz/data/ilist.scala
@@ -130,9 +130,9 @@ object IListModule {
 
   implicit final val ilistUnfoldable: Unfoldable[IList] =
     instanceOf[UnfoldableClass[IList]](new UnfoldableClass[IList] {
-      override def unfoldRight[A, B](f: B => Maybe2[A, B])(z: B): Maybe[IList[A]] =
+      override def unfoldRight[A, B](f: B => Maybe2[A, B])(z: B): IList[A] =
         fromList(IList.unfoldRight(f)(z))
-      override def fromList[A](as: IList[A]): Maybe[IList[A]] = Maybe.just[IList[A]](as)
+      override def fromList[A](as: IList[A]): IList[A] = as
     })
 
   implicit final class ToIListOps[A](self: IList[A]) {

--- a/base/shared/src/main/scala/scalaz/tc/package.scala
+++ b/base/shared/src/main/scala/scalaz/tc/package.scala
@@ -32,6 +32,7 @@ package object tc {
   type Strong[F[_, _]]        = InstanceOf[StrongClass[F]]
   type Traversable[T[_]]      = InstanceOf[TraversableClass[T]]
   type Unfoldable[F[_]]       = InstanceOf[UnfoldableClass[F]]
+  type Unfoldable1[F[_]]      = InstanceOf[Unfoldable1Class[F]]
 
   final def Applicative[F[_]](implicit F: Applicative[F]): Applicative[F]                = F
   final def Apply[F[_]](implicit F: Apply[F]): Apply[F]                                  = F
@@ -54,4 +55,5 @@ package object tc {
   final def Strong[P[_, _]](implicit P: Strong[P]): Strong[P]                            = P
   final def Traversable[T[_]](implicit T: Traversable[T]): Traversable[T]                = T
   final def Unfoldable[F[_]](implicit F: Unfoldable[F]): Unfoldable[F]                   = F
+  final def Unfoldable1[F[_]](implicit F: Unfoldable1[F]): Unfoldable1[F]                = F
 }

--- a/base/shared/src/main/scala/scalaz/tc/unfoldable.scala
+++ b/base/shared/src/main/scala/scalaz/tc/unfoldable.scala
@@ -3,7 +3,17 @@ package tc
 
 import scalaz.data.{ IList, Maybe, Maybe2 }
 
-trait UnfoldableClass[T[_]] {
-  def unfoldRight[A, B](f: B => Maybe2[A, B])(b: B): Maybe[T[A]]
-  def fromList[A](as: IList[A]): Maybe[T[A]] = unfoldRight(IList.uncons[A])(as)
+trait UnfoldableClass[F[_]] extends Unfoldable1Class[F] {
+  def unfoldRight[A, B](f: B => Maybe2[A, B])(b: B): F[A]
+
+  def unfoldRight1[A, B](f: B => (A, Maybe[B]))(b: B): F[A] =
+    unfoldRight[A, B](
+      b =>
+        f(b) match {
+          case (a, Maybe.Just(b1)) => Maybe2.just2(a, b1)
+          case (_, Maybe.Empty())  => Maybe2.empty2
+      }
+    )(b)
+
+  def fromList[A](as: IList[A]): F[A] = unfoldRight(IList.uncons[A])(as)
 }

--- a/base/shared/src/main/scala/scalaz/tc/unfoldable1.scala
+++ b/base/shared/src/main/scala/scalaz/tc/unfoldable1.scala
@@ -1,0 +1,8 @@
+package scalaz.tc
+
+import scalaz.data.Maybe
+
+trait Unfoldable1Class[F[_]] {
+  def unfoldRight1[A, B](f: B => (A, Maybe[B]))(b: B): F[A]
+  //  def fromNonEmptyList[A](as: NonEmptyList[A]): F[A]
+}

--- a/microsite/src/main/resources/microsite/data/menu.yml
+++ b/microsite/src/main/resources/microsite/data/menu.yml
@@ -39,6 +39,8 @@ options:
       url: tc/Strong.html
     - title: Unfoldable
       url: tc/Unfoldable.html
+    - title: Unfoldable1
+      url: tc/Unfoldable1.html
 
   - title: Data classes
     url: data/index.html

--- a/microsite/src/main/tut/typeclass/Unfoldable.md
+++ b/microsite/src/main/tut/typeclass/Unfoldable.md
@@ -9,7 +9,7 @@ title:  "Unfoldable"
 
 The generating function `f` in `unfoldr(f)(b)` is understood as follows:
 
-- if `f(b)` is `Empty2`, then `unfoldr(f)(b)` should be empty.
+- if `f(b)` is `Empty2`, then `unfoldr(f)(b)` should represent an empty structure.
 - if `f(b)` is `Just2(a, b1)`, then `unfoldr(f)(b)` should consist of an appended to the result of `unfoldr(f)(b1)`.
 
 **Typical imports**

--- a/microsite/src/main/tut/typeclass/Unfoldable1.md
+++ b/microsite/src/main/tut/typeclass/Unfoldable1.md
@@ -1,0 +1,26 @@
+---
+layout: docs
+title:  "Unfoldable1"
+---
+
+# Unfoldable1 [![GitHub](../img/github.png)](https://github.com/scalaz/scalaz/blob/series/8.0.x/base/shared/src/main/scala/scalaz/tc/unfoldable1.scala)
+
+* `Unfoldable1` identifies non-empty data structures which can be unfolded*, and it's a more general form than `Unfoldable`.
+Given a seed value `b` of type `B`, `unfoldRight1(f)(b)` let's you define how to generate (*unfold*) a non-empty data structure of type `F[A]`.
+The generating function `f` always return a value, and then optionally a value to continue unfolding from.
+
+**Typical imports**
+
+```tut:silent
+import scalaz.tc._
+import scalaz.data._
+import scalaz.Scalaz._
+```
+
+# Usage
+
+TBD A sample with NonEmptyList (when they'll be availlable in scalaz 8), like:
+
+```scala
+Unfoldable[NonEmptyList].unfoldRight1[Int, Int](b => if (b == 0) (b, empty) else (b, just(b - 1)))(10)
+```


### PR DESCRIPTION
This PR will:
- add Unfoldable1
- update Unfoldable, removing the annoying `Maybe` in the output of `unfoldRight`

The representation is now just like the one in [Purescript](https://pursuit.purescript.org/packages/purescript-unfoldable/3.0.0/docs/Data.Unfoldable) and #1626 (with a difference in the encoding).

I also updated the microsite, even if I think a resonable example may arise with `NonEmptyList`, which is still missing in Scalaz 8.