### PR TITLE
Add the StreamTMergeMonad instance (for #2223)

### DIFF
--- a/core/src/main/scala/scalaz/StreamT.scala
+++ b/core/src/main/scala/scalaz/StreamT.scala
@@ -244,6 +244,42 @@ sealed class StreamT[M[_], A](val step: M[StreamT.Step[A, StreamT[M, A]]]) {
   def mergeWith(f2: => StreamT[M, A])(implicit M: Nondeterminism[M]): StreamT[M, A] = {
     StreamT(mergeFStep(this.step, f2.step))
   }
+
+  def mergeMap[B](f: A => StreamT[M, B])(implicit M: Nondeterminism[M]): StreamT[M, B] = {
+    def mergeMapInitStep(fsa: M[Step[A, StreamT[M, A]]]): M[Step[B, StreamT[M, B]]] = {
+      M.map(fsa) {
+        case Yield(a, s) =>
+          Skip(() => StreamT(mergeMapStep(s().step, f(a).step)))
+        case Skip(s) =>
+          Skip(() => StreamT(mergeMapInitStep(s().step)))
+        case Done() =>
+          Done()
+      }
+    }
+    def mergeMapStep(fsa: M[Step[A, StreamT[M, A]]], fsb: M[Step[B, StreamT[M, B]]]): M[Step[B, StreamT[M, B]]] = {
+      M.map(M.choose(fsa, fsb)) {
+        case -\/((sa, fsb)) =>
+          sa match {
+            case Yield(a, s) =>
+              Skip(() => StreamT(mergeMapStep(s().step, mergeFStep(f(a).step, fsb))))
+            case Skip(s) =>
+              Skip(() => StreamT(mergeMapStep(s().step, fsb)))
+            case Done() =>
+              Skip(() => StreamT(fsb))
+          }
+        case \/-((fsa, sb)) =>
+          sb match {
+            case Yield(b, s) => 
+              Yield(b, () => StreamT(mergeMapStep(fsa, s().step)))
+            case Skip(s) =>
+              Skip(() => StreamT(mergeMapStep(fsa, s().step)))
+            case Done() =>
+              Skip(() => StreamT(mergeMapInitStep(fsa)))
+          }
+      }
+    }
+    StreamT(mergeMapInitStep(this.step))
+  }
 }
 
 //
@@ -281,6 +317,15 @@ sealed abstract class StreamTInstances extends StreamTInstances0 {
   implicit def StreamTMergeMonoid[F[_], A](implicit F0: Nondeterminism[F]): Monoid[StreamT[F, A] @@ Tags.Parallel] =
     new StreamTMergeMonoid[F, A] {
       implicit def F: Nondeterminism[F] = F0
+    }
+  implicit def StreamTMergeMonad[F[_]](implicit F0: Nondeterminism[F]): Monad[λ[α => StreamT[F, α] @@ Tags.Parallel]] =
+    new Monad[λ[α => StreamT[F, α] @@ Tags.Parallel]] {
+
+      def bind[A, B](fa: StreamT[F, A] @@ Tags.Parallel)(f: A => StreamT[F, B] @@ Tags.Parallel): StreamT[F, B] @@ Tags.Parallel =
+        Tags.Parallel(Tags.Parallel.unwrap(fa).mergeMap(Tags.Parallel.unsubst(f)))
+
+      def point[A](a: => A): StreamT[F, A] @@ Tags.Parallel =
+        Tags.Parallel(StreamTMonadPlus(F0).point(a))
     }
 }
 

--- a/tests/src/test/scala/scalaz/StreamTTest.scala
+++ b/tests/src/test/scala/scalaz/StreamTTest.scala
@@ -204,5 +204,6 @@ object StreamTTest extends SpecLite {
     def functor[F[_]: Applicative] = Functor[StreamT[F, *]]
     def bind[F[_]: Applicative] = Bind[StreamT[F, *]]
     def plus[F[_]: Applicative] = Plus[StreamT[F, *]]
+    def monoid[F[_]: Nondeterminism, A] = Monoid[StreamT[F, A] @@ Tags.Parallel]
   }
 }


### PR DESCRIPTION
This PR adds the ReactiveX `flapMap` operator (named `mergeMap` in this PR), and the corresponding `StreamTMergeMonoid` instance

See 
http://reactivex.io/documentation/operators/flatmap.html

This PR is based on #2224