### PR TITLE
Fix typos

### DIFF
--- a/core/src/main/scala/scalaz/Monad.scala
+++ b/core/src/main/scala/scalaz/Monad.scala
@@ -15,7 +15,7 @@ trait Monad[F[_]] extends Applicative[F] with Bind[F] { self =>
 
   /**
    * Execute an action repeatedly as long as the given `Boolean` expression
-   * returns `true`. The condition is evalated before the loop body.
+   * returns `true`. The condition is evaluated before the loop body.
    * Collects the results into an arbitrary `MonadPlus` value, such as a `List`.
    */
   def whileM[G[_], A](p: F[Boolean], body: => F[A])(implicit G: MonadPlus[G]): F[G[A]] = {

--- a/example/src/main/scala/scalaz/example/AdjunctUsage.scala
+++ b/example/src/main/scala/scalaz/example/AdjunctUsage.scala
@@ -35,7 +35,7 @@ object AdjunctUsage extends App {
 
   // Writer and Reader Functors form an adjunction that gives us a
   // Monad that behaves like State. Think of it as a function which
-  // Reads the state, perfoms a computation and Writes the new state.
+  // Reads the state, performs a computation and Writes the new state.
   type RWState[S,A] = Reader[S, Writer[S, A]]
 
   // here is our checkForRepeats function rewritten for the new form

--- a/example/src/main/scala/scalaz/example/ApplyUsage.scala
+++ b/example/src/main/scala/scalaz/example/ApplyUsage.scala
@@ -11,7 +11,7 @@ object ApplyUsage extends App {
   import scalaz.syntax.equal._
   import scalaz.syntax.std.option._
 
-  // Apply extends the (hopefully familar) Functor Typeclass by adding
+  // Apply extends the (hopefully familiar) Functor Typeclass by adding
   // a method named "ap" which is similar to "map" from Functor in
   // that it applies a function to values in a context, however with
   // ap, the function is also in the same context. Here are some

--- a/example/src/main/scala/scalaz/example/EndoUsage.scala
+++ b/example/src/main/scala/scalaz/example/EndoUsage.scala
@@ -15,7 +15,7 @@ object EndoUsage extends App {
   // there already exists a Monoid instance for any Function1 where
   // there exists a monoid for the codomain, the append function of
   // this monoid returns a function which for a given input, returns
-  // the resut of applying each function to this input and append the
+  // the result of applying each function to this input and append the
   // two results to each other:
   val f1: Int => Int = _ + 1
   val f2: Int => Int = _ * 10

--- a/example/src/main/scala/scalaz/example/FunctorUsage.scala
+++ b/example/src/main/scala/scalaz/example/FunctorUsage.scala
@@ -43,7 +43,7 @@ object FunctorUsage extends App {
   // lift
   //
 
-  // We can use the Funtor to "lift" a function to operate on the Functor type:
+  // We can use the Functor to "lift" a function to operate on the Functor type:
   val lenOption: Option[String] => Option[Int] = Functor[Option].lift(len)
   assert(lenOption(Some("abcd")) === Some(4))
 


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos, with https://github.com/bwignall/typochecker to help automate the checking.