### PR TITLE
 Applicative.Par instance for EitherT

### DIFF
--- a/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
+++ b/scalacheck-binding/src/main/scala/scalaz/scalacheck/ScalazArbitrary.scala
@@ -426,4 +426,6 @@ object ScalazArbitrary extends ScalazArbitraryPlatform {
     ))
   }
 
+  implicit def parallelArbitrary[A](implicit A: Arbitrary[A]): Arbitrary[A @@ Parallel] = 
+    Parallel.subst(A)
 }


### PR DESCRIPTION
Since we can't have the bare `Applicative` instance for `EitherT`
due to potential inconsistencies, maybe we can have the
`Applicative.Par` instance?