### PR TITLE
Reenable StreamTTest in Scala.js.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -181,10 +181,6 @@ lazy val tests = crossProject(JSPlatform, JVMPlatform, NativePlatform).crossType
     minSuccessfulTests := 33,
   )
   .jsSettings(
-    Test / sources ~= { values =>
-      // https://github.com/scala-js/scala-js/issues/3953
-      values.filter(_.getName != "StreamTTest.scala")
-    },
     minSuccessfulTests := 10
   )
   .dependsOn(core, effect, iteratee, scalacheckBinding)


### PR DESCRIPTION
The upstream issue that prevented it from working, https://github.com/scala-js/scala-js/issues/3953, was fixed in Scala.js 1.7.0.