### PR TITLE
Use a stable ZIO release, update instances for it, rudimentary IO tests

### DIFF
--- a/base/shared/src/main/scala/scalaz/tc/applicative.scala
+++ b/base/shared/src/main/scala/scalaz/tc/applicative.scala
@@ -1,11 +1,9 @@
 package scalaz
 package tc
 
-import java.lang.Throwable
 import scala.language.experimental.macros
-import scala.{ List, Nothing, Unit }
 
-import zio.{ Fiber, IO }
+import zio.Fiber
 
 trait ApplicativeClass[F[_]] extends ApplyClass[F] {
   def pure[A](a: A): F[A]
@@ -19,20 +17,13 @@ object ApplicativeClass {
 
   implicit def fiberApplicative[E]: Applicative[Fiber[E, ?]] =
     instanceOf(new ApplicativeClass[Fiber[E, ?]] {
-      def pure[A](a: A): Fiber[E, A] = new Fiber[E, A] {
-        def join: IO[E, A]                                     = IO.point(a)
-        def interrupt0(ts: List[Throwable]): IO[Nothing, Unit] = IO.unit
-      }
-
-      def ap[A, B](fa: Fiber[E, A])(f: Fiber[E, A => B]): Fiber[E, B] = new Fiber[E, B] {
-        def join: IO[E, B]                                     = fa.join.flatMap(a => f.join.map(f => f(a)))
-        def interrupt0(ts: List[Throwable]): IO[Nothing, Unit] = fa.interrupt0(ts) *> f.interrupt0(ts)
-      }
-
-      def map[A, B](ma: Fiber[E, A])(f: A => B): Fiber[E, B] = new Fiber[E, B] {
-        def join: IO[E, B]                                     = ma.join.map(f)
-        def interrupt0(ts: List[Throwable]): IO[Nothing, Unit] = ma.interrupt0(ts)
-      }
+      def pure[A](a: A): Fiber[E, A] = Fiber.point(a)
+      def ap[A, B](fa: Fiber[E, A])(f: Fiber[E, A => B]): Fiber[E, B] =
+        (fa zipWith f) { (a, f) =>
+          f(a)
+        }
+      def map[A, B](fa: Fiber[E, A])(f: A => B): Fiber[E, B] =
+        fa.map(f)
     })
 }
 

--- a/base/shared/src/main/scala/scalaz/tc/applicative.scala
+++ b/base/shared/src/main/scala/scalaz/tc/applicative.scala
@@ -19,9 +19,7 @@ object ApplicativeClass {
     instanceOf(new ApplicativeClass[Fiber[E, ?]] {
       def pure[A](a: A): Fiber[E, A] = Fiber.point(a)
       def ap[A, B](fa: Fiber[E, A])(f: Fiber[E, A => B]): Fiber[E, B] =
-        (fa zipWith f) { (a, f) =>
-          f(a)
-        }
+        (f zipWith fa)(_(_))
       def map[A, B](fa: Fiber[E, A])(f: A => B): Fiber[E, B] =
         fa.map(f)
     })

--- a/base/shared/src/main/scala/scalaz/tc/monoid.scala
+++ b/base/shared/src/main/scala/scalaz/tc/monoid.scala
@@ -3,10 +3,9 @@ package tc
 
 import Predef._
 
-import zio.{ Fiber, IO }
+import zio.Fiber
 
-import java.lang.Throwable
-import scala.{ List, Nothing, Unit }
+import scala.{ List, Unit }
 
 trait MonoidClass[A] extends SemigroupClass[A] {
   def mempty: A
@@ -26,15 +25,13 @@ object MonoidClass {
   implicit def listMonoid[A]: Monoid[List[A]] =
     instanceOf(new MonoidClass[List[A]] {
       def mappend(a1: List[A], a2: => List[A]): List[A] = a1 ++ a2
-      def mempty: List[Nothing]                         = List.empty
+      def mempty: List[A]                               = List.empty
     })
 
   implicit def fiberMonoid[E, A](implicit A: Monoid[A]): Monoid[Fiber[E, A]] =
     instanceOf(new MonoidClass[Fiber[E, A]] {
-      def mappend(a1: Fiber[E, A], a2: => Fiber[E, A]): Fiber[E, A] = a1.zipWith(a2)(A.mappend(_, _))
-      def mempty: Fiber[E, A] = new Fiber[E, A] {
-        def join: IO[E, A]                                     = IO.now(A.mempty)
-        def interrupt0(ts: List[Throwable]): IO[Nothing, Unit] = IO.unit
-      }
+      def mappend(a1: Fiber[E, A], a2: => Fiber[E, A]): Fiber[E, A] =
+        a1.zipWith(a2)(A.mappend(_, _))
+      def mempty: Fiber[E, A] = Fiber.point(A.mempty)
     })
 }

--- a/build.sbt
+++ b/build.sbt
@@ -31,11 +31,11 @@ lazy val root = project
   .aggregate(baseJVM, baseJS, lawsJVM, lawsJS, tests, metaJVM, metaJS, microsite, benchmarks)
   .enablePlugins(ScalaJSPlugin)
 
-resolvers in ThisBuild += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+resolvers in ThisBuild += "Sonatype OSS Releases" at "https://oss.sonatype.org/content/repositories/releases"
 
 lazy val base = crossProject.module
   .dependsOn(meta)
-  .settings(libraryDependencies += "org.scalaz" %%% "scalaz-zio" % "0.1-SNAPSHOT")
+  .settings(libraryDependencies += "org.scalaz" %%% "scalaz-zio" % "0.2.7")
 
 lazy val baseJVM = base.jvm
 

--- a/tests/src/main/scala/scalaz/tests/IOTests.scala
+++ b/tests/src/main/scala/scalaz/tests/IOTests.scala
@@ -1,0 +1,107 @@
+package scalaz
+package tests
+
+import scala.{ List, Range, StringContext }
+import scala.Predef.String
+
+import Scalaz._
+
+import testz._, z._
+import laws._, FunctorLaws._
+
+import zio._
+
+object IOTests {
+
+  case class Error(msg: String)
+
+  // a probably-too-large selection of IO actions; more could be added
+  val ios = {
+    type IOES = IO[Error, String]
+    type Endo = IOES => IOES
+    val seeds = List[IOES](
+      IO.now("now"),
+      IO.unit.map(_ => "unit"),
+      IO.point("point"),
+      IO.fail(Error("error")),
+      //IO.sleep(scala.concurrent.duration.Duration.fromNanos(1)).map(_ => "slept")
+    )
+    val endos0: List[Endo] =
+      seeds.map(s => (io: IOES) => io.flatMap(_ => s)) :::
+        List(fns.s1, fns.s2, fns.f).map(f => (io: IOES) => io.flatMap(f)) :::
+        List[Endo](
+        _.map(_ + "ishly"),
+      )
+    val endos = Range(1, endos0.size)
+      .flatMap(endos0.combinations)
+      .flatMap(l => l)
+    seeds.flatMap(s => endos.map(_(s)))
+  }
+
+  object RTS extends RTS
+
+  def ioEql[E, A](l: IO[E, A], r: IO[E, A]): Result =
+    assert(RTS.unsafeRunSync(l.attempt) == RTS.unsafeRunSync(r.attempt))
+
+  object fns {
+    val s1 = (s: String) => IO.point(s"foo$s")
+    val s2 = (s: String) => IO.point(s + s)
+    val f  = (s: String) => IO.fail(Error(s))
+  }
+
+  def tests[T](harness: Harness[T]): T = {
+    import harness._
+    namedSection("zio.IO instances")(
+      namedSection("bifunctor")(
+        test("identityToIdentity") { () =>
+          ios.foldMap(Bifunctor.identityToIdentity(_)(ioEql))
+        },
+      ),
+      namedSection("functor")(
+        test("identity") { () =>
+          ios.foldMap(Functor.identityToIdentity(_)(ioEql))
+        },
+      ),
+      namedSection("applicative")(
+        test("applyIdentity") { () =>
+          ios.foldMap(ApplicativeLaws.applyIdentity(_)(ioEql))
+        },
+      ),
+      namedSection("bind")(
+        namedSection("bindAssoc")(
+          test("success/success") { () =>
+            ios.foldMap(BindLaws.bindAssoc(_)(fns.s1, fns.s2)(ioEql))
+          },
+          test("failure/success") { () =>
+            ios.foldMap(BindLaws.bindAssoc(_)(fns.f, fns.s2)(ioEql))
+          },
+          test("failure/failure") { () =>
+            ios.foldMap(BindLaws.bindAssoc(_)(fns.f, fns.f)(ioEql))
+          },
+          test("success/failure") { () =>
+            ios.foldMap(BindLaws.bindAssoc(_)(fns.s1, fns.f)(ioEql))
+          },
+        )
+      ),
+      namedSection("monad")(
+        namedSection("bindLeftIdentity")(
+          test("success") { () =>
+            MonadLaws.bindLeftIdentity("mxyplyzyk")(fns.s1)(ioEql)
+          },
+          test("failure") { () =>
+            MonadLaws.bindLeftIdentity("mxyplyzyk")(fns.f)(ioEql)
+          },
+        ),
+        namedSection("bindRightIdentity")(
+          test("success") { () =>
+            ios.foldMap(MonadLaws.bindRightIdentity(_)(ioEql))
+          },
+          test("failure") { () =>
+            ios.foldMap(MonadLaws.bindRightIdentity(_)(ioEql))
+          },
+        ),
+      )
+    )
+  }
+
+}

--- a/tests/src/main/scala/scalaz/tests/IOTests.scala
+++ b/tests/src/main/scala/scalaz/tests/IOTests.scala
@@ -86,10 +86,10 @@ object IOTests {
       namedSection("monad")(
         namedSection("bindLeftIdentity")(
           test("success") { () =>
-            MonadLaws.bindLeftIdentity("mxyplyzyk")(fns.s1)(ioEql)
+            MonadLaws.bindLeftIdentity("mxyzptlk")(fns.s1)(ioEql)
           },
           test("failure") { () =>
-            MonadLaws.bindLeftIdentity("mxyplyzyk")(fns.f)(ioEql)
+            MonadLaws.bindLeftIdentity("mxyzptlk")(fns.f)(ioEql)
           },
         ),
         namedSection("bindRightIdentity")(

--- a/tests/src/main/scala/scalaz/tests/IOTests.scala
+++ b/tests/src/main/scala/scalaz/tests/IOTests.scala
@@ -24,6 +24,9 @@ object IOTests {
       IO.unit.map(_ => "unit"),
       IO.point("point"),
       IO.fail(Error("error")),
+      IO.sync("sync"),
+      IO.async[Error, String](_(ExitResult.Completed("async success"))),
+      IO.async[Error, String](_(ExitResult.Failed(Error("async failüre")))),
       //IO.sleep(scala.concurrent.duration.Duration.fromNanos(1)).map(_ => "slept")
     )
     val endos0: List[Endo] =

--- a/tests/src/main/scala/scalaz/tests/TestMain.scala
+++ b/tests/src/main/scala/scalaz/tests/TestMain.scala
@@ -39,6 +39,7 @@ object TestMain {
         Future(cont("Debug Interpolator Tests", DebugInterpolatorTest.tests(harness)))(ec),
         Future(cont("Double Tests", (new DoubleTests).tests(harness)))(ec),
         Future(cont("IList Tests", (new IListTests).tests(harness)))(ec),
+        Future(cont("IO Tests", IOTests.tests(harness)))(ec),
         Future(cont("Scala Map Tests", SMapTests.tests(harness)))(ec),
       )
 


### PR DESCRIPTION
Depending on a snapshot version of zio is unwise, since changes there can break us.

The `0.1-SNAPSHOT` release wasn't resolving at all.

This uses the 0.2.7 stable release, and updates `Applicative` and `Monoid`'s `Fiber` instances to use `Fiber` methods rather than directly subclassing `Fiber`.

Also, some tests for `IO`'s instances.