### PR TITLE
Benchmark tests

### DIFF
--- a/benchmarks/src/main/scala/scalaz/tests/TestBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/tests/TestBenchmark.scala
@@ -15,9 +15,6 @@ import scalaz.Predef._
 @Measurement(iterations = 1, batchSize = 1, time = 1, timeUnit = TimeUnit.MILLISECONDS)
 class TestBenchmark {
   @Benchmark
-  def allTests(): Unit = {
+  def allTests(): Unit =
     TestMain.main(Array.empty)
-  }
 }
-
-

--- a/benchmarks/src/main/scala/scalaz/tests/TestBenchmark.scala
+++ b/benchmarks/src/main/scala/scalaz/tests/TestBenchmark.scala
@@ -1,0 +1,23 @@
+package scalaz
+package tests
+
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+import scala.Array
+import scala.Predef.{ wrapString, String }
+import scalaz.Predef._
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(value = 5, jvmArgsAppend = Array("-Xms2g", "-Xmx2g"))
+@Warmup(iterations = 0, batchSize = 1)
+@Measurement(iterations = 1, batchSize = 1, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+class TestBenchmark {
+  @Benchmark
+  def allTests(): Unit = {
+    TestMain.main(Array.empty)
+  }
+}
+
+

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ lazy val baseJVM = base.jvm
 lazy val baseJS = base.js
 
 lazy val benchmarks = project.module
-  .dependsOn(baseJVM)
+  .dependsOn(baseJVM, tests)
   .enablePlugins(JmhPlugin)
   .settings(
     skip in publish := true,


### PR DESCRIPTION
If you'd like to benchmark the tests, this is a good way. We make sure to fork 5 JVMs and only actually run the benchmark once per iteration for realistic conditions (no JIT, classloading has to be redone on each iteration). The best way to use this is with async-profiler, as described at https://github.com/ktoso/sbt-jmh.