### PR TITLE
safe methods in splitWith and selectSplit implementation#2051

### DIFF
--- a/core/src/main/scala/scalaz/Foldable.scala
+++ b/core/src/main/scala/scalaz/Foldable.scala
@@ -364,15 +364,14 @@ trait Foldable[F[_]]  { self =>
   /**
    * Selects groups of elements that satisfy p and discards others.
    */
-  def selectSplit[A](fa: F[A])(p: A => Boolean): List[NonEmptyList[A]] =
-    foldRight(fa, (List.empty[NonEmptyList[A]], true))((a, lb) => (lb, p(a)) match {
-      case ((l, _), false) =>
-        (l, true)
-      case ((x :: xs, false), true) =>
-        ((a <:: x) :: xs, false)
-      case ((l, _), true) =>
-        (NonEmptyList(a) :: l, false)
-    })._1
+  def selectSplit[A](fa: F[A])(p: A => Boolean): List[NonEmptyList[A]] = {
+    def squash(t: (List[NonEmptyList[A]], IList[A])): List[NonEmptyList[A]] = t._2.toNel.toList ::: t._1
+
+    squash(foldRight(fa, (List.empty[NonEmptyList[A]], IList.empty[A]))((a, l) =>
+      if (p(a)) (l._1, a :: l._2)
+      else (squash(l), IList.empty)
+    ))
+  }
 
   /** ``O(n log n)`` complexity */
   def distinct[A](fa: F[A])(implicit A: Order[A]): IList[A] =

--- a/core/src/main/scala/scalaz/Foldable.scala
+++ b/core/src/main/scala/scalaz/Foldable.scala
@@ -335,7 +335,7 @@ trait Foldable[F[_]]  { self =>
       val pa = p(a)
       (b match {
         case (_, Empty()) => List(NonEmptyList(a))
-        case (x@Nil, _) => NonEmptyList(a) :: x
+        case (Nil, _) => List(NonEmptyList(a))
         case (x@(head :: tail), Just(q)) => if (pa == q) (a <:: head) :: tail else NonEmptyList(a) :: x
       }, just(pa))
     })._1

--- a/core/src/main/scala/scalaz/Foldable.scala
+++ b/core/src/main/scala/scalaz/Foldable.scala
@@ -1,7 +1,5 @@
 package scalaz
 
