### PR TITLE
Reduce memory leaks due to choose

### DIFF
--- a/core/src/main/scala/scalaz/std/Future.scala
+++ b/core/src/main/scala/scalaz/std/Future.scala
@@ -25,12 +25,20 @@ private class FutureInstance(implicit ec: ExecutionContext) extends Nondetermini
     val fs = (head +: tail).zipWithIndex
     val counter = new AtomicInteger(fs.length)
     val result = Promise[(A, Int)]()
+    var mutableResult = result
     def attemptComplete(t: Try[(A, Int)]): Unit = {
       val remaining = counter.decrementAndGet
-      t match {
-        case TSuccess(_) => val _ = result tryComplete t
-        case _ if remaining == 0 => val _ = result tryComplete t
-        case _ =>
+      val result = mutableResult
+      if (result != null) {
+        t match {
+          case TSuccess(_) =>
+            val _ = result tryComplete t
+            mutableResult = null
+          case _ if remaining == 0 =>
+            val _ = result tryComplete t
+            mutableResult = null
+          case _ =>
+        }
       }
     }
 


### PR DESCRIPTION
This PR cleans up the reference from the handler to the completed `Promise`, allowing the completed `Promise`, which might reference the whole execution, to be garbage-collected.

The handler itself is still a memory leak, however this is relatively mild.

See https://stackoverflow.com/a/36422958/955091 for the similar issue in `firstCompletedOf`