### PR TITLE
Divisible decidable alt apply instances

### DIFF
--- a/core/src/main/scala/scalaz/ApplicativePlus.scala
+++ b/core/src/main/scala/scalaz/ApplicativePlus.scala
@@ -26,7 +26,14 @@ trait ApplicativePlus[F[_]] extends Applicative[F] with PlusEmpty[F] { self =>
   val applicativePlusSyntax = new scalaz.syntax.ApplicativePlusSyntax[F] { def F = ApplicativePlus.this }
 }
 
-object ApplicativePlus {
+abstract class ApplicativePlusInstances {
+
+  implicit def applicativePlusAlt[F[_]](implicit A0: ApplicativePlus[F]): Alt[F] = new ApplicativePlusAlt[F] {
+    implicit def A: ApplicativePlus[F] = A0
+  }
+}
+
+object ApplicativePlus extends ApplicativePlusInstances {
   @inline def apply[F[_]](implicit F: ApplicativePlus[F]): ApplicativePlus[F] = F
 
   import Isomorphism._
@@ -47,4 +54,14 @@ trait IsomorphismApplicativePlus[F[_], G[_]] extends ApplicativePlus[F] with Iso
   ////
 
   ////
+}
+
+private trait ApplicativePlusAlt[F[_]] extends Alt[F] {
+  implicit def A: ApplicativePlus[F]
+
+  def point[A](a: => A): F[A] = A.point(a)
+
+  def ap[A, B](fa: => F[A])(f: => F[A => B]): F[B] = A.ap(fa)(f)
+
+  def alt[A](a1: =>F[A], a2: =>F[A]): F[A] = A.plus(a1, a2)
 }

--- a/core/src/main/scala/scalaz/Arrow.scala
+++ b/core/src/main/scala/scalaz/Arrow.scala
@@ -67,10 +67,24 @@ trait Arrow[=>:[_, _]] extends Split[=>:] with Strong[=>:] with Category[=>:] { 
   val arrowSyntax = new scalaz.syntax.ArrowSyntax[=>:] { def F = Arrow.this }
 }
 
-abstract class ArrowInstances {
+sealed abstract class ArrowInstances0 {
+
+  implicit def arrowDivide[F[_, _], A](implicit A0: Arrow[F], S0: Semigroup[A]): Divide[F[?, A]] = new ArrowDivide[F, A] {
+    implicit def A: Arrow[F] = A0
+    implicit def S: Semigroup[A] = S0
+  }
+}
+
+abstract class ArrowInstances extends ArrowInstances0 {
 
   implicit def arrowApply[F[_, _], A](implicit A0: Arrow[F]): Apply[F[A, ?]] = new ArrowApply[F, A] {
     implicit def A: Arrow[F] = A0
+  }
+
+  implicit def arrowDecidable[F[_, _], A](implicit A0: Arrow[F], C0: Choice[F], M0: Monoid[A]): Decidable[F[?, A]] = new ArrowDecidable[F, A] {
+    implicit def A: Arrow[F] = A0
+    implicit def C: Choice[F] = C0
+    implicit def M: Monoid[A] = M0
   }
 }
 
@@ -106,4 +120,25 @@ private trait ArrowApply[F[_, _], A] extends Apply[F[A, ?]] {
 
   def ap[B,C](fa: => F[A, B])(f: => F[A, B => C]): F[A, C] =
     A.mapsnd(A.combine(f, fa))(t => t._1(t._2))
+}
+
+private trait ArrowDecidable[F[_, _], A] extends Decidable[F[?, A]] {
+  implicit def A: Arrow[F]
+  implicit def C: Choice[F]
+  implicit def M: Monoid[A]
+
+  def choose2[Z, A1, A2](a1: =>F[A1, A], a2: =>F[A2, A])(f: Z => (A1 \/ A2)): F[Z, A] =
+    A.mapfst(C.choice(a1, a2))(f)
+  def divide2[A1, A2, Z](a1: => F[A1, A],a2: => F[A2, A])(f: Z => (A1, A2)): F[Z, A] =
+    A.compose(A.arr((t: (A, A)) => M.append(t._1, t._2)), A.compose(A.splitA(a1, a2), A.arr(f)))
+  def conquer[A1]: F[A1, A] = A.arr((_: A1) => M.zero)
+}
+
+private trait ArrowDivide[F[_, _], A0] extends Divide[F[?, A0]] {
+  implicit def A: Arrow[F]
+  implicit def S: Semigroup[A0]
+
+  def contramap[A, B](r: F[A, A0])(f: B => A): F[B, A0] = A.mapfst(r)(f)
+  def divide2[A1, A2, Z](a1: =>F[A1, A0], a2: =>F[A2, A0])(f: Z => (A1, A2)): F[Z, A0] =
+    A.compose(A.arr((t: (A0, A0)) => S.append(t._1, t._2)), A.compose(A.splitA(a1, a2), A.arr(f)))
 }

--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
@@ -612,4 +612,6 @@ object ScalazArbitrary extends ScalazArbitraryPlatform {
     ))
   }
 
