### PR TITLE
Add collect method for Heap

### DIFF
--- a/core/src/main/scala/scalaz/Heap.scala
+++ b/core/src/main/scala/scalaz/Heap.scala
@@ -113,6 +113,10 @@ sealed abstract class Heap[A] {
   def filter(p: A => Boolean): Heap[A] =
     fold(Empty[A], (_, leq, t) => t foldMap (x => if (p(x.value)) singletonWith(leq, x.value) else Empty[A]))
 
+  /**Builds a new heap by applying a partial function to all elements of this heap on which the function is defined. O(n)*/
+  def collect[B: Order](pf: PartialFunction[A, B]): Heap[B] =
+    fold(Empty[B], (_, _, t) => t.foldMap(x => if (pf.isDefinedAt(x.value)) singleton(pf.apply(x.value)) else Empty[B]))
+
   /**Partition the heap according to a predicate. The first heap contains all elements that
    * satisfy the predicate. The second contains all elements that fail the predicate. O(n)*/
   def partition(p: A => Boolean): (Heap[A], Heap[A]) =

--- a/tests/src/test/scala/scalaz/HeapTest.scala
+++ b/tests/src/test/scala/scalaz/HeapTest.scala
@@ -39,8 +39,12 @@ object HeapTest extends SpecLite {
       gt.forall(_ > x) must_===(true)
   }
 
+  val pf: PartialFunction[Int, Int] = {
+    case i: Int if pred(i) => i-1
+  }
+
   "collect" ! forAll {
     (a: Heap[Int]) =>
-      a.collect {case i if i % 2 == 0 => i*2 }.toLazyList must_===(a.toLazyList.collect{case i if i % 2 == 0 => i*2 })
+      a.collect(pf).toLazyList must_===(a.toLazyList.collect(pf).sorted)
   }
 }

--- a/tests/src/test/scala/scalaz/HeapTest.scala
+++ b/tests/src/test/scala/scalaz/HeapTest.scala
@@ -38,4 +38,9 @@ object HeapTest extends SpecLite {
       eq.forall(_ == x) must_===(true)
       gt.forall(_ > x) must_===(true)
   }
+
+  "collect" ! forAll {
+    (a: Heap[Int]) =>
+      a.collect {case i if i % 2 == 0 => i*2 }.toLazyList must_===(a.toLazyList.collect{case i if i % 2 == 0 => i*2 })
+  }
 }


### PR DESCRIPTION
Hello, 

I often use the Heap type in my projects and I am often used to do map/filter operations. To avoid 2 Heap runs I suggest you to add the very simple `collect` method.