### PR TITLE
macros to generate IsoSet for case classes and sealed traits

### DIFF
--- a/tests/src/test/scala/scalaz/IsomorphismTest.scala
+++ b/tests/src/test/scala/scalaz/IsomorphismTest.scala
@@ -1,0 +1,57 @@
+package scalaz
+
+import std.list._, std.tuple._, std.anyVal._
+import Isomorphism._
+
+object IsomorphismTest extends SpecLite {
+
+  sealed trait Gaz
+  case class Foo(s: String, i: Int) extends Gaz
+  case class Bar(txt: String, num: Long) extends Gaz
+  case class Baz() extends Gaz
+
+  sealed trait Poly[A]
+  case class PolyFoo[A](s: String, i: A) extends Poly[A]
+  case class PolyBar() extends Poly[Unit]
+
+  // TODO this breaks the OneOf derivation
+  //case object Car extends Gaz
+
+  implicit class toOps[A](val a: A) extends AnyVal {
+    def to[B](implicit O: Iso[Function1, A, B]): B = O.to(a)
+  }
+
+  "case class derivation" ! {
+    val (s, i) = Foo("hello", 1).to
+    assert(Tag.unwrap(s) == "hello")
+    assert(Tag.unwrap(i) == 1)
+  }
+
+  "sealed trait derivation" ! {
+    (Bar("hello", 1) : Gaz).to match {
+      case OneOf3.V2(Bar(s, i)) =>
+        assert(s == "hello")
+        assert(i == 1)
+      case _ => assert(false)
+    }
+  }
+
+  "polymorphic case clas derivation" ! {
+    val (s, i) = PolyFoo("hello", 1).to
+    assert(Tag.unwrap(s) == "hello")
+    assert(Tag.unwrap(i) == 1)
+  }
+
+  // TODO polymorphic sealed traits don't seem to work
+  // def testPolySealedTrait = {
+  //   (PolyFoo("hello", 1) : Poly[Int]).to match {
+  //     case OneOf2.V1(PolyFoo(s, i)) =>
+  //       assert(s == "hello")
+  //       assert(i == 1)
+  //     case _ => assert(false)
+  //   }
+  // }
+
+}
+
+


### PR DESCRIPTION
This is a novel typeclass derivation mechanism that is much simpler than scalaz-deriving, magnolia, and shapeless, yet slightly more powerful than Magnolia (and thus scalaz-deriving). I am working up this idea in a standalone repository, but it seems that this could also be part of scalaz, see https://gitlab.com/fommil/bourbaki/ for the standalone variant.

I plan on generating further boilerplate so that for any typeclass having a Divisible or Applicative, it may be derived for any case class with a single line (!!! yes, really !!!). Likewise for Decidable and Alt for sealed traits. It is also possible to use this mechanism to derive non-lawful typeclasses such as JSON encoders and decoders (but it benefits from https://github.com/propensive/adversaria and `TypeName`). Therefore, this PR if accepted, deprecates scalaz-deriving.

@xuwei-k I would love to hear your thoughts on this, and some help with the following:

- [ ] I can't get the tests to compile (they compile in my standalone variant, so this is scalaz specific)
- [ ] the macro should work in scala 2.12 and below, even though it uses singleton type literals, but people can't do anything with it because there is no ValueOf, but I think it can be backported using the technique that shapeless used prior to its inclusion in scala 2.13
- [ ] it should be possible to rewrite the macro for scala 3, I need the most help here
- [ ] my changes to the build are unhygienic