-import scalaz.Maybe.{Empty, Just, just}
-
 ////
 /**
  * A type parameter implying the ability to extract zero or more
@@ -334,10 +332,10 @@ trait Foldable[F[_]]  { self =>
     foldRight(fa, (List.empty[NonEmptyList[A]], Maybe.empty[Boolean]))((a, b) => {
       val pa = p(a)
       (b match {
-        case (_, Empty()) => List(NonEmptyList(a))
+        case (_, Maybe.Empty()) => List(NonEmptyList(a))
         case (Nil, _) => List(NonEmptyList(a))
-        case (x@(head :: tail), Just(q)) => if (pa == q) (a <:: head) :: tail else NonEmptyList(a) :: x
-      }, just(pa))
+        case (x@(head :: tail), Maybe.Just(q)) => if (pa == q) (a <:: head) :: tail else NonEmptyList(a) :: x
+      }, Maybe.just(pa))
     })._1
 
   /**

--- a/tests/src/test/scala/scalaz/FoldableTest.scala
+++ b/tests/src/test/scala/scalaz/FoldableTest.scala
@@ -313,7 +313,7 @@ object FoldableTest extends SpecLite {
     (limit: Int) =>
       val l = Math.abs(limit)
       val splitRange = L.selectSplit(List.range(0, l))(_ % 2 != 0)
-      splitRange.size must_=== (l + 1)/2
+      splitRange.size must_=== l/2
       splitRange.forall(_.size == 1) must_=== true
   }
 

--- a/tests/src/test/scala/scalaz/FoldableTest.scala
+++ b/tests/src/test/scala/scalaz/FoldableTest.scala
@@ -310,9 +310,9 @@ object FoldableTest extends SpecLite {
   }
 
   "selectSplit range consistent with filter" ! forAll {
-    (limit: Byte) =>
-      val l = Math.abs(limit.toInt)
-      val range = List.range(0, l)
+    (i1: Byte, i2: Byte) =>
+      val (s, e) = (Math.min(i1.toInt, i2.toInt), Math.max(i1.toInt, i2.toInt))
+      val range = List.range(s, e)
       L.selectSplit(range)(_ % 2 != 0) must_=== range.filter(_ % 2 != 0).map(NonEmptyList(_))
   }
 

--- a/tests/src/test/scala/scalaz/FoldableTest.scala
+++ b/tests/src/test/scala/scalaz/FoldableTest.scala
@@ -281,6 +281,34 @@ object FoldableTest extends SpecLite {
        must_===((l ++ l2).reverse))
   }
 
+  "splitWith on sorted list produces at most 2 elements" ! forAll {
+    (l: List[Int], p: Int => Boolean) =>
+      L.splitWith(l.sortBy(p))(p).size mustBe_< 3
+  }
+
+  "splitWith consistent with partition" ! forAll {
+    (l: List[Int], p: Int => Boolean) =>
+      import scalaz.syntax.std.list._
+      val (trueL, falseL) = l.partition(p)
+      L.splitWith(l.sortBy(p))(p) must_=== List(falseL, trueL).flatMap(_.toNel)
+  }
+
+  "selectSplit: removes all non-satisfying elements" ! forAll {
+    (l: List[Int]) =>
+      L.selectSplit(l)(_ => false).size must_=== 0
+  }
+
+  "selectSplit: keeps all satisfying elements" ! forAll {
+    (l: List[Int]) =>
+      import scalaz.syntax.std.list._
+      L.selectSplit(l)(_ => true) must_=== l.toNel.toList
+  }
+
+  "selectSplit: consistent with partition" ! forAll {
+    (l: List[Int], p: Int => Boolean) =>
+      L.selectSplit(l)(p).flatMap(_.toList) must_=== l.partition(p)._1
+  }
+
   /*
   "foldRight from foldMap" should {
 

--- a/tests/src/test/scala/scalaz/FoldableTest.scala
+++ b/tests/src/test/scala/scalaz/FoldableTest.scala
@@ -309,12 +309,11 @@ object FoldableTest extends SpecLite {
       L.selectSplit(l)(p).flatMap(_.toList) must_=== l.partition(p)._1
   }
 
-  "selectSplit: more than one list for multiple ranges" ! forAll {
-    (limit: Int) =>
-      val l = Math.abs(limit)
-      val splitRange = L.selectSplit(List.range(0, l))(_ % 2 != 0)
-      splitRange.size must_=== l/2
-      splitRange.forall(_.size == 1) must_=== true
+  "selectSplit range consistent with filter" ! forAll {
+    (limit: Byte) =>
+      val l = Math.abs(limit.toInt)
+      val range = List.range(0, l)
+      L.selectSplit(range)(_ % 2 != 0) must_=== range.filter(_ % 2 != 0).map(NonEmptyList(_))
   }
 
   /*

--- a/tests/src/test/scala/scalaz/FoldableTest.scala
+++ b/tests/src/test/scala/scalaz/FoldableTest.scala
@@ -309,6 +309,14 @@ object FoldableTest extends SpecLite {
       L.selectSplit(l)(p).flatMap(_.toList) must_=== l.partition(p)._1
   }
 
+  "selectSplit: more than one list for multiple ranges" ! forAll {
+    (limit: Int) =>
+      val l = Math.abs(limit)
+      val splitRange = L.selectSplit(List.range(0, l))(_ % 2 != 0)
+      splitRange.size must_=== (l + 1)/2
+      splitRange.forall(_.size == 1) must_=== true
+  }
+
   /*
   "foldRight from foldMap" should {
 


### PR DESCRIPTION
This uses only safe methods in Foldable.splitWith and Foldable.selectSplit without changing the logic.

I need this in order to perform migration to scalaz IList ( #2051 ) which does not have unsafe `tail` and `head` methods.
Also I think with explicit pattern matching - the implementation is cleaner. For example in `selectSplit`
there's no need to pass `boolean` in accumulator, to check for the previous state, since it is guaranteed by nonemptiness of the List.