+  implicit def CodensityArbitrary[F[_], A](implicit A: Arbitrary[F[A]], M: Monad[F]): Arbitrary[Codensity[F, A]] =
+    Functor[Arbitrary].map(A)(Codensity.rep(_))
 }

--- a/tests/src/test/scala/scalaz/AltTest.scala
+++ b/tests/src/test/scala/scalaz/AltTest.scala
@@ -48,5 +48,4 @@ class AltTest extends SpecLite {
       Default[GTree[String]].default must_==(GLeaf(""))
     }
   }
-
 }

--- a/tests/src/test/scala/scalaz/ApplicativePlusTest.scala
+++ b/tests/src/test/scala/scalaz/ApplicativePlusTest.scala
@@ -1,0 +1,22 @@
+package scalaz
+
+import std.AllInstances._
+import scalaz.scalacheck.ScalazProperties._
+import scalaz.scalacheck.ScalazArbitrary._
+import org.scalacheck.Prop.forAll
+
+object ApplicativePlusTest extends SpecLite {
+
+  implicit val eqCodensityListInt = new Equal[Codensity[List, Int]] {
+    def equal(f1: Codensity[List, Int], f2: Codensity[List, Int]): Boolean =
+      f1.improve == f2.improve
+  }
+
+  implicit val codensityListAlt = {
+    import ApplicativePlus._
+    // obtain via ApplicativePlus[List]
+    Alt[Codensity[List, ?]]
+  }
+
+  checkAll(alt.laws[Codensity[List, ?]])
+}

--- a/tests/src/test/scala/scalaz/ArrowTest.scala
+++ b/tests/src/test/scala/scalaz/ArrowTest.scala
@@ -3,13 +3,57 @@ package scalaz
 import std.AllInstances._
 import scalaz.scalacheck.ScalazProperties._
 import scalaz.scalacheck.ScalazArbitrary._
