### PR TITLE
[7.2.x] move `Liskov.isa` method to LiskovInstances

### DIFF
--- a/core/src/main/scala/scalaz/Liskov.scala
+++ b/core/src/main/scala/scalaz/Liskov.scala
@@ -29,6 +29,11 @@ sealed abstract class LiskovInstances {
 
     def compose[A, B, C](bc: B <~< C, ab: A <~< B): (A <~< C) = trans(bc, ab)
   }
+  
+  /**Lift Scala's subtyping relationship */
+  implicit def isa[A, B >: A]: A <~< B = new (A <~< B) {
+    def subst[F[-_]](p: F[B]): F[A] = p
+  }
 }
 
 object Liskov extends LiskovInstances {
@@ -38,11 +43,6 @@ object Liskov extends LiskovInstances {
 
   /**A flipped alias, for those used to their arrows running left to right */
   type >~>[+B, -A] = Liskov[A, B]
-
-  /**Lift Scala's subtyping relationship */
-  implicit def isa[A, B >: A]: A <~< B = new (A <~< B) {
-    def subst[F[-_]](p: F[B]): F[A] = p
-  }
 
   /**We can witness equality by using it to convert between types */
   implicit def witness[A, B](lt: A <~< B): A => B = {


### PR DESCRIPTION
https://github.com/scalaz/scalaz/commit/c65027c7ac7fafa86c7341badaebd2a7049d4de8