### PR TITLE
Add StreamT.noSkip and StreamT.noSkipRec

### DIFF
--- a/tests/src/test/scala/scalaz/StreamTTest.scala
+++ b/tests/src/test/scala/scalaz/StreamTTest.scala
@@ -13,6 +13,16 @@ object StreamTTest extends SpecLite {
       StreamT.fromLazyList[Id.Id, Byte](xs).weakMemoize must_=== StreamT.fromLazyList[Id.Id, Byte](xs)
   }
 
+  "noSkipRec" ! forAll {
+    (xs: LazyList[Byte]) =>
+      StreamT.fromLazyList[Id.Id, Byte](xs).noSkipRec must_=== StreamT.fromLazyList[Id.Id, Byte](xs)
+  }
+
+  "noSkip" ! forAll {
+    (xs: LazyList[Byte]) =>
+      StreamT.fromLazyList[Id.Id, Byte](xs).noSkip must_=== StreamT.fromLazyList[Id.Id, Byte](xs)
+  }
+
   "recursive" in {
     val s = Scalaz.fix[StreamT[Id.Id, Int]] { stream =>
       1 #:: stream.map(_ * 2)


### PR DESCRIPTION
It would be helpful for creating recursive `StreamT`s, otherwise it would create infinite `M.map` calls with `Skip` steps.