### PR TITLE
Fix unmanagedSourceDirectories settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,6 +85,7 @@ lazy val example = Project(
   base = file("example")
 ).settings(
   standardSettings,
+  unmanagedSourcePathSettings,
   name := "scalaz-example",
   notPublish,
   TaskKey[Unit]("runAllMain") := {
@@ -103,6 +104,7 @@ lazy val scalacheckBinding =
   crossProject(JVMPlatform, JSPlatform).crossType(ScalazCrossType)
     .in(file("scalacheck-binding"))
     .settings(standardSettings)
+    .platformsSettings(JSPlatform, JVMPlatform)(unmanagedSourcePathSettings)
     .settings(
       name := "scalaz-scalacheck-binding",
       scalacOptions in (Compile, compile) -= "-Ywarn-value-discard",
@@ -117,6 +119,7 @@ lazy val scalacheckBindingJS  = scalacheckBinding.js
 
 lazy val tests = crossProject(JSPlatform, JVMPlatform).crossType(ScalazCrossType)
   .settings(standardSettings)
+  .platformsSettings(JSPlatform, JVMPlatform)(unmanagedSourcePathSettings)
   .settings(
     name := "scalaz-tests",
     notPublish,


### PR DESCRIPTION
Stop polluting my oss folder. `show unmanagedSourceDirectories`:
```diff
[info] effectJVM / Compile / unmanagedSourceDirectories
[info] 	List(/Users/KrasteGe/work/oss/scalaz/scalaz/effect/jvm/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/effect/jvm/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/effect/jvm/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/effect/jvm/src/main/java, /Users/KrasteGe/work/oss/scalaz/scalaz/effect/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/effect/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/effect/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/effect/src/main/scala-2.13)
[info] scalacheckBindingJS / Compile / unmanagedSourceDirectories
[info] 	List(/Users/KrasteGe/work/oss/scalaz/scalaz/scalacheck-binding/js/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/scalacheck-binding/js/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/scalacheck-binding/js/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/scalacheck-binding/js/src/main/java, /Users/KrasteGe/work/oss/scalaz/scalaz/scalacheck-binding/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/scalacheck-binding/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/scalacheck-binding/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/scalacheck-binding/src/main/scala-2.13)
[info] testsJS / Compile / unmanagedSourceDirectories
[info] 	List(/Users/KrasteGe/work/oss/scalaz/scalaz/tests/js/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/tests/js/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/tests/js/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/tests/js/src/main/java, /Users/KrasteGe/work/oss/scalaz/scalaz/tests/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/tests/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/tests/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/tests/src/main/scala-2.13)
[info] example / Compile / unmanagedSourceDirectories
[info] 	List(/Users/KrasteGe/work/oss/scalaz/scalaz/example/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/example/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/example/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/example/src/main/java, /Users/KrasteGe/work/oss/scalaz/scalaz/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/src/main/scala-2.13)
[info] scalacheckBindingJVM / Compile / unmanagedSourceDirectories
[info] 	List(/Users/KrasteGe/work/oss/scalaz/scalaz/scalacheck-binding/jvm/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/scalacheck-binding/jvm/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/scalacheck-binding/jvm/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/scalacheck-binding/jvm/src/main/java, /Users/KrasteGe/work/oss/scalaz/scalaz/scalacheck-binding/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/scalacheck-binding/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/scalacheck-binding/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/scalacheck-binding/src/main/scala-2.13)
[info] effectJS / Compile / unmanagedSourceDirectories
[info] 	List(/Users/KrasteGe/work/oss/scalaz/scalaz/effect/js/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/effect/js/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/effect/js/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/effect/js/src/main/java, /Users/KrasteGe/work/oss/scalaz/scalaz/effect/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/effect/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/effect/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/effect/src/main/scala-2.13)
[info] testsJVM / Compile / unmanagedSourceDirectories
[info] 	List(/Users/KrasteGe/work/oss/scalaz/scalaz/tests/jvm/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/tests/jvm/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/tests/jvm/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/tests/jvm/src/main/java, /Users/KrasteGe/work/oss/scalaz/scalaz/tests/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/tests/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/tests/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/tests/src/main/scala-2.13)
[info] iterateeJS / Compile / unmanagedSourceDirectories
[info] 	List(/Users/KrasteGe/work/oss/scalaz/scalaz/iteratee/js/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/iteratee/js/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/iteratee/js/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/iteratee/js/src/main/java, /Users/KrasteGe/work/oss/scalaz/scalaz/iteratee/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/iteratee/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/iteratee/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/iteratee/src/main/scala-2.13)
[info] coreJVM / Compile / unmanagedSourceDirectories
[info] 	List(/Users/KrasteGe/work/oss/scalaz/scalaz/core/jvm/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/core/jvm/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/core/jvm/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/core/jvm/src/main/java, /Users/KrasteGe/work/oss/scalaz/scalaz/core/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/core/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/core/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/core/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/core/jvm_js/src/main/scala)
[info] coreJS / Compile / unmanagedSourceDirectories
[info] 	List(/Users/KrasteGe/work/oss/scalaz/scalaz/core/js/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/core/js/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/core/js/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/core/js/src/main/java, /Users/KrasteGe/work/oss/scalaz/scalaz/core/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/core/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/core/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/core/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/core/jvm_js/src/main/scala)
[info] iterateeJVM / Compile / unmanagedSourceDirectories
[info] 	List(/Users/KrasteGe/work/oss/scalaz/scalaz/iteratee/jvm/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/iteratee/jvm/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/iteratee/jvm/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/iteratee/jvm/src/main/java, /Users/KrasteGe/work/oss/scalaz/scalaz/iteratee/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/iteratee/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/iteratee/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/iteratee/src/main/scala-2.13)
[info] Compile / unmanagedSourceDirectories
+ [info] 	List(/Users/KrasteGe/work/oss/scalaz/scalaz/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/src/main/java)
- [info] 	List(/Users/KrasteGe/work/oss/scalaz/scalaz/src/main/scala, /Users/KrasteGe/work/oss/scalaz/scalaz/src/main/scala-2.13, /Users/KrasteGe/work/oss/scalaz/scalaz/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/scalaz/src/main/java, /Users/KrasteGe/work/oss/scalaz/src/main/scala-2, /Users/KrasteGe/work/oss/scalaz/src/main/scala-2.13)
```

Now importing the project in Intellij doesn't also import the parent directory 🎉 