### PR TITLE
 Make @@ abstract and add implicit scope to it 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ tags
 .classpath
 .project
 .settings
+.bloop
+.metals

--- a/core/src/main/scala/scalaz/package.scala
+++ b/core/src/main/scala/scalaz/package.scala
@@ -96,7 +96,13 @@ package object scalaz {
 
   implicit val idInstance: Traverse1[Id] with Monad[Id] with BindRec[Id] with Comonad[Id] with Distributive[Id] with Zip[Id] with Unzip[Id] with Align[Id] with Cozip[Id] with Optional[Id] = Id.id
 
-  private[scalaz] type Tagged[A, T] = {type Tag = T; type Self = A}
+  private[scalaz] final class TagModule {
+    type Tagged = Any { type Tag }
+    trait Scope[A, T] extends Any
+    type @@[T, Tag] <: Tagged with Scope[T, Tag]
+  }
+
+  private[scalaz] val TagModule: TagModule = new TagModule
 
   /**
    * Tag a type `T` with `Tag`.
@@ -107,7 +113,7 @@ package object scalaz {
    *
    * Credit to Miles Sabin for the idea.
    */
-  type @@[T, Tag] = Tagged[T, Tag]
+  type @@[T, Tag] = TagModule.@@[T, Tag]
 
   /** A [[scalaz.NaturalTransformation]][F, G]. */
   type ~>[-F[_], +G[_]] = NaturalTransformation[F, G]

--- a/tests/src/test/scala/scalaz/TagTest.scala
+++ b/tests/src/test/scala/scalaz/TagTest.scala
@@ -50,4 +50,20 @@ object TagTest extends SpecLite {
       }
     }
   }
+
+  object instances {
+    class Reverse
+    object Reverse {
+      implicit def reverseOrder[A: Order]: Order[A @@ Reverse] =
+        Tag.subst(Order[A].reverseOrder)
+    }
+
+    class BiTask[L, R]
+    object BiTask {
+      implicit def parallel[L]: Applicative.Par[BiTask[L, ?]] = ???
+    }
+
+    def reverseOrder[A: Order] = Order[A @@ Reverse]
+    def parallel[L] = implicitly[Applicative.Par[BiTask[L, ?]]]
+  }
 }


### PR DESCRIPTION
One of the most important use cases of tagged types is to define
alternative typeclass instances. But the fact that currently the
companion objects of the tag and the tagged type are not in the
implicit scope makes the whole feature very cumbersome to use.
We rectify the situation by adding implicit scope to tagged types.