### PR TITLE
Define non-orphan typeclass instances with less boilerplate

### DIFF
--- a/base/shared/src/main/scala/scalaz/tc/applicative.scala
+++ b/base/shared/src/main/scala/scalaz/tc/applicative.scala
@@ -1,8 +1,8 @@
 package scalaz
 package tc
 
+import scala.List
 import scala.Unit
-
 import scala.language.experimental.macros
 
 import zio.Fiber
@@ -17,6 +17,8 @@ trait ApplicativeClass[F[_]] extends ApplyClass[F] {
 }
 
 object ApplicativeClass {
+
+  implicit val instanceList: Applicative[List] = instanceOf(instances.list.control)
 
   implicit def fiberApplicative[E]: Applicative[Fiber[E, ?]] =
     instanceOf(new ApplicativeClass[Fiber[E, ?]] {

--- a/base/shared/src/main/scala/scalaz/tc/apply.scala
+++ b/base/shared/src/main/scala/scalaz/tc/apply.scala
@@ -1,6 +1,7 @@
 package scalaz
 package tc
 
+import scala.List
 import scala.language.experimental.macros
 
 @meta.minimal("ap", "zip")
@@ -11,6 +12,10 @@ trait ApplyClass[F[_]] extends FunctorClass[F] {
     ap(fb)(map(fa)(f.curried))
 
   def zip[A, B](fa: F[A], fb: F[B]): F[(A, B)] = ap(fa)(map(fb)(b => a => (a, b)))
+}
+
+object ApplyClass {
+  implicit val instanceList: Apply[List] = instanceOf(instances.list.control)
 }
 
 trait ApplySyntax {

--- a/base/shared/src/main/scala/scalaz/tc/bind.scala
+++ b/base/shared/src/main/scala/scalaz/tc/bind.scala
@@ -1,9 +1,10 @@
 package scalaz
 package tc
 
-import Predef._
-
+import scala.List
 import scala.language.experimental.macros
+
+import Predef._
 
 @meta.minimal("flatMap", "flatten")
 trait BindClass[M[_]] extends ApplyClass[M] {
@@ -12,6 +13,11 @@ trait BindClass[M[_]] extends ApplyClass[M] {
   def flatten[A](ma: M[M[A]]): M[A] = flatMap(ma)(identity)
 
   override def ap[A, B](fa: M[A])(f: M[A => B]): M[B] = flatMap(f)(map(fa))
+}
+
+object BindClass {
+
+  implicit val instanceList: Bind[List] = instanceOf(instances.list.control)
 }
 
 trait BindFunctions {

--- a/base/shared/src/main/scala/scalaz/tc/cobind.scala
+++ b/base/shared/src/main/scala/scalaz/tc/cobind.scala
@@ -20,12 +20,7 @@ object CobindClass {
       Some(f(fa))
   })
 
-  implicit val listCobind: Cobind[List] = instanceOf(new CobindClass[List] {
-    override def map[A, B](fa: List[A])(f: A => B): List[B] = fa.map(f)
-
-    override def cobind[A, B](fa: List[A])(f: List[A] => B): List[B] =
-      List(f(fa))
-  })
+  implicit val instanceList: Cobind[List] = instanceOf(instances.list.control)
 }
 
 trait CobindSyntax {

--- a/base/shared/src/main/scala/scalaz/tc/foldable.scala
+++ b/base/shared/src/main/scala/scalaz/tc/foldable.scala
@@ -28,6 +28,10 @@ trait FoldableClass[F[_]] {
     foldLeft(fa, List[A]())((t, h) => h :: t).reverse
 }
 
+object FoldableClass {
+  implicit val instanceList: Foldable[List] = instanceOf(instances.list.control)
+}
+
 trait FoldableSyntax {
   implicit final class ToFoldableOps[F[_], A](self: F[A]) {
     def foldLeft[B](f: B)(g: (B, A) => B)(implicit ev: Foldable[F]): B = macro ops.Ops.ia_1_1

--- a/base/shared/src/main/scala/scalaz/tc/functor.scala
+++ b/base/shared/src/main/scala/scalaz/tc/functor.scala
@@ -1,6 +1,7 @@
 package scalaz
 package tc
 
+import scala.List
 import scala.language.experimental.macros
 
 import Predef._
@@ -13,6 +14,10 @@ trait FunctorClass[F[_]] extends InvariantFunctorClass[F] {
 
   def compose[G[_]](implicit G: FunctorClass[G]): Functor[λ[α => F[G[α]]]] =
     instanceOf(new CompositionFunctorClass[F, G]()(this, G))
+}
+
+object FunctorClass {
+  implicit val instanceList: Functor[List] = instanceOf(instances.list.control)
 }
 
 trait FunctorFunctions {

--- a/base/shared/src/main/scala/scalaz/tc/instances/list.scala
+++ b/base/shared/src/main/scala/scalaz/tc/instances/list.scala
@@ -1,0 +1,40 @@
+package scalaz
+
+package tc
+
+package instances
+
+import scala.List
+
+object list {
+
+  def data[A]: MonoidClass[List[A]] =
+    new MonoidClass[List[A]] {
+      def mappend(a1: List[A], a2: => List[A]): List[A] = a1 ++ a2
+      def mempty: List[A]                               = List.empty
+    }
+
+  val control: CobindClass[List] with MonadClass[List] with TraversableClass[List] =
+    new CobindClass[List] with MonadClass[List] with TraversableClass[List] {
+      override def ap[A, B](xs: List[A])(f: List[A => B]): List[B]      = xs.flatMap(a => f.map(_(a)))
+      override def flatMap[A, B](xs: List[A])(f: A => List[B]): List[B] = xs.flatMap(f)
+      override def map[A, B](xs: List[A])(f: A => B): List[B]           = xs.map(f)
+      override def pure[A](a: A): List[A]                               = List(a)
+      override def cobind[A, B](fa: List[A])(f: List[A] => B): List[B]  = List(f(fa))
+
+      override def traverse[F[_], A, B](ta: List[A])(f: A => F[B])(implicit F: Applicative[F]): F[List[B]] =
+        ta.reverse.foldLeft(F.pure(List.empty[B])) { (flb, a) =>
+          F.ap(f(a))(F.map(flb)(lb => (b: B) => b :: lb))
+        }
+
+      override def foldLeft[A, B](fa: List[A], z: B)(f: (B, A) => B): B =
+        fa.foldLeft(z)(f)
+
+      override def foldRight[A, B](fa: List[A], z: => B)(f: (A, => B) => B): B =
+        fa.foldRight(z) { (a, b) =>
+          f(a, b)
+        }
+
+      override def toList[A](xs: List[A]): List[A] = xs
+    }
+}

--- a/base/shared/src/main/scala/scalaz/tc/monad.scala
+++ b/base/shared/src/main/scala/scalaz/tc/monad.scala
@@ -49,12 +49,7 @@ object MonadClass {
       override final def pure[A](a: A): IO[E, A] = IO.now(a)
     })
 
-  implicit val listMonad: Monad[List] = instanceOf(new MonadClass[List] {
-    override def ap[A, B](xs: List[A])(f: List[A => B]): List[B]      = xs.flatMap(a => f.map(_(a)))
-    override def flatMap[A, B](xs: List[A])(f: A => List[B]): List[B] = xs.flatMap(f)
-    override def map[A, B](xs: List[A])(f: A => B): List[B]           = xs.map(f)
-    override def pure[A](a: A): List[A]                               = List(a)
-  })
+  implicit val instanceList: Monad[List] = instanceOf(instances.list.control)
 
   implicit val optionMonad: Monad[Option] =
     instanceOf(new MonadClass[Option] {

--- a/base/shared/src/main/scala/scalaz/tc/monoid.scala
+++ b/base/shared/src/main/scala/scalaz/tc/monoid.scala
@@ -23,10 +23,7 @@ object MonoidClass {
   })
 
   implicit def listMonoid[A]: Monoid[List[A]] =
-    instanceOf(new MonoidClass[List[A]] {
-      def mappend(a1: List[A], a2: => List[A]): List[A] = a1 ++ a2
-      def mempty: List[A]                               = List.empty
-    })
+    instanceOf(instances.list.data[A])
 
   implicit def fiberMonoid[E, A](implicit A: Monoid[A]): Monoid[Fiber[E, A]] =
     instanceOf(new MonoidClass[Fiber[E, A]] {

--- a/base/shared/src/main/scala/scalaz/tc/semigroup.scala
+++ b/base/shared/src/main/scala/scalaz/tc/semigroup.scala
@@ -1,8 +1,10 @@
 package scalaz
 package tc
 
-import scala.Int
 import java.lang.String
+
+import scala.Int
+import scala.List
 
 import scala.annotation.tailrec
 import scala.language.experimental.macros
@@ -24,6 +26,10 @@ trait SemigroupClass[A] {
 }
 
 object SemigroupClass {
+
+  implicit def listSemigroup[A]: Semigroup[List[A]] =
+    instanceOf(instances.list.data[A])
+
   implicit val StringSemigroup: Semigroup[String] = instanceOf(new SemigroupClass[String] {
     def mappend(a1: String, a2: => String) = a1 + a2
   })

--- a/base/shared/src/main/scala/scalaz/tc/traversable.scala
+++ b/base/shared/src/main/scala/scalaz/tc/traversable.scala
@@ -21,8 +21,8 @@ object TraversableClass {
   implicit val listTraversable: Traversable[List] =
     instanceOf(new TraversableClass[List] {
       override def traverse[F[_], A, B](ta: List[A])(f: A => F[B])(implicit F: Applicative[F]): F[List[B]] =
-        ta.foldLeft[F[List[B]]](F.pure(List.empty[B])) { (flb, a) =>
-          F.ap(flb)(F.map(f(a))(b => (xs: List[B]) => b :: xs))
+        ta.reverse.foldLeft(F.pure(List.empty[B])) { (flb, a) =>
+          F.ap(f(a))(F.map(flb)(lb => (b: B) => b :: lb))
         }
 
       override def foldLeft[A, B](fa: List[A], z: B)(f: (B, A) => B): B = fa.foldLeft(z)(f)

--- a/base/shared/src/main/scala/scalaz/tc/traversable.scala
+++ b/base/shared/src/main/scala/scalaz/tc/traversable.scala
@@ -19,22 +19,7 @@ trait TraversableClass[T[_]] extends FunctorClass[T] with FoldableClass[T] {
 
 object TraversableClass {
   implicit val listTraversable: Traversable[List] =
-    instanceOf(new TraversableClass[List] {
-      override def traverse[F[_], A, B](ta: List[A])(f: A => F[B])(implicit F: Applicative[F]): F[List[B]] =
-        ta.reverse.foldLeft(F.pure(List.empty[B])) { (flb, a) =>
-          F.ap(f(a))(F.map(flb)(lb => (b: B) => b :: lb))
-        }
-
-      override def foldLeft[A, B](fa: List[A], z: B)(f: (B, A) => B): B = fa.foldLeft(z)(f)
-
-      override def foldRight[A, B](fa: List[A], z: => B)(f: (A, => B) => B): B = fa.foldRight(z) { (a, b) =>
-        f(a, b)
-      }
-
-      override def toList[A](xs: List[A]): List[A] = xs
-
-      override def map[A, B](fa: List[A])(f: A => B) = fa.map(f)
-    })
+    instanceOf(instances.list.control)
 
   implicit def tuple2Traversable[C]: Traversable[Tuple2[C, ?]] =
     instanceOf(new TraversableClass[Tuple2[C, ?]] {


### PR DESCRIPTION
- Save some boilerplate when creating instances. For eg. `Monad` and `Traversable` which share `Functor`'s code.
- Users don't need to import `scalaz.Scalaz._` if they only need less powerful TC, for eg. `Functor`. This reduces implicit scope and speedup compile time.

To illustrate, console setup (note that there is no `import scalaz.Scalaz._`):
```scala
scala> import scalaz.tc._

scala> import scala.List

scala> def ft[F[_]](implicit F: Functor[F]): Functor[F] = F
ft: [F[_]](implicit F: scalaz.tc.Functor[F])scalaz.tc.Functor[F]

scala> def mn[F[_]](implicit F: Monad[F]): Monad[F] = F
mn: [F[_]](implicit F: scalaz.tc.Monad[F])scalaz.tc.Monad[F]
```
Before the change
```scala
scala> ft[List]
<console>:17: error: could not find implicit value for parameter F: scalaz.tc.Functor[List]
       ft[List]
```
After the change
```scala
scala> mn[List]
res0: scalaz.tc.Monad[List] = scalaz.tc.instances.list$$anon$1@382dacc3

scala> ft[List]
res1: scalaz.tc.Functor[List] = scalaz.tc.instances.list$$anon$1@382dacc3

scala> mf[List]
res2: scalaz.tc.Functor[List] = scalaz.tc.instances.list$$anon$1@382dacc3
```
In this PR only `List` has the new scheme of instances, but other data types can have the same too. Further steps might be to organize imports into `scalaz.syntax`, `scalaz.hierarchy`, etc. for more flexible usecases.