### PR TITLE
[7.3.x] move `Liskov.isa` method to LiskovInstances

### DIFF
--- a/core/src/main/scala/scalaz/Liskov.scala
+++ b/core/src/main/scala/scalaz/Liskov.scala
@@ -33,6 +33,12 @@ sealed abstract class LiskovInstances {
 
     def compose[A, B, C](bc: B <~< C, ab: A <~< B): (A <~< C) = trans(bc, ab)
   }
+  
+  /** Lift Scala's subtyping relationship */
+  implicit def isa[A, B >: A]: A <~< B = new (A <~< B) {
+    def substCo[F[+ _]](p: F[A]) = p
+    def substCt[F[- _]](p: F[B]) = p
+  }
 }
 
 object Liskov extends LiskovInstances {
@@ -42,12 +48,6 @@ object Liskov extends LiskovInstances {
 
   /** A flipped alias, for those used to their arrows running left to right */
   type >~>[+B, -A] = Liskov[A, B]
-
-  /** Lift Scala's subtyping relationship */
-  implicit def isa[A, B >: A]: A <~< B = new (A <~< B) {
-    def substCo[F[+ _]](p: F[A]) = p
-    def substCt[F[- _]](p: F[B]) = p
-  }
 
   /** We can witness equality by using it to convert between types */
   implicit def witness[A, B](lt: A <~< B): A => B = {


### PR DESCRIPTION
https://github.com/scalaz/scalaz/commit/c65027c7ac7fafa86c7341badaebd2a7049d4de8