+import scalaz.scalacheck.ScalaCheckBinding._
+import org.scalacheck.Arbitrary
 import org.scalacheck.Prop.forAll
 
 object ArrowTest extends SpecLite {
 
-  implicit val eqBooleanInt = new Equal[Boolean => Int] {
-    def equal(f1: Boolean => Int, f2: Boolean => Int): Boolean =
-      f1(true) == f2(true) && f1(false) == f2(false)
+  case class Fn1[A, B](run: A => B)
+
+  implicit def ArbitraryFn1[A, B](implicit A: Arbitrary[A => B]): Arbitrary[Fn1[A, B]] =
+    Functor[Arbitrary].map(A)(Fn1(_))
+
+  val isoFn1Function1 = new Isomorphism.IsoBifunctorTemplate[Fn1, Function1] {
+    def to[A, B](fn: Fn1[A, B]): (A => B) = fn.run
+    def from[A, B](fn: (A => B)): Fn1[A, B] = Fn1(fn)
   }
-  checkAll(apply.laws[Function1[Boolean, ?]])
+  implicit val fn1Arrow: Arrow[Fn1] = Arrow.fromIso(isoFn1Function1)
+  implicit val fn1Choice: Choice[Fn1] = Choice.fromIso(isoFn1Function1)
+
+  implicit val eqFn1BooleanInt = new Equal[Fn1[Boolean, Int]] {
+    def equal(f1: Fn1[Boolean, Int], f2: Fn1[Boolean, Int]): Boolean =
+      f1.run(true) == f2.run(true) && f1.run(false) == f2.run(false)
+  }
+
+  implicit val ApplyFn1 = {
+    import Arrow._
+    // obtain via Arrow[Fn1]
+    Apply[Fn1[Boolean, ?]]
+  }
+  checkAll(apply.laws[Fn1[Boolean, ?]])
+
+  // TODO - this is not legitimate. Laws seem to plug in Int wherever there's a hole?
+  implicit val eqFn1IntBoolean = new Equal[Fn1[Int, Boolean]] {
+    def equal(f1: Fn1[Int, Boolean], f2: Fn1[Int, Boolean]): Boolean =
+      (0 to 100).toList.map(i => f1.run(i) == f2.run(i)).forall(identity _)
+  }
+
+  val DecidableFn1 = {
+    import Arrow._
+    implicit val boolMonoid = std.anyVal.booleanInstance.conjunction
+    // obtain via Arrow[Fn1]
+    Decidable[Fn1[?, Boolean]]
+  }
+
+  checkAll(decidable.laws[Fn1[?, Boolean]](DecidableFn1, implicitly, implicitly, implicitly))
+
+  val DivideFn1 = {
+    import Arrow._
+    implicit val boolSemigroup: Semigroup[Boolean] = std.anyVal.booleanInstance.conjunction
+    // obtain via Arrow[Fn1]
+    Divide[Fn1[?, Boolean]]
+  }
+
+  checkAll(divide.laws[Fn1[?, Boolean]](DivideFn1, implicitly, implicitly, implicitly))
 }

--- a/tests/src/test/scala/scalaz/ArrowTest.scala
+++ b/tests/src/test/scala/scalaz/ArrowTest.scala
@@ -1,0 +1,15 @@
+package scalaz
+
+import std.AllInstances._
+import scalaz.scalacheck.ScalazProperties._
+import scalaz.scalacheck.ScalazArbitrary._
+import org.scalacheck.Prop.forAll
+
+object ArrowTest extends SpecLite {
+
+  implicit val eqBooleanInt = new Equal[Boolean => Int] {
+    def equal(f1: Boolean => Int, f2: Boolean => Int): Boolean =
+      f1(true) == f2(true) && f1(false) == f2(false)
+  }
+  checkAll(apply.laws[Function1[Boolean, ?]])
+}


### PR DESCRIPTION
This adds several new instances that serve the techniques laid out in the derivation chapter of FP for Mortals.

*  Alt in terms of ApplicativePlus
*  Apply for any F[A, ?] in terms of Arrow[F]
*  Decidable for any F[?, A] in terms of Arrow[F], Choice[F] and Monoid[A]
*  Divide for any F[?, A] in terms of Arrow[F] and Semigroup[A]

A few notes on this.

1. These are "orphaned" instances in the sense that you need to import them to use them. They are all defined in terms of other typeclasses. Putting them in the companion objects of their own typeclasses themselves seems wrong because it creates ambiguity, but they target polymorphic types so there's no other companion object to house them. I couldn't determine whether there's precedent for this sort of thing in the project as of now.

2. There's a TODO on some hand-wavy garbage Equal instance I threw in a test for functions that return Int. I figured I'd see if this was super offensive to anyone before deep diving into the laws to see if I could target a type with less inhabitants. If anyone is offended and doesn't mind guiding me in a direction to do better, I'd appreciate the help.

3. It seems kind of odd to me to have Decidable extend Divisible. Here are the instances I ported - https://gist.github.com/beezee/533285b2123fb7cf6fd77456f061853e which target slightly different definitions of Decidable and Divide. The constraints for those implementation are much less, and they serve the purpose of typeclass derivation faithfully with the weaker definitions.

Awaiting feedback if people find value in this